### PR TITLE
feat(server): observability foundation — metric macro + reader seam, dead-metric wiring, correlation, call/client telemetry, LiveKit scrape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@
 - Our job doesn't stop after we push, we always monitor CI and fix it until all checks are green
 - XMPP Native, Never use out of band non-XMPP APIs.
   - Exception: browser observability beacons to the configured Grafana Faro
-    collector, plus W3C trace-context headers to configured backend origins,
+    collector, plus W3C trace-context headers to configured backend origins
+    (carried as a `traceparent` query parameter on the XMPP WebSocket
+    upgrade URL, since the browser WebSocket API cannot set headers),
     are allowed as operational telemetry only. They must not carry XMPP
     control semantics, replace XMPP APIs, or alter XMPP wire behavior.
 - XEP conformance hard rule:

--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -19,6 +19,7 @@ import { applyReactionUpdate, type ReactionPolicy } from "@/lib/messaging/reacti
 import { applyRetraction as applyRetractionUpdate, retractTimelineMessage } from "@/lib/messaging/retraction";
 import { insertLiveMessage } from "@/lib/messaging/timeline-insert";
 import { classifyRoomMessage } from "@/lib/xmpp/classify-room-message";
+import { reportDisplayedMarkerFailure } from "@/lib/telemetry";
 
 // Inbound merge composable for the channel side: applies incoming
 // retractions (XEP-0424 / 0425), corrections (XEP-0308), reactions
@@ -63,8 +64,19 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
 
   /** XEP-0333 displayed marker — shared merge, no channel divergences. */
   function applyDisplayed(messageId: string, nick: string) {
-    const next = applyDisplayedMarker(messages.value, messageId, nick);
-    if (next) messages.value = next;
+    const target = findMessageById(messages.value, messageId);
+    if (!target) return;
+    try {
+      const next = applyDisplayedMarker(messages.value, messageId, nick);
+      if (next) messages.value = next;
+    } catch {
+      reportDisplayedMarkerFailure({
+        direction: "receive",
+        kind: "room",
+        reason: "receive-processing-failed",
+        roundTripMs: elapsedSince(target.createdAt),
+      });
+    }
   }
 
   /**
@@ -227,4 +239,9 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
     mergeLiveMessage,
     handleRoomMessage,
   };
+}
+
+function elapsedSince(createdAt: string): number | null {
+  const startedAt = Date.parse(createdAt);
+  return Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : null;
 }

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -38,6 +38,7 @@ import {
 import { mentionMatchesBareJid } from "@/lib/mentions";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import { roomJidForChannelSummary } from "@/lib/channel-room";
+import { withSpan } from "@/lib/telemetry";
 import {
   applyForumContext,
   isFeedTimelineMessage,
@@ -605,7 +606,11 @@ export function useChannelMessages(
     metadataSeed: TimelineMessage[] = [],
   ) {
     messageSearch.reset();
-    return paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed);
+    return withSpan(
+      "xmpp.initial_render",
+      { "conversation.kind": "room" },
+      () => paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed),
+    );
   }
 
   async function selectChannel(channelId: string) {

--- a/chat/src/channels/read-markers.ts
+++ b/chat/src/channels/read-markers.ts
@@ -6,6 +6,7 @@ import { findMessageById } from "@/lib/message-ids";
 import { roomKey, setLastSeen } from "@/lib/last-seen-store";
 import { latestRemoteMessageIdFor } from "@/lib/timeline-state";
 import { useReadReceiptPreference } from "@/preferences/read-receipts";
+import { reportDisplayedMarkerFailure } from "@/lib/telemetry";
 
 const NS_STANZA_ID = "urn:xmpp:sid:0";
 
@@ -77,7 +78,12 @@ export function useChannelReadMarkers(deps: UseChannelReadMarkersDeps) {
     if (sendDisplayedMarkers.value) {
       void client
         .sendDisplayed(spaceId, channelId, stanzaId, thread)
-        .catch(() => undefined);
+        .catch(() => reportDisplayedMarkerFailure({
+          direction: "send",
+          kind: "room",
+          reason: "send-failed",
+          roundTripMs: elapsedSince(target.createdAt),
+        }));
     }
     // XEP-0490 §3 publish — MUC stanza-id by= room JID. Only fires
     // when the room actually stamped the message (XEP-0359 §3.4
@@ -100,4 +106,9 @@ export function useChannelReadMarkers(deps: UseChannelReadMarkersDeps) {
     markDisplayed,
     persistLastSeen,
   };
+}
+
+function elapsedSince(createdAt: string): number | null {
+  const startedAt = Date.parse(createdAt);
+  return Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : null;
 }

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -13,6 +13,7 @@ import { applyDisplayedMarker } from "@/lib/messaging/displayed";
 import { applyReactionUpdate, type ReactionPolicy } from "@/lib/messaging/reactions";
 import { applyRetraction as applyRetractionUpdate, retractTimelineMessage } from "@/lib/messaging/retraction";
 import { insertLiveMessage } from "@/lib/messaging/timeline-insert";
+import { reportDisplayedMarkerFailure } from "@/lib/telemetry";
 
 // Inbound merge composable for DMs: applies incoming retractions
 // (XEP-0424), corrections (XEP-0308), reactions (XEP-0444), and displayed
@@ -56,8 +57,19 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
 
   /** XEP-0333 displayed marker — shared merge, no DM divergences. */
   function applyDisplayed(messageId: string, nick: string) {
-    const next = applyDisplayedMarker(messages.value, messageId, nick);
-    if (next) messages.value = next;
+    const target = findMessageById(messages.value, messageId);
+    if (!target) return;
+    try {
+      const next = applyDisplayedMarker(messages.value, messageId, nick);
+      if (next) messages.value = next;
+    } catch {
+      reportDisplayedMarkerFailure({
+        direction: "receive",
+        kind: "dm",
+        reason: "receive-processing-failed",
+        roundTripMs: elapsedSince(target.createdAt),
+      });
+    }
   }
 
   /**
@@ -170,4 +182,9 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
     mergeLiveMessage,
     handleIncomingMessage,
   };
+}
+
+function elapsedSince(createdAt: string): number | null {
+  const startedAt = Date.parse(createdAt);
+  return Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : null;
 }

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -36,6 +36,7 @@ import { useDmChatStates } from "@/dms/chat-states";
 import { useDmReadMarkers } from "@/dms/read-markers";
 import { useDmMessageSearch } from "@/dms/message-search";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
+import { withSpan } from "@/lib/telemetry";
 import {
   $dmCallOutcomeAnchor,
   $dmCallStartedAnchor,
@@ -314,7 +315,11 @@ export function useDirectMessages(
   // clears stale results.
   async function loadMessages(peerJid: string, unreadAtLoad = 0) {
     messageSearch.reset();
-    return paging.loadMessages(peerJid, unreadAtLoad);
+    return withSpan(
+      "xmpp.initial_render",
+      { "conversation.kind": "dm" },
+      () => paging.loadMessages(peerJid, unreadAtLoad),
+    );
   }
 
   /** On a fresh session (SM resume failed), re-fetch MAM to close any gap

--- a/chat/src/dms/read-markers.ts
+++ b/chat/src/dms/read-markers.ts
@@ -7,6 +7,7 @@ import { dmKey, setLastSeen } from "@/lib/last-seen-store";
 import { latestRemoteMessageIdFor } from "@/lib/timeline-state";
 import { useReadReceiptPreference } from "@/preferences/read-receipts";
 import { dmThreadRefFromMessage } from "@/dms/threading";
+import { reportDisplayedMarkerFailure } from "@/lib/telemetry";
 
 // XEP-0333 chat-marker outbound state for the DM side. Mirrors
 // useChannelReadMarkers; uses the exact conversation identity as the
@@ -48,7 +49,12 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
       const scope = conversationScope?.(peerJid);
       void client
         .sendDmDisplayed(peerJid, targetId, dmThreadRefFromMessage(target), scope)
-        .catch(() => undefined);
+        .catch(() => reportDisplayedMarkerFailure({
+          direction: "send",
+          kind: "dm",
+          reason: "send-failed",
+          roundTripMs: elapsedSince(target.createdAt),
+        }));
     }
     // XEP-0490 §3 publish for the DM. The chat id is the peer bare
     // JID; `stanza_id_by` is the user's own server JID (carried on
@@ -72,4 +78,9 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
     markDisplayed,
     persistLastSeen,
   };
+}
+
+function elapsedSince(createdAt: string): number | null {
+  const startedAt = Date.parse(createdAt);
+  return Number.isFinite(startedAt) ? Math.max(0, Date.now() - startedAt) : null;
 }

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -183,7 +183,10 @@ export function suspendCallForPageHide(): void {
   } | null)?.persistResumeStateForPageHide?.();
   const current = $callState.get();
   if (current.phase === "idle" || current.phase === "ended") return;
-  clearCallState();
+  // This page's media connection is ending even when a refreshed page later
+  // rediscovers the protocol call. A rediscovery is a distinct connection
+  // attempt and owns its own lifecycle event.
+  clearCallState({ endReason: "error" });
   void useCallEngine().engine.disconnect();
 }
 

--- a/chat/src/lib/calls/call-effects.ts
+++ b/chat/src/lib/calls/call-effects.ts
@@ -10,6 +10,7 @@ import {
   isSameCallBareJid,
 } from "./tie-break";
 import type { CallEvent, CallState } from "./types";
+import { reportDeclinedCallAttempt } from "./call-lifecycle-telemetry";
 
 /**
  * Side-effect handler invoked by the chat-side `on_call` wrapper
@@ -65,6 +66,7 @@ export async function handleCallEventSideEffect(
         await outboundCalls.retractTieBreak(sender, event.from, prev.sid);
         acceptIncomingTieBreakPropose(event);
       } else {
+        reportDeclinedCallAttempt(event.sid);
         await outboundCalls.rejectTieBreak(sender, event.from, event.sid);
       }
     } catch (err) {
@@ -107,6 +109,7 @@ export async function handleCallEventSideEffect(
     prev.phase !== "idle" &&
     prev.phase !== "ended"
   ) {
+    reportDeclinedCallAttempt(event.sid);
     try {
       await outboundCalls.reject(sender, event.from, event.sid);
     } catch (err) {

--- a/chat/src/lib/calls/call-lifecycle-telemetry.ts
+++ b/chat/src/lib/calls/call-lifecycle-telemetry.ts
@@ -1,0 +1,225 @@
+import {
+  type CallConnectionPhase,
+  type CallConnectionQuality,
+} from "./connection-quality";
+import { reportCallLifecycle } from "../telemetry";
+
+export type CallKind = "dm" | "muc";
+export type CallSetupOutcome = "proposed" | "accepted" | "declined" | "timeout" | "failed";
+export type CallEndReason = "hangup" | "peer-left" | "error" | "reconnect-exhausted";
+export type CallDurationBucket = "none" | "under-1m" | "1m-10m" | "10m-60m" | "over-60m";
+export type CallRttBand = "unknown" | "under-100ms" | "100ms-300ms" | "over-300ms";
+export type CallPacketLossBand = "unknown" | "under-1pct" | "1pct-5pct" | "over-5pct";
+
+export type CallLifecyclePayload = {
+  setupOutcome: CallSetupOutcome;
+  endReason?: CallEndReason;
+  durationBucket: CallDurationBucket;
+  callKind: CallKind;
+  rttBand: CallRttBand;
+  packetLossBand: CallPacketLossBand;
+  connectionQuality: CallConnectionQuality;
+  reconnectCount: number;
+};
+
+type Attempt = {
+  sid: string;
+  callKind: CallKind;
+  accepted: boolean;
+  acceptedAtMs: number | null;
+  maxRttMs: number | null;
+  maxPacketLossPct: number | null;
+  worstConnectionQuality: CallConnectionQuality;
+  reconnectCount: number;
+  previousConnectionPhase: CallConnectionPhase;
+  reconnectInProgress: boolean;
+};
+
+const QUALITY_SEVERITY: Record<CallConnectionQuality, number> = {
+  unknown: 0,
+  excellent: 1,
+  good: 2,
+  poor: 3,
+  lost: 4,
+};
+
+const attempts = new Map<string, Attempt>();
+const emittedSids = new Set<string>();
+const MAX_EMITTED_SIDS = 256;
+let currentSid: string | null = null;
+
+export function durationBucket(durationMs: number): CallDurationBucket {
+  if (durationMs <= 0) return "none";
+  if (durationMs < 60_000) return "under-1m";
+  if (durationMs < 600_000) return "1m-10m";
+  if (durationMs < 3_600_000) return "10m-60m";
+  return "over-60m";
+}
+
+export function rttBand(rttMs: number | null): CallRttBand {
+  if (rttMs === null) return "unknown";
+  if (rttMs < 100) return "under-100ms";
+  if (rttMs <= 300) return "100ms-300ms";
+  return "over-300ms";
+}
+
+export function packetLossBand(packetLossPct: number | null): CallPacketLossBand {
+  if (packetLossPct === null) return "unknown";
+  if (packetLossPct < 1) return "under-1pct";
+  if (packetLossPct <= 5) return "1pct-5pct";
+  return "over-5pct";
+}
+
+export function beginCallAttempt(sid: string, callKind: CallKind): void {
+  if (!sid) return;
+  // An explicit begin is a new attempt even when a restored call reuses the
+  // same protocol sid after a prior disconnect in this SPA lifetime.
+  emittedSids.delete(sid);
+  if (currentSid && currentSid !== sid) {
+    const current = attempts.get(currentSid);
+    finishCallAttempt(currentSid, {
+      setupOutcome: "proposed",
+      ...(current?.accepted ? { endReason: "error" as const } : {}),
+    });
+  }
+  if (!attempts.has(sid)) {
+    attempts.set(sid, {
+      sid,
+      callKind,
+      accepted: false,
+      acceptedAtMs: null,
+      maxRttMs: null,
+      maxPacketLossPct: null,
+      worstConnectionQuality: "unknown",
+      reconnectCount: 0,
+      previousConnectionPhase: "disconnected",
+      reconnectInProgress: false,
+    });
+  }
+  currentSid = sid;
+}
+
+/** Classify a terminal media transport loss using observed reconnect state. */
+export function finishCallAttemptForTransportDisconnect(sid: string): CallLifecyclePayload | null {
+  const attempt = attempts.get(sid);
+  return finishCallAttempt(sid, {
+    setupOutcome: "accepted",
+    endReason: attempt?.reconnectInProgress ? "reconnect-exhausted" : "error",
+  });
+}
+
+export function markCallAttemptAccepted(sid: string, now: number = Date.now()): void {
+  const attempt = attempts.get(sid);
+  if (attempt) {
+    attempt.accepted = true;
+    attempt.acceptedAtMs ??= now;
+  }
+}
+
+export function observeCallStats(sample: {
+  rttMs: number | null;
+  packetLossPct: number | null;
+}): void {
+  const attempt = currentAttempt();
+  if (!attempt) return;
+  if (sample.rttMs !== null) {
+    attempt.maxRttMs = Math.max(attempt.maxRttMs ?? 0, sample.rttMs);
+  }
+  if (sample.packetLossPct !== null) {
+    attempt.maxPacketLossPct = Math.max(attempt.maxPacketLossPct ?? 0, sample.packetLossPct);
+  }
+}
+
+export function observeCallConnectionQuality(quality: CallConnectionQuality): void {
+  const attempt = currentAttempt();
+  if (!attempt) return;
+  if (QUALITY_SEVERITY[quality] > QUALITY_SEVERITY[attempt.worstConnectionQuality]) {
+    attempt.worstConnectionQuality = quality;
+  }
+}
+
+export function observeCallConnectionPhase(phase: CallConnectionPhase): void {
+  const attempt = currentAttempt();
+  if (!attempt) return;
+  if (phase === "reconnecting" && attempt.previousConnectionPhase !== "reconnecting") {
+    attempt.reconnectCount += 1;
+  }
+  if (phase === "reconnecting") attempt.reconnectInProgress = true;
+  if (phase === "connected") attempt.reconnectInProgress = false;
+  attempt.previousConnectionPhase = phase;
+}
+
+export function finishCallAttempt(
+  sid: string,
+  terminal: { setupOutcome?: CallSetupOutcome; endReason?: CallEndReason },
+  now: number = Date.now(),
+): CallLifecyclePayload | null {
+  if (emittedSids.has(sid)) return null;
+  const attempt = attempts.get(sid);
+  if (!attempt) return null;
+  const payload: CallLifecyclePayload = {
+    setupOutcome: attempt.accepted ? "accepted" : (terminal.setupOutcome ?? "proposed"),
+    ...(terminal.endReason ? { endReason: terminal.endReason } : {}),
+    durationBucket: durationBucket(attempt.acceptedAtMs === null ? 0 : now - attempt.acceptedAtMs),
+    callKind: attempt.callKind,
+    rttBand: rttBand(attempt.maxRttMs),
+    packetLossBand: packetLossBand(attempt.maxPacketLossPct),
+    connectionQuality: attempt.worstConnectionQuality,
+    reconnectCount: attempt.reconnectCount,
+  };
+  emittedSids.add(sid);
+  trimEmittedSids();
+  attempts.delete(sid);
+  if (currentSid === sid) currentSid = null;
+  reportCallLifecycle(payload);
+  return payload;
+}
+
+/** Emit a declined inbound proposal that never occupied the single call slot. */
+export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"): void {
+  if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
+  emittedSids.add(sid);
+  trimEmittedSids();
+  reportCallLifecycle({
+    setupOutcome: "declined",
+    durationBucket: "none",
+    callKind,
+    rttBand: "unknown",
+    packetLossBand: "unknown",
+    connectionQuality: "unknown",
+    reconnectCount: 0,
+  });
+}
+
+/** Emit a failed setup that ended before it could occupy the call store. */
+export function reportFailedCallAttempt(sid: string, callKind: CallKind): void {
+  if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
+  emittedSids.add(sid);
+  trimEmittedSids();
+  reportCallLifecycle({
+    setupOutcome: "failed",
+    durationBucket: "none",
+    callKind,
+    rttBand: "unknown",
+    packetLossBand: "unknown",
+    connectionQuality: "unknown",
+    reconnectCount: 0,
+  });
+}
+
+function trimEmittedSids(): void {
+  if (emittedSids.size <= MAX_EMITTED_SIDS) return;
+  const oldest = emittedSids.values().next().value;
+  if (oldest) emittedSids.delete(oldest);
+}
+
+function currentAttempt(): Attempt | undefined {
+  return currentSid ? attempts.get(currentSid) : undefined;
+}
+
+/** Test seam: lifecycle state must not leak across Bun test cases. */
+export function __resetCallLifecycleTelemetryForTesting(): void {
+  attempts.clear();
+  emittedSids.clear();
+  currentSid = null;
+}

--- a/chat/src/lib/calls/call-media-issues.ts
+++ b/chat/src/lib/calls/call-media-issues.ts
@@ -1,4 +1,5 @@
 import { atom } from "nanostores";
+import { reportCallMediaError } from "../telemetry";
 
 /**
  * Why the local microphone or camera could not be published for the
@@ -139,7 +140,9 @@ export function mediaErrorMessage(error: unknown): string | null {
 
 /** Record a capture failure for `kind`, classifying the error. */
 export function recordMediaIssue(kind: MediaKind, error: unknown): void {
-  $callMediaIssues.set({ ...$callMediaIssues.get(), [kind]: classifyMediaError(error) });
+  const reason = classifyMediaError(error);
+  $callMediaIssues.set({ ...$callMediaIssues.get(), [kind]: reason });
+  reportCallMediaError(kind, reason);
 }
 
 /** Clear the recorded issue for `kind` (e.g. after a successful retry). */

--- a/chat/src/lib/calls/call-stats.ts
+++ b/chat/src/lib/calls/call-stats.ts
@@ -67,6 +67,8 @@ export type VideoStatsSummary = {
 type AudioStatsSummary = {
   codec: string | null;
   bitrateKbps: number | null;
+  packetLossPct: number | null;
+  rttMs: number | null;
   iceCandidateType: IceCandidateType | null;
   iceTransport: IceTransport | null;
 };
@@ -317,6 +319,7 @@ export function summarizeAudioStats(
 ): { summary: AudioStatsSummary; sample: CallStatSample | null } {
   const mainType = direction === "send" ? "outbound-rtp" : "inbound-rtp";
   const mains: RtpLike[] = [];
+  const remoteInbounds: RtpLike[] = [];
   const candidatePairs: RtpLike[] = [];
   let selectedPairId: string | undefined;
   const byId = new Map<string, RtpLike>();
@@ -326,6 +329,8 @@ export function summarizeAudioStats(
     if (stat.id !== undefined) byId.set(stat.id, stat);
     if (stat.type === mainType && isAudio(stat)) {
       mains.push(stat);
+    } else if (stat.type === "remote-inbound-rtp" && isAudio(stat)) {
+      remoteInbounds.push(stat);
     } else if (stat.type === "candidate-pair") {
       candidatePairs.push(stat);
     } else if (stat.type === "transport" && stat.selectedCandidatePairId !== undefined) {
@@ -343,7 +348,36 @@ export function summarizeAudioStats(
   const sample = sampleFromRtp(mains, direction === "send" ? "bytesSent" : "bytesReceived");
   const bitrateKbps = bitrateFromSamples(sample, prev);
 
-  return { summary: { codec, bitrateKbps, iceCandidateType, iceTransport }, sample };
+  const packetLossPct = direction === "recv"
+    ? recvPacketLoss(mains)
+    : sendPacketLoss(mains, remoteInbounds);
+  let rttSec: number | undefined;
+  if (direction === "send") {
+    for (const remote of remoteInbounds) {
+      if (remote.roundTripTime !== undefined) {
+        rttSec = rttSec === undefined ? remote.roundTripTime : Math.max(rttSec, remote.roundTripTime);
+      }
+    }
+  }
+  if (rttSec === undefined) {
+    rttSec = candidatePair?.currentRoundTripTime
+      ?? candidatePairs.find(
+        (pair) => pair.state !== "failed" && pair.currentRoundTripTime !== undefined,
+      )?.currentRoundTripTime;
+  }
+  const rttMs = rttSec !== undefined ? Math.round(rttSec * 1000) : null;
+
+  return {
+    summary: {
+      codec,
+      bitrateKbps,
+      packetLossPct,
+      rttMs,
+      iceCandidateType,
+      iceTransport,
+    },
+    sample,
+  };
 }
 
 function clampPercent(value: number): number {

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -454,15 +454,8 @@ export function clearCallState(terminal: {
   );
   const current = $callState.get();
   if (current.phase !== "idle" && current.phase !== "ended") {
-    const defaultOutcome: CallSetupOutcome = current.phase === "incoming"
-      ? "declined"
-      : current.phase === "muc-pending"
-        ? "failed"
-        : current.phase === "outgoing"
-          ? "proposed"
-          : "accepted";
     finishCallAttempt(current.sid, {
-      setupOutcome: terminal.setupOutcome ?? defaultOutcome,
+      setupOutcome: terminal.setupOutcome ?? teardownSetupOutcome(current.phase),
       ...(terminal.endReason
         ? { endReason: terminal.endReason }
         : current.phase === "active" ? { endReason: "error" as const } : {}),
@@ -725,6 +718,27 @@ export function clearLastCallError(): void {
  * unreachable-side teardown ("gone", per XEP-0166 §7.4) so the peer
  * UI can label the ended state correctly.
  */
+/**
+ * Setup outcome for a call attempt that is being torn down / cleared
+ * from a given phase. Shared by `clearCallState` and
+ * `tearDownActiveCall` so the two teardown paths cannot drift: a
+ * `muc-pending` group-call setup that gets torn down is a *failed*
+ * attempt (its Muji accept/preparation waiters are cancelled), never
+ * a merely "proposed" one.
+ */
+export function teardownSetupOutcome(phase: CallState["phase"]): CallSetupOutcome {
+  switch (phase) {
+    case "active":
+      return "accepted";
+    case "incoming":
+      return "declined";
+    case "muc-pending":
+      return "failed";
+    default:
+      return "proposed";
+  }
+}
+
 export async function tearDownActiveCall(
   sender: CallWireSender | null,
   reason: "success" | "gone",
@@ -733,9 +747,7 @@ export async function tearDownActiveCall(
   const s = $callState.get();
   if (s.phase !== "idle" && s.phase !== "ended") {
     finishCallAttempt(s.sid, {
-      setupOutcome: s.phase === "active"
-        ? "accepted"
-        : s.phase === "incoming" ? "declined" : "proposed",
+      setupOutcome: teardownSetupOutcome(s.phase),
       ...(s.phase === "active"
         ? { endReason: reason === "success" ? "hangup" as const : "error" as const }
         : {}),

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -20,12 +20,21 @@ import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
 import { mediaErrorMessage } from "./call-media-issues";
 import {
+  beginCallAttempt,
+  finishCallAttempt,
+  markCallAttemptAccepted,
+  reportFailedCallAttempt,
+  type CallEndReason,
+  type CallSetupOutcome,
+} from "./call-lifecycle-telemetry";
+import {
   dmCallStartedAnchorFromTransition,
   publishDmCallOutcomeAnchor,
   publishDmCallStartedAnchor,
 } from "./dm-call-anchor";
 import { barePeerJid } from "../xmpp/jid";
 import type { IncomingCallAlertController } from "@/shell/audio-alerts";
+import { reportError as reportTelemetryError } from "../telemetry";
 
 /**
  * XEP-0272 §Joining MUST: a client emitting a preparing presence
@@ -335,6 +344,24 @@ export function applyCallEvent(
   }
   const before = $callState.get();
   const next = reduceCallState(before, event);
+  if (
+    next.phase === "incoming"
+    && (before.phase !== "incoming" || before.sid !== next.sid)
+  ) {
+    beginCallAttempt(next.sid, "dm");
+  }
+  if (next.phase === "active" && (before.phase !== "active" || before.sid !== next.sid)) {
+    markCallAttemptAccepted(next.sid);
+  }
+  if (next.phase === "ended" && (before.phase !== "ended" || before.sid !== next.sid)) {
+    if (event.kind === "reject") {
+      finishCallAttempt(next.sid, { setupOutcome: "declined" });
+    } else if (event.kind === "retract") {
+      finishCallAttempt(next.sid, { setupOutcome: "proposed" });
+    } else {
+      finishCallAttempt(next.sid, callLifecycleTerminalForRemoteEnd(before, event, next.reason));
+    }
+  }
   if (next !== before) {
     $lastCallError.set(null);
     // Any transition out of outgoing cancels the auto-retract timer.
@@ -356,6 +383,34 @@ export function applyCallEvent(
   // archived `<proceed/>` row, which never reaches the live timeline).
   const dmCallAnchor = dmCallStartedAnchorFromTransition(before, next, new Date().toISOString());
   if (dmCallAnchor) publishDmCallStartedAnchor(dmCallAnchor);
+}
+
+const CALL_ERROR_REASONS = new Set([
+  "connectivity-error",
+  "failed-application",
+  "failed-transport",
+  "general-error",
+  "incompatible-parameters",
+  "media-error",
+  "security-error",
+  "unsupported-applications",
+  "unsupported-transports",
+  "error",
+]);
+
+export function callLifecycleTerminalForRemoteEnd(
+  before: CallState,
+  _event: CallEvent,
+  reason: string | null,
+): { setupOutcome?: CallSetupOutcome; endReason?: CallEndReason } {
+  const isFailure = reason !== null && CALL_ERROR_REASONS.has(reason);
+  if (before.phase === "active") {
+    return { endReason: isFailure || reason === "timeout" ? "error" : "peer-left" };
+  }
+  if (reason === "timeout") return { setupOutcome: "timeout" };
+  if (reason === "decline") return { setupOutcome: "declined" };
+  if (isFailure) return { setupOutcome: "failed" };
+  return { setupOutcome: "proposed" };
 }
 
 function applyIncomingCallAlerts(before: CallState, next: CallState): void {
@@ -389,12 +444,30 @@ function emitRingingOnIncomingPropose(
  * Mark the local call slot as idle. Called when the UI dismisses
  * the `ended` state (the toast closes, the user clicks dismiss).
  */
-export function clearCallState(): void {
+export function clearCallState(terminal: {
+  setupOutcome?: CallSetupOutcome;
+  endReason?: CallEndReason;
+} = {}): void {
   cancelCallTimers();
   rejectAllPendingMujiAccepts(
     new Error("Muji session-accept wait cancelled while clearing call state"),
   );
   const current = $callState.get();
+  if (current.phase !== "idle" && current.phase !== "ended") {
+    const defaultOutcome: CallSetupOutcome = current.phase === "incoming"
+      ? "declined"
+      : current.phase === "muc-pending"
+        ? "failed"
+        : current.phase === "outgoing"
+          ? "proposed"
+          : "accepted";
+    finishCallAttempt(current.sid, {
+      setupOutcome: terminal.setupOutcome ?? defaultOutcome,
+      ...(terminal.endReason
+        ? { endReason: terminal.endReason }
+        : current.phase === "active" ? { endReason: "error" as const } : {}),
+    });
+  }
   if (current.phase === "incoming") {
     incomingCallAlerts?.stop(current.sid);
   } else {
@@ -416,6 +489,7 @@ export function clearCallState(): void {
 
 export function failCallState(err: unknown, sid: string): void {
   cancelCallTimers();
+  finishCallAttempt(sid, { setupOutcome: "failed", endReason: "error" });
   $callState.set({ phase: "ended", sid, reason: "error" });
   reportCallError(err);
 }
@@ -424,12 +498,20 @@ export function acceptIncomingTieBreakPropose(
   event: Extract<CallEvent, { kind: "propose" }>,
 ): void {
   cancelCallTimers();
+  const replaced = $callState.get();
+  if (replaced.phase === "active" && replaced.sid !== event.sid) {
+    finishCallAttempt(replaced.sid, {
+      setupOutcome: "accepted",
+      endReason: "peer-left",
+    });
+  }
   $callState.set({
     phase: "incoming",
     from: event.from,
     sid: event.sid,
     media: event.media,
   });
+  beginCallAttempt(event.sid, "dm");
   incomingCallAlerts?.start({
     peerJid: barePeerJid(event.from) || event.from,
     sid: event.sid,
@@ -456,6 +538,7 @@ export function beginOutgoingCall(
       ? { phase: "outgoing", to, sid, media, initiator }
       : { phase: "outgoing", to, sid, media },
   );
+  beginCallAttempt(sid, "dm");
   applyDmCallEvent({
     event: {
       kind: "propose",
@@ -522,6 +605,7 @@ export function scheduleOutgoingTimeout(
       .catch((err) => reportCallError(err));
     publishNoAnswerOutcome(s.to, sid, s.media, s.initiator);
     clearDmCallActivity(s.to, sid);
+    finishCallAttempt(sid, { setupOutcome: "timeout" });
     $callState.set({
       phase: "ended",
       sid,
@@ -554,6 +638,7 @@ export function scheduleSessionAcceptTimeout(
       .catch((err) => reportCallError(err));
     publishNoAnswerOutcome(peerFullJid, sid, s.media, s.initiator);
     clearDmCallActivity(peerFullJid, sid);
+    finishCallAttempt(sid, { setupOutcome: "timeout" });
     $callState.set({
       phase: "ended",
       sid,
@@ -607,6 +692,10 @@ export function reportCallError(err: unknown): void {
   // path (e.g. a mid-call device switch in the settings dialog).
   const message =
     mediaErrorMessage(err) ?? (err instanceof Error ? err.message : String(err));
+  reportTelemetryError("call.operation", err, {
+    recoverable: true,
+    detail: "call-operation",
+  });
   $lastCallError.set(message);
   if (clearTimer) clearTimeout(clearTimer);
   clearTimer = setTimeout(() => $lastCallError.set(null), AUTO_CLEAR_MS);
@@ -642,6 +731,16 @@ export async function tearDownActiveCall(
 ): Promise<void> {
   cancelCallTimers();
   const s = $callState.get();
+  if (s.phase !== "idle" && s.phase !== "ended") {
+    finishCallAttempt(s.sid, {
+      setupOutcome: s.phase === "active"
+        ? "accepted"
+        : s.phase === "incoming" ? "declined" : "proposed",
+      ...(s.phase === "active"
+        ? { endReason: reason === "success" ? "hangup" as const : "error" as const }
+        : {}),
+    });
+  }
   if (sender) {
     try {
       switch (s.phase) {
@@ -970,27 +1069,32 @@ export async function beginMucCall(
   selfNick?: string,
   expectedMixerJid?: string | null,
   selfFullJid?: string | null,
+  lifecycleAttemptId: string = crypto.randomUUID(),
 ): Promise<void> {
+  const attemptId = lifecycleAttemptId;
   const normalizedRoomJid = normalizeMucCallRoomJid(roomJid);
   if (!normalizedRoomJid) {
+    reportFailedCallAttempt(attemptId, "muc");
     throw new Error("Cannot start a group call without a room JID");
   }
   // Fresh call: a hand left raised from a prior session in this room must
   // not silently re-raise on the new active presence (#1029).
   setSelfRaisedHand(normalizedRoomJid, false);
   if (!selfNick) {
+    reportFailedCallAttempt(attemptId, "muc");
     throw new Error("Cannot start a group call before MUC presence has a nick");
   }
   if (!sender.update_muji_presence) {
+    reportFailedCallAttempt(attemptId, "muc");
     throw new Error(
       "wasm client does not expose update_muji_presence; rebuild the wasm bundle",
     );
   }
   const current = $callState.get();
   if (current.phase !== "idle" && current.phase !== "ended") {
+    reportFailedCallAttempt(attemptId, "muc");
     throw new Error("Cannot start a group call while another call is active or starting");
   }
-  const attemptId = crypto.randomUUID();
 
   $callState.set({
     phase: "muc-pending",
@@ -1002,6 +1106,7 @@ export async function beginMucCall(
     selfFullJid,
     attemptId,
   });
+  beginCallAttempt(attemptId, "muc");
   $lastCallError.set(null);
 
   // Step 1 — preparing presence (XEP-0272 §Joining two-phase flow).
@@ -1070,7 +1175,6 @@ export async function beginMucCall(
       attemptId,
       activePresencePublished: true,
     });
-
     // Step 3 — session-initiate. The SFU mixer's session-accept
     // arrives after the active Muji presence is already room-visible.
     const join = await sendMujiSessionInitiate(
@@ -1092,6 +1196,7 @@ export async function beginMucCall(
       selfNick,
       selfFullJid,
     });
+    markCallAttemptAccepted(attemptId);
     rememberMucCallSession({
       roomJid: normalizedRoomJid,
       sid: attemptId,
@@ -1117,6 +1222,7 @@ export async function beginMucCall(
         activePresencePublished,
         attemptId,
       );
+      finishCallAttempt(attemptId, { setupOutcome: "failed", endReason: "error" });
       $callState.set({ phase: "idle" });
     }
     throw err;

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -18,6 +18,11 @@ import {
 } from "./outbound";
 import type { CallMedia } from "./types";
 import { barePeerJid } from "../xmpp/jid";
+import {
+  beginCallAttempt,
+  finishCallAttempt,
+  markCallAttemptAccepted,
+} from "./call-lifecycle-telemetry";
 
 export async function startDmCallAction(options: {
   peerBareJid: string;
@@ -45,6 +50,7 @@ export async function startDmCallAction(options: {
   } catch (err) {
     const next = $callState.get();
     if (next.phase === "outgoing" && next.sid === sid) {
+      finishCallAttempt(sid, { setupOutcome: "failed", endReason: "error" });
       $callState.set({ phase: "idle" });
     }
     clearDmCallActivity(options.peerBareJid, sid);
@@ -104,6 +110,7 @@ export async function answerIncomingDmCallActivity(options: {
   } catch (err) {
     const next = $callState.get();
     if (needsHydratedIncoming && next.phase === "incoming" && next.sid === options.sid) {
+      finishCallAttempt(options.sid, { setupOutcome: "failed", endReason: "error" });
       $callState.set({ phase: "idle" });
     } else if (canUseCurrentIncoming && next.phase === "incoming" && next.sid === options.sid) {
       $callState.set({ ...next, accepting: false });
@@ -138,6 +145,8 @@ export function resumeDmCallActivity(options: {
     join: activity.join,
     initiator: selfFullJid,
   });
+  beginCallAttempt(activity.sid, "dm");
+  markCallAttemptAccepted(activity.sid);
   return true;
 }
 

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -209,7 +209,7 @@ export type CallEngineEvents = {
    * before our event listener attached.
    */
   connected: (snapshot: { localIdentity: string; remoteIdentities: string[] }) => void;
-  disconnected: (reason?: string) => void;
+  disconnected: (reason: "local" | "transport") => void;
   /**
    * Fires when LiveKit reports whether remote audio can currently
    * play. Browser autoplay policy can suspend Web Audio playback until
@@ -1081,7 +1081,7 @@ export class CallEngine {
     this.emit("participantDisconnected", participant.identity);
   };
 
-  private handleDisconnected = (reason?: unknown) => {
+  private handleDisconnected = (_reason?: unknown) => {
     this.clearParticipantAudioVolumes();
     // LiveKit destroys the processor when the track stops; just reset our
     // per-track failure guard + capture-NS state so the next call starts clean.
@@ -1091,7 +1091,10 @@ export class CallEngine {
     // our per-track guard + applied effect so the next call starts clean.
     this.backgroundFailedEffects.clear();
     this.appliedBackgroundEffect = BACKGROUND_OFF;
-    this.emit("disconnected", typeof reason === "string" ? reason : undefined);
+    // LiveKit exposes a numeric SDK enum here. Keep that unstable detail at
+    // the boundary; lifecycle telemetry combines this terminal transport loss
+    // with the independently observed reconnect phase before classifying it.
+    this.emit("disconnected", "transport");
   };
 
   private handleAudioPlaybackStatusChanged = (canPlaybackAudio: boolean) => {

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -9,6 +9,11 @@ import {
   readMucCallSession,
 } from "./muc-call-session-cache";
 import type { CallMedia, LiveKitJoin } from "./types";
+import {
+  beginCallAttempt,
+  markCallAttemptAccepted,
+  reportFailedCallAttempt,
+} from "./call-lifecycle-telemetry";
 
 type MucCallStartActionOptions = {
   roomJid: string;
@@ -57,6 +62,7 @@ export async function startMucCallAction({
   if (isBusy()) return false;
   const sender = getSender();
   if (!sender) return false;
+  const lifecycleAttemptId = crypto.randomUUID();
   setStarting(true);
   try {
     await ensureJoined?.();
@@ -76,9 +82,11 @@ export async function startMucCallAction({
       getSelfNick(),
       getExpectedMixerJid?.(),
       getSelfFullJid?.(),
+      lifecycleAttemptId,
     );
     return true;
   } catch (err) {
+    reportFailedCallAttempt(lifecycleAttemptId, "muc");
     reportCallError(err);
     return false;
   } finally {
@@ -252,6 +260,8 @@ export async function resumeMucCallActivity({
     selfNick,
     selfFullJid,
   });
+  beginCallAttempt(session.sid, "muc");
+  markCallAttemptAccepted(session.sid);
 
   // Best-effort republish of Muji active presence under the current
   // resource. Non-fatal — the LK→Muji webhook bridge will reconcile

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -53,6 +53,13 @@ import {
   setCallConnectionQuality,
 } from "./connection-quality";
 import { resetCallActiveSince, setCallActiveSince } from "./call-duration";
+import {
+  observeCallConnectionPhase,
+  observeCallConnectionQuality,
+  observeCallStats,
+  finishCallAttemptForTransportDisconnect,
+  type CallKind,
+} from "./call-lifecycle-telemetry";
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -166,7 +173,17 @@ function resetActiveSpeakers(): void {
  * no-op when Faro isn't configured. Reset on disconnect so the next call
  * re-arms from scratch.
  */
-const micAudioProcessingBeacon = createCallAudioProcessingBeacon(reportCallAudioProcessing);
+function currentCallKind(): CallKind | null {
+  const state = $callState.get();
+  if (state.phase === "active" || state.phase === "muc-pending") return state.kind;
+  if (state.phase === "incoming" || state.phase === "outgoing") return "dm";
+  return null;
+}
+
+const micAudioProcessingBeacon = createCallAudioProcessingBeacon((state) => {
+  const callKind = currentCallKind();
+  if (callKind) reportCallAudioProcessing(state, callKind);
+});
 
 /**
  * Fleet-measurement beacon for the media path each call track actually got
@@ -176,7 +193,10 @@ const micAudioProcessingBeacon = createCallAudioProcessingBeacon(reportCallAudio
  * silent "stuck on TCP relay" rate — is captured on every call. De-dupes to at
  * most one event per distinct path per call; reset on disconnect.
  */
-const callMediaPathBeacon = createCallMediaPathBeacon(reportCallMediaPath);
+const callMediaPathBeacon = createCallMediaPathBeacon((snapshot) => {
+  const callKind = currentCallKind();
+  if (callKind) reportCallMediaPath(snapshot, callKind);
+});
 
 /** Cadence of the observational media-path poll. Codec/ICE settle within the
  * first seconds and then rarely change, and the beacon de-dupes, so a slow 5 s
@@ -207,13 +227,15 @@ const audioMediaPathSamples = new Map<string, CallStatSample>();
 async function sampleTrackMediaPath(
   track: LocalMediaTrack | RemoteMediaTrack,
   direction: CallStatDirection,
-): Promise<CallMediaPathSnapshot | null> {
+): Promise<{ snapshot: CallMediaPathSnapshot | null; rttMs: number | null; packetLossPct: number | null } | null> {
   try {
     const report = await track.track.getRTCStatsReport();
     if (!report) return null;
     const { summary } = summarizeVideoStats(report, direction);
-    if (summary.codec === null && summary.iceCandidateType === null) return null;
-    return {
+    if (summary.codec === null && summary.iceCandidateType === null) {
+      return { snapshot: null, rttMs: summary.rttMs, packetLossPct: summary.packetLossPct };
+    }
+    return { snapshot: {
       direction,
       source: track.source === "screen_share" ? "screen" : "camera",
       codec: summary.codec,
@@ -223,7 +245,7 @@ async function sampleTrackMediaPath(
       // The negotiated top-layer resolution bucket: a fleet shift from 1080p to
       // 720p is the camera-cap egress signal (#1001).
       videoResolutionBand: videoResolutionBand(summary.resolution),
-    };
+    }, rttMs: summary.rttMs, packetLossPct: summary.packetLossPct };
   } catch {
     return null;
   }
@@ -235,6 +257,8 @@ type AudioMediaPathResult = {
   snapshot: CallMediaPathSnapshot | null;
   key: string;
   sample: CallStatSample | null;
+  rttMs: number | null;
+  packetLossPct: number | null;
 };
 
 /**
@@ -279,7 +303,13 @@ async function sampleAudioTrackMediaPath(
             audioBitrateBand: band,
             videoResolutionBand: null, // audio paths carry no resolution band
           };
-    return { snapshot, key, sample };
+    return {
+      snapshot,
+      key,
+      sample,
+      rttMs: summary.rttMs,
+      packetLossPct: summary.packetLossPct,
+    };
   } catch {
     return null;
   }
@@ -316,11 +346,14 @@ async function sampleMediaPaths(generation: number): Promise<void> {
     // to a torn-down call and must not observe into the (reset) beacon or seed
     // the next call's bitrate samples.
     if (generation !== mediaPathGeneration) return;
-    for (const snapshot of videoSnapshots) {
-      if (snapshot) callMediaPathBeacon.observe(snapshot);
+    for (const result of videoSnapshots) {
+      if (!result) continue;
+      observeCallStats({ rttMs: result.rttMs, packetLossPct: result.packetLossPct });
+      if (result.snapshot) callMediaPathBeacon.observe(result.snapshot);
     }
     for (const result of audioResults) {
       if (!result) continue;
+      observeCallStats({ rttMs: result.rttMs, packetLossPct: result.packetLossPct });
       if (result.sample) audioMediaPathSamples.set(result.key, result.sample);
       if (result.snapshot) callMediaPathBeacon.observe(result.snapshot);
     }
@@ -450,11 +483,13 @@ export function useCallEngine(): {
       // LiveKit re-scored the local participant's connection — drives the
       // ambient signal-bars chip on the call bar.
       setCallConnectionQuality(quality);
+      observeCallConnectionQuality(quality);
     });
     singletonEngine.on("connectionPhaseChanged", (phase) => {
       // Transport phase (connected ↔ reconnecting) — overrides the quality
       // bars with a "Reconnecting…" label while the path is re-establishing.
       setCallConnectionPhase(phase);
+      observeCallConnectionPhase(phase);
     });
     singletonEngine.on("activeSpeakersChanged", (identities) => {
       // LiveKit re-derived who is speaking. Feed it through the brief hold so
@@ -475,7 +510,11 @@ export function useCallEngine(): {
       if (!roomJid) return;
       removeLiveCallParticipant(roomJid, identity);
     });
-    singletonEngine.on("disconnected", () => {
+    singletonEngine.on("disconnected", (reason) => {
+      const disconnectedCall = $callState.get();
+      if (reason !== "local" && disconnectedCall.phase === "active") {
+        finishCallAttemptForTransportDisconnect(disconnectedCall.sid);
+      }
       remoteTracks.value = [];
       localTracks.value = [];
       // Drop the active-speaker highlight + its pending sweep so a stale

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -25,10 +25,9 @@
  * connect handshake over WebSocket, outbound message bookkeeping —
  * so we still get client-side timing and failure attribution. The
  * browser WebSocket API does not allow custom headers on the upgrade
- * request, so these manual spans are NOT trace-parented to the
- * server's XMPP session by themselves. Any `fetch` issued inside a
- * `withSpan` callback IS propagated (via the active context set by
- * `context.with`) and will cross-link into backend spans correctly.
+ * request, so `xmpp.connect` propagates its W3C `traceparent` through the
+ * sanctioned WebSocket query parameter. Any `fetch` issued inside a
+ * `withSpan` callback is likewise propagated through normal headers.
  */
 import {
   initializeFaro,
@@ -48,8 +47,13 @@ import {
   callMediaPathEventAttributes,
   type CallMediaPathSnapshot,
 } from "./calls/call-media-path-telemetry";
+import type {
+  CallKind,
+  CallLifecyclePayload,
+} from "./calls/call-lifecycle-telemetry";
 
 type MessageKind = "room" | "dm";
+type DisplayedMarkerLatencyBand = "unknown" | "under-250ms" | "250ms-1s" | "1s-5s" | "over-5s";
 
 /** Errors we classify coarsely so Tempo filters stay useful. */
 export type ErrorKind =
@@ -63,6 +67,8 @@ export type ErrorKind =
   | "storage.write"
   | "http.fetch"
   | "upload"
+  | "call.operation"
+  | "call.media"
   | "window-error"
   | "unhandled-rejection"
   | "vue-render-error";
@@ -128,6 +134,8 @@ const SENSITIVE_ERROR_CONTEXT_KEYS = new Set([
   "key",
   "storagekey",
 ]);
+const TRACEPARENT_PATTERN = /^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/;
+const XMPP_RESOURCE_PATTERN = /^web-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type SpanAttributeValue = string | number;
 type FaroEventPayload = {
@@ -748,14 +756,36 @@ function scrubUrl(value: string | undefined, trustedOrigins: Set<string>): strin
   try {
     const url = new URL(value, currentPageHref());
     if (isSensitiveSpanUrl(url)) return UNKNOWN_FILE_TRANSFER_URL;
-    if (!trustedOrigins.has(url.origin)) return scrubExternalUrl();
+    if (!isTrustedSpanOrigin(url, trustedOrigins)) return scrubExternalUrl();
     url.pathname = scrubUrlPath(url.pathname);
+    const traceparent = sanitizedTraceparent(url.searchParams.get("traceparent"));
     url.search = "";
+    if (traceparent) url.searchParams.set("traceparent", traceparent);
     url.hash = "";
     return url.toString();
   } catch {
     return scrubUrlPath(value.split(/[?#]/, 1)[0] ?? "");
   }
+}
+
+function isTrustedSpanOrigin(url: URL, trustedOrigins: Set<string>): boolean {
+  if (trustedOrigins.has(url.origin)) return true;
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") return false;
+  const httpEquivalent = new URL(url.origin);
+  httpEquivalent.protocol = url.protocol === "wss:" ? "https:" : "http:";
+  return trustedOrigins.has(httpEquivalent.origin);
+}
+
+function sanitizedTraceparent(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  return isValidTraceparent(normalized) ? normalized : undefined;
+}
+
+function isValidTraceparent(value: string): boolean {
+  if (!TRACEPARENT_PATTERN.test(value)) return false;
+  const [, traceId, spanId] = value.split("-");
+  return !/^0{32}$/.test(traceId ?? "") && !/^0{16}$/.test(spanId ?? "");
 }
 
 function currentPageHref(): string {
@@ -817,6 +847,55 @@ export function __setFaroForTesting(instance: Faro | null): void {
     lastGlobalErrorKey = "";
     lastGlobalErrorAtMs = 0;
   }
+}
+
+/** Attach the privacy-safe XMPP resource to Faro's current browser session. */
+export function setXmppResourceForTelemetry(resource: string): void {
+  if (!faro || !XMPP_RESOURCE_PATTERN.test(resource)) return;
+  const current = faro.api.getSession();
+  faro.api.setSession({
+    ...current,
+    attributes: {
+      ...current?.attributes,
+      xmpp_resource: resource,
+    },
+  });
+}
+
+/**
+ * Append the active Faro/OpenTelemetry span as W3C trace context to a WebSocket
+ * upgrade URL. Browsers cannot set upgrade headers, so the sanctioned query
+ * parameter is the only cross-stack propagation channel available here.
+ */
+export function websocketUrlWithTraceparent(value: string): string {
+  const spanContext = trace.getSpan(context.active())?.spanContext();
+  if (!spanContext) return value;
+  return websocketUrlWithSpanContext(value, spanContext);
+}
+
+function websocketUrlWithSpanContext(
+  value: string,
+  spanContext: { traceId: string; spanId: string; traceFlags: number },
+): string {
+  const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff)
+    .toString(16)
+    .padStart(2, "0")}`;
+  if (!isValidTraceparent(traceparent)) return value;
+  try {
+    const url = new URL(value);
+    url.searchParams.set("traceparent", traceparent);
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+/** For tests only — exercise positive WebSocket trace injection deterministically. */
+export function __websocketUrlWithTraceparentForTesting(
+  value: string,
+  spanContext: { traceId: string; spanId: string; traceFlags: number },
+): string {
+  return websocketUrlWithSpanContext(value, spanContext);
 }
 
 /** For tests only — exercise the final transport guard without calling Grafana. */
@@ -976,6 +1055,28 @@ export function reportMessageAcked(payload: {
   }, { context: { kind: payload.kind } });
 }
 
+function displayedMarkerLatencyBand(latencyMs: number | null): DisplayedMarkerLatencyBand {
+  if (latencyMs === null || !Number.isFinite(latencyMs) || latencyMs < 0) return "unknown";
+  if (latencyMs < 250) return "under-250ms";
+  if (latencyMs < 1_000) return "250ms-1s";
+  if (latencyMs < 5_000) return "1s-5s";
+  return "over-5s";
+}
+
+export function reportDisplayedMarkerFailure(payload: {
+  direction: "send" | "receive";
+  kind: MessageKind;
+  reason: "send-failed" | "receive-processing-failed";
+  roundTripMs: number | null;
+}): void {
+  faro?.api.pushEvent("chat.xmpp.displayed_marker.failed", {
+    direction: payload.direction,
+    kind: payload.kind,
+    reason: payload.reason,
+    round_trip_latency_band: displayedMarkerLatencyBand(payload.roundTripMs),
+  });
+}
+
 export function reportSendEnqueued(payload: {
   kind: MessageKind;
   reason: string;
@@ -987,6 +1088,7 @@ export function reportSendEnqueued(payload: {
 }
 
 export function reportQueueDepthChange(payload: {
+  kind: MessageKind;
   persisted: number;
   inflight: number;
 }): void {
@@ -997,7 +1099,7 @@ export function reportQueueDepthChange(payload: {
       persisted: payload.persisted,
       inflight: payload.inflight,
     },
-  });
+  }, { context: { kind: payload.kind } });
 }
 
 export function reportSessionLifecycle(payload: {
@@ -1016,8 +1118,14 @@ export function reportSessionLifecycle(payload: {
  * effect. De-dup (at most once per call per distinct state) is the caller's job
  * via `createCallAudioProcessingBeacon`.
  */
-export function reportCallAudioProcessing(state: VerifiedCallAudioProcessing): void {
-  faro?.api.pushEvent("chat.call.audio_processing", callAudioProcessingEventAttributes(state));
+export function reportCallAudioProcessing(
+  state: VerifiedCallAudioProcessing,
+  callKind: CallKind,
+): void {
+  faro?.api.pushEvent("chat.call.audio_processing", {
+    ...callAudioProcessingEventAttributes(state),
+    call_kind: callKind,
+  });
 }
 
 /**
@@ -1030,8 +1138,36 @@ export function reportCallAudioProcessing(state: VerifiedCallAudioProcessing): v
  * effect. De-dup (at most once per call per distinct path) is the caller's job
  * via `createCallMediaPathBeacon`.
  */
-export function reportCallMediaPath(snapshot: CallMediaPathSnapshot): void {
-  faro?.api.pushEvent("chat.call.media_path", callMediaPathEventAttributes(snapshot));
+export function reportCallMediaPath(snapshot: CallMediaPathSnapshot, callKind: CallKind): void {
+  faro?.api.pushEvent("chat.call.media_path", {
+    ...callMediaPathEventAttributes(snapshot),
+    call_kind: callKind,
+  });
+}
+
+export function reportCallLifecycle(payload: CallLifecyclePayload): void {
+  faro?.api.pushEvent("chat.call.lifecycle", {
+    setup_outcome: payload.setupOutcome,
+    ...(payload.endReason ? { end_reason: payload.endReason } : {}),
+    duration_bucket: payload.durationBucket,
+    call_kind: payload.callKind,
+    rtt_band: payload.rttBand,
+    packet_loss_band: payload.packetLossBand,
+    connection_quality: payload.connectionQuality,
+    reconnect_count: String(payload.reconnectCount),
+  });
+}
+
+export function reportCallMediaError(
+  mediaKind: "mic" | "cam" | "screen",
+  reason: "denied" | "missing" | "in-use" | "failed",
+): void {
+  reportError("call.media", new Error(`call.media.${mediaKind}.${reason}`), {
+    recoverable: true,
+    detail: "media-capture",
+    media_kind: mediaKind,
+    reason,
+  });
 }
 
 export function reportStatusChange(payload: {
@@ -1160,6 +1296,7 @@ export function reportReconnectScheduled(payload: { attempt: number; delayMs: nu
 export function reportCatchup(payload: {
   conversations: number;
   pages: number;
+  pageFailures: number;
   messages: number;
   durationMs: number;
   processedConversations?: number;
@@ -1172,6 +1309,7 @@ export function reportCatchup(payload: {
       conversations: payload.conversations,
       processed_conversations: payload.processedConversations ?? payload.conversations,
       pages: payload.pages,
+      page_failures: payload.pageFailures,
       messages: payload.messages,
       duration_ms: Math.round(payload.durationMs),
       hidden_ms: metric.hiddenMs,

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -617,10 +617,15 @@ export class OfflineSendQueue {
   }
 
   private emitQueueDepth(): void {
-    this.deps.events.emitSafe("queueDepthChange", {
-      persisted: countQueuedMessages(this.deps.queueScope()),
-      inflight: this.inflightQueuedIds.size,
-    });
+    const entries = listQueuedMessages(this.deps.queueScope());
+    for (const kind of ["dm", "room"] as const) {
+      const kindEntries = entries.filter((entry) => entry.kind === kind);
+      this.deps.events.emitSafe("queueDepthChange", {
+        kind,
+        persisted: kindEntries.length,
+        inflight: kindEntries.filter((entry) => this.inflightQueuedIds.has(entry.id)).length,
+      });
+    }
   }
 
   private noteQueuedMessage(): void {

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -73,6 +73,7 @@ export type CatchupHookInfo = {
   conversations: number;
   processedConversations: number;
   pages: number;
+  pageFailures: number;
   messages: number;
   durationMs: number;
   outcome: CatchupOutcome;
@@ -125,7 +126,7 @@ export type ClientEvents = {
   sessionLifecycleHook: [event: SessionLifecycleEvent];
   statusHook: [status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }];
   sendEnqueued: [info: { kind: "room" | "dm"; reason: string }];
-  queueDepthChange: [depth: { persisted: number; inflight: number }];
+  queueDepthChange: [depth: { kind: "room" | "dm"; persisted: number; inflight: number }];
   error: [event: XmppErrorEvent];
   reconnectScheduled: [info: { attempt: number; delayMs: number }];
   catchup: [info: CatchupHookInfo];

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -42,7 +42,7 @@ const RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION = 5;
 
 export type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
 
-type CatchupRunStats = { pages: number; messages: number };
+type CatchupRunStats = { pages: number; pageFailures: number; messages: number };
 type CatchupOutcome = "completed" | "aborted" | "failed";
 
 /**
@@ -594,7 +594,7 @@ export class MamPager {
     // long it took (background-tab HUNG investigation). Keep stats local
     // because old/new xmpp handles can briefly overlap during reconnects.
     const startedAt = performance.now();
-    const stats: CatchupRunStats = { pages: 0, messages: 0 };
+    const stats: CatchupRunStats = { pages: 0, pageFailures: 0, messages: 0 };
     let processedConversations = 0;
     let outcome: CatchupOutcome = "completed";
     try {
@@ -667,6 +667,7 @@ export class MamPager {
         conversations: entries.length,
         processedConversations,
         pages: stats.pages,
+        pageFailures: stats.pageFailures,
         messages: stats.messages,
         durationMs: performance.now() - startedAt,
         outcome,
@@ -696,6 +697,7 @@ export class MamPager {
         try {
           page = await xmpp.fetch_dm_history_page(archivePeerJid, 100, { type: "after", after });
         } catch (error) {
+          stats.pageFailures += 1;
           if (isMamCursorNotFound(classifyMamError(error))) {
             const since = entry.since ?? this.deps.catchup.getDmLastSeen(entry.key);
             if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats, entry.scope);
@@ -739,6 +741,7 @@ export class MamPager {
         try {
           page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after });
         } catch (error) {
+          stats.pageFailures += 1;
           if (isMamCursorNotFound(classifyMamError(error))) {
             const since = entry.since ?? this.deps.catchup.getRoomLastSeen(entry.key);
             if (since) await this.runRoomTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
@@ -789,7 +792,13 @@ export class MamPager {
       }
     };
     while (true) {
-      const page = await xmpp.fetch_dm_history_page?.(archivePeerJid, 100, pageParam);
+      let page: WasmMamPage | null | undefined;
+      try {
+        page = await xmpp.fetch_dm_history_page?.(archivePeerJid, 100, pageParam);
+      } catch (error) {
+        if (stats) stats.pageFailures += 1;
+        throw error;
+      }
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
@@ -826,7 +835,13 @@ export class MamPager {
       }
     };
     while (true) {
-      const page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam);
+      let page: WasmMamPage | null | undefined;
+      try {
+        page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam);
+      } catch (error) {
+        if (stats) stats.pageFailures += 1;
+        throw error;
+      }
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1,4 +1,7 @@
-import { withSpan } from "@/lib/telemetry";
+import {
+  websocketUrlWithTraceparent,
+  withSpan,
+} from "@/lib/telemetry";
 import { stanzaErrorContext } from "@/lib/xmpp/stanza-error-context";
 import { inferredFileDisposition, type ExtensionLaunchDescriptor } from "@/lib/chat-ui";
 import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filters";
@@ -372,8 +375,31 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
 let wasmModulePromise: Promise<WasmModule> | null = null;
 
 function createXmppResource() {
-  const randomId = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  const randomId = globalThis.crypto?.randomUUID?.() ?? fallbackUuid();
   return `web-${randomId}`;
+}
+
+function fallbackUuid(randomBytes?: Uint8Array): string {
+  const bytes = randomBytes ? new Uint8Array(randomBytes) : new Uint8Array(16);
+  if (bytes.length !== 16) throw new Error("UUID fallback requires 16 random bytes");
+  if (!randomBytes) {
+    if (globalThis.crypto?.getRandomValues) {
+      globalThis.crypto.getRandomValues(bytes);
+    } else {
+      for (let index = 0; index < bytes.length; index += 1) {
+        bytes[index] = Math.floor(Math.random() * 256);
+      }
+    }
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}
+
+/** For tests only — prove the no-randomUUID path remains UUID-shaped. */
+export function __createFallbackXmppResourceForTesting(bytes: Uint8Array): string {
+  return `web-${fallbackUuid(bytes)}`;
 }
 
 async function loadWasmModule(): Promise<WasmModule> {
@@ -632,6 +658,9 @@ export class BrowserXmppClient {
    * call layer when constructing Jingle session-initiate / accept,
    * which must address the peer's full JID and stamp our own. */
   get fullJid(): string { return `${this.session.jid}/${this.resource}`; }
+
+  /** Random resource bound by this browser session; safe telemetry correlation id. */
+  get xmppResource(): string { return this.resource; }
   /** Bare JID for this session. */
   get bareJid(): string { return this.session.jid; }
 
@@ -726,6 +755,7 @@ export class BrowserXmppClient {
       kind: "muc-join",
       recoverable: true,
       detail: `room join rejected — ${room}`,
+      roomLocalpart: jidLocalpart(room),
       ...stanzaErrorContext({
         condition: presence.error_condition,
         errorType: presence.error_type,
@@ -777,7 +807,7 @@ export class BrowserXmppClient {
   onSessionLifecycle(hook: (event: SessionLifecycleEvent) => void) { this.events.on("sessionLifecycleHook", hook); }
   onStatus(hook: (status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }) => void) { this.events.on("statusHook", hook); }
   onSendEnqueued(hook: (info: { kind: "room" | "dm"; reason: string }) => void) { this.events.on("sendEnqueued", hook); }
-  onQueueDepthChange(hook: (depth: { persisted: number; inflight: number }) => void) { this.events.on("queueDepthChange", hook); }
+  onQueueDepthChange(hook: (depth: { kind: "room" | "dm"; persisted: number; inflight: number }) => void) { this.events.on("queueDepthChange", hook); }
   onError(hook: (event: XmppErrorEvent) => void) { this.events.on("error", hook); }
   onReconnectScheduled(hook: (info: { attempt: number; delayMs: number }) => void) { this.events.on("reconnectScheduled", hook); }
   onCatchup(hook: (info: CatchupHookInfo) => void) { this.events.on("catchup", hook); }
@@ -866,6 +896,7 @@ export class BrowserXmppClient {
 
   private async doConnect(): Promise<void> {
     const epoch = ++this.connectEpoch;
+    const websocketUrl = websocketUrlWithTraceparent(this.session.xmpp_websocket_url);
     const mod = await this.loadModule();
     // Stale continuation: a newer connect attempt started (or the
     // timeout tore this one down) while the module load was pending.
@@ -873,7 +904,7 @@ export class BrowserXmppClient {
     // connection now.
     if (epoch !== this.connectEpoch || this.destroying) return;
     const config = new mod.WaddleConfig(
-      this.session.xmpp_websocket_url,
+      websocketUrl,
       this.session.jid,
       this.session.session_id,
       this.resource,
@@ -1321,7 +1352,11 @@ export class BrowserXmppClient {
     this.currentRoom = nextRoom;
     this.dispatchFocusedRoomHandlers();
     try {
-      await this.ensureJoined(nextRoom);
+      await withSpan(
+        "xmpp.room_switch",
+        { "conversation.kind": "room" },
+        () => this.ensureJoined(nextRoom),
+      );
     } catch (err) {
       if (!this.isCurrentXmpp(xmpp)) return;
       throw err;
@@ -2476,7 +2511,7 @@ export class BrowserXmppClient {
     // pumping bytes until the next call replaced it. Tearing the
     // singleton engine down here is idempotent (no-op when nothing's
     // connected).
-    clearCallState();
+    clearCallState({ endReason: "error" });
     clearMucCallParticipants();
     clearAllRaisedHands();
     clearAllMuted();

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -169,6 +169,8 @@ export interface XmppErrorEvent {
   errorType?: XmppStanzaErrorType;
   /** Server-provided `<text/>` of a received error stanza. */
   errorText?: string;
+  /** Denied MUC room node only; never the domain, resource, or full room JID. */
+  roomLocalpart?: string;
   /** XEP-0198 stream-management extension detail when a stream error carries one. */
   streamManagementError?: {
     kind: "handled-count-too-high";

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -25,6 +25,7 @@ import {
   reportSendEnqueued,
   reportSessionLifecycle,
   reportStatusChange,
+  setXmppResourceForTelemetry,
 } from "@/lib/telemetry";
 
 const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
@@ -36,6 +37,7 @@ const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
   "muc-join": "xmpp.stream",
 };
 export function installInstrumentation(client: BrowserXmppClient): void {
+  setXmppResourceForTelemetry(client.xmppResource);
   client.onMessageAcked((id, meta) => {
     reportMessageAcked({ id, kind: meta.kind, latencyMs: meta.latencyMs });
   });
@@ -74,7 +76,10 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       detail,
       ...(condition ? { condition } : {}),
       ...(event.errorType ? { errorType: event.errorType } : {}),
-      ...(event.errorText ? { errorText: event.errorText } : {}),
+      ...(event.kind !== "muc-join" && event.errorText ? { errorText: event.errorText } : {}),
+      ...(event.kind === "muc-join" && event.roomLocalpart
+        ? { roomLocalpart: event.roomLocalpart }
+        : {}),
       ...(errorSource ? { errorSource } : {}),
       ...(streamDetail ? { streamDetail } : {}),
       ...(smCounts ?? {}),

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -48,6 +48,13 @@ import type { LiveKitJoin } from "../src/lib/calls/types";
 import { Track } from "livekit-client";
 import { renderVueComponent as renderSfcComponent } from "./helpers/render-vue-sfc";
 import { $callUiMode } from "../src/lib/calls/ui-mode";
+import {
+  __resetCallLifecycleTelemetryForTesting,
+  beginCallAttempt,
+  finishCallAttempt,
+  markCallAttemptAccepted,
+} from "../src/lib/calls/call-lifecycle-telemetry";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const require = createRequire(import.meta.url);
 
@@ -100,6 +107,8 @@ afterEach(() => {
   // The engine is a process-wide singleton; drop any injected room
   // stub so it doesn't leak into the next test.
   (useCallEngine().engine as unknown as { room: unknown }).room = null;
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
 });
 
 describe("screenshare support detection", () => {
@@ -125,6 +134,35 @@ describe("screenshare support detection", () => {
 });
 
 describe("call page lifecycle controls", () => {
+  test("pagehide finalizes this attempt and rediscovery owns a separate lifecycle event", () => {
+    const events: Array<{ name: string }> = [];
+    __setFaroForTesting({
+      api: { pushEvent: (name: string) => events.push({ name }) },
+    } as never);
+    beginCallAttempt("refresh-sid", "dm");
+    markCallAttemptAccepted("refresh-sid", 1_000);
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "refresh-sid",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+
+    suspendCallForPageHide();
+    expect(events).toEqual([{ name: "chat.call.lifecycle" }]);
+
+    __resetCallLifecycleTelemetryForTesting();
+    beginCallAttempt("refresh-sid", "dm");
+    markCallAttemptAccepted("refresh-sid", 2_000);
+    finishCallAttempt("refresh-sid", { endReason: "hangup" }, 3_000);
+    expect(events).toEqual([
+      { name: "chat.call.lifecycle" },
+      { name: "chat.call.lifecycle" },
+    ]);
+  });
+
   test("pagehide suspension clears only local media state, preserving rediscoverable DM activity", () => {
     $callState.set({
       phase: "active",

--- a/chat/tests/call-lifecycle-telemetry.test.ts
+++ b/chat/tests/call-lifecycle-telemetry.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __resetCallLifecycleTelemetryForTesting,
+  beginCallAttempt,
+  durationBucket,
+  finishCallAttempt,
+  finishCallAttemptForTransportDisconnect,
+  markCallAttemptAccepted,
+  observeCallConnectionPhase,
+  observeCallConnectionQuality,
+  observeCallStats,
+  packetLossBand,
+  reportDeclinedCallAttempt,
+  reportFailedCallAttempt,
+  rttBand,
+} from "../src/lib/calls/call-lifecycle-telemetry";
+import { __setFaroForTesting } from "../src/lib/telemetry";
+
+function createFaroStub() {
+  const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+  return {
+    events,
+    api: {
+      pushEvent(name: string, attributes?: Record<string, string>) {
+        events.push({ name, attributes });
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
+});
+
+afterEach(() => {
+  __setFaroForTesting(null);
+});
+
+describe("call lifecycle mappings", () => {
+  test("maps duration, RTT, and packet loss into coarse bands", () => {
+    expect(durationBucket(0)).toBe("none");
+    expect(durationBucket(59_999)).toBe("under-1m");
+    expect(durationBucket(60_000)).toBe("1m-10m");
+    expect(rttBand(null)).toBe("unknown");
+    expect(rttBand(100)).toBe("100ms-300ms");
+    expect(rttBand(301)).toBe("over-300ms");
+    expect(packetLossBand(0.5)).toBe("under-1pct");
+    expect(packetLossBand(5)).toBe("1pct-5pct");
+    expect(packetLossBand(5.1)).toBe("over-5pct");
+  });
+
+  test("emits one declined DM setup outcome for an unaccepted attempt", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    beginCallAttempt("dm-1", "dm");
+
+    const first = finishCallAttempt("dm-1", { setupOutcome: "declined" }, 1_000);
+    const duplicate = finishCallAttempt("dm-1", { setupOutcome: "failed" }, 2_000);
+
+    expect(first).toMatchObject({
+      setupOutcome: "declined",
+      callKind: "dm",
+      durationBucket: "none",
+    });
+    expect(duplicate).toBeNull();
+    expect(stub.events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: {
+        setup_outcome: "declined",
+        duration_bucket: "none",
+        call_kind: "dm",
+        rtt_band: "unknown",
+        packet_loss_band: "unknown",
+        connection_quality: "unknown",
+        reconnect_count: "0",
+      },
+    }]);
+  });
+
+  test("records a busy declined proposal without replacing the active attempt", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    beginCallAttempt("active", "dm");
+    markCallAttemptAccepted("active");
+
+    reportDeclinedCallAttempt("busy-proposal");
+    finishCallAttempt("active", { endReason: "hangup" });
+
+    expect(stub.events.map((event) => event.attributes)).toEqual([
+      expect.objectContaining({ setup_outcome: "declined", call_kind: "dm" }),
+      expect.objectContaining({ setup_outcome: "accepted", end_reason: "hangup" }),
+    ]);
+  });
+
+  test("classifies transport loss from observed reconnect state and permits explicit SID reuse", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    beginCallAttempt("restored-sid", "dm");
+    markCallAttemptAccepted("restored-sid");
+    expect(finishCallAttemptForTransportDisconnect("restored-sid")?.endReason).toBe("error");
+
+    beginCallAttempt("restored-sid", "dm");
+    markCallAttemptAccepted("restored-sid");
+    observeCallConnectionPhase("reconnecting");
+    expect(finishCallAttemptForTransportDisconnect("restored-sid")?.endReason)
+      .toBe("reconnect-exhausted");
+
+    expect(stub.events).toHaveLength(2);
+  });
+
+  test("does not call a later transport loss exhausted after a successful reconnect", () => {
+    beginCallAttempt("dm-recovered", "dm");
+    markCallAttemptAccepted("dm-recovered");
+    observeCallConnectionPhase("reconnecting");
+    observeCallConnectionPhase("connected");
+
+    expect(finishCallAttemptForTransportDisconnect("dm-recovered")?.endReason).toBe("error");
+  });
+
+  test("keeps duration and quality owned by each sequential attempt", () => {
+    beginCallAttempt("first", "dm");
+    markCallAttemptAccepted("first", 1_000);
+    observeCallConnectionQuality("poor");
+    finishCallAttempt("first", { endReason: "hangup" }, 91_000);
+
+    beginCallAttempt("second", "dm");
+    const second = finishCallAttempt("second", { setupOutcome: "failed" }, 100_000);
+
+    expect(second).toMatchObject({
+      durationBucket: "none",
+      connectionQuality: "unknown",
+    });
+  });
+
+  test("emits a standalone failed MUC preflight exactly once", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    reportFailedCallAttempt("muc-preflight", "muc");
+    reportFailedCallAttempt("muc-preflight", "muc");
+
+    expect(stub.events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({ setup_outcome: "failed", call_kind: "muc" }),
+    }]);
+  });
+
+  test("accepted MUC calls retain call_kind, end reason, and end-of-call quality", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    beginCallAttempt("muc-1", "muc");
+    markCallAttemptAccepted("muc-1", 1_000);
+    observeCallStats({ rttMs: 340, packetLossPct: 6.2 });
+    observeCallConnectionQuality("poor");
+    observeCallConnectionPhase("connected");
+    observeCallConnectionPhase("reconnecting");
+    observeCallConnectionPhase("reconnecting");
+    observeCallConnectionPhase("connected");
+
+    const payload = finishCallAttempt(
+      "muc-1",
+      { setupOutcome: "failed", endReason: "hangup" },
+      91_000,
+    );
+
+    expect(payload).toEqual({
+      setupOutcome: "accepted",
+      endReason: "hangup",
+      durationBucket: "1m-10m",
+      callKind: "muc",
+      rttBand: "over-300ms",
+      packetLossBand: "over-5pct",
+      connectionQuality: "poor",
+      reconnectCount: 1,
+    });
+    expect(stub.events[0]?.attributes).toMatchObject({
+      setup_outcome: "accepted",
+      end_reason: "hangup",
+      call_kind: "muc",
+      reconnect_count: "1",
+    });
+  });
+});

--- a/chat/tests/call-media-issues.test.ts
+++ b/chat/tests/call-media-issues.test.ts
@@ -8,6 +8,7 @@ import {
   mediaIssueMessage,
   recordMediaIssue,
 } from "../src/lib/calls/call-media-issues";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 function domError(name: string): Error {
   const err = new Error(`${name} message`);
@@ -17,6 +18,7 @@ function domError(name: string): Error {
 
 afterEach(() => {
   clearAllMediaIssues();
+  __setFaroForTesting(null);
 });
 
 describe("classifyMediaError", () => {
@@ -68,6 +70,49 @@ describe("mediaIssueMessage (notice copy)", () => {
 });
 
 describe("$callMediaIssues store", () => {
+  test("reports permission and missing-device failures as recoverable Faro errors", () => {
+    const errors: Array<{
+      error: Error;
+      options: { type?: string; context?: Record<string, string> };
+    }> = [];
+    __setFaroForTesting({
+      api: {
+        pushError: (error: Error, options?: { type?: string; context?: Record<string, string> }) => {
+          errors.push({ error, options: options ?? {} });
+        },
+      },
+    } as never);
+
+    recordMediaIssue("mic", domError("NotAllowedError"));
+    recordMediaIssue("cam", domError("NotFoundError"));
+
+    expect(errors.map(({ options }) => options)).toEqual([
+      {
+        type: "call.media",
+        context: expect.objectContaining({
+          kind: "call.media",
+          recoverable: "true",
+          media_kind: "mic",
+          reason: "denied",
+        }),
+      },
+      {
+        type: "call.media",
+        context: expect.objectContaining({
+          kind: "call.media",
+          recoverable: "true",
+          media_kind: "cam",
+          reason: "missing",
+        }),
+      },
+    ]);
+    expect(errors.map(({ error }) => error.message)).toEqual([
+      "call.media.mic.denied",
+      "call.media.cam.missing",
+    ]);
+    expect(errors.map(({ error }) => error.message).join(" ")).not.toContain("NotAllowedError message");
+  });
+
   test("record/clear a single kind without touching the other", () => {
     recordMediaIssue("mic", domError("NotFoundError"));
     expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });

--- a/chat/tests/call-stats.test.ts
+++ b/chat/tests/call-stats.test.ts
@@ -606,8 +606,29 @@ describe("summarizeAudioStats — inbound (recv) audio and ICE path", () => {
     expect(summary).toEqual({
       codec: null,
       bitrateKbps: null,
+      packetLossPct: null,
+      rttMs: null,
       iceCandidateType: null,
       iceTransport: null,
     });
+  });
+
+  test("captures packet loss and RTT for audio-only calls", () => {
+    const inbound = {
+      type: "inbound-rtp",
+      kind: "audio",
+      packetsReceived: 95,
+      packetsLost: 5,
+    };
+    const pair = {
+      type: "candidate-pair",
+      state: "succeeded",
+      currentRoundTripTime: 0.18,
+    };
+
+    const { summary } = summarizeAudioStats(report([inbound, pair]), "recv");
+
+    expect(summary.packetLossPct).toBe(5);
+    expect(summary.rttMs).toBe(180);
   });
 });

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -4,6 +4,7 @@ import {
   $lastCallError,
   applyCallEvent,
   beginOutgoingCall,
+  callLifecycleTerminalForRemoteEnd,
   clearCallState,
   clearLastCallError,
   reduceCallState,
@@ -13,7 +14,8 @@ import {
   clearDmCallActivities,
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
-import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "../src/lib/calls/types";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const audioVideo: CallMedia = { audio: true, video: true };
 const join: LiveKitJoin = {
@@ -407,6 +409,49 @@ describe("call-store reducer", () => {
   });
 });
 
+describe("call lifecycle terminal mapping", () => {
+  const incoming: CallState = {
+    phase: "incoming",
+    from: "alice@waddle.test/desktop",
+    sid: "c1",
+    media: audioVideo,
+  };
+  const active: CallState = {
+    phase: "active",
+    peer: "alice@waddle.test/desktop",
+    sid: "c1",
+    media: audioVideo,
+    join,
+    kind: "dm",
+  };
+  const terminate = (reason: string): CallEvent => ({
+    kind: "session-terminate",
+    from: "alice@waddle.test/desktop",
+    sid: "c1",
+    reason,
+  });
+
+  test.each([
+    ["failed-transport", "failed"],
+    ["incompatible-parameters", "failed"],
+    ["timeout", "timeout"],
+    ["decline", "declined"],
+    ["success", "proposed"],
+  ])("maps pre-active %s to setup outcome %s", (reason, setupOutcome) => {
+    expect(callLifecycleTerminalForRemoteEnd(incoming, terminate(reason), reason))
+      .toEqual({ setupOutcome });
+  });
+
+  test.each([
+    ["failed-transport", "error"],
+    ["timeout", "error"],
+    ["success", "peer-left"],
+  ])("maps active %s to end reason %s", (reason, endReason) => {
+    expect(callLifecycleTerminalForRemoteEnd(active, terminate(reason), reason))
+      .toEqual({ endReason });
+  });
+});
+
 describe("clearLastCallError", () => {
   test("clears the error without touching $callState", () => {
     // Pre-transition rejection scenario: a `beginMucCall` failure
@@ -414,11 +459,24 @@ describe("clearLastCallError", () => {
     // overkill here (it would emit a redundant state set);
     // `clearLastCallError` is the targeted helper.
     clearCallState();
+    const errors: Array<{ type?: string; context?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushError: (_error: Error, options?: { type?: string; context?: Record<string, string> }) => {
+          errors.push(options ?? {});
+        },
+      },
+    } as never);
     reportCallError(new Error("muc-call: transport missing @url"));
     expect($lastCallError.get()).toBe("muc-call: transport missing @url");
     const phaseBefore = $callState.get().phase;
     clearLastCallError();
     expect($lastCallError.get()).toBeNull();
     expect($callState.get().phase).toBe(phaseBefore);
+    expect(errors[0]).toEqual({
+      type: "call.operation",
+      context: expect.objectContaining({ recoverable: "true", detail: "call-operation" }),
+    });
+    __setFaroForTesting(null);
   });
 });

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -9,6 +9,7 @@ import {
   clearLastCallError,
   reduceCallState,
   reportCallError,
+  teardownSetupOutcome,
 } from "../src/lib/calls/call-store";
 import {
   clearDmCallActivities,
@@ -440,6 +441,17 @@ describe("call lifecycle terminal mapping", () => {
   ])("maps pre-active %s to setup outcome %s", (reason, setupOutcome) => {
     expect(callLifecycleTerminalForRemoteEnd(incoming, terminate(reason), reason))
       .toEqual({ setupOutcome });
+  });
+
+  test.each([
+    ["active", "accepted"],
+    ["incoming", "declined"],
+    // A torn-down pending group-call setup is a failed attempt, not a
+    // proposed one — greptile P1 on PR #1415.
+    ["muc-pending", "failed"],
+    ["outgoing", "proposed"],
+  ] as const)("teardown from %s reports setup outcome %s", (phase, setupOutcome) => {
+    expect(teardownSetupOutcome(phase)).toBe(setupOutcome);
   });
 
   test.each([

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -1,12 +1,15 @@
 // Direct unit tests for useChannelLiveMerge covering the per-XEP apply*
 // helpers and the typed-dispatch path through handleRoomMessage.
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { ref } from "vue";
 import { useChannelLiveMerge } from "../src/channels/live-merge";
 import type { LiveRoomMessage } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
 import type { TimelineMessage } from "../src/lib/chat-ui";
+import { __setFaroForTesting } from "../src/lib/telemetry";
+
+afterEach(() => __setFaroForTesting(null));
 
 const session: WaddleSession = {
   username: "alice",
@@ -63,6 +66,35 @@ describe("applyDisplayed (XEP-0333)", () => {
     ];
     h.liveMerge.applyDisplayed("m1", "bob");
     expect(h.messages.value[0]?.readBy).toEqual(["bob"]);
+  });
+
+  test("ignores unloaded targets and reports only real receive-processing failures", () => {
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({ api: { pushEvent: (name: string, attributes?: Record<string, string>) => {
+      events.push({ name, attributes });
+    } } } as never);
+    const h = harness();
+    h.liveMerge.applyDisplayed("outside-loaded-window", "bob");
+    expect(events).toEqual([]);
+
+    h.messages.value = [{
+      id: "m1",
+      createdAt: "2020-01-01T00:00:00Z",
+      body: "",
+      nick: "alice",
+      get readBy(): string[] { throw new Error("broken row"); },
+    } as TimelineMessage];
+    h.liveMerge.applyDisplayed("m1", "bob");
+
+    expect(events[0]).toEqual({
+      name: "chat.xmpp.displayed_marker.failed",
+      attributes: {
+        direction: "receive",
+        kind: "room",
+        reason: "receive-processing-failed",
+        round_trip_latency_band: "over-5s",
+      },
+    });
   });
 });
 

--- a/chat/tests/client-connection.test.ts
+++ b/chat/tests/client-connection.test.ts
@@ -162,7 +162,7 @@ describe("OfflineSendQueue drain ordering", () => {
 
   test("ack removes the persisted copy and reports queue depth + latency", async () => {
     const { queue, events } = createQueue();
-    const depths: Array<{ persisted: number; inflight: number }> = [];
+    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
     const acked: Array<{ id: string; kind: "room" | "dm" }> = [];
     events.on("queueDepthChange", (depth) => depths.push(depth));
     events.on("messageAcked", (id, meta) => acked.push({ id, kind: meta.kind }));
@@ -173,7 +173,10 @@ describe("OfflineSendQueue drain ordering", () => {
 
     expect(listQueuedMessages(SCOPE)).toHaveLength(0);
     expect(acked).toEqual([{ id: "dm-1", kind: "dm" }]);
-    expect(depths.at(-1)).toEqual({ persisted: 0, inflight: 0 });
+    expect(depths.slice(-2)).toEqual([
+      { kind: "dm", persisted: 0, inflight: 0 },
+      { kind: "room", persisted: 0, inflight: 0 },
+    ]);
   });
 
   test("non-retryable send failures are discarded instead of retried forever", async () => {
@@ -244,7 +247,7 @@ describe("OfflineSendQueue drain ordering", () => {
 
   test("seedFromResumeState tracks XEP-0198 replayed stanza ids so acks clear the store", () => {
     const { queue, events } = createQueue();
-    const depths: Array<{ persisted: number; inflight: number }> = [];
+    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
     events.on("queueDepthChange", (depth) => depths.push(depth));
 
     queue.queueDirectMessage("bob@example.com", "native replay", { id: "dm-native" });
@@ -258,7 +261,10 @@ describe("OfflineSendQueue drain ordering", () => {
     queue.handleAck("dm-native");
 
     expect(listQueuedMessages(SCOPE)).toHaveLength(0);
-    expect(depths.at(-1)).toEqual({ persisted: 0, inflight: 0 });
+    expect(depths.slice(-2)).toEqual([
+      { kind: "dm", persisted: 0, inflight: 0 },
+      { kind: "room", persisted: 0, inflight: 0 },
+    ]);
   });
 });
 

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -1,13 +1,16 @@
 // Direct unit tests for useDmLiveMerge: per-XEP apply* helpers, the
 // handleIncomingMessage dispatcher, and self-echo reconciliation for 1:1.
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { ref } from "vue";
 import { useDmLiveMerge } from "../src/dms/live-merge";
 import { buildDmCallStartedAnchor, dmCallAnchorId } from "../src/lib/calls/dm-call-anchor";
 import type { LiveDmMessage } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
 import type { TimelineMessage } from "../src/lib/chat-ui";
+import { __setFaroForTesting } from "../src/lib/telemetry";
+
+afterEach(() => __setFaroForTesting(null));
 
 const session: WaddleSession = {
   username: "alice",
@@ -58,6 +61,32 @@ describe("applyDisplayed (XEP-0333)", () => {
     h.liveMerge.applyDisplayed("m1", "bob");
     h.liveMerge.applyDisplayed("m1", "bob");
     expect(h.messages.value[0]?.readBy).toEqual(["bob"]);
+  });
+
+  test("reports a receive merge failure but not an unloaded target", () => {
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({ api: { pushEvent: (name: string, attributes?: Record<string, string>) => {
+      events.push({ name, attributes });
+    } } } as never);
+    const h = harness();
+    h.liveMerge.applyDisplayed("outside-loaded-window", "bob");
+    expect(events).toEqual([]);
+
+    h.messages.value = [{
+      id: "m1",
+      createdAt: "2020-01-01T00:00:00Z",
+      body: "",
+      nick: "alice",
+      get readBy(): string[] { throw new Error("broken row"); },
+    } as TimelineMessage];
+    h.liveMerge.applyDisplayed("m1", "bob");
+
+    expect(events[0]?.attributes).toEqual({
+      direction: "receive",
+      kind: "dm",
+      reason: "receive-processing-failed",
+      round_trip_latency_band: "over-5s",
+    });
   });
 });
 

--- a/chat/tests/read-markers.test.ts
+++ b/chat/tests/read-markers.test.ts
@@ -10,6 +10,7 @@ import { useReadReceiptPreference } from "../src/preferences/read-receipts";
 import type { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { TimelineMessage } from "../src/lib/chat-ui";
 import type { ChannelSummary } from "../src/lib/chat-types";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const NS_STANZA_ID = "urn:xmpp:sid:0";
 
@@ -37,7 +38,18 @@ function channel(features: string[] = [NS_STANZA_ID]): ChannelSummary {
 
 afterEach(() => {
   useReadReceiptPreference().setReadReceiptPreference("send");
+  __setFaroForTesting(null);
 });
+
+function faroEvents() {
+  const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+  __setFaroForTesting({
+    api: {
+      pushEvent: (name: string, attributes?: Record<string, string>) => events.push({ name, attributes }),
+    },
+  } as never);
+  return events;
+}
 
 describe("useChannelReadMarkers", () => {
   test("markDisplayed does not invent a MUC marker target without a room stanza-id", () => {
@@ -88,6 +100,39 @@ describe("useChannelReadMarkers", () => {
       "room-stanza-id",
       "general@rooms.example.com",
     );
+  });
+
+  test("reports a failed room displayed-marker send without message identifiers", async () => {
+    const events = faroEvents();
+    const sendDisplayed = mock(async () => { throw new Error("write failed"); });
+    const messages = ref<TimelineMessage[]>([{
+      id: "private-message-id",
+      stanzaId: "private-stanza-id",
+      stanzaIdBy: "general@rooms.example.com",
+      createdAt: "2020-01-01T00:00:00Z",
+      body: "private body",
+      nick: "bob",
+    } as TimelineMessage]);
+    const markers = useChannelReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendDisplayed)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+      currentChannel: ref(channel()),
+      messages,
+    });
+
+    markers.markDisplayed("private-message-id");
+    await Promise.resolve();
+
+    expect(events).toEqual([{
+      name: "chat.xmpp.displayed_marker.failed",
+      attributes: {
+        direction: "send",
+        kind: "room",
+        reason: "send-failed",
+        round_trip_latency_band: "over-5s",
+      },
+    }]);
   });
 
   test("read-receipt opt-out suppresses MUC XEP-0333 while preserving MDS", () => {
@@ -240,6 +285,35 @@ describe("useDmReadMarkers", () => {
     expect(sendDmDisplayed).toHaveBeenCalledTimes(1);
     expect(sendDmDisplayed.mock.calls[0]![0]).toBe("bob@example.com");
     expect(sendDmDisplayed.mock.calls[0]![1]).toBe("dm1");
+  });
+
+  test("reports a failed DM displayed-marker send with a latency band", async () => {
+    const events = faroEvents();
+    const sendDmDisplayed = mock(async () => { throw new Error("write failed"); });
+    const markers = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmDisplayed)),
+      activePeerJid: ref("bob@example.com"),
+      messages: ref<TimelineMessage[]>([{
+        id: "dm-private-id",
+        createdAt: "2020-01-01T00:00:00Z",
+        body: "private body",
+        nick: "bob",
+        displayedMarkerRequested: true,
+      } as TimelineMessage]),
+    });
+
+    markers.markDisplayed("dm-private-id");
+    await Promise.resolve();
+
+    expect(events[0]).toEqual({
+      name: "chat.xmpp.displayed_marker.failed",
+      attributes: {
+        direction: "send",
+        kind: "dm",
+        reason: "send-failed",
+        round_trip_latency_band: "over-5s",
+      },
+    });
   });
 
   test("markDisplayed echoes XEP-0201 thread metadata for threaded DMs", () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { BrowserXmppClient, type SessionLifecycleEvent } from "../src/lib/xmpp-client";
+import { __createFallbackXmppResourceForTesting } from "../src/lib/xmpp/client";
 import {
   __clearSensitiveUrlsForTesting,
   __scrubMissingFetchSpanUrlForTesting,
@@ -8,11 +9,14 @@ import {
   __scrubXhrSpanUrlForTesting,
   __sanitizeFaroTransportItemForTesting,
   __setFaroForTesting,
+  __websocketUrlWithTraceparentForTesting,
   initTelemetry,
   markSensitiveUrlForTelemetry,
   reportCallAudioProcessing,
+  reportCallMediaPath,
   reportCatchup,
   reportError,
+  reportDisplayedMarkerFailure,
   reportMessageAcked,
   reportMessageFailed,
   reportQueueDepthChange,
@@ -21,6 +25,8 @@ import {
   reportSendEnqueued,
   reportSessionLifecycle,
   reportStatusChange,
+  setXmppResourceForTelemetry,
+  websocketUrlWithTraceparent,
 } from "../src/lib/telemetry";
 import { DiscoTimeoutError, discoverChannels } from "../src/lib/xmpp/discovery";
 import { installInstrumentation } from "../src/lib/xmpp/xmpp-instrumentation";
@@ -76,11 +82,22 @@ function createFaroStub() {
     error: Error;
     options?: { type?: string; context?: Record<string, string> };
   }> = [];
+  const sessions: Array<{ attributes?: Record<string, string> }> = [];
+  let currentSession: { id?: string; attributes?: Record<string, string> } = {
+    id: "faro-session",
+    attributes: { retained: "yes" },
+  };
   return {
     events,
     measurements,
     errors,
+    sessions,
     api: {
+      getSession: () => currentSession,
+      setSession: (meta: { attributes?: Record<string, string> }) => {
+        currentSession = meta;
+        sessions.push(meta);
+      },
       pushEvent: (name: string, attributes?: Record<string, string>) => {
         events.push({ name, attributes });
       },
@@ -143,7 +160,7 @@ describe("reportCallAudioProcessing", () => {
           autoGainControl: "unknown",
         },
         aiNoiseFilter: { kind: "active", model: null },
-      }),
+      }, "dm"),
     ).not.toThrow();
   });
 
@@ -159,7 +176,7 @@ describe("reportCallAudioProcessing", () => {
         autoGainControl: "unknown",
       },
       aiNoiseFilter: { kind: "active", model: "rnnoise" },
-    });
+    }, "muc");
 
     expect(stub.events).toEqual([
       {
@@ -170,9 +187,40 @@ describe("reportCallAudioProcessing", () => {
           echo_cancellation: "off",
           auto_gain_control: "unknown",
           ai_noise_filter: "rnnoise",
+          call_kind: "muc",
         },
       },
     ]);
+  });
+});
+
+describe("call beacon kind tagging", () => {
+  test("adds call_kind to media-path events", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    reportCallMediaPath({
+      direction: "send",
+      source: "camera",
+      codec: "VP9",
+      iceCandidateType: "host",
+      iceTransport: "udp",
+      audioBitrateBand: null,
+      videoResolutionBand: "720p",
+    }, "dm");
+
+    expect(stub.events[0]).toEqual({
+      name: "chat.call.media_path",
+      attributes: {
+        direction: "send",
+        source: "camera",
+        codec: "VP9",
+        ice_candidate_type: "host",
+        ice_transport: "udp",
+        video_resolution_band: "720p",
+        call_kind: "dm",
+      },
+    });
   });
 });
 
@@ -190,11 +238,11 @@ describe("telemetry module no-op behaviour", () => {
       reportMessageAcked({ id: "x", kind: "room", latencyMs: 5 });
       reportMessageFailed({ id: "x", kind: "dm" });
       reportSendEnqueued({ kind: "room", reason: "offline" });
-      reportQueueDepthChange({ persisted: 0, inflight: 0 });
+      reportQueueDepthChange({ kind: "dm", persisted: 0, inflight: 0 });
       reportSessionLifecycle({ type: "fresh" });
       reportStatusChange({ state: "online" });
       reportReconnectScheduled({ attempt: 1, delayMs: 2_000 });
-      reportCatchup({ conversations: 1, pages: 1, messages: 1, durationMs: 10 });
+      reportCatchup({ conversations: 1, pages: 1, pageFailures: 0, messages: 1, durationMs: 10 });
       reportResumeDrain({ buffered: 1, durationMs: 10 });
     }).not.toThrow();
   });
@@ -206,7 +254,7 @@ describe("telemetry module no-op behaviour", () => {
     reportMessageAcked({ id: "m-1", kind: "room", latencyMs: 123.4 });
     reportMessageFailed({ id: "m-2", kind: "dm" });
     reportSendEnqueued({ kind: "dm", reason: "offline" });
-    reportQueueDepthChange({ persisted: 2, inflight: 1 });
+    reportQueueDepthChange({ kind: "room", persisted: 2, inflight: 1 });
     reportSessionLifecycle({ type: "resumed" });
     reportStatusChange({ state: "reconnecting" });
     reportStatusChange({ state: "online", reconnectDurationMs: 4_321 });
@@ -215,6 +263,7 @@ describe("telemetry module no-op behaviour", () => {
       conversations: 2,
       processedConversations: 1,
       pages: 4,
+      pageFailures: 2,
       messages: 12,
       durationMs: 88.6,
       outcome: "aborted",
@@ -252,6 +301,7 @@ describe("telemetry module no-op behaviour", () => {
 
     const depthMeasurement = stub.measurements[1];
     expect(depthMeasurement.values).toEqual({ persisted: 2, inflight: 1 });
+    expect(depthMeasurement.context).toEqual({ kind: "room" });
 
     const reconnectMeasurement = stub.measurements[2];
     expect(reconnectMeasurement.values.duration_ms).toBe(4_321);
@@ -270,6 +320,7 @@ describe("telemetry module no-op behaviour", () => {
       conversations: 2,
       processed_conversations: 1,
       pages: 4,
+      page_failures: 2,
       messages: 12,
       duration_ms: 89,
       hidden_ms: 0,
@@ -283,6 +334,108 @@ describe("telemetry module no-op behaviour", () => {
     const resumeDrain = stub.measurements[5];
     expect(resumeDrain.values).toEqual({ buffered: 5, duration_ms: 12, hidden_ms: 0 });
     expect(resumeDrain.context).toEqual({ visibility: "visible", hidden_bucket: "visible" });
+  });
+
+  test("maps displayed-marker failures to low-cardinality latency bands", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    reportDisplayedMarkerFailure({
+      direction: "send",
+      kind: "dm",
+      reason: "send-failed",
+      roundTripMs: 1_250,
+    });
+    reportDisplayedMarkerFailure({
+      direction: "receive",
+      kind: "room",
+      reason: "receive-processing-failed",
+      roundTripMs: null,
+    });
+
+    expect(stub.events).toEqual([
+      {
+        name: "chat.xmpp.displayed_marker.failed",
+        attributes: {
+          direction: "send",
+          kind: "dm",
+          reason: "send-failed",
+          round_trip_latency_band: "1s-5s",
+        },
+      },
+      {
+        name: "chat.xmpp.displayed_marker.failed",
+        attributes: {
+          direction: "receive",
+          kind: "room",
+          reason: "receive-processing-failed",
+          round_trip_latency_band: "unknown",
+        },
+      },
+    ]);
+  });
+
+  test("records the generated XMPP resource as a Faro session attribute", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session({ jid: "alice@example.com" }));
+    installInstrumentation(client);
+
+    expect(client.fullJid).toMatch(/^alice@example\.com\/web-/);
+    expect(stub.sessions).toEqual([{
+      id: "faro-session",
+      attributes: {
+        retained: "yes",
+        xmpp_resource: client.xmppResource,
+      },
+    }]);
+  });
+
+  test("keeps the no-randomUUID XMPP resource fallback UUID-shaped", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const resource = __createFallbackXmppResourceForTesting(new Uint8Array(16));
+    setXmppResourceForTelemetry(resource);
+
+    expect(resource).toBe("web-00000000-0000-4000-8000-000000000000");
+    expect(stub.sessions.at(-1)?.attributes?.xmpp_resource).toBe(resource);
+  });
+
+  test("passes a valid traceparent while dropping session-bearing query values", () => {
+    const traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    expect(__scrubSpanUrlForTesting(
+      `wss://xmpp.example/ws?session_id=secret&traceparent=${traceparent}`,
+      ["https://xmpp.example"],
+    )).toBe(`wss://xmpp.example/:route?traceparent=${traceparent}`);
+  });
+
+  test("leaves WebSocket URLs unchanged when there is no active span", () => {
+    expect(websocketUrlWithTraceparent("wss://xmpp.example/ws?transport=websocket"))
+      .toBe("wss://xmpp.example/ws?transport=websocket");
+  });
+
+  test("appends the active trace context without dropping existing WebSocket query values", () => {
+    expect(__websocketUrlWithTraceparentForTesting(
+      "wss://xmpp.example/ws?transport=websocket",
+      {
+        traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+        spanId: "00f067aa0ba902b7",
+        traceFlags: 1,
+      },
+    )).toBe(
+      "wss://xmpp.example/ws?transport=websocket&traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    );
+  });
+
+  test("drops W3C-invalid all-zero trace identifiers", () => {
+    const zeroTraceparent = "00-00000000000000000000000000000000-0000000000000000-01";
+    expect(__scrubSpanUrlForTesting(
+      `wss://xmpp.example/ws?traceparent=${zeroTraceparent}`,
+      ["https://xmpp.example"],
+    )).toBe("wss://xmpp.example/:route");
   });
 
   test("reportError drops identifier-bearing context fields", () => {
@@ -606,6 +759,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
       conversations: 1,
       processedConversations: 1,
       pages: 2,
+      pageFailures: 0,
       messages: 3,
       durationMs: 4,
       outcome: "completed",
@@ -635,6 +789,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
       conversations: number;
       processedConversations: number;
       pages: number;
+      pageFailures: number;
       messages: number;
       outcome: string;
     }> = [];
@@ -681,6 +836,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
       conversations: 2,
       processedConversations: 2,
       pages: 1,
+      pageFailures: 1,
       messages: 1,
       outcome: "failed",
     });
@@ -803,7 +959,10 @@ describe("BrowserXmppClient telemetry hooks", () => {
         detail: string;
         cause?: unknown;
         condition?: string;
-        errorType?: string;
+      errorType?: string;
+      errorText?: string;
+      roomLocalpart?: string;
+        roomLocalpart?: string;
         errorText?: string;
       }) => void;
     };
@@ -876,6 +1035,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
       detail: "room join rejected — room@muc.example.com",
       condition: "registration-required",
       errorType: "auth",
+      errorText: "private invitation for alice@example.com says secret words",
+      roomLocalpart: "room",
     });
 
     expect(stub.errors).toHaveLength(1);
@@ -884,7 +1045,10 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(joinErr.options?.context?.detail).toBe("room-join-registration-required");
     expect(joinErr.options?.context?.condition).toBe("registration-required");
     expect(joinErr.options?.context?.errorType).toBe("auth");
+    expect(joinErr.options?.context?.errorText).toBeUndefined();
     expect(joinErr.options?.context?.errorSource).toBe("server");
+    expect(joinErr.options?.context?.roomLocalpart).toBe("room");
+    expect(joinErr.options?.context?.roomLocalpart).not.toContain("@");
   });
 
   test("disco failures report to Faro with condition or local-timeout attribution", async () => {
@@ -1130,7 +1294,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
     });
 
     const enqueued: Array<{ kind: string; reason: string }> = [];
-    const depths: Array<{ persisted: number; inflight: number }> = [];
+    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
     client.onSendEnqueued((info) => enqueued.push(info));
     client.onQueueDepthChange((d) => depths.push(d));
 
@@ -1138,8 +1302,9 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     expect(enqueued).toHaveLength(1);
     expect(enqueued[0].kind).toBe("dm");
-    expect(depths).toHaveLength(1);
-    expect(depths[0].persisted).toBe(1);
+    expect(depths).toHaveLength(2);
+    expect(depths.find((depth) => depth.kind === "dm")?.persisted).toBe(1);
+    expect(depths.find((depth) => depth.kind === "room")?.persisted).toBe(0);
   });
 
   test("hook exceptions are swallowed and do not break chat", () => {
@@ -1180,7 +1345,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
     const client = new BrowserXmppClient(session());
 
     const fails: Array<{ id: string; kind: "room" | "dm" }> = [];
-    const depths: Array<{ persisted: number; inflight: number }> = [];
+    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
     client.onMessageDeliveryFailed((id, meta) => fails.push({ id, kind: meta.kind }));
     client.onQueueDepthChange((d) => depths.push(d));
 
@@ -1211,8 +1376,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
     stubXmpp.emit("message:failed", { id: "dm-fail-1" });
 
     expect(fails).toEqual([{ id: "dm-fail-1", kind: "dm" }]);
-    expect(depths).toHaveLength(1);
-    expect(depths[0].inflight).toBe(0);
+    expect(depths).toHaveLength(2);
+    expect(depths.find((depth) => depth.kind === "dm")?.inflight).toBe(0);
   });
 
   test("message:failed without a recorded pending entry does not fire the failure hook", () => {

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: livekit-sfu
 description: Minimal LiveKit SFU chart for Waddle infrastructure.
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: v1.11.0
 
 sources:

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
@@ -81,6 +81,11 @@ spec:
             - name: http
               containerPort: {{ .Values.livekit.port }}
               protocol: TCP
+            {{- if .Values.livekit.prometheus_port }}
+            - name: prometheus
+              containerPort: {{ .Values.livekit.prometheus_port }}
+              protocol: TCP
+            {{- end }}
             {{- if .Values.livekit.rtc.tcp_port }}
             - name: rtc-tcp
               containerPort: {{ .Values.livekit.rtc.tcp_port }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/service.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/service.yaml
@@ -15,5 +15,11 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if .Values.livekit.prometheus_port }}
+    - name: prometheus
+      port: {{ .Values.livekit.prometheus_port }}
+      targetPort: prometheus
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "livekit-sfu.selectorLabels" . | nindent 4 }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
@@ -45,6 +45,7 @@ webhook:
 
 livekit:
   port: 7880
+  prometheus_port: 6789
   log_level: info
   rtc:
     use_external_ip: true

--- a/infrastructure/waddle.cloud/docs/livekit-metrics.md
+++ b/infrastructure/waddle.cloud/docs/livekit-metrics.md
@@ -1,0 +1,100 @@
+# LiveKit SFU metrics: starter queries
+
+Grafana Alloy scrapes each LiveKit pod every 30 seconds. In Grafana Cloud, start
+with `{job="livekit-sfu"}`; `instance` is the Kubernetes pod name. LiveKit also
+adds `node_id` and `node_type` to its native metrics.
+
+These queries match the metrics emitted by the deployed LiveKit v1.11.0 server:
+the [room and participant gauges][rooms-source] and the [packet-loss and byte
+counters][packets-source].
+
+## Active rooms
+
+Cluster total:
+
+```promql
+sum(livekit_room_total{job="livekit-sfu"})
+```
+
+To spot an imbalanced or unhealthy SFU, break the same gauge out by pod:
+
+```promql
+sum by (instance) (livekit_room_total{job="livekit-sfu"})
+```
+
+## Active participants
+
+Cluster total:
+
+```promql
+sum(livekit_participant_total{job="livekit-sfu"})
+```
+
+Per pod:
+
+```promql
+sum by (instance) (livekit_participant_total{job="livekit-sfu"})
+```
+
+## Packet loss
+
+Lost packets per second, split by media direction, track source, and media type:
+
+```promql
+sum by (direction, source, type) (
+  rate(livekit_packet_loss_total{job="livekit-sfu"}[5m])
+)
+```
+
+Approximate p95 of LiveKit's observed packet-loss percentage samples:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le, direction, source, type) (
+    rate(livekit_packet_loss_percent_bucket{job="livekit-sfu"}[5m])
+  )
+)
+```
+
+The p95 is computed from LiveKit's fixed percentage buckets, so it is an
+approximation rather than a packet-weighted loss ratio. The lost-packets rate is
+usually the better alert input; use the percentile to understand severity.
+
+## Bitrate
+
+SFU media bitrate in bits per second, split into traffic entering and leaving
+the SFU and excluding retransmissions:
+
+```promql
+8 * sum by (direction) (
+  rate(livekit_packet_bytes_total{
+    job="livekit-sfu",
+    transmission="initial"
+  }[5m])
+)
+```
+
+To graph total RTP packet bitrate observed by the SFU, including
+retransmissions, remove the `transmission="initial"` selector. This is not
+NIC-level throughput and does not include every transport or protocol overhead.
+To find a hot pod, add `instance` to the `sum by (...)` grouping.
+
+## Query caveats
+
+- These native server metrics are node-level aggregates. They do not carry a
+  room name, participant identity, or track ID, so they cannot produce
+  per-call or per-user QoS views.
+- LiveKit adds `direction`, `source`, `type`, and `country` only where relevant.
+  Use Grafana Explore to inspect the values present before adding filters; enum
+  spelling can change between LiveKit releases.
+- A newly started or idle pod may not expose every labeled counter series until
+  it has handled matching traffic. `rate(...[5m])` also needs at least two
+  samples, so a new series can be temporarily absent.
+- Re-check the upstream definitions after a LiveKit image upgrade. The metric
+  namespace (`livekit`) and constant node labels are initialized in LiveKit's
+  [Prometheus registry setup][node-source].
+
+[rooms-source]: https://github.com/livekit/livekit/blob/v1.11.0/pkg/telemetry/prometheus/rooms.go
+[packets-source]: https://github.com/livekit/livekit/blob/v1.11.0/pkg/telemetry/prometheus/packets.go
+[node-source]: https://github.com/livekit/livekit/blob/v1.11.0/pkg/telemetry/prometheus/node.go

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -117,6 +117,52 @@ spec:
               metrics = [otelcol.processor.batch.default.input]
             }
           }
+
+          // ---------- Prometheus scrape of LiveKit SFU /metrics ----------
+          // The livekit-sfu Service exposes LiveKit's native Prometheus
+          // listener on the `prometheus` port. Discover endpoints rather
+          // than the Service IP so each SFU pod keeps its own instance label.
+          discovery.kubernetes "livekit_sfu" {
+            role = "endpoints"
+            namespaces {
+              names = ["livekit"]
+            }
+          }
+
+          discovery.relabel "livekit_sfu" {
+            targets = discovery.kubernetes.livekit_sfu.targets
+            rule {
+              source_labels = ["__meta_kubernetes_service_name"]
+              action        = "keep"
+              regex         = "livekit-sfu"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_endpoint_port_name"]
+              action        = "keep"
+              regex         = "prometheus"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "instance"
+            }
+            rule {
+              target_label = "job"
+              replacement  = "livekit-sfu"
+            }
+          }
+
+          prometheus.scrape "livekit_sfu" {
+            targets         = discovery.relabel.livekit_sfu.output
+            forward_to      = [otelcol.receiver.prometheus.livekit_sfu.receiver]
+            metrics_path    = "/metrics"
+            scrape_interval = "30s"
+          }
+
+          otelcol.receiver.prometheus "livekit_sfu" {
+            output {
+              metrics = [otelcol.processor.batch.default.input]
+            }
+          }
       # Inject Grafana Cloud creds from the ExternalSecret. The chart key
       # is `envFrom` (not `extraEnvFrom`); helm silently drops unknown
       # values, so the typo would leave the alloy container with no
@@ -137,7 +183,7 @@ spec:
           targetPort: 4318
           protocol: TCP
     # Alloy needs read access to Service / Endpoint objects across the
-    # cluster for the discovery.kubernetes target above. The chart's
+    # cluster for the discovery.kubernetes targets above. The chart's
     # default RBAC already grants this when `rbac.create=true`.
     rbac:
       create: true

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml
@@ -39,6 +39,15 @@ spec:
       app.kubernetes.io/name: livekit-sfu
       app.kubernetes.io/instance: livekit-sfu
   ingress:
+    # Native Prometheus metrics. Grafana Alloy discovers the per-pod
+    # `prometheus` Service endpoints and scrapes LiveKit directly on 6789.
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: grafana-alloy
+      toPorts:
+        - ports:
+            - port: "6789"
+              protocol: TCP
     # Signaling: the Cilium gateway proxy fronts `sfu.waddle.social`
     # and forwards to `livekit-sfu:7880`. Gateway traffic carries the
     # reserved `ingress` identity; with `gatewayAPI.hostNetwork.enabled`

--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -87,6 +87,11 @@ spec:
     telemetry:
       otlpEndpoint: "http://grafana-alloy.grafana-alloy.svc.cluster.local:4317"
       serviceName: "waddle-server"
+      deploymentEnvironment: "production"
+      # Explicit spec defaults so trace volume has a visible dial
+      # here; lower the ratio to shed trace volume without a rebuild.
+      tracesSampler: "parentbased_traceidratio"
+      tracesSamplerArg: "1.0"
     containerExtraEnv:
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
         value: "grpc"

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -7,6 +7,27 @@
 - Never add clippy allows in general, fix the code
 - If something can be a trait, use a trait and plan for extension
 
+## Telemetry
+
+- **New metrics go through the create-at-increment macros only**
+  (`waddle_xmpp::counter_add!` / `waddle_xmpp::histogram_record!` in
+  `crates/waddle-xmpp/src/telemetry/`). There is no standalone
+  registration API and none may be added: instrument creation happens
+  at the increment site, so a registered-but-never-wired metric cannot
+  exist.
+- **The Prometheus text renderer is frozen.** Never add a new metric
+  family to `crates/waddle-xmpp/src/prometheus.rs`; it is being retired
+  family-by-family (#1330).
+- Metric names are dot.case, the unit is UCUM on the instrument (never
+  in the name), and attributes come exclusively from the enumerated
+  allowlist in `telemetry/attributes.rs`. JIDs, room JIDs, stream ids,
+  and message ids are never metric attributes — they belong on spans
+  and logs. The cardinality budget is documented in the `telemetry`
+  module docs.
+- Metric tests assert exported samples through
+  `telemetry::test_support` (the in-memory reader seam), never
+  instrument internals.
+
 ## Runtime
 
 This project uses **Bun** as its JavaScript/TypeScript runtime. Prefer Bun APIs over Node.js equivalents:

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -7797,6 +7797,7 @@ dependencies = [
  "minidom",
  "mockito",
  "opentelemetry",
+ "opentelemetry_sdk",
  "p256",
  "pbkdf2",
  "rand 0.10.1",

--- a/server/charts/waddle-server/Chart.yaml
+++ b/server/charts/waddle-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waddle-server
 description: Helm chart for deploying Waddle Social server to Kubernetes.
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.1.0"
 # ADR-0017 Phase 0: the graceful-shutdown preStop hook uses the native Sleep
 # lifecycle action (`lifecycle.preStop.sleep`), which is GA in Kubernetes 1.32

--- a/server/charts/waddle-server/templates/configmap.yaml
+++ b/server/charts/waddle-server/templates/configmap.yaml
@@ -70,13 +70,15 @@ data:
   OTEL_SERVICE_VERSION: {{ .Values.telemetry.serviceVersion | quote }}
   {{- end }}
   {{- if .Values.telemetry.deploymentEnvironment }}
-  OTEL_DEPLOYMENT_ENVIRONMENT: {{ .Values.telemetry.deploymentEnvironment | quote }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ printf "deployment.environment=%s" .Values.telemetry.deploymentEnvironment | quote }}
   {{- end }}
   {{- if .Values.telemetry.tracesSampler }}
   OTEL_TRACES_SAMPLER: {{ .Values.telemetry.tracesSampler | quote }}
   {{- end }}
-  {{- if .Values.telemetry.tracesSamplerArg }}
-  OTEL_TRACES_SAMPLER_ARG: {{ .Values.telemetry.tracesSamplerArg | quote }}
+  {{- /* toString-compare: a numeric 0 ratio is falsy in `if` but is a
+       valid "sample nothing" argument and must still render. */}}
+  {{- if ne (.Values.telemetry.tracesSamplerArg | toString) "" }}
+  OTEL_TRACES_SAMPLER_ARG: {{ .Values.telemetry.tracesSamplerArg | toString | quote }}
   {{- end }}
   {{- if .Values.config.s3Endpoint }}
   WADDLE_S3_ENDPOINT: {{ .Values.config.s3Endpoint | quote }}

--- a/server/charts/waddle-server/templates/configmap.yaml
+++ b/server/charts/waddle-server/templates/configmap.yaml
@@ -69,6 +69,15 @@ data:
   {{- if .Values.telemetry.serviceVersion }}
   OTEL_SERVICE_VERSION: {{ .Values.telemetry.serviceVersion | quote }}
   {{- end }}
+  {{- if .Values.telemetry.deploymentEnvironment }}
+  OTEL_DEPLOYMENT_ENVIRONMENT: {{ .Values.telemetry.deploymentEnvironment | quote }}
+  {{- end }}
+  {{- if .Values.telemetry.tracesSampler }}
+  OTEL_TRACES_SAMPLER: {{ .Values.telemetry.tracesSampler | quote }}
+  {{- end }}
+  {{- if .Values.telemetry.tracesSamplerArg }}
+  OTEL_TRACES_SAMPLER_ARG: {{ .Values.telemetry.tracesSamplerArg | quote }}
+  {{- end }}
   {{- if .Values.config.s3Endpoint }}
   WADDLE_S3_ENDPOINT: {{ .Values.config.s3Endpoint | quote }}
   {{- end }}

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -200,6 +200,14 @@ telemetry:
   otlpEndpoint: ""
   serviceName: waddle-server
   serviceVersion: ""
+  # deployment.environment resource attribute (e.g. "production").
+  # Omitted from the OTLP resource when empty.
+  deploymentEnvironment: ""
+  # Trace sampler per the OTel spec's OTEL_TRACES_SAMPLER /
+  # OTEL_TRACES_SAMPLER_ARG. The server defaults to
+  # parentbased_traceidratio with ratio 1.0 when unset.
+  tracesSampler: ""
+  tracesSamplerArg: ""
 
 secret:
   create: true

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -201,7 +201,8 @@ telemetry:
   serviceName: waddle-server
   serviceVersion: ""
   # deployment.environment resource attribute (e.g. "production").
-  # Omitted from the OTLP resource when empty.
+  # Rendered as the standard OTEL_RESOURCE_ATTRIBUTES env var and
+  # merged by the SDK's env resource detector; omitted when empty.
   deploymentEnvironment: ""
   # Trace sampler per the OTel spec's OTEL_TRACES_SAMPLER /
   # OTEL_TRACES_SAMPLER_ARG. The server defaults to

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -2462,7 +2462,19 @@ impl OrderedRelayDeliveryBridge {
         {
             Ok(RelayRemoteResourceFrameReply {
                 status: RelayRemoteResourceFrameStatus::Delivered,
-            }) => Some(FullJidDeliveryOutcome::Delivered),
+            }) => {
+                // The direct remote-resource path bypasses the counted
+                // owner-node delivery channels AND the deliberately
+                // uncounted socket endpoint, so the flagship delivered-
+                // message counter must be bumped here — once, on the
+                // owner node, upon the socket node's acknowledgment.
+                if let Some(message_kind) =
+                    waddle_xmpp::telemetry::messages::delivered_message_kind(stanza)
+                {
+                    waddle_xmpp::telemetry::messages::record_delivered_message(message_kind);
+                }
+                Some(FullJidDeliveryOutcome::Delivered)
+            }
             Ok(RelayRemoteResourceFrameReply {
                 status: RelayRemoteResourceFrameStatus::Backpressure,
             }) => Some(FullJidDeliveryOutcome::Dropped),

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -828,15 +828,26 @@ async fn interpret_with_depth(
 }
 
 async fn enrich_message_event(deps: &Deps<'_>, message: Message) -> Message {
-    if deps.extension_manager.is_none() {
+    // Observability (#1320): time the enrichment pass and count the
+    // embeds it adds as the payload-count delta before/after.
+    let started = std::time::Instant::now();
+    let payloads_before = message.payloads.len();
+    let enriched = if deps.extension_manager.is_none() {
         debug!(
             "RequestEnrichment: no extension_manager in Deps; \
              feeding original message back unchanged"
         );
-        return message;
-    }
-    debug!("RequestEnrichment: direct messages do not carry a typed Waddle scope; skipping");
-    message
+        message
+    } else {
+        debug!("RequestEnrichment: direct messages do not carry a typed Waddle scope; skipping");
+        message
+    };
+    let embeds_added = enriched.payloads.len().saturating_sub(payloads_before) as u64;
+    waddle_xmpp::metrics::record_extension_enrichment(
+        started.elapsed().as_secs_f64() * 1000.0,
+        embeds_added,
+    );
+    enriched
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -2464,6 +2464,7 @@ async fn enrichment_request_without_extension_manager_fails_open_with_original_m
     // legacy fail-open contract (see `enrich_message` in the
     // legacy `message.rs` path).
     use waddle_xmpp::protocol::event::CallbackId;
+    let guard = waddle_xmpp::telemetry::test_support::acquire().await;
     let registry = ConnectionRegistry::new();
     let deps = Deps::registry_only(&registry);
 
@@ -2489,6 +2490,14 @@ async fn enrichment_request_without_extension_manager_fails_open_with_original_m
         }
         other => panic!("expected EnrichmentComplete, got {other:?}"),
     }
+
+    // #1320: every enrichment pass times itself, even the fail-open
+    // no-op path that adds zero embeds.
+    assert_eq!(
+        guard.histogram_count("xmpp.extensions.enrichment.latency", &[]),
+        Some(1),
+        "enrichment must record one latency sample per pass",
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -54,26 +54,29 @@ async fn xmpp_websocket_handler(
 
     // #1326 phase A: the browser cannot set headers on a WebSocket
     // upgrade, so the client's connect trace arrives as a
-    // `traceparent` query parameter. Link (not parent) it onto the
-    // connection-scoped span so the browser's `xmpp.connect` span and
-    // this server session become one navigable graph in Tempo.
-    let connection_span =
-        tracing::info_span!("xmpp.connection", client.trace_id = tracing::field::Empty,);
+    // `traceparent` query parameter. Emit a short-lived
+    // `xmpp.connection.established` span carrying an OTel span LINK to
+    // the client's context plus `client.trace_id`, so the browser's
+    // `xmpp.connect` span and this server session join in Tempo.
+    //
+    // Deliberately NOT instrumenting the whole connection future: a
+    // span wrapping a connection that lives for hours would only
+    // export at close and would pull every `xmpp.stanza.dispatch`
+    // span on the session into one giant trace (Tempo truncates
+    // those). Dispatch spans stay independent roots, correlated via
+    // their `xmpp.resource`/`user` attributes instead.
     if let Some(client_context) = crate::server::trace::client_trace_context_from_query(uri.query())
     {
-        connection_span.record(
-            "client.trace_id",
-            tracing::field::display(client_context.trace_id()),
+        let established_span = tracing::info_span!(
+            "xmpp.connection.established",
+            client.trace_id = %client_context.trace_id(),
         );
-        tracing_opentelemetry::OpenTelemetrySpanExt::add_link(&connection_span, client_context);
+        tracing_opentelemetry::OpenTelemetrySpanExt::add_link(&established_span, client_context);
+        let _enter = established_span.enter();
     }
 
-    ws.protocols(["xmpp"]).on_upgrade(move |socket| {
-        tracing::Instrument::instrument(
-            handle_xmpp_websocket(socket, state, connection_guard),
-            connection_span,
-        )
-    })
+    ws.protocols(["xmpp"])
+        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
 }
 
 /// Size of the outbound message channel buffer

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -34,6 +34,7 @@ pub fn router(state: Arc<WebSocketState>) -> Router {
 /// Upgrades HTTP connection to WebSocket and handles XMPP framing.
 async fn xmpp_websocket_handler(
     ws: WebSocketUpgrade,
+    uri: axum::http::Uri,
     State(state): State<Arc<WebSocketState>>,
 ) -> Response {
     // Graceful shutdown gate (issue #1091). The guard is minted BEFORE
@@ -51,8 +52,28 @@ async fn xmpp_websocket_handler(
     }
     info!("XMPP WebSocket connection request");
 
-    ws.protocols(["xmpp"])
-        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
+    // #1326 phase A: the browser cannot set headers on a WebSocket
+    // upgrade, so the client's connect trace arrives as a
+    // `traceparent` query parameter. Link (not parent) it onto the
+    // connection-scoped span so the browser's `xmpp.connect` span and
+    // this server session become one navigable graph in Tempo.
+    let connection_span =
+        tracing::info_span!("xmpp.connection", client.trace_id = tracing::field::Empty,);
+    if let Some(client_context) = crate::server::trace::client_trace_context_from_query(uri.query())
+    {
+        connection_span.record(
+            "client.trace_id",
+            tracing::field::display(client_context.trace_id()),
+        );
+        tracing_opentelemetry::OpenTelemetrySpanExt::add_link(&connection_span, client_context);
+    }
+
+    ws.protocols(["xmpp"]).on_upgrade(move |socket| {
+        tracing::Instrument::instrument(
+            handle_xmpp_websocket(socket, state, connection_guard),
+            connection_span,
+        )
+    })
 }
 
 /// Size of the outbound message channel buffer

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -257,7 +257,7 @@ async fn handle_xmpp_frame_impl(
             // longer freeze the connection's frame loop indefinitely; on elapse
             // an IQ get/set gets a conformant resource-constraint/wait error and
             // message/presence are dropped (logged + metered).
-            let backstop = StanzaBackstop::capture(&stanza);
+            let backstop = StanzaBackstop::capture(&stanza, phase.bound_jid());
             let dispatch = async {
                 match *stanza {
                     Stanza::Iq(iq) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -141,7 +141,7 @@ impl StanzaBackstop {
             span.record("message_id", message_id.as_str());
         }
         if let Some(room) = &correlation.room {
-            span.record("room", room.as_str());
+            span.record("room", tracing::field::display(room));
         }
         if let Some(jid) = bound_jid {
             span.record("xmpp.resource", jid.resource().as_str());
@@ -207,7 +207,8 @@ impl StanzaBackstop {
 /// borrowed stanza before it moves into the dispatch future.
 struct MessageCorrelation {
     message_id: Option<String>,
-    room: Option<String>,
+    /// Typed until the span-record boundary, per the typed-payloads rule.
+    room: Option<jid::BareJid>,
 }
 
 impl MessageCorrelation {
@@ -216,7 +217,7 @@ impl MessageCorrelation {
             Stanza::Message(message) => Self {
                 message_id: message.id.as_ref().map(|id| id.0.clone()),
                 room: (message.type_ == xmpp_parsers::message::MessageType::Groupchat)
-                    .then(|| message.to.as_ref().map(|to| to.to_bare().to_string()))
+                    .then(|| message.to.as_ref().map(|to| to.to_bare()))
                     .flatten(),
             },
             _ => Self {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -82,8 +82,12 @@ pub(super) struct StanzaBackstop {
 
 impl StanzaBackstop {
     /// Capture backstop metadata from a borrowed stanza before it is moved into
-    /// the dispatch future.
-    pub(super) fn capture(stanza: &Stanza) -> Self {
+    /// the dispatch future. `bound_jid` (the session's bound full JID, once
+    /// binding happened) stamps the correlation attributes from #1326: the
+    /// XMPP resource plus the bare user JID, so one attribute search joins a
+    /// browser session's Faro beacons to its server-side spans.
+    pub(super) fn capture(stanza: &Stanza, bound_jid: Option<&jid::FullJid>) -> Self {
+        let correlation = MessageCorrelation::capture(stanza);
         match stanza {
             // Only IQ `get`/`set` carry a request payload AND owe a response, so
             // a single match keeps the namespace and the reply addressing in
@@ -98,23 +102,51 @@ impl StanzaBackstop {
                         from: iq.to().map(|jid| jid.to_string()),
                         to: iq.from().map(|jid| jid.to_string()),
                     }),
+                    correlation,
+                    bound_jid,
                 ),
-                _ => Self::build("iq", String::new(), None),
+                _ => Self::build("iq", String::new(), None, correlation, bound_jid),
             },
-            Stanza::Presence(_) => Self::build("presence", String::new(), None),
-            Stanza::Message(_) => Self::build("message", String::new(), None),
+            Stanza::Presence(_) => {
+                Self::build("presence", String::new(), None, correlation, bound_jid)
+            }
+            Stanza::Message(_) => {
+                Self::build("message", String::new(), None, correlation, bound_jid)
+            }
         }
     }
 
-    fn build(kind: &'static str, payload_ns: String, iq_reply: Option<IqReply>) -> Self {
+    fn build(
+        kind: &'static str,
+        payload_ns: String,
+        iq_reply: Option<IqReply>,
+        correlation: MessageCorrelation,
+        bound_jid: Option<&jid::FullJid>,
+    ) -> Self {
         // `otel.status_code` is declared Empty and recorded as ERROR on elapse;
         // `tracing-opentelemetry` maps that field onto the OTEL span status.
+        // The correlation fields (#1321/#1326) are declared Empty and recorded
+        // only when known, so absent values don't serialize at all.
         let span = info_span!(
             "xmpp.stanza.dispatch",
             stanza_kind = kind,
             payload_ns = %payload_ns,
             otel.status_code = tracing::field::Empty,
+            message_id = tracing::field::Empty,
+            room = tracing::field::Empty,
+            xmpp.resource = tracing::field::Empty,
+            user = tracing::field::Empty,
         );
+        if let Some(message_id) = &correlation.message_id {
+            span.record("message_id", message_id.as_str());
+        }
+        if let Some(room) = &correlation.room {
+            span.record("room", room.as_str());
+        }
+        if let Some(jid) = bound_jid {
+            span.record("xmpp.resource", jid.resource().as_str());
+            span.record("user", tracing::field::display(jid.to_bare()));
+        }
         Self {
             kind,
             payload_ns,
@@ -170,9 +202,39 @@ impl StanzaBackstop {
     }
 }
 
+/// Message-correlation fields for the dispatch span (#1321): the stanza's
+/// message id, and the room bare JID for groupchat traffic. Captured from the
+/// borrowed stanza before it moves into the dispatch future.
+struct MessageCorrelation {
+    message_id: Option<String>,
+    room: Option<String>,
+}
+
+impl MessageCorrelation {
+    fn capture(stanza: &Stanza) -> Self {
+        match stanza {
+            Stanza::Message(message) => Self {
+                message_id: message.id.as_ref().map(|id| id.0.clone()),
+                room: (message.type_ == xmpp_parsers::message::MessageType::Groupchat)
+                    .then(|| message.to.as_ref().map(|to| to.to_bare().to_string()))
+                    .flatten(),
+            },
+            _ => Self {
+                message_id: None,
+                room: None,
+            },
+        }
+    }
+}
+
 /// Drive a stanza's dispatch under the wedge backstop: run `dispatch` within the
 /// backstop span and the [`STANZA_HANDLER_WEDGE_TIMEOUT`]; on elapse, return the
 /// conformant timeout response instead of letting the connection hang.
+///
+/// Completed dispatches feed the `xmpp.stanzas.processed` counter and the
+/// `xmpp.stanza.latency` histogram (#1320 wire-up / #1321 dispatch seam);
+/// timeouts keep their dedicated counter and are not double-counted as
+/// processed.
 pub(super) async fn run_with_backstop<F>(
     backstop: StanzaBackstop,
     dispatch: F,
@@ -181,8 +243,14 @@ where
     F: Future<Output = Vec<String>> + Send,
 {
     let span = backstop.span.clone();
+    let kind = backstop.kind;
+    let started = std::time::Instant::now();
     match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {
-        Ok(responses) => Ok(responses),
+        Ok(responses) => {
+            metrics::record_stanza(kind, "inbound");
+            metrics::record_stanza_latency(started.elapsed().as_secs_f64() * 1000.0, kind);
+            Ok(responses)
+        }
         Err(_elapsed) => Err(backstop.on_timeout()),
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -55,7 +55,7 @@ fn responses_and_disposition(
 #[tokio::test(start_paused = true)]
 async fn iq_get_timeout_yields_conformant_resource_constraint() {
     let stanza = iq_get_stanza("disco-1", "alice@example.com/web", "upload.example.com");
-    let backstop = StanzaBackstop::capture(&stanza);
+    let backstop = StanzaBackstop::capture(&stanza, None);
 
     let mut fut = Box::pin(run_with_backstop(backstop, pending::<Vec<String>>()));
     assert!(
@@ -120,7 +120,7 @@ async fn iq_get_timeout_yields_conformant_resource_constraint() {
 #[tokio::test(start_paused = true)]
 async fn message_timeout_yields_no_response() {
     let stanza = message_stanza();
-    let backstop = StanzaBackstop::capture(&stanza);
+    let backstop = StanzaBackstop::capture(&stanza, None);
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
@@ -137,7 +137,7 @@ async fn message_timeout_yields_no_response() {
 #[tokio::test(start_paused = true)]
 async fn presence_timeout_yields_no_response() {
     let stanza = presence_stanza();
-    let backstop = StanzaBackstop::capture(&stanza);
+    let backstop = StanzaBackstop::capture(&stanza, None);
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
@@ -153,7 +153,7 @@ async fn iq_result_timeout_yields_no_response() {
     // IQ must NOT synthesize an error reply (locks the `_ => None` arm in
     // `capture`).
     let stanza = iq_result_stanza("ack-1");
-    let backstop = StanzaBackstop::capture(&stanza);
+    let backstop = StanzaBackstop::capture(&stanza, None);
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
@@ -170,7 +170,7 @@ async fn iq_result_timeout_yields_no_response() {
 #[tokio::test(start_paused = true)]
 async fn fast_dispatch_passes_through_untouched() {
     let stanza = iq_get_stanza("disco-2", "alice@example.com/web", "example.com");
-    let backstop = StanzaBackstop::capture(&stanza);
+    let backstop = StanzaBackstop::capture(&stanza, None);
 
     // A handler that completes immediately must pass its response through
     // unchanged, with no timeout reply.

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -608,6 +608,99 @@ mod tests {
     }
 }
 
+/// What the managed-channel affiliation/membership resolver reported
+/// for a denied join, recorded on the admission-denial log (#1315).
+/// This is diagnostic context on the log only — it is never a metric
+/// attribute (the counter keys on the stanza error condition alone).
+#[derive(Debug, Clone, Copy)]
+enum ManagedAdmissionResolverOutcome {
+    /// The join carried no authenticated session, so the resolver was
+    /// never consulted.
+    SessionMissing,
+    /// The authenticated session's JID failed to parse, so the
+    /// resolver was never consulted.
+    SessionJidMalformed,
+    /// The resolver reported the joiner is banned (outcast).
+    Banned,
+    /// The resolver reported no channel affiliation for the joiner in a
+    /// members-only channel.
+    NoAffiliation,
+    /// The resolver failed to produce an affiliation (backend error).
+    ResolverError,
+}
+
+impl ManagedAdmissionResolverOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionMissing => "session-missing",
+            Self::SessionJidMalformed => "session-jid-malformed",
+            Self::Banned => "banned",
+            Self::NoAffiliation => "no-affiliation",
+            Self::ResolverError => "resolver-error",
+        }
+    }
+}
+
+/// The typed descriptor of a single managed-channel admission denial:
+/// the XEP-0045 §7.2 stanza error it maps to plus the diagnostic
+/// context (`members_only`, resolver outcome) recorded on the log.
+struct ManagedAdmissionDenial {
+    /// The RFC 6120 §8.3.3 stanza error condition; the counter keys on
+    /// this alone.
+    condition: waddle_xmpp::telemetry::attributes::StanzaErrorCondition,
+    /// The `<error type=.../>` class carried on the presence error.
+    error_type: ErrorType,
+    /// Whether admission treated the channel as members-only.
+    members_only: bool,
+    /// What the affiliation/membership resolver reported.
+    resolver_outcome: ManagedAdmissionResolverOutcome,
+    /// Human-facing `<text/>` on the presence error.
+    message: &'static str,
+}
+
+/// Central choke point for managed-channel admission denials (#1315).
+///
+/// Every managed-channel join rejection routes through here so the
+/// denial is never invisible again: it emits one info-level structured
+/// log (bare room JID, bare user JID, condition, `members_only`, and
+/// the resolver outcome) and increments the
+/// `waddle.muc.admission.denied` counter keyed by the stanza error
+/// condition, then returns the XEP-0045 §7.2 presence-error frame
+/// unchanged. JIDs live on the log only — never as a metric attribute.
+fn deny_managed_channel_admission(
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+    nick: &str,
+    denial: ManagedAdmissionDenial,
+) -> Vec<String> {
+    info!(
+        room = %room_jid,
+        user = %sender_jid.to_bare(),
+        condition = denial.condition.as_str(),
+        members_only = denial.members_only,
+        resolver_outcome = denial.resolver_outcome.as_str(),
+        "managed-channel admission denied"
+    );
+    waddle_xmpp::counter_add!(
+        "waddle.muc.admission.denied",
+        "{denial}",
+        "Managed-channel admission denials by stanza error condition.",
+        1,
+        denial.condition,
+    );
+    vec![build_muc_presence_error_xml(
+        room_jid,
+        nick,
+        sender_jid,
+        StanzaError::new(
+            denial.error_type,
+            denial.condition.to_xmpp(),
+            "en",
+            denial.message,
+        ),
+    )]
+}
+
 async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'_>) -> Vec<String> {
     let MucJoinWork {
         domain,
@@ -713,34 +806,38 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
             .unwrap_or(0);
         let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
             let Some(session) = authenticated_session else {
-                return vec![build_muc_presence_error_xml(
+                return deny_managed_channel_admission(
                     room_jid,
-                    &nick,
                     sender_jid,
-                    StanzaError::new(
-                        ErrorType::Auth,
-                        DefinedCondition::NotAuthorized,
-                        "en",
-                        "Authentication required to join managed channel.",
-                    ),
-                )];
+                    &nick,
+                    ManagedAdmissionDenial {
+                        condition:
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::NotAuthorized,
+                        error_type: ErrorType::Auth,
+                        members_only: channel.members_only,
+                        resolver_outcome: ManagedAdmissionResolverOutcome::SessionMissing,
+                        message: "Authentication required to join managed channel.",
+                    },
+                );
             };
             let admission_members_only = existing_room_snapshot
                 .as_ref()
                 .map(|snapshot| snapshot.room.config.members_only)
                 .unwrap_or(channel.members_only);
             let Ok(session_bare) = session.user_jid.parse::<BareJid>() else {
-                return vec![build_muc_presence_error_xml(
+                return deny_managed_channel_admission(
                     room_jid,
-                    &nick,
                     sender_jid,
-                    StanzaError::new(
-                        ErrorType::Wait,
-                        DefinedCondition::InternalServerError,
-                        "en",
-                        "Failed to resolve managed-channel affiliation.",
-                    ),
-                )];
+                    &nick,
+                    ManagedAdmissionDenial {
+                        condition:
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                        error_type: ErrorType::Wait,
+                        members_only: admission_members_only,
+                        resolver_outcome: ManagedAdmissionResolverOutcome::SessionJidMalformed,
+                        message: "Failed to resolve managed-channel affiliation.",
+                    },
+                );
             };
             match resolve_managed_channel_affiliation(
                 state,
@@ -776,17 +873,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         Affiliation::Outcast,
                         admission_revision,
                     );
-                    return vec![build_muc_presence_error_xml(
+                    return deny_managed_channel_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Auth,
-                            DefinedCondition::Forbidden,
-                            "en",
-                            "Banned from managed channel.",
-                        ),
-                    )];
+                        &nick,
+                        ManagedAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::Forbidden,
+                            error_type: ErrorType::Auth,
+                            members_only: admission_members_only,
+                            resolver_outcome: ManagedAdmissionResolverOutcome::Banned,
+                            message: "Banned from managed channel.",
+                        },
+                    );
                 }
                 Ok(Some(affiliation)) => Some(affiliation),
                 Ok(None) => {
@@ -809,32 +908,36 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                             Affiliation::None,
                             admission_revision,
                         );
-                        return vec![build_muc_presence_error_xml(
+                        return deny_managed_channel_admission(
                             room_jid,
-                            &nick,
                             sender_jid,
-                            StanzaError::new(
-                                ErrorType::Auth,
-                                DefinedCondition::RegistrationRequired,
-                                "en",
-                                "Membership required to join managed channel.",
-                            ),
-                        )];
+                            &nick,
+                            ManagedAdmissionDenial {
+                                condition:
+                                    waddle_xmpp::telemetry::attributes::StanzaErrorCondition::RegistrationRequired,
+                                error_type: ErrorType::Auth,
+                                members_only: admission_members_only,
+                                resolver_outcome: ManagedAdmissionResolverOutcome::NoAffiliation,
+                                message: "Membership required to join managed channel.",
+                            },
+                        );
                     }
                     Some(Affiliation::None)
                 }
                 Err(()) => {
-                    return vec![build_muc_presence_error_xml(
+                    return deny_managed_channel_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Wait,
-                            DefinedCondition::InternalServerError,
-                            "en",
-                            "Failed to resolve managed-channel affiliation.",
-                        ),
-                    )];
+                        &nick,
+                        ManagedAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                            error_type: ErrorType::Wait,
+                            members_only: admission_members_only,
+                            resolver_outcome: ManagedAdmissionResolverOutcome::ResolverError,
+                            message: "Failed to resolve managed-channel affiliation.",
+                        },
+                    );
                 }
             }
         } else {

--- a/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
@@ -195,8 +195,12 @@ pub(super) fn handle_sasl_scram_response(
     };
 
     let server_final = match scram.process_client_final(&client_final) {
-        Ok(result) => result,
+        Ok(result) => {
+            waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", true);
+            result
+        }
         Err(e) => {
+            waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", false);
             warn!(
                 error = %e,
                 username = %scram.username(),

--- a/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
@@ -1,4 +1,13 @@
 use super::transport_xml::{element_to_xml, sasl_failure_xml, sasl_success_xml};
+
+/// Count the failed attempt on `xmpp.auth.attempts` (#1320) and build
+/// the SASL failure frame. Every failure return in this module routes
+/// through here so early-step rejections (bad base64, unknown user,
+/// malformed first message) are not invisible to the counter.
+fn sasl_failure_counted(mechanism: &'static str) -> String {
+    waddle_xmpp::metrics::record_auth_attempt(mechanism, false);
+    sasl_failure_xml("not-authorized")
+}
 use super::*;
 
 /// Handle SASL OAUTHBEARER authentication.
@@ -14,7 +23,7 @@ pub(super) async fn handle_sasl_oauthbearer(
         Ok(data) => data,
         Err(e) => {
             warn!(error = %e, "SASL OAUTHBEARER: failed to decode base64 data");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("OAUTHBEARER")];
         }
     };
 
@@ -22,11 +31,11 @@ pub(super) async fn handle_sasl_oauthbearer(
         Ok(OAuthBearerResult::Credentials(credentials)) => credentials.token,
         Ok(OAuthBearerResult::DiscoveryRequest) => {
             warn!("SASL OAUTHBEARER: discovery request received on token-auth WebSocket path");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("OAUTHBEARER")];
         }
         Err(e) => {
             warn!(error = %e, "SASL OAUTHBEARER: failed to parse bearer data");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("OAUTHBEARER")];
         }
     };
 
@@ -48,7 +57,7 @@ pub(super) async fn handle_sasl_oauthbearer(
                             error = %e,
                             "SASL OAUTHBEARER: failed to build JID from session localpart",
                         );
-                        return vec![sasl_failure_xml("not-authorized")];
+                        return vec![sasl_failure_counted("OAUTHBEARER")];
                     }
                 };
 
@@ -56,7 +65,7 @@ pub(super) async fn handle_sasl_oauthbearer(
                 Ok(jid) => jid,
                 Err(e) => {
                     warn!(jid = %bare_jid_str, error = %e, "SASL OAUTHBEARER: JID construction failed");
-                    return vec![sasl_failure_xml("not-authorized")];
+                    return vec![sasl_failure_counted("OAUTHBEARER")];
                 }
             };
 
@@ -69,11 +78,12 @@ pub(super) async fn handle_sasl_oauthbearer(
             *authenticated_session = Some(session);
             *phase = ConnectionPhase::authenticated(&full_jid);
 
+            waddle_xmpp::metrics::record_auth_attempt("OAUTHBEARER", true);
             vec![sasl_success_xml()]
         }
         Err(e) => {
             warn!(error = %e, "SASL OAUTHBEARER authentication failed");
-            vec![sasl_failure_xml("not-authorized")]
+            vec![sasl_failure_counted("OAUTHBEARER")]
         }
     }
 }
@@ -95,7 +105,7 @@ pub(super) async fn handle_sasl_scram_client_first(
         Ok(data) => data,
         Err(e) => {
             warn!(error = %e, "SCRAM: failed to decode base64 client-first");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -103,7 +113,7 @@ pub(super) async fn handle_sasl_scram_client_first(
         Ok(s) => s,
         Err(e) => {
             warn!(error = %e, "SCRAM: invalid UTF-8 in client-first");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -115,7 +125,7 @@ pub(super) async fn handle_sasl_scram_client_first(
             Ok(result) => result.username,
             Err(e) => {
                 warn!(error = %e, "SCRAM: failed to parse client-first");
-                return vec![sasl_failure_xml("not-authorized")];
+                return vec![sasl_failure_counted("SCRAM-SHA-256")];
             }
         }
     };
@@ -131,11 +141,11 @@ pub(super) async fn handle_sasl_scram_client_first(
         Ok(Some(creds)) => creds,
         Ok(None) => {
             warn!(username = %username, "SCRAM: user not found");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
         Err(e) => {
             warn!(error = %e, username = %username, "SCRAM: credential lookup failed");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -146,7 +156,7 @@ pub(super) async fn handle_sasl_scram_client_first(
         Ok(result) => result,
         Err(e) => {
             warn!(error = %e, "SCRAM: failed to process client-first with stored params");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -182,7 +192,7 @@ pub(super) fn handle_sasl_scram_response(
         Ok(data) => data,
         Err(e) => {
             warn!(error = %e, "SCRAM: failed to decode base64 client-final");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -190,7 +200,7 @@ pub(super) fn handle_sasl_scram_response(
         Ok(s) => s,
         Err(e) => {
             warn!(error = %e, "SCRAM: invalid UTF-8 in client-final");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -200,13 +210,12 @@ pub(super) fn handle_sasl_scram_response(
             result
         }
         Err(e) => {
-            waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", false);
             warn!(
                 error = %e,
                 username = %scram.username(),
                 "SCRAM-SHA-256 authentication failed"
             );
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -216,7 +225,7 @@ pub(super) fn handle_sasl_scram_response(
         Ok(jid) => jid,
         Err(e) => {
             warn!(error = %e, jid = %bare_jid_str, "SCRAM: JID construction failed");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 
@@ -224,7 +233,7 @@ pub(super) fn handle_sasl_scram_response(
         Ok(jid) => jid,
         Err(e) => {
             warn!(error = %e, "SCRAM: bare JID parse failed");
-            return vec![sasl_failure_xml("not-authorized")];
+            return vec![sasl_failure_counted("SCRAM-SHA-256")];
         }
     };
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1042,6 +1042,131 @@ async fn managed_members_only_join_requires_explicit_channel_member_affiliation(
     );
 }
 
+/// #1315: a managed members-only join by an unaffiliated user is
+/// rejected with `<registration-required/>`, and that denial must now
+/// be visible — the `waddle.muc.admission.denied` counter records it,
+/// keyed by the stanza error condition, through the metric-reader seam.
+#[tokio::test]
+async fn managed_registration_required_denial_increments_admission_counter() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let state = create_test_websocket_state().await;
+    let session = crate::auth::Session::new("alice@example.com", "alice", "alice");
+    let room_jid: BareJid = "locked-space@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "locked-space".to_string(),
+            name: "Locked Space".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: true,
+            public_room: false,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(session),
+    )
+    .await;
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("registration-required"),
+        "unaffiliated managed members-only join must be registration-required: {denied:?}"
+    );
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.muc.admission.denied",
+            &[("condition", "registration-required")]
+        ),
+        Some(1),
+        "the registration-required admission denial must increment the counter exactly once"
+    );
+    assert!(
+        get_room_actor(state.as_ref(), &room_jid).await.is_none(),
+        "denied members-only join must not create the room actor"
+    );
+}
+
+/// #1315: a channel-banned (outcast) joiner is rejected with
+/// `<forbidden/>` per XEP-0045 §7.2.8, even in an open room. The
+/// denial must be counted under the `forbidden` condition through the
+/// metric-reader seam.
+#[tokio::test]
+async fn managed_forbidden_ban_denial_increments_admission_counter() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let state = create_test_websocket_state().await;
+    let session = crate::auth::Session::new("mallory@example.com", "mallory", "mallory");
+    let room_jid: BareJid = "guarded-space@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "mallory@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "guarded-space".to_string(),
+            name: "Guarded Space".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: false,
+            public_room: true,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    // An explicit channel-level ban makes the resolver report Outcast,
+    // which XEP-0045 §7.2.8 maps to <forbidden/> even in an open room.
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "guarded-space"),
+                Relation::new("outcast"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("channel outcast tuple");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "mallory",
+        None,
+        &Some(session),
+    )
+    .await;
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("forbidden"),
+        "a channel-banned managed joiner must be forbidden: {denied:?}"
+    );
+    assert_eq!(
+        metrics.counter_sum("waddle.muc.admission.denied", &[("condition", "forbidden")]),
+        Some(1),
+        "the forbidden (ban) admission denial must increment the counter exactly once"
+    );
+}
+
 #[tokio::test]
 async fn managed_public_channel_allows_deployment_member_without_channel_tuple() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -53,11 +53,24 @@ pub(crate) fn client_trace_context_from_query(
     let version = parts.next()?;
     let trace_id = TraceId::from_hex(parts.next()?).ok()?;
     let span_id = SpanId::from_hex(parts.next()?).ok()?;
-    let flags = u8::from_str_radix(parts.next()?, 16).ok()?;
-    // Version 00 has exactly four fields; future versions may append
-    // more, which we accept per the spec's forward-compat rule but
-    // only after a parseable 00-shaped prefix.
-    if version.len() != 2 || version == "ff" {
+    let flags_field = parts.next()?;
+    if flags_field.len() != 2 {
+        return None;
+    }
+    let flags = u8::from_str_radix(flags_field, 16).ok()?;
+    // W3C trace-context: the version is exactly two lowercase hex
+    // digits and 0xff is forbidden; version 00 has exactly four
+    // fields (higher versions may append more, which we accept after
+    // a parseable 00-shaped prefix).
+    if version.len() != 2
+        || !version
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        || version == "ff"
+    {
+        return None;
+    }
+    if version == "00" && parts.next().is_some() {
         return None;
     }
     if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
@@ -127,6 +140,13 @@ mod tests {
             Some("traceparent=00-00000000000000000000000000000000-b7ad6b7169203331-01"),
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"),
             Some("traceparent=ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            // Non-hex / uppercase version bytes are rejected outright.
+            Some("traceparent=zz-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            Some("traceparent=0F-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            // Version 00 must have exactly four fields.
+            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra"),
+            // Flags must be exactly two hex digits.
+            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0"),
         ] {
             assert!(
                 client_trace_context_from_query(query).is_none(),

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -31,6 +31,47 @@ pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>)
     span
 }
 
+/// Parse a W3C `traceparent` value carried as a WebSocket-upgrade
+/// **query parameter** (#1326 phase A). The browser `WebSocket` API
+/// cannot set headers, so the chat client appends
+/// `?traceparent=00-<trace-id>-<span-id>-<flags>` to the upgrade URL;
+/// the resulting remote `SpanContext` becomes an OTel span **link**
+/// on the connection-scoped span (links, not parenting — the
+/// connection outlives the browser's connect span).
+///
+/// Returns `None` for absent, malformed, or all-zero ids — a garbage
+/// value from a client must never poison the server span.
+pub(crate) fn client_trace_context_from_query(
+    query: Option<&str>,
+) -> Option<opentelemetry::trace::SpanContext> {
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
+
+    let traceparent = query?
+        .split('&')
+        .find_map(|pair| pair.strip_prefix("traceparent="))?;
+    let mut parts = traceparent.split('-');
+    let version = parts.next()?;
+    let trace_id = TraceId::from_hex(parts.next()?).ok()?;
+    let span_id = SpanId::from_hex(parts.next()?).ok()?;
+    let flags = u8::from_str_radix(parts.next()?, 16).ok()?;
+    // Version 00 has exactly four fields; future versions may append
+    // more, which we accept per the spec's forward-compat rule but
+    // only after a parseable 00-shaped prefix.
+    if version.len() != 2 || version == "ff" {
+        return None;
+    }
+    if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
+        return None;
+    }
+    Some(SpanContext::new(
+        trace_id,
+        span_id,
+        TraceFlags::new(flags),
+        true,
+        TraceState::default(),
+    ))
+}
+
 fn redacted_request_uri(uri: &Uri) -> String {
     let path = uri.path();
     let Some(token_and_suffix) = path.strip_prefix("/api/calendar/community/") else {
@@ -59,6 +100,39 @@ mod tests {
             redacted_request_uri(&uri),
             "/api/calendar/community/:token/events.ics",
         );
+    }
+
+    #[test]
+    fn traceparent_query_parses_to_remote_span_context() {
+        let context = client_trace_context_from_query(Some(
+            "protocol=xmpp&traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        ))
+        .expect("valid traceparent must parse");
+        assert_eq!(
+            context.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(context.span_id().to_string(), "b7ad6b7169203331");
+        assert!(context.is_remote());
+        assert!(context.is_sampled());
+    }
+
+    #[test]
+    fn garbage_or_zero_traceparent_is_rejected() {
+        for query in [
+            None,
+            Some(""),
+            Some("traceparent="),
+            Some("traceparent=nonsense"),
+            Some("traceparent=00-00000000000000000000000000000000-b7ad6b7169203331-01"),
+            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"),
+            Some("traceparent=ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+        ] {
+            assert!(
+                client_trace_context_from_query(query).is_none(),
+                "must reject {query:?}"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -39,13 +39,77 @@ fn build_resource() -> Resource {
         uuid::Uuid::new_v4().simple().to_string().as_str(),
     );
 
-    Resource::builder()
-        .with_attributes([
-            KeyValue::new("service.name", service_name),
-            KeyValue::new("service.version", service_version),
-            KeyValue::new("service.instance.id", service_instance_id),
-        ])
-        .build()
+    let mut attributes = vec![
+        KeyValue::new("service.name", service_name),
+        KeyValue::new("service.version", service_version),
+        KeyValue::new("service.instance.id", service_instance_id),
+    ];
+    if let Some(environment) = nonblank(std::env::var("OTEL_DEPLOYMENT_ENVIRONMENT").ok()) {
+        attributes.push(KeyValue::new("deployment.environment", environment));
+    }
+
+    Resource::builder().with_attributes(attributes).build()
+}
+
+/// Parsed trace-sampler configuration. Mirrors the OTel spec's
+/// `OTEL_TRACES_SAMPLER` values; a typed intermediate so selection is
+/// unit-testable (`Sampler::ParentBased` boxes a `dyn ShouldSample`
+/// and cannot be inspected after construction).
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SamplerChoice {
+    AlwaysOn,
+    AlwaysOff,
+    TraceIdRatio(f64),
+    ParentBasedAlwaysOn,
+    ParentBasedAlwaysOff,
+    ParentBasedTraceIdRatio(f64),
+}
+
+/// Resolve the trace sampler from `OTEL_TRACES_SAMPLER` /
+/// `OTEL_TRACES_SAMPLER_ARG` (helm `telemetry.tracesSampler*`).
+/// Unset or unrecognized values fall back to the spec default,
+/// `parentbased_traceidratio` with ratio 1.0, so trace volume has a
+/// dial before it has a bill without changing today's behavior.
+fn sampler_choice(name: Option<String>, arg: Option<String>) -> SamplerChoice {
+    let ratio = nonblank(arg)
+        .and_then(|raw| raw.parse::<f64>().ok())
+        .filter(|ratio| (0.0..=1.0).contains(ratio))
+        .unwrap_or(1.0);
+
+    match nonblank(name).as_deref() {
+        Some("always_on") => SamplerChoice::AlwaysOn,
+        Some("always_off") => SamplerChoice::AlwaysOff,
+        Some("traceidratio") => SamplerChoice::TraceIdRatio(ratio),
+        Some("parentbased_always_on") => SamplerChoice::ParentBasedAlwaysOn,
+        Some("parentbased_always_off") => SamplerChoice::ParentBasedAlwaysOff,
+        // "parentbased_traceidratio", unset, and anything
+        // unrecognized: the spec default.
+        _ => SamplerChoice::ParentBasedTraceIdRatio(ratio),
+    }
+}
+
+impl SamplerChoice {
+    fn build(self) -> opentelemetry_sdk::trace::Sampler {
+        use opentelemetry_sdk::trace::Sampler;
+        match self {
+            Self::AlwaysOn => Sampler::AlwaysOn,
+            Self::AlwaysOff => Sampler::AlwaysOff,
+            Self::TraceIdRatio(ratio) => Sampler::TraceIdRatioBased(ratio),
+            Self::ParentBasedAlwaysOn => Sampler::ParentBased(Box::new(Sampler::AlwaysOn)),
+            Self::ParentBasedAlwaysOff => Sampler::ParentBased(Box::new(Sampler::AlwaysOff)),
+            Self::ParentBasedTraceIdRatio(ratio) => {
+                Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio)))
+            }
+        }
+    }
+}
+
+fn sampler_from_env() -> opentelemetry_sdk::trace::Sampler {
+    sampler_choice(
+        std::env::var("OTEL_TRACES_SAMPLER").ok(),
+        std::env::var("OTEL_TRACES_SAMPLER_ARG").ok(),
+    )
+    .build()
 }
 
 /// Resolve the `service.instance.id` resource attribute.
@@ -165,6 +229,10 @@ fn build_log_filter() -> EnvFilter {
 /// - `OTEL_SERVICE_INSTANCE_ID`: Per-replica instance id (default:
 ///   `<HOSTNAME>-<pid>` — the pod name in Kubernetes — then a
 ///   pid+entropy fallback when no hostname is available)
+/// - `OTEL_DEPLOYMENT_ENVIRONMENT`: Sets the `deployment.environment`
+///   resource attribute (omitted when unset)
+/// - `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`: Trace sampler
+///   (default: `parentbased_traceidratio` with ratio 1.0)
 /// - `RUST_LOG`: Log filter (default: info)
 ///
 /// # Example
@@ -205,9 +273,14 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .with_endpoint(&otlp_endpoint)
         .build()?;
 
-    // Build tracer provider with batch processor
+    // Build tracer provider with batch processor. The sampler comes
+    // from OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG (default
+    // parentbased_traceidratio 1.0 — today's sample-everything
+    // behavior, but now operator-tunable from helm values).
+    let sampler = sampler_from_env();
     let tracer_provider = SdkTracerProvider::builder()
         .with_batch_exporter(trace_exporter)
+        .with_sampler(sampler)
         .with_resource(resource.clone())
         .build();
 
@@ -413,6 +486,78 @@ mod tests {
         // Note: Can only initialize once per process
         // This test just verifies the function compiles
         // let _ = super::init_local();
+    }
+
+    #[test]
+    fn sampler_defaults_to_parentbased_ratio_one() {
+        assert_eq!(
+            super::sampler_choice(None, None),
+            super::SamplerChoice::ParentBasedTraceIdRatio(1.0)
+        );
+    }
+
+    #[test]
+    fn sampler_honors_parentbased_traceidratio_arg() {
+        assert_eq!(
+            super::sampler_choice(
+                Some("parentbased_traceidratio".to_string()),
+                Some("0.25".to_string()),
+            ),
+            super::SamplerChoice::ParentBasedTraceIdRatio(0.25)
+        );
+    }
+
+    #[test]
+    fn sampler_supports_every_spec_variant() {
+        use super::SamplerChoice;
+        assert_eq!(
+            super::sampler_choice(Some("always_on".to_string()), None),
+            SamplerChoice::AlwaysOn
+        );
+        assert_eq!(
+            super::sampler_choice(Some("always_off".to_string()), None),
+            SamplerChoice::AlwaysOff
+        );
+        assert_eq!(
+            super::sampler_choice(Some("traceidratio".to_string()), Some("0.5".to_string())),
+            SamplerChoice::TraceIdRatio(0.5)
+        );
+        assert_eq!(
+            super::sampler_choice(Some("parentbased_always_on".to_string()), None),
+            SamplerChoice::ParentBasedAlwaysOn
+        );
+        assert_eq!(
+            super::sampler_choice(Some("parentbased_always_off".to_string()), None),
+            SamplerChoice::ParentBasedAlwaysOff
+        );
+    }
+
+    #[test]
+    fn sampler_falls_back_on_garbage_input() {
+        // Unknown sampler name and out-of-range/unparsable ratios must
+        // not disable tracing; they fall back to the 1.0 default.
+        for arg in [Some("7.5".to_string()), Some("nan".to_string()), None] {
+            assert_eq!(
+                super::sampler_choice(Some("bogus_sampler".to_string()), arg),
+                super::SamplerChoice::ParentBasedTraceIdRatio(1.0)
+            );
+        }
+    }
+
+    #[test]
+    fn every_sampler_choice_builds() {
+        // Building must not panic for any variant; the ParentBased
+        // internals are opaque past this point by SDK design.
+        for choice in [
+            super::SamplerChoice::AlwaysOn,
+            super::SamplerChoice::AlwaysOff,
+            super::SamplerChoice::TraceIdRatio(0.5),
+            super::SamplerChoice::ParentBasedAlwaysOn,
+            super::SamplerChoice::ParentBasedAlwaysOff,
+            super::SamplerChoice::ParentBasedTraceIdRatio(1.0),
+        ] {
+            let _sampler = choice.build();
+        }
     }
 
     #[test]

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -39,16 +39,16 @@ fn build_resource() -> Resource {
         uuid::Uuid::new_v4().simple().to_string().as_str(),
     );
 
-    let mut attributes = vec![
-        KeyValue::new("service.name", service_name),
-        KeyValue::new("service.version", service_version),
-        KeyValue::new("service.instance.id", service_instance_id),
-    ];
-    if let Some(environment) = nonblank(std::env::var("OTEL_DEPLOYMENT_ENVIRONMENT").ok()) {
-        attributes.push(KeyValue::new("deployment.environment", environment));
-    }
-
-    Resource::builder().with_attributes(attributes).build()
+    // `Resource::builder()` includes the SDK's `EnvResourceDetector`,
+    // so standard `OTEL_RESOURCE_ATTRIBUTES` entries (helm sets
+    // `deployment.environment` there) merge in without bespoke code.
+    Resource::builder()
+        .with_attributes([
+            KeyValue::new("service.name", service_name),
+            KeyValue::new("service.version", service_version),
+            KeyValue::new("service.instance.id", service_instance_id),
+        ])
+        .build()
 }
 
 /// Parsed trace-sampler configuration. Mirrors the OTel spec's
@@ -76,15 +76,19 @@ fn sampler_choice(name: Option<String>, arg: Option<String>) -> SamplerChoice {
         .filter(|ratio| (0.0..=1.0).contains(ratio))
         .unwrap_or(1.0);
 
-    match nonblank(name).as_deref() {
+    // Sampler names are matched case-insensitively per the OTel
+    // env-var spec. The ratio argument applies only when a ratio
+    // sampler is explicitly selected; unset or unrecognized names get
+    // the documented default with ratio 1.0 so a stray
+    // OTEL_TRACES_SAMPLER_ARG can never silently shed traces.
+    match nonblank(name).map(|n| n.to_ascii_lowercase()).as_deref() {
         Some("always_on") => SamplerChoice::AlwaysOn,
         Some("always_off") => SamplerChoice::AlwaysOff,
         Some("traceidratio") => SamplerChoice::TraceIdRatio(ratio),
         Some("parentbased_always_on") => SamplerChoice::ParentBasedAlwaysOn,
         Some("parentbased_always_off") => SamplerChoice::ParentBasedAlwaysOff,
-        // "parentbased_traceidratio", unset, and anything
-        // unrecognized: the spec default.
-        _ => SamplerChoice::ParentBasedTraceIdRatio(ratio),
+        Some("parentbased_traceidratio") => SamplerChoice::ParentBasedTraceIdRatio(ratio),
+        _ => SamplerChoice::ParentBasedTraceIdRatio(1.0),
     }
 }
 
@@ -102,6 +106,20 @@ impl SamplerChoice {
             }
         }
     }
+}
+
+/// The `OTEL_TRACES_SAMPLER` names `sampler_choice` maps to a
+/// dedicated variant (everything else falls back to the default).
+fn is_known_sampler(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "always_on"
+            | "always_off"
+            | "traceidratio"
+            | "parentbased_always_on"
+            | "parentbased_always_off"
+            | "parentbased_traceidratio"
+    )
 }
 
 fn sampler_from_env() -> opentelemetry_sdk::trace::Sampler {
@@ -229,8 +247,9 @@ fn build_log_filter() -> EnvFilter {
 /// - `OTEL_SERVICE_INSTANCE_ID`: Per-replica instance id (default:
 ///   `<HOSTNAME>-<pid>` — the pod name in Kubernetes — then a
 ///   pid+entropy fallback when no hostname is available)
-/// - `OTEL_DEPLOYMENT_ENVIRONMENT`: Sets the `deployment.environment`
-///   resource attribute (omitted when unset)
+/// - `OTEL_RESOURCE_ATTRIBUTES`: Standard comma-separated resource
+///   attributes (helm sets `deployment.environment=<env>` here),
+///   merged by the SDK's env detector
 /// - `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`: Trace sampler
 ///   (default: `parentbased_traceidratio` with ratio 1.0)
 /// - `RUST_LOG`: Log filter (default: info)
@@ -356,6 +375,17 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         endpoint = %otlp_endpoint,
         "OpenTelemetry initialized with OTLP export"
     );
+
+    // The sampler was resolved before the subscriber existed, so an
+    // unrecognized name could only fall back silently; surface it now.
+    if let Some(name) = nonblank(std::env::var("OTEL_TRACES_SAMPLER").ok()) {
+        if !is_known_sampler(&name) {
+            tracing::warn!(
+                sampler = %name,
+                "Unrecognized OTEL_TRACES_SAMPLER; using parentbased_traceidratio 1.0"
+            );
+        }
+    }
 
     Ok(())
 }
@@ -529,6 +559,36 @@ mod tests {
         assert_eq!(
             super::sampler_choice(Some("parentbased_always_off".to_string()), None),
             SamplerChoice::ParentBasedAlwaysOff
+        );
+    }
+
+    #[test]
+    fn sampler_names_match_case_insensitively() {
+        assert_eq!(
+            super::sampler_choice(Some("ALWAYS_OFF".to_string()), None),
+            super::SamplerChoice::AlwaysOff
+        );
+        assert_eq!(
+            super::sampler_choice(
+                Some("ParentBased_TraceIdRatio".to_string()),
+                Some("0.1".to_string())
+            ),
+            super::SamplerChoice::ParentBasedTraceIdRatio(0.1)
+        );
+        assert!(super::is_known_sampler("TRACEIDRATIO"));
+    }
+
+    #[test]
+    fn sampler_arg_applies_only_to_explicit_ratio_samplers() {
+        // A stray OTEL_TRACES_SAMPLER_ARG with no (or an unknown)
+        // sampler name must never shed traces.
+        assert_eq!(
+            super::sampler_choice(None, Some("0.01".to_string())),
+            super::SamplerChoice::ParentBasedTraceIdRatio(1.0)
+        );
+        assert_eq!(
+            super::sampler_choice(Some("bogus".to_string()), Some("0.01".to_string())),
+            super::SamplerChoice::ParentBasedTraceIdRatio(1.0)
         );
     }
 

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -42,6 +42,10 @@ anyhow = { workspace = true }
 # Observability
 tracing = { workspace = true }
 opentelemetry = { workspace = true }
+# SDK is test-only: production metric emission goes through the API
+# crate (`telemetry` module macros); the SDK is needed solely for the
+# in-memory metric-reader test seam.
+opentelemetry_sdk = { workspace = true, features = ["testing"], optional = true }
 
 # Utilities
 uuid = { workspace = true }
@@ -89,6 +93,7 @@ tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 waddle-xmpp-core = { path = "../waddle-xmpp-core", features = ["test-utils"] }
 mockito = "1.7"
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [features]
 # Exposes `insert_raw_*_for_test` storage helpers (and other test-only
@@ -99,4 +104,4 @@ mockito = "1.7"
 # Enabling `test-utils` here transitively enables the same feature on
 # `waddle-xmpp-core` so the `ArchivedMessage::for_test` fixture
 # constructor is also visible to consumers.
-test-utils = ["waddle-xmpp-core/test-utils"]
+test-utils = ["waddle-xmpp-core/test-utils", "dep:opentelemetry_sdk"]

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -45,6 +45,7 @@ pub mod registry;
 pub mod roster;
 pub mod routing;
 pub mod stream_management;
+pub mod telemetry;
 pub mod tombstone;
 pub mod xep;
 

--- a/server/crates/waddle-xmpp/src/metrics.rs
+++ b/server/crates/waddle-xmpp/src/metrics.rs
@@ -19,6 +19,17 @@ static METER: OnceLock<Meter> = OnceLock::new();
 /// [`adjust_muc_occupant_total`].
 static MUC_OCCUPANT_TOTAL: AtomicI64 = AtomicI64::new(0);
 
+/// Per-pod count of active MUC rooms, published by the room-registry
+/// actor (which serializes its own room-map mutations) after every
+/// insert/remove. Read by the observable rooms gauge.
+static MUC_ROOMS_ACTIVE: AtomicI64 = AtomicI64::new(0);
+
+/// Per-pod count of registered connections, adjusted with ±1 deltas at
+/// exactly the seams that bump the legacy connected-users counter
+/// (register, unregister, and stale-channel eviction). Read by the
+/// observable connections gauge.
+static CONNECTIONS_ACTIVE: AtomicI64 = AtomicI64::new(0);
+
 fn meter() -> &'static Meter {
     METER.get_or_init(|| opentelemetry::global::meter("waddle-xmpp"))
 }
@@ -67,31 +78,50 @@ pub fn muc_presence_events() -> Counter<u64> {
 // Gauges (Current State)
 // ============================================================================
 
-/// Gauge for active XMPP connections.
-pub fn connections_active() -> Gauge<i64> {
-    meter()
-        .i64_gauge("xmpp.connections.active")
-        .with_description("Current number of active XMPP connections")
-        .with_unit("connection")
-        .build()
-}
-
-/// Gauge for active MUC rooms.
-pub fn muc_rooms_active() -> Gauge<i64> {
-    meter()
-        .i64_gauge("xmpp.muc.rooms.active")
-        .with_description("Current number of active MUC rooms")
-        .with_unit("room")
-        .build()
-}
-
-/// Gauge for MUC occupants.
-pub fn muc_occupants() -> Gauge<i64> {
-    meter()
-        .i64_gauge("xmpp.muc.occupants")
-        .with_description("Current number of MUC occupants")
-        .with_unit("user")
-        .build()
+/// The three pod-wide occupancy gauges are **observable**: their values
+/// live in process atomics mutated at the state-change seams, and the
+/// SDK reads the atomics at collection time via callbacks. A callback
+/// read cannot interleave with another writer's `record` the way a
+/// synchronous last-value gauge can (write A computes 1, write B
+/// computes and records 2, write A records 1 → stale forever), so the
+/// exported sample always reflects the latest total.
+///
+/// Registered lazily on the first state change (create-at-increment,
+/// same rule as the macros); the instruments are held here so the
+/// callbacks stay alive for the process lifetime.
+fn ensure_pod_gauges() {
+    static GAUGES: OnceLock<[opentelemetry::metrics::ObservableGauge<i64>; 3]> = OnceLock::new();
+    GAUGES.get_or_init(|| {
+        [
+            meter()
+                .i64_observable_gauge("xmpp.connections.active")
+                .with_description("Current number of active XMPP connections")
+                .with_unit("connection")
+                .with_callback(|observer| {
+                    observer.observe(
+                        CONNECTIONS_ACTIVE.load(Ordering::Relaxed),
+                        &[KeyValue::new("transport", "websocket")],
+                    );
+                })
+                .build(),
+            meter()
+                .i64_observable_gauge("xmpp.muc.rooms.active")
+                .with_description("Current number of active MUC rooms")
+                .with_unit("room")
+                .with_callback(|observer| {
+                    observer.observe(MUC_ROOMS_ACTIVE.load(Ordering::Relaxed), &[]);
+                })
+                .build(),
+            meter()
+                .i64_observable_gauge("xmpp.muc.occupants")
+                .with_description("Current number of MUC occupants")
+                .with_unit("user")
+                .with_callback(|observer| {
+                    observer.observe(MUC_OCCUPANT_TOTAL.load(Ordering::Relaxed), &[]);
+                })
+                .build(),
+        ]
+    });
 }
 
 // ============================================================================
@@ -192,16 +222,22 @@ pub fn record_auth_attempt(mechanism: &str, success: bool) {
     );
 }
 
-/// Record connection count change.
-pub fn record_connection_count(count: i64, transport: &str) {
-    connections_active().record(count, &[KeyValue::new("transport", transport.to_string())]);
+/// Apply a ±1 delta to the per-pod connection count. Call `+1` exactly
+/// where the legacy connected-users counter increments (a genuinely new
+/// registration) and `-1` where it decrements (unregister or
+/// stale-channel eviction), so both stay in lockstep.
+pub fn adjust_connections_active(delta: i64) {
+    CONNECTIONS_ACTIVE.fetch_add(delta, Ordering::Relaxed);
+    ensure_pod_gauges();
 }
 
-/// Publish the current number of active MUC rooms on this pod to the
-/// `xmpp.muc.rooms.active` gauge. No attributes — the room JID is
-/// unbounded and never a metric dimension.
-pub fn record_muc_rooms_active(count: i64) {
-    muc_rooms_active().record(count, &[]);
+/// Publish the current number of active MUC rooms on this pod. Called by
+/// the room-registry actor after every room-map mutation — the actor
+/// serializes those, so a plain store is race-free. No attributes: the
+/// room JID is unbounded and never a metric dimension.
+pub fn publish_muc_rooms_active(count: i64) {
+    MUC_ROOMS_ACTIVE.store(count, Ordering::Relaxed);
+    ensure_pod_gauges();
 }
 
 /// Record stanza processing latency in milliseconds.
@@ -308,24 +344,17 @@ pub fn record_muc_presence(event_type: &str) {
     muc_presence_events().add(1, &[KeyValue::new("event", event_type.to_string())]);
 }
 
-/// Publish the pod-wide MUC occupant total to the `xmpp.muc.occupants`
-/// gauge. The room JID is not an attribute (unbounded); this is the
-/// single per-pod total across every active room.
-pub fn record_muc_occupant_count(count: i64) {
-    muc_occupants().record(count, &[]);
-}
-
-/// Apply a signed occupancy `delta` to the per-pod running total and
-/// republish it to the occupants gauge. Call with `+1` when a join adds
-/// a brand-new occupant, `-1` when a leave removes an occupant's last
-/// session, and `0` for multi-session joins / partial leaves that leave
-/// the occupant set unchanged (pass the pre/post occupant-count diff and
-/// this holds automatically).
+/// Apply a signed occupancy `delta` to the per-pod running total. Call
+/// with `+1` when a join adds a brand-new occupant, `-1` when a leave
+/// removes an occupant's last session, and `0` for multi-session joins /
+/// partial leaves that leave the occupant set unchanged (pass the
+/// pre/post occupant-count diff and this holds automatically). The
+/// observable occupants gauge reads the atomic at collection time, so
+/// concurrent adjustments from independent room actors can never publish
+/// a stale total.
 pub fn adjust_muc_occupant_total(delta: i64) {
-    let total = MUC_OCCUPANT_TOTAL
-        .fetch_add(delta, Ordering::Relaxed)
-        .saturating_add(delta);
-    record_muc_occupant_count(total);
+    MUC_OCCUPANT_TOTAL.fetch_add(delta, Ordering::Relaxed);
+    ensure_pod_gauges();
 }
 
 // ============================================================================
@@ -400,26 +429,26 @@ mod tests {
     #[tokio::test]
     async fn record_muc_rooms_active_emits_gauge() {
         let guard = test_support::acquire().await;
-        record_muc_rooms_active(3);
+        publish_muc_rooms_active(3);
 
         assert!(
             guard
                 .metric_names()
                 .contains(&"xmpp.muc.rooms.active".to_string()),
-            "rooms-active gauge must export after a recording",
+            "rooms-active gauge must export after a publication",
         );
     }
 
     #[tokio::test]
     async fn record_connection_count_emits_transport_gauge() {
         let guard = test_support::acquire().await;
-        record_connection_count(7, "websocket");
+        adjust_connections_active(7);
 
         assert!(
             guard
                 .metric_names()
                 .contains(&"xmpp.connections.active".to_string()),
-            "connections gauge must export after a recording",
+            "connections gauge must export after an adjustment",
         );
     }
 

--- a/server/crates/waddle-xmpp/src/metrics.rs
+++ b/server/crates/waddle-xmpp/src/metrics.rs
@@ -6,9 +6,18 @@
 
 use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 use opentelemetry::KeyValue;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::OnceLock;
 
 static METER: OnceLock<Meter> = OnceLock::new();
+
+/// Per-pod running total of MUC occupants (nicks) across every active
+/// room on this process. Occupancy changes happen inside independent
+/// per-room actors, so the pod-wide gauge value cannot be read cheaply
+/// from any single room; instead each occupancy change contributes a
+/// signed delta here and republishes the resulting total. See
+/// [`adjust_muc_occupant_total`].
+static MUC_OCCUPANT_TOTAL: AtomicI64 = AtomicI64::new(0);
 
 fn meter() -> &'static Meter {
     METER.get_or_init(|| opentelemetry::global::meter("waddle-xmpp"))
@@ -188,6 +197,13 @@ pub fn record_connection_count(count: i64, transport: &str) {
     connections_active().record(count, &[KeyValue::new("transport", transport.to_string())]);
 }
 
+/// Publish the current number of active MUC rooms on this pod to the
+/// `xmpp.muc.rooms.active` gauge. No attributes — the room JID is
+/// unbounded and never a metric dimension.
+pub fn record_muc_rooms_active(count: i64) {
+    muc_rooms_active().record(count, &[]);
+}
+
 /// Record stanza processing latency in milliseconds.
 pub fn record_stanza_latency(latency_ms: f64, stanza_type: &str) {
     stanza_latency().record(
@@ -278,20 +294,38 @@ pub fn record_actor_restart(actor: &str, reason: &str) {
     );
 }
 
-/// Record a MUC presence event (join or leave).
-pub fn record_muc_presence(event_type: &str, room: &str) {
-    muc_presence_events().add(
-        1,
-        &[
-            KeyValue::new("event", event_type.to_string()),
-            KeyValue::new("room", room.to_string()),
-        ],
-    );
+/// Record one MUC groupchat message accepted for room fanout.
+pub fn record_muc_message() {
+    muc_messages().add(1, &[]);
 }
 
-/// Update the MUC occupants gauge.
-pub fn record_muc_occupant_count(count: i64, room: &str) {
-    muc_occupants().record(count, &[KeyValue::new("room", room.to_string())]);
+/// Record a MUC presence event (join or leave).
+///
+/// `event_type` is a bounded label (`"join"` / `"leave"`); the room JID
+/// is deliberately not an attribute — it is unbounded and belongs on
+/// spans/logs per the cardinality budget (`telemetry` module docs).
+pub fn record_muc_presence(event_type: &str) {
+    muc_presence_events().add(1, &[KeyValue::new("event", event_type.to_string())]);
+}
+
+/// Publish the pod-wide MUC occupant total to the `xmpp.muc.occupants`
+/// gauge. The room JID is not an attribute (unbounded); this is the
+/// single per-pod total across every active room.
+pub fn record_muc_occupant_count(count: i64) {
+    muc_occupants().record(count, &[]);
+}
+
+/// Apply a signed occupancy `delta` to the per-pod running total and
+/// republish it to the occupants gauge. Call with `+1` when a join adds
+/// a brand-new occupant, `-1` when a leave removes an occupant's last
+/// session, and `0` for multi-session joins / partial leaves that leave
+/// the occupant set unchanged (pass the pre/post occupant-count diff and
+/// this holds automatically).
+pub fn adjust_muc_occupant_total(delta: i64) {
+    let total = MUC_OCCUPANT_TOTAL
+        .fetch_add(delta, Ordering::Relaxed)
+        .saturating_add(delta);
+    record_muc_occupant_count(total);
 }
 
 // ============================================================================
@@ -321,6 +355,112 @@ pub fn record_extension_enrichment(latency_ms: f64, embeds: u64) {
     extension_enrichment_latency().record(latency_ms, &[]);
     if embeds > 0 {
         extension_embeds_added().add(embeds, &[]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::test_support;
+
+    #[tokio::test]
+    async fn record_muc_presence_emits_bounded_event_label() {
+        let guard = test_support::acquire().await;
+        record_muc_presence("join");
+        record_muc_presence("join");
+        record_muc_presence("leave");
+
+        assert_eq!(
+            guard.counter_sum("xmpp.muc.presence", &[("event", "join")]),
+            Some(2),
+        );
+        assert_eq!(
+            guard.counter_sum("xmpp.muc.presence", &[("event", "leave")]),
+            Some(1),
+        );
+    }
+
+    #[tokio::test]
+    async fn adjust_muc_occupant_total_publishes_running_total_gauge() {
+        let guard = test_support::acquire().await;
+        // A brand-new occupant, then a multi-session join (delta 0), then
+        // a leave that removed the last session.
+        adjust_muc_occupant_total(1);
+        adjust_muc_occupant_total(0);
+        adjust_muc_occupant_total(-1);
+
+        assert!(
+            guard
+                .metric_names()
+                .contains(&"xmpp.muc.occupants".to_string()),
+            "occupants gauge must export after an adjustment",
+        );
+    }
+
+    #[tokio::test]
+    async fn record_muc_rooms_active_emits_gauge() {
+        let guard = test_support::acquire().await;
+        record_muc_rooms_active(3);
+
+        assert!(
+            guard
+                .metric_names()
+                .contains(&"xmpp.muc.rooms.active".to_string()),
+            "rooms-active gauge must export after a recording",
+        );
+    }
+
+    #[tokio::test]
+    async fn record_connection_count_emits_transport_gauge() {
+        let guard = test_support::acquire().await;
+        record_connection_count(7, "websocket");
+
+        assert!(
+            guard
+                .metric_names()
+                .contains(&"xmpp.connections.active".to_string()),
+            "connections gauge must export after a recording",
+        );
+    }
+
+    #[tokio::test]
+    async fn record_auth_attempt_labels_outcome() {
+        let guard = test_support::acquire().await;
+        record_auth_attempt("SCRAM-SHA-256", true);
+        record_auth_attempt("SCRAM-SHA-256", false);
+
+        assert_eq!(
+            guard.counter_sum(
+                "xmpp.auth.attempts",
+                &[("mechanism", "SCRAM-SHA-256"), ("result", "success")],
+            ),
+            Some(1),
+        );
+        assert_eq!(
+            guard.counter_sum(
+                "xmpp.auth.attempts",
+                &[("mechanism", "SCRAM-SHA-256"), ("result", "failure")],
+            ),
+            Some(1),
+        );
+    }
+
+    #[tokio::test]
+    async fn record_extension_enrichment_counts_only_added_embeds() {
+        let guard = test_support::acquire().await;
+        // A zero-embed pass records latency but must not touch the embed
+        // counter; a two-embed pass adds two.
+        record_extension_enrichment(1.5, 0);
+        record_extension_enrichment(2.0, 2);
+
+        assert_eq!(
+            guard.counter_sum("xmpp.extensions.embeds.added", &[]),
+            Some(2),
+        );
+        assert_eq!(
+            guard.histogram_count("xmpp.extensions.enrichment.latency", &[]),
+            Some(2),
+        );
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -575,6 +575,21 @@ pub enum RoomActorError {
     OwnershipUnavailable,
 }
 
+impl Drop for RoomActor {
+    fn drop(&mut self) {
+        // Compensate the pod-wide `xmpp.muc.occupants` gauge for any
+        // occupants still present when this actor tears down — owner
+        // destroy, dormancy/seal eviction, and supervision replacement
+        // all bypass `LeaveByRealJid`, so join/leave deltas alone would
+        // inflate the process-lifetime total forever. `Drop` is the one
+        // seam every teardown path shares.
+        let remaining = self.room.occupants.len();
+        if remaining > 0 {
+            crate::metrics::adjust_muc_occupant_total(-(remaining as i64));
+        }
+    }
+}
+
 impl RoomActor {
     /// Create a new `RoomActor` wrapping the given room.
     pub fn new(

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -182,6 +182,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
             })
             .collect();
 
+        let occupant_count_before = self.room.occupant_count();
         let new_occupant = self.room.add_occupant_with_affiliation(
             msg.sender_jid,
             msg.nick.clone(),
@@ -190,6 +191,14 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         let new_occupant_affiliation = new_occupant.affiliation;
         let new_occupant_role = new_occupant.role;
         let occupant_count = self.room.occupant_count();
+        // Observability (#1320): every accepted join is a MUC presence
+        // event; the pod-wide occupant gauge advances only when the
+        // occupant set actually grew (multi-session joins / rejoins add a
+        // session, not an occupant, so the diff is 0).
+        crate::metrics::record_muc_presence("join");
+        crate::metrics::adjust_muc_occupant_total(
+            occupant_count as i64 - occupant_count_before as i64,
+        );
         let room_jid = self.room.room_jid.clone();
         if matches!(msg.affiliation_grant, JoinAffiliationGrant::Resolver(_))
             && !resolver_join_advanced_admission_revision
@@ -278,6 +287,7 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
             .muji_state
             .get(&nick)
             .is_some_and(|entries| entries.contains_key(&msg.sender_jid));
+        let occupant_count_before = self.room.occupant_count();
         let removed_last_session = self
             .room
             .remove_occupant_session(&nick, &msg.sender_jid)
@@ -308,6 +318,13 @@ impl kameo::message::Message<LeaveByRealJid> for RoomActor {
                 .map(|occupant| occupant.real_jid.clone())
         };
         let occupant_count = self.room.occupant_count();
+        // Observability (#1320): a processed leave is a MUC presence
+        // event; the occupant gauge decreases only when this leave
+        // removed the occupant's final session.
+        crate::metrics::record_muc_presence("leave");
+        crate::metrics::adjust_muc_occupant_total(
+            occupant_count as i64 - occupant_count_before as i64,
+        );
         let is_persistent = self.room.config.persistent;
         let occupancy_revision = self.occupancy_revision;
         Ok(Some(LeaveOutcome {

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -320,6 +320,47 @@ async fn test_join_existing_session_allowed_when_room_full() {
 }
 
 #[tokio::test]
+async fn join_and_leave_emit_presence_and_occupant_metrics() {
+    let guard = crate::telemetry::test_support::acquire().await;
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+            local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&actor).await,
+        })
+        .await
+        .expect("join should succeed");
+
+    assert_eq!(
+        guard.counter_sum("xmpp.muc.presence", &[("event", "join")]),
+        Some(1),
+        "an accepted join must emit exactly one presence join event",
+    );
+    assert!(
+        guard
+            .metric_names()
+            .contains(&"xmpp.muc.occupants".to_string()),
+        "a brand-new occupant must publish the occupants gauge",
+    );
+
+    actor
+        .ask(LeaveByRealJid { sender_jid: alice })
+        .await
+        .expect("leave is infallible");
+
+    assert_eq!(
+        guard.counter_sum("xmpp.muc.presence", &[("event", "leave")]),
+        Some(1),
+        "a processed leave must emit exactly one presence leave event",
+    );
+}
+
+#[tokio::test]
 async fn test_leave() {
     let actor = spawn_room_actor().await;
 

--- a/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
@@ -18,12 +18,21 @@ impl MucRoom {
     /// - The message is sent from the room JID with sender's nick as resource
     /// - All occupants receive the message (including the sender as echo)
     /// - Visitors in moderated rooms cannot send messages
-    #[instrument(skip(self, message), fields(room = %self.room_jid))]
+    #[instrument(
+        name = "xmpp.muc.fanout",
+        skip(self, message),
+        fields(
+            room = %self.room_jid,
+            message_id = message.id.as_ref().map(|id| id.0.as_str()).unwrap_or_default(),
+            recipients = tracing::field::Empty,
+        )
+    )]
     pub fn broadcast_message(
         &self,
         sender_nick: &str,
         message: &Message,
     ) -> Result<Vec<OutboundMucMessage>, XmppError> {
+        let fanout_started = std::time::Instant::now();
         let sender = self.occupants.get(sender_nick).ok_or_else(|| {
             XmppError::forbidden(Some(format!(
                 "You are not an occupant of {}",
@@ -60,6 +69,16 @@ impl MucRoom {
                 outbound.push(OutboundMucMessage::new(recipient_jid, broadcast_msg));
             }
         }
+
+        tracing::Span::current().record("recipients", outbound.len());
+        crate::metrics::record_muc_message();
+        crate::histogram_record!(
+            "waddle.muc.fanout.duration",
+            "ms",
+            "MUC fanout latency: groupchat broadcast accepted until every \
+             per-recipient send is enqueued.",
+            fanout_started.elapsed().as_secs_f64() * 1000.0,
+        );
 
         debug!(
             message_count = outbound.len(),

--- a/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
@@ -75,8 +75,8 @@ impl MucRoom {
         crate::histogram_record!(
             "waddle.muc.fanout.duration",
             "ms",
-            "MUC fanout latency: groupchat broadcast accepted until every \
-             per-recipient send is enqueued.",
+            "MUC fanout latency: groupchat broadcast accepted until the \
+             per-recipient outbound set is built.",
             fanout_started.elapsed().as_secs_f64() * 1000.0,
         );
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry.rs
@@ -140,6 +140,7 @@ impl MucRoomRegistry {
         self.rooms.insert(room_jid.clone(), handle.clone());
         self.room_data.insert(room_jid.clone(), room_data);
         prometheus::increment_room_count();
+        crate::metrics::record_muc_rooms_active(self.room_count() as i64);
 
         info!("Created new MUC room");
         Ok(handle)
@@ -210,6 +211,7 @@ impl MucRoomRegistry {
         self.rooms.insert(room_jid.clone(), handle.clone());
         self.room_data.insert(room_jid.clone(), room_data);
         prometheus::increment_room_count();
+        crate::metrics::record_muc_rooms_active(self.room_count() as i64);
 
         info!("Created instant MUC room (XEP-0045)");
         Ok(handle)
@@ -222,6 +224,7 @@ impl MucRoomRegistry {
         let removed = self.rooms.remove(room_jid);
         if removed.is_some() {
             prometheus::decrement_room_count();
+            crate::metrics::record_muc_rooms_active(self.room_count() as i64);
             info!("Destroyed MUC room");
         } else {
             warn!("Attempted to destroy non-existent room");

--- a/server/crates/waddle-xmpp/src/muc/room_registry.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry.rs
@@ -140,7 +140,7 @@ impl MucRoomRegistry {
         self.rooms.insert(room_jid.clone(), handle.clone());
         self.room_data.insert(room_jid.clone(), room_data);
         prometheus::increment_room_count();
-        crate::metrics::record_muc_rooms_active(self.room_count() as i64);
+        crate::metrics::publish_muc_rooms_active(self.room_count() as i64);
 
         info!("Created new MUC room");
         Ok(handle)
@@ -211,7 +211,7 @@ impl MucRoomRegistry {
         self.rooms.insert(room_jid.clone(), handle.clone());
         self.room_data.insert(room_jid.clone(), room_data);
         prometheus::increment_room_count();
-        crate::metrics::record_muc_rooms_active(self.room_count() as i64);
+        crate::metrics::publish_muc_rooms_active(self.room_count() as i64);
 
         info!("Created instant MUC room (XEP-0045)");
         Ok(handle)
@@ -224,7 +224,7 @@ impl MucRoomRegistry {
         let removed = self.rooms.remove(room_jid);
         if removed.is_some() {
             prometheus::decrement_room_count();
-            crate::metrics::record_muc_rooms_active(self.room_count() as i64);
+            crate::metrics::publish_muc_rooms_active(self.room_count() as i64);
             info!("Destroyed MUC room");
         } else {
             warn!("Attempted to destroy non-existent room");

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -558,8 +558,18 @@ impl RoomRegistryActor {
         }
     }
 
+    /// Publish the current room count to the pod-wide rooms gauge.
+    /// Called after every `self.rooms` mutation; the actor serializes
+    /// those, so the published value is exact (#1415 review — the gauge
+    /// was previously wired only into the test-only legacy registry and
+    /// never emitted in production).
+    fn publish_room_count(&self) {
+        crate::metrics::publish_muc_rooms_active(self.rooms.len() as i64);
+    }
+
     async fn evict_ownership_lost_room(&mut self, room_jid: &BareJid, entry: RoomEntry) {
         self.rooms.remove(room_jid);
+        self.publish_room_count();
         self.poisoned_rooms.remove(room_jid);
         self.retire_ownership_lost_entry(room_jid, entry).await;
     }
@@ -1743,6 +1753,7 @@ impl RoomRegistryActor {
                 claim_fence: claim_fence.clone(),
             },
         );
+        self.publish_room_count();
         // The cache is a legacy room-JID fan-out fence. Make it visible only
         // after its matching ready actor and immutable fence are in the
         // registry, so a predecessor cannot borrow the successor generation.
@@ -1796,6 +1807,7 @@ impl RoomRegistryActor {
                 }
             }
             self.rooms.remove(room_jid);
+            self.publish_room_count();
             self.poisoned_rooms.insert(room_jid.clone());
             warn!(
                 room = %room_jid,
@@ -2005,6 +2017,7 @@ impl RoomRegistryActor {
                         .is_some_and(|entry| entry.claim_fence == claim_fence);
                     if matching_entry {
                         self.rooms.remove(&room_jid);
+                        self.publish_room_count();
                     }
                     actor_ref.kill();
                     self.transfer_exact_responsibility_to_pending_release(
@@ -3060,6 +3073,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             {
                 if let Some(entry) = self.rooms.remove(&msg.room_jid) {
                     entry.actor_ref.kill();
+                    self.publish_room_count();
                 }
             }
             self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
@@ -3095,6 +3109,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             {
                 if let Some(entry) = self.rooms.remove(&msg.room_jid) {
                     entry.actor_ref.kill();
+                    self.publish_room_count();
                 }
             }
             if let Some(store) = &self.durable_store {
@@ -3119,6 +3134,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                 entry.actor_ref.kill();
             }
             self.rooms.remove(&msg.room_jid);
+            self.publish_room_count();
             if let Some(store) = &self.durable_store {
                 store.forget_claim_fence(&msg.room_jid, &entry.claim_fence);
             }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
@@ -54,7 +54,7 @@ impl ConnectionRegistry {
             debug!("Replaced existing connection registration");
         } else {
             prometheus::increment_connected_users();
-            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+            crate::metrics::adjust_connections_active(1);
             debug!("Registered new connection");
         }
         carbons_handle
@@ -75,7 +75,7 @@ impl ConnectionRegistry {
             debug!("Replaced existing connection registration");
         } else {
             prometheus::increment_connected_users();
-            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+            crate::metrics::adjust_connections_active(1);
             debug!("Registered new connection");
         }
         carbons_handle
@@ -106,7 +106,7 @@ impl ConnectionRegistry {
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
                 vacant.insert(entry);
                 prometheus::increment_connected_users();
-                crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+                crate::metrics::adjust_connections_active(1);
                 debug!("Registered new connection");
                 true
             }
@@ -121,7 +121,7 @@ impl ConnectionRegistry {
         let removed = self.connections.remove(jid);
         if removed.is_some() {
             prometheus::decrement_connected_users();
-            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+            crate::metrics::adjust_connections_active(-1);
             self.presence_states.remove(jid);
             debug!("Unregistered connection");
         } else {
@@ -143,7 +143,7 @@ impl ConnectionRegistry {
         });
         if removed.is_some() {
             prometheus::decrement_connected_users();
-            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+            crate::metrics::adjust_connections_active(-1);
             self.presence_states.remove(jid);
             debug!("Unregistered owned connection");
         } else {
@@ -173,7 +173,7 @@ impl ConnectionRegistry {
         });
         if removed.is_some() {
             prometheus::decrement_connected_users();
-            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
+            crate::metrics::adjust_connections_active(-1);
             self.presence_states.remove(jid);
             debug!("Unregistered SM-owned connection at expiry");
         } else {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
@@ -54,6 +54,7 @@ impl ConnectionRegistry {
             debug!("Replaced existing connection registration");
         } else {
             prometheus::increment_connected_users();
+            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
             debug!("Registered new connection");
         }
         carbons_handle
@@ -74,6 +75,7 @@ impl ConnectionRegistry {
             debug!("Replaced existing connection registration");
         } else {
             prometheus::increment_connected_users();
+            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
             debug!("Registered new connection");
         }
         carbons_handle
@@ -104,6 +106,7 @@ impl ConnectionRegistry {
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
                 vacant.insert(entry);
                 prometheus::increment_connected_users();
+                crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
                 debug!("Registered new connection");
                 true
             }
@@ -118,6 +121,7 @@ impl ConnectionRegistry {
         let removed = self.connections.remove(jid);
         if removed.is_some() {
             prometheus::decrement_connected_users();
+            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
             self.presence_states.remove(jid);
             debug!("Unregistered connection");
         } else {
@@ -139,6 +143,7 @@ impl ConnectionRegistry {
         });
         if removed.is_some() {
             prometheus::decrement_connected_users();
+            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
             self.presence_states.remove(jid);
             debug!("Unregistered owned connection");
         } else {
@@ -168,6 +173,7 @@ impl ConnectionRegistry {
         });
         if removed.is_some() {
             prometheus::decrement_connected_users();
+            crate::metrics::record_connection_count(self.connections.len() as i64, "websocket");
             self.presence_states.remove(jid);
             debug!("Unregistered SM-owned connection at expiry");
         } else {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -250,13 +250,14 @@ impl ConnectionRegistry {
             }
         };
 
-        let delivered_kind = crate::telemetry::messages::delivered_message_kind(&outbound.stanza);
+        // Deliberately NOT counted in `waddle.messages.delivered`: the only
+        // production caller is the clustered route bridge on the socket
+        // node, and the message was already counted on the UserActor-owner
+        // node when it entered the relay pump — counting here would double
+        // every cross-node delivery.
         match sender.try_send(outbound) {
             Ok(()) => {
                 prometheus::increment_broadcast_delivered();
-                if let Some(kind) = delivered_kind {
-                    crate::telemetry::messages::record_delivered_message(kind);
-                }
                 BroadcastOutcome::Delivered
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -289,6 +289,7 @@ impl ConnectionRegistry {
             .remove_if(jid, |_, entry| entry.sender.is_closed());
         if removed.is_some() {
             prometheus::decrement_connected_users();
+            crate::metrics::adjust_connections_active(-1);
             self.presence_states.remove(jid);
             debug!(jid = %jid, "Evicted stale closed connection entry");
         }
@@ -310,6 +311,7 @@ impl ConnectionRegistry {
         });
         if removed.is_some() {
             prometheus::decrement_connected_users();
+            crate::metrics::adjust_connections_active(-1);
             self.presence_states.remove(jid);
             debug!(jid = %jid, "Evicted stale owned closed connection entry");
         }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -194,9 +194,13 @@ impl ConnectionRegistry {
             }
         };
 
+        let delivered_kind = crate::telemetry::messages::delivered_message_kind(&stanza);
         match sender.try_send(OutboundStanza::new(stanza)) {
             Ok(()) => {
                 prometheus::increment_broadcast_delivered();
+                if let Some(kind) = delivered_kind {
+                    crate::telemetry::messages::record_delivered_message(kind);
+                }
                 BroadcastOutcome::Delivered
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -246,9 +250,13 @@ impl ConnectionRegistry {
             }
         };
 
+        let delivered_kind = crate::telemetry::messages::delivered_message_kind(&outbound.stanza);
         match sender.try_send(outbound) {
             Ok(()) => {
                 prometheus::increment_broadcast_delivered();
+                if let Some(kind) = delivered_kind {
+                    crate::telemetry::messages::record_delivered_message(kind);
+                }
                 BroadcastOutcome::Delivered
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -252,9 +252,12 @@ impl ConnectionRegistry {
 
         // Deliberately NOT counted in `waddle.messages.delivered`: the only
         // production caller is the clustered route bridge on the socket
-        // node, and the message was already counted on the UserActor-owner
-        // node when it entered the relay pump — counting here would double
-        // every cross-node delivery.
+        // node, and cross-node deliveries are counted exactly once on the
+        // UserActor-owner node — pump-relayed frames at relay-channel
+        // entry (`try_deliver`/`try_send_to`), direct remote-resource
+        // frames on the socket node's Delivered acknowledgment in
+        // `deliver_registered_remote_resource_with_registration`.
+        // Counting here would double every cross-node delivery.
         match sender.try_send(outbound) {
             Ok(()) => {
                 prometheus::increment_broadcast_delivered();

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
@@ -55,6 +55,24 @@ fn test_register_connection() {
     assert_eq!(registry.connection_count(), 1);
 }
 
+#[tokio::test]
+async fn register_and_unregister_publish_connection_gauge() {
+    let guard = crate::telemetry::test_support::acquire().await;
+    let registry = ConnectionRegistry::new();
+    let jid = test_jid("user1");
+    let (tx, _rx) = mpsc::channel(16);
+
+    registry.register(jid.clone(), tx);
+    registry.unregister(&jid);
+
+    assert!(
+        guard
+            .metric_names()
+            .contains(&"xmpp.connections.active".to_string()),
+        "register/unregister must publish the active-connections gauge",
+    );
+}
+
 #[test]
 fn test_register_replaces_existing() {
     let registry = ConnectionRegistry::new();

--- a/server/crates/waddle-xmpp/src/registry/user_actor/delivery.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor/delivery.rs
@@ -51,9 +51,13 @@ impl UserActor {
             prometheus::increment_broadcast_not_connected();
             return BroadcastOutcome::NotConnected;
         };
+        let delivered_kind = crate::telemetry::messages::delivered_message_kind(&outbound.stanza);
         match entry.sender.try_send(outbound) {
             Ok(()) => {
                 prometheus::increment_broadcast_delivered();
+                if let Some(kind) = delivered_kind {
+                    crate::telemetry::messages::record_delivered_message(kind);
+                }
                 BroadcastOutcome::Delivered
             }
             Err(TrySendError::Full(_)) => {

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -1,0 +1,183 @@
+//! The metric-attribute allowlist (the cardinality budget's teeth).
+//!
+//! Every metric attribute is a closed enum here implementing the
+//! sealed [`MetricAttribute`] trait. The macros in
+//! [`crate::telemetry`] accept only these types, so an unbounded
+//! value — a JID, a room JID, a stream id, a message id, user input —
+//! cannot become a metric attribute by construction. Adding a new
+//! attribute key or value means editing this file, where review can
+//! hold the cardinality line.
+
+use opentelemetry::KeyValue;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A typed metric attribute: a static key and a value drawn from a
+/// closed enum. Sealed — only the allowlist in this module implements
+/// it.
+pub trait MetricAttribute: sealed::Sealed {
+    /// The attribute key, e.g. `"kind"`.
+    fn key(&self) -> &'static str;
+    /// The enumerated attribute value, e.g. `"muc_pm"`.
+    fn value(&self) -> &'static str;
+    /// The OTel key/value pair for this attribute.
+    fn key_value(&self) -> KeyValue {
+        KeyValue::new(self.key(), self.value())
+    }
+}
+
+/// `kind` — what flavor of message traffic a sample counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    /// One-to-one chat message.
+    Dm,
+    /// Groupchat message fanned out through a MUC room.
+    Muc,
+    /// Private message addressed to a single MUC occupant.
+    MucPm,
+}
+
+impl sealed::Sealed for MessageKind {}
+impl MetricAttribute for MessageKind {
+    fn key(&self) -> &'static str {
+        "kind"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Dm => "dm",
+            Self::Muc => "muc",
+            Self::MucPm => "muc_pm",
+        }
+    }
+}
+
+/// `janitor` — which background sweep loop a sample belongs to.
+/// One variant per janitor loop in `waddle-server`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Janitor {
+    /// Expired detached XEP-0198 stream-management sessions.
+    SmExpiry,
+    /// Orphaned SM/room claims after node loss (clustering).
+    OrphanReaper,
+    /// Orphaned/aged-out pending-delivery claims.
+    PendingDeliveryClaim,
+    /// XEP-0357 push publish-job queue.
+    PushPublishJob,
+    /// Notification outbox drain/retry/dead-letter.
+    NotificationOutbox,
+    /// Expired OAuth/device auth state.
+    AuthState,
+    /// Dormant MUC room eviction.
+    RoomDormancy,
+    /// Empty user-actor reaping.
+    UserActorReaper,
+    /// Remote MUC membership reconciliation (clustering).
+    RemoteMucMembership,
+}
+
+impl sealed::Sealed for Janitor {}
+impl MetricAttribute for Janitor {
+    fn key(&self) -> &'static str {
+        "janitor"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::SmExpiry => "sm_expiry",
+            Self::OrphanReaper => "orphan_reaper",
+            Self::PendingDeliveryClaim => "pending_delivery_claim",
+            Self::PushPublishJob => "push_publish_job",
+            Self::NotificationOutbox => "notification_outbox",
+            Self::AuthState => "auth_state",
+            Self::RoomDormancy => "room_dormancy",
+            Self::UserActorReaper => "user_actor_reaper",
+            Self::RemoteMucMembership => "remote_muc_membership",
+        }
+    }
+}
+
+/// `outcome` — how a janitor sweep (or comparable bounded operation)
+/// ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepOutcome {
+    /// The sweep ran to completion, including zero-work sweeps.
+    Completed,
+    /// The sweep aborted on an error.
+    Failed,
+}
+
+impl sealed::Sealed for SweepOutcome {}
+impl MetricAttribute for SweepOutcome {
+    fn key(&self) -> &'static str {
+        "outcome"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// `condition` — the RFC 6120 §8.3.3 defined stanza-error conditions.
+/// This is the complete allowlist; there is deliberately no
+/// catch-all-with-string variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StanzaErrorCondition {
+    BadRequest,
+    Conflict,
+    FeatureNotImplemented,
+    Forbidden,
+    Gone,
+    InternalServerError,
+    ItemNotFound,
+    JidMalformed,
+    NotAcceptable,
+    NotAllowed,
+    NotAuthorized,
+    PolicyViolation,
+    RecipientUnavailable,
+    Redirect,
+    RegistrationRequired,
+    RemoteServerNotFound,
+    RemoteServerTimeout,
+    ResourceConstraint,
+    ServiceUnavailable,
+    SubscriptionRequired,
+    UndefinedCondition,
+    UnexpectedRequest,
+}
+
+impl sealed::Sealed for StanzaErrorCondition {}
+impl MetricAttribute for StanzaErrorCondition {
+    fn key(&self) -> &'static str {
+        "condition"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::BadRequest => "bad-request",
+            Self::Conflict => "conflict",
+            Self::FeatureNotImplemented => "feature-not-implemented",
+            Self::Forbidden => "forbidden",
+            Self::Gone => "gone",
+            Self::InternalServerError => "internal-server-error",
+            Self::ItemNotFound => "item-not-found",
+            Self::JidMalformed => "jid-malformed",
+            Self::NotAcceptable => "not-acceptable",
+            Self::NotAllowed => "not-allowed",
+            Self::NotAuthorized => "not-authorized",
+            Self::PolicyViolation => "policy-violation",
+            Self::RecipientUnavailable => "recipient-unavailable",
+            Self::Redirect => "redirect",
+            Self::RegistrationRequired => "registration-required",
+            Self::RemoteServerNotFound => "remote-server-not-found",
+            Self::RemoteServerTimeout => "remote-server-timeout",
+            Self::ResourceConstraint => "resource-constraint",
+            Self::ServiceUnavailable => "service-unavailable",
+            Self::SubscriptionRequired => "subscription-required",
+            Self::UndefinedCondition => "undefined-condition",
+            Self::UnexpectedRequest => "unexpected-request",
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -120,34 +120,11 @@ impl MetricAttribute for SweepOutcome {
     }
 }
 
-/// `condition` — the RFC 6120 §8.3.3 defined stanza-error conditions.
-/// This is the complete allowlist; there is deliberately no
-/// catch-all-with-string variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StanzaErrorCondition {
-    BadRequest,
-    Conflict,
-    FeatureNotImplemented,
-    Forbidden,
-    Gone,
-    InternalServerError,
-    ItemNotFound,
-    JidMalformed,
-    NotAcceptable,
-    NotAllowed,
-    NotAuthorized,
-    PolicyViolation,
-    RecipientUnavailable,
-    Redirect,
-    RegistrationRequired,
-    RemoteServerNotFound,
-    RemoteServerTimeout,
-    ResourceConstraint,
-    ServiceUnavailable,
-    SubscriptionRequired,
-    UndefinedCondition,
-    UnexpectedRequest,
-}
+/// `condition` — the RFC 6120 §8.3.3 defined stanza-error conditions,
+/// reusing the crate's existing typed enum (its `as_str()` already
+/// yields the hyphenated wire names). Re-exported here so metric call
+/// sites can name it through the allowlist module.
+pub use crate::error::StanzaErrorCondition;
 
 impl sealed::Sealed for StanzaErrorCondition {}
 impl MetricAttribute for StanzaErrorCondition {
@@ -155,29 +132,6 @@ impl MetricAttribute for StanzaErrorCondition {
         "condition"
     }
     fn value(&self) -> &'static str {
-        match self {
-            Self::BadRequest => "bad-request",
-            Self::Conflict => "conflict",
-            Self::FeatureNotImplemented => "feature-not-implemented",
-            Self::Forbidden => "forbidden",
-            Self::Gone => "gone",
-            Self::InternalServerError => "internal-server-error",
-            Self::ItemNotFound => "item-not-found",
-            Self::JidMalformed => "jid-malformed",
-            Self::NotAcceptable => "not-acceptable",
-            Self::NotAllowed => "not-allowed",
-            Self::NotAuthorized => "not-authorized",
-            Self::PolicyViolation => "policy-violation",
-            Self::RecipientUnavailable => "recipient-unavailable",
-            Self::Redirect => "redirect",
-            Self::RegistrationRequired => "registration-required",
-            Self::RemoteServerNotFound => "remote-server-not-found",
-            Self::RemoteServerTimeout => "remote-server-timeout",
-            Self::ResourceConstraint => "resource-constraint",
-            Self::ServiceUnavailable => "service-unavailable",
-            Self::SubscriptionRequired => "subscription-required",
-            Self::UndefinedCondition => "undefined-condition",
-            Self::UnexpectedRequest => "unexpected-request",
-        }
+        self.as_str()
     }
 }

--- a/server/crates/waddle-xmpp/src/telemetry/messages.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/messages.rs
@@ -1,0 +1,127 @@
+//! The flagship traffic metric (#1320): message stanzas delivered to
+//! a local recipient's connection queue, by kind.
+//!
+//! Classification happens once, at the delivery choke points
+//! (`ConnectionRegistry` sends and `UserActor::try_deliver`), from
+//! the stanza itself:
+//!
+//! - `type='groupchat'` → `muc`
+//! - a XEP-0045 §7.5 private message (delivered PMs carry exactly one
+//!   `muc#user` `<x/>` marker) → `muc_pm`
+//! - anything else with a body → `dm`
+//!
+//! Only messages with a body count — chat states, receipts, and
+//! markers are message stanzas but not messages a user would count.
+
+use super::attributes::MessageKind;
+use crate::Stanza;
+use xmpp_parsers::message::MessageType;
+
+/// Classify a stanza about to be queued for local delivery. `None`
+/// for non-messages and body-less message stanzas.
+pub fn delivered_message_kind(stanza: &Stanza) -> Option<MessageKind> {
+    let Stanza::Message(message) = stanza else {
+        return None;
+    };
+    if message.bodies.is_empty() {
+        return None;
+    }
+    if message.type_ == MessageType::Groupchat {
+        return Some(MessageKind::Muc);
+    }
+    let is_muc_pm = message
+        .payloads
+        .iter()
+        .any(|payload| payload.is("x", xmpp_parsers::ns::MUC_USER));
+    if is_muc_pm {
+        Some(MessageKind::MucPm)
+    } else {
+        Some(MessageKind::Dm)
+    }
+}
+
+/// Count one delivered message: the legacy flagship
+/// `waddle_messages_total` text counter (wired at last — #1320) and
+/// its kind-labeled OTel successor.
+pub fn record_delivered_message(kind: MessageKind) {
+    crate::prometheus::record_message_processed();
+    crate::counter_add!(
+        "waddle.messages.delivered",
+        "{message}",
+        "Message stanzas with a body queued to a local recipient's connection, by kind \
+         (dm | muc | muc_pm).",
+        1,
+        kind,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::message::{Lang, Message};
+
+    fn message_with_body(type_: MessageType) -> Message {
+        let mut message = Message::new(Some("peer@example.com".parse().expect("valid jid")));
+        message.type_ = type_;
+        message.bodies.insert(Lang::new(), "hello".to_string());
+        message
+    }
+
+    #[test]
+    fn groupchat_with_body_is_muc() {
+        let stanza = Stanza::Message(message_with_body(MessageType::Groupchat));
+        assert_eq!(delivered_message_kind(&stanza), Some(MessageKind::Muc));
+    }
+
+    #[test]
+    fn chat_with_muc_user_marker_is_muc_pm() {
+        let mut message = message_with_body(MessageType::Chat);
+        message
+            .payloads
+            .push(minidom::Element::builder("x", xmpp_parsers::ns::MUC_USER).build());
+        let stanza = Stanza::Message(message);
+        assert_eq!(delivered_message_kind(&stanza), Some(MessageKind::MucPm));
+    }
+
+    #[test]
+    fn plain_chat_with_body_is_dm() {
+        let stanza = Stanza::Message(message_with_body(MessageType::Chat));
+        assert_eq!(delivered_message_kind(&stanza), Some(MessageKind::Dm));
+    }
+
+    #[test]
+    fn bodyless_messages_and_non_messages_do_not_count() {
+        let mut chat_state_only =
+            Message::new(Some("peer@example.com".parse().expect("valid jid")));
+        chat_state_only.type_ = MessageType::Chat;
+        assert_eq!(
+            delivered_message_kind(&Stanza::Message(chat_state_only)),
+            None
+        );
+        let presence = Stanza::Presence(xmpp_parsers::presence::Presence::new(
+            xmpp_parsers::presence::Type::None,
+        ));
+        assert_eq!(delivered_message_kind(&presence), None);
+    }
+
+    #[tokio::test]
+    async fn record_delivered_message_feeds_both_families() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        crate::prometheus::reset_metrics_for_test();
+
+        record_delivered_message(MessageKind::Dm);
+        record_delivered_message(MessageKind::Muc);
+        record_delivered_message(MessageKind::Muc);
+
+        assert_eq!(
+            guard.counter_sum("waddle.messages.delivered", &[("kind", "dm")]),
+            Some(1)
+        );
+        assert_eq!(
+            guard.counter_sum("waddle.messages.delivered", &[("kind", "muc")]),
+            Some(2)
+        );
+        // The legacy flagship counter must advance in lockstep.
+        assert!(crate::prometheus::render_metrics().contains("waddle_messages_total 3"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -48,6 +48,7 @@
 //! `test`/`test-utils`).
 
 pub mod attributes;
+pub mod messages;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -20,11 +20,26 @@
 //! # Cardinality budget
 //!
 //! Every attribute is a closed enum defined in [`attributes`]; adding
-//! an attribute value means editing that allowlist in review. Worst
-//! case today: ~70 instruments × ≤22 attribute values × 2 pods stays
-//! well under 5k active series. Never implement
+//! an attribute value means editing that allowlist in review. An
+//! instrument takes **at most two attribute dimensions** (review
+//! enforces this; the janitor heartbeat's `janitor` × `outcome` = 18
+//! series is the intended ceiling). Budget: ~70 instruments × ≤22
+//! series each × 2 pods stays well under 5k active series — never
+//! stack the larger enums (`condition` × `janitor` would be 198
+//! series per instrument). Never implement
 //! [`attributes::MetricAttribute`] for a type whose value space is
 //! unbounded (user input, JIDs, ids of any kind).
+//!
+//! # Initialization order
+//!
+//! Instruments bind to the **global meter provider live at their
+//! first increment** and are then cached for the process lifetime.
+//! `waddle-server` installs the OTLP provider in `telemetry::init()`
+//! as the first act of `main`, before any increment can run; keep it
+//! that way — an increment that races ahead of `init()` binds to the
+//! noop provider and is silently lost. In tests, acquire the
+//! [`test_support`] guard before the first increment (under
+//! `cargo nextest`, one process per test, this is automatic).
 //!
 //! # Testing
 //!

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -1,0 +1,182 @@
+//! Create-at-increment OTel metrics — the single convention for new
+//! Waddle metrics (spec #1323, foundation #1325).
+//!
+//! # Convention
+//!
+//! - **Creation and use are the same act.** The only way to emit a
+//!   metric is [`counter_add!`] / [`histogram_record!`]; the first
+//!   invocation lazily creates the instrument behind a `OnceLock`.
+//!   There is no standalone registration API, so a
+//!   registered-but-never-wired metric cannot exist by construction.
+//! - **Names are dot.case** (`waddle.sm.unacked.evicted`), validated
+//!   at compile time by [`validate_metric_name`]. The unit is never
+//!   part of the name.
+//! - **Units are UCUM** and set on the instrument (`"{message}"`,
+//!   `"ms"`, `"By"`, `"1"`).
+//! - **Attributes come only from the enumerated sets** in
+//!   [`attributes`]. JIDs, room JIDs, stream ids, and message ids are
+//!   never metric attributes — they belong on spans and logs.
+//!
+//! # Cardinality budget
+//!
+//! Every attribute is a closed enum defined in [`attributes`]; adding
+//! an attribute value means editing that allowlist in review. Worst
+//! case today: ~70 instruments × ≤22 attribute values × 2 pods stays
+//! well under 5k active series. Never implement
+//! [`attributes::MetricAttribute`] for a type whose value space is
+//! unbounded (user input, JIDs, ids of any kind).
+//!
+//! # Testing
+//!
+//! Tests assert **exported samples**, not internal state, through the
+//! in-memory reader seam in [`test_support`] (gated behind
+//! `test`/`test-utils`).
+
+pub mod attributes;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_support;
+#[cfg(test)]
+mod tests;
+
+/// Macro internals. Not public API — only referenced from macro
+/// expansions, which may live in downstream crates.
+#[doc(hidden)]
+pub mod __export {
+    pub use opentelemetry::metrics::{Counter, Histogram};
+    pub use opentelemetry::KeyValue;
+    pub use std::sync::OnceLock;
+}
+
+/// The meter every macro-created instrument attaches to. Resolved
+/// from the global meter provider at instrument-creation time, so
+/// production instruments bind to the OTLP pipeline installed by
+/// `waddle-server::telemetry::init` and tests bind to the in-memory
+/// reader from [`test_support`].
+#[doc(hidden)]
+pub fn meter() -> opentelemetry::metrics::Meter {
+    opentelemetry::global::meter("waddle")
+}
+
+/// Compile-time metric-name validation: dot.case, lowercase ascii
+/// segments that start with a letter, digits and `_` allowed within a
+/// segment, and no Prometheus-style `_total` suffix (the exporter adds
+/// that at the wire boundary). Returns the name unchanged so the macro
+/// can bind it in a `const`.
+#[must_use]
+pub const fn validate_metric_name(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    assert!(!bytes.is_empty(), "metric name must not be empty");
+    let mut i = 0;
+    let mut segment_len = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if byte == b'.' {
+            assert!(
+                segment_len > 0,
+                "metric name must not have empty segments (leading, trailing, or doubled dots)"
+            );
+            segment_len = 0;
+        } else if byte.is_ascii_lowercase() {
+            segment_len += 1;
+        } else if byte.is_ascii_digit() || byte == b'_' {
+            assert!(
+                segment_len > 0,
+                "metric name segments must start with a lowercase letter"
+            );
+            segment_len += 1;
+        } else {
+            panic!(
+                "metric names are dot.case: lowercase ascii letters, digits and '_' within \
+                 segments, '.' between segments"
+            );
+        }
+        i += 1;
+    }
+    assert!(segment_len > 0, "metric name must not end with '.'");
+
+    const TOTAL_SUFFIX: &[u8] = b"_total";
+    if bytes.len() >= TOTAL_SUFFIX.len() {
+        let offset = bytes.len() - TOTAL_SUFFIX.len();
+        let mut j = 0;
+        let mut is_total = true;
+        while j < TOTAL_SUFFIX.len() {
+            if bytes[offset + j] != TOTAL_SUFFIX[j] {
+                is_total = false;
+                break;
+            }
+            j += 1;
+        }
+        assert!(
+            !is_total,
+            "metric names must not carry a Prometheus-style `_total` suffix; \
+             the exporter appends it at the wire boundary"
+        );
+    }
+
+    name
+}
+
+/// Add to a `u64` counter, creating the instrument on first use.
+///
+/// ```
+/// use waddle_xmpp::counter_add;
+/// use waddle_xmpp::telemetry::attributes::MessageKind;
+///
+/// counter_add!(
+///     "waddle.messages.delivered",
+///     "{message}",
+///     "Message stanzas delivered to a local session.",
+///     1,
+///     MessageKind::Dm,
+/// );
+/// ```
+///
+/// The name is validated at compile time (dot.case, no `_total`
+/// suffix); the unit is UCUM; attributes must implement
+/// [`crate::telemetry::attributes::MetricAttribute`], which only the
+/// enumerated allowlist types do.
+#[macro_export]
+macro_rules! counter_add {
+    ($name:literal, $unit:literal, $desc:literal, $value:expr $(, $attr:expr)* $(,)?) => {{
+        const _VALIDATED: &str = $crate::telemetry::validate_metric_name($name);
+        static INSTRUMENT: $crate::telemetry::__export::OnceLock<
+            $crate::telemetry::__export::Counter<u64>,
+        > = $crate::telemetry::__export::OnceLock::new();
+        let attributes: &[$crate::telemetry::__export::KeyValue] = &[
+            $($crate::telemetry::attributes::MetricAttribute::key_value(&$attr)),*
+        ];
+        INSTRUMENT
+            .get_or_init(|| {
+                $crate::telemetry::meter()
+                    .u64_counter($name)
+                    .with_unit($unit)
+                    .with_description($desc)
+                    .build()
+            })
+            .add($value, attributes);
+    }};
+}
+
+/// Record into an `f64` histogram, creating the instrument on first
+/// use. Same naming/unit/attribute rules as [`counter_add!`].
+#[macro_export]
+macro_rules! histogram_record {
+    ($name:literal, $unit:literal, $desc:literal, $value:expr $(, $attr:expr)* $(,)?) => {{
+        const _VALIDATED: &str = $crate::telemetry::validate_metric_name($name);
+        static INSTRUMENT: $crate::telemetry::__export::OnceLock<
+            $crate::telemetry::__export::Histogram<f64>,
+        > = $crate::telemetry::__export::OnceLock::new();
+        let attributes: &[$crate::telemetry::__export::KeyValue] = &[
+            $($crate::telemetry::attributes::MetricAttribute::key_value(&$attr)),*
+        ];
+        INSTRUMENT
+            .get_or_init(|| {
+                $crate::telemetry::meter()
+                    .f64_histogram($name)
+                    .with_unit($unit)
+                    .with_description($desc)
+                    .build()
+            })
+            .record($value, attributes);
+    }};
+}

--- a/server/crates/waddle-xmpp/src/telemetry/test_support.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/test_support.rs
@@ -1,0 +1,170 @@
+//! In-memory metric-reader test seam — the one approved metric test
+//! seam from spec #1323.
+//!
+//! Tests assert **exported samples** (name, unit, attributes, value),
+//! never instrument internals. The pipeline is a process-global
+//! `SdkMeterProvider` backed by an [`InMemoryMetricExporter`] with
+//! **delta temporality**: each [`MetricsTestGuard`] drains the
+//! exporter on acquire, so a test observes only increments made while
+//! it holds the guard.
+//!
+//! Serialization piggybacks on the existing
+//! [`crate::prometheus::metrics_test_lock`] pattern so tests touching
+//! the OTel pipeline, the legacy atomics, or both (dual-emit
+//! migration tests) all contend on the same lock.
+//!
+//! The provider is installed globally exactly once per process and
+//! never swapped, so instruments cached in macro `OnceLock`s always
+//! bind to it — provided the guard is acquired before the first
+//! increment in the process. Under `cargo nextest` (one process per
+//! test) this holds trivially.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, InMemoryMetricExporterBuilder, PeriodicReader, SdkMeterProvider,
+    Temporality,
+};
+
+struct TestPipeline {
+    exporter: InMemoryMetricExporter,
+    provider: SdkMeterProvider,
+}
+
+fn pipeline() -> &'static TestPipeline {
+    static PIPELINE: OnceLock<TestPipeline> = OnceLock::new();
+    PIPELINE.get_or_init(|| {
+        let exporter = InMemoryMetricExporterBuilder::new()
+            .with_temporality(Temporality::Delta)
+            .build();
+        // The interval only exists to keep the background reader
+        // quiet; collection happens through `force_flush`.
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(Duration::from_secs(3600))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        opentelemetry::global::set_meter_provider(provider.clone());
+        TestPipeline { exporter, provider }
+    })
+}
+
+/// Serialize on the shared metrics lock, install the in-memory
+/// pipeline (idempotent), and drain samples left over from earlier
+/// tests in this process.
+pub async fn acquire() -> MetricsTestGuard {
+    let lock = crate::prometheus::metrics_test_lock().lock().await;
+    let pipeline = pipeline();
+    let _ = pipeline.provider.force_flush();
+    pipeline.exporter.reset();
+    MetricsTestGuard { _lock: lock }
+}
+
+/// Holds the metrics test lock and reads exported samples.
+pub struct MetricsTestGuard {
+    _lock: tokio::sync::MutexGuard<'static, ()>,
+}
+
+impl MetricsTestGuard {
+    /// Flush and return every batch exported since the guard was
+    /// acquired (delta temporality: values are per-flush deltas).
+    pub fn exported(&self) -> Vec<ResourceMetrics> {
+        let pipeline = pipeline();
+        pipeline
+            .provider
+            .force_flush()
+            .expect("in-memory meter provider must flush");
+        pipeline
+            .exporter
+            .get_finished_metrics()
+            .expect("in-memory exporter must yield finished metrics")
+    }
+
+    /// Names of every metric exported since acquire.
+    pub fn metric_names(&self) -> Vec<String> {
+        self.exported()
+            .iter()
+            .flat_map(|resource| resource.scope_metrics())
+            .flat_map(|scope| scope.metrics())
+            .map(|metric| metric.name().to_string())
+            .collect()
+    }
+
+    /// The UCUM unit of the named metric, if it was exported.
+    pub fn metric_unit(&self, name: &str) -> Option<String> {
+        self.exported()
+            .iter()
+            .flat_map(|resource| resource.scope_metrics())
+            .flat_map(|scope| scope.metrics())
+            .find(|metric| metric.name() == name)
+            .map(|metric| metric.unit().to_string())
+    }
+
+    /// Sum of every `u64` counter data point for `name` whose
+    /// attributes contain all `required` pairs. `None` when the
+    /// instrument never exported (i.e. was never incremented).
+    pub fn counter_sum(&self, name: &str, required: &[(&str, &str)]) -> Option<u64> {
+        let mut found = false;
+        let mut total: u64 = 0;
+        for resource in self.exported() {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    if metric.name() != name {
+                        continue;
+                    }
+                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+                        continue;
+                    };
+                    found = true;
+                    for point in sum.data_points() {
+                        if attributes_contain(point.attributes(), required) {
+                            total += point.value();
+                        }
+                    }
+                }
+            }
+        }
+        found.then_some(total)
+    }
+
+    /// Total sample count of every `f64` histogram data point for
+    /// `name` whose attributes contain all `required` pairs.
+    pub fn histogram_count(&self, name: &str, required: &[(&str, &str)]) -> Option<u64> {
+        let mut found = false;
+        let mut total: u64 = 0;
+        for resource in self.exported() {
+            for scope in resource.scope_metrics() {
+                for metric in scope.metrics() {
+                    if metric.name() != name {
+                        continue;
+                    }
+                    let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = metric.data()
+                    else {
+                        continue;
+                    };
+                    found = true;
+                    for point in histogram.data_points() {
+                        if attributes_contain(point.attributes(), required) {
+                            total += point.count();
+                        }
+                    }
+                }
+            }
+        }
+        found.then_some(total)
+    }
+}
+
+fn attributes_contain<'a>(
+    actual: impl Iterator<Item = &'a KeyValue>,
+    required: &[(&str, &str)],
+) -> bool {
+    let actual: Vec<&KeyValue> = actual.collect();
+    required.iter().all(|(key, value)| {
+        actual
+            .iter()
+            .any(|kv| kv.key.as_str() == *key && kv.value.as_str() == *value)
+    })
+}

--- a/server/crates/waddle-xmpp/src/telemetry/test_support.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/test_support.rs
@@ -23,7 +23,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use opentelemetry::KeyValue;
-use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, Metric, MetricData, ResourceMetrics};
 use opentelemetry_sdk::metrics::{
     InMemoryMetricExporter, InMemoryMetricExporterBuilder, PeriodicReader, SdkMeterProvider,
     Temporality,
@@ -94,66 +94,61 @@ impl MetricsTestGuard {
 
     /// The UCUM unit of the named metric, if it was exported.
     pub fn metric_unit(&self, name: &str) -> Option<String> {
-        self.exported()
-            .iter()
-            .flat_map(|resource| resource.scope_metrics())
-            .flat_map(|scope| scope.metrics())
-            .find(|metric| metric.name() == name)
-            .map(|metric| metric.unit().to_string())
+        let mut unit = None;
+        self.each_metric(name, |metric| {
+            unit.get_or_insert_with(|| metric.unit().to_string());
+        });
+        unit
     }
 
     /// Sum of every `u64` counter data point for `name` whose
     /// attributes contain all `required` pairs. `None` when the
     /// instrument never exported (i.e. was never incremented).
     pub fn counter_sum(&self, name: &str, required: &[(&str, &str)]) -> Option<u64> {
-        let mut found = false;
-        let mut total: u64 = 0;
-        for resource in self.exported() {
-            for scope in resource.scope_metrics() {
-                for metric in scope.metrics() {
-                    if metric.name() != name {
-                        continue;
-                    }
-                    let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
-                        continue;
-                    };
-                    found = true;
-                    for point in sum.data_points() {
-                        if attributes_contain(point.attributes(), required) {
-                            total += point.value();
-                        }
-                    }
+        let mut total = None;
+        self.each_metric(name, |metric| {
+            let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+                return;
+            };
+            let entry = total.get_or_insert(0);
+            for point in sum.data_points() {
+                if attributes_contain(point.attributes(), required) {
+                    *entry += point.value();
                 }
             }
-        }
-        found.then_some(total)
+        });
+        total
     }
 
     /// Total sample count of every `f64` histogram data point for
     /// `name` whose attributes contain all `required` pairs.
     pub fn histogram_count(&self, name: &str, required: &[(&str, &str)]) -> Option<u64> {
-        let mut found = false;
-        let mut total: u64 = 0;
+        let mut total = None;
+        self.each_metric(name, |metric| {
+            let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = metric.data() else {
+                return;
+            };
+            let entry = total.get_or_insert(0);
+            for point in histogram.data_points() {
+                if attributes_contain(point.attributes(), required) {
+                    *entry += point.count();
+                }
+            }
+        });
+        total
+    }
+
+    /// Visit every exported batch of the named metric.
+    fn each_metric(&self, name: &str, mut visit: impl FnMut(&Metric)) {
         for resource in self.exported() {
             for scope in resource.scope_metrics() {
                 for metric in scope.metrics() {
-                    if metric.name() != name {
-                        continue;
-                    }
-                    let AggregatedMetrics::F64(MetricData::Histogram(histogram)) = metric.data()
-                    else {
-                        continue;
-                    };
-                    found = true;
-                    for point in histogram.data_points() {
-                        if attributes_contain(point.attributes(), required) {
-                            total += point.count();
-                        }
+                    if metric.name() == name {
+                        visit(metric);
                     }
                 }
             }
         }
-        found.then_some(total)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/telemetry/tests.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/tests.rs
@@ -146,6 +146,26 @@ async fn histogram_records_samples_with_attributes() {
     );
 }
 
+#[tokio::test]
+async fn consecutive_guards_observe_only_their_own_increments() {
+    {
+        let _first = test_support::acquire().await;
+        crate::counter_add!(
+            "waddle.telemetry.selftest.isolation",
+            "{event}",
+            "Telemetry self-test counter: guard isolation.",
+            7,
+        );
+    }
+    let second = test_support::acquire().await;
+    // Delta temporality plus the acquire-time drain: increments made
+    // under the first guard must be invisible to the second.
+    assert_eq!(
+        second.counter_sum("waddle.telemetry.selftest.isolation", &[]),
+        None
+    );
+}
+
 #[test]
 fn valid_metric_names_pass_validation() {
     assert_eq!(

--- a/server/crates/waddle-xmpp/src/telemetry/tests.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/tests.rs
@@ -1,0 +1,215 @@
+//! Telemetry-foundation tests: every assertion reads exported
+//! samples through the in-memory reader seam, never internal state.
+
+use super::attributes::{
+    Janitor, MessageKind, MetricAttribute, StanzaErrorCondition, SweepOutcome,
+};
+use super::test_support;
+use super::validate_metric_name;
+
+#[tokio::test]
+async fn counter_is_created_at_first_increment_only() {
+    let guard = test_support::acquire().await;
+
+    assert!(
+        !guard
+            .metric_names()
+            .contains(&"waddle.telemetry.selftest.lazy".to_string()),
+        "instrument must not exist before the first increment"
+    );
+    assert_eq!(
+        guard.counter_sum("waddle.telemetry.selftest.lazy", &[]),
+        None
+    );
+
+    crate::counter_add!(
+        "waddle.telemetry.selftest.lazy",
+        "{event}",
+        "Telemetry self-test counter: created at the increment site.",
+        1,
+    );
+
+    assert_eq!(
+        guard.counter_sum("waddle.telemetry.selftest.lazy", &[]),
+        Some(1)
+    );
+}
+
+#[tokio::test]
+async fn counter_carries_ucum_unit() {
+    let guard = test_support::acquire().await;
+
+    crate::counter_add!(
+        "waddle.telemetry.selftest.unit",
+        "{message}",
+        "Telemetry self-test counter: unit lands on the instrument.",
+        1,
+    );
+
+    assert_eq!(
+        guard.metric_unit("waddle.telemetry.selftest.unit"),
+        Some("{message}".to_string())
+    );
+}
+
+#[tokio::test]
+async fn counter_attributes_render_enumerated_values() {
+    let guard = test_support::acquire().await;
+
+    crate::counter_add!(
+        "waddle.telemetry.selftest.kinds",
+        "{message}",
+        "Telemetry self-test counter: enumerated kind attribute.",
+        2,
+        MessageKind::MucPm,
+    );
+    crate::counter_add!(
+        "waddle.telemetry.selftest.kinds",
+        "{message}",
+        "Telemetry self-test counter: enumerated kind attribute.",
+        3,
+        MessageKind::Dm,
+    );
+
+    assert_eq!(
+        guard.counter_sum("waddle.telemetry.selftest.kinds", &[("kind", "muc_pm")]),
+        Some(2)
+    );
+    assert_eq!(
+        guard.counter_sum("waddle.telemetry.selftest.kinds", &[("kind", "dm")]),
+        Some(3)
+    );
+    assert_eq!(
+        guard.counter_sum("waddle.telemetry.selftest.kinds", &[]),
+        Some(5)
+    );
+}
+
+#[tokio::test]
+async fn counter_supports_multiple_attributes() {
+    let guard = test_support::acquire().await;
+
+    crate::counter_add!(
+        "waddle.telemetry.selftest.sweeps",
+        "{sweep}",
+        "Telemetry self-test counter: janitor heartbeat shape.",
+        1,
+        Janitor::RoomDormancy,
+        SweepOutcome::Completed,
+    );
+
+    assert_eq!(
+        guard.counter_sum(
+            "waddle.telemetry.selftest.sweeps",
+            &[("janitor", "room_dormancy"), ("outcome", "completed")]
+        ),
+        Some(1)
+    );
+    assert_eq!(
+        guard.counter_sum(
+            "waddle.telemetry.selftest.sweeps",
+            &[("janitor", "room_dormancy"), ("outcome", "failed")]
+        ),
+        Some(0)
+    );
+}
+
+#[tokio::test]
+async fn histogram_records_samples_with_attributes() {
+    let guard = test_support::acquire().await;
+
+    crate::histogram_record!(
+        "waddle.telemetry.selftest.latency",
+        "ms",
+        "Telemetry self-test histogram.",
+        12.5,
+        StanzaErrorCondition::ServiceUnavailable,
+    );
+    crate::histogram_record!(
+        "waddle.telemetry.selftest.latency",
+        "ms",
+        "Telemetry self-test histogram.",
+        7.25,
+        StanzaErrorCondition::ServiceUnavailable,
+    );
+
+    assert_eq!(
+        guard.histogram_count(
+            "waddle.telemetry.selftest.latency",
+            &[("condition", "service-unavailable")]
+        ),
+        Some(2)
+    );
+    assert_eq!(
+        guard.metric_unit("waddle.telemetry.selftest.latency"),
+        Some("ms".to_string())
+    );
+}
+
+#[test]
+fn valid_metric_names_pass_validation() {
+    assert_eq!(
+        validate_metric_name("waddle.sm.unacked.evicted"),
+        "waddle.sm.unacked.evicted"
+    );
+    assert_eq!(
+        validate_metric_name("waddle.janitor.sweeps"),
+        "waddle.janitor.sweeps"
+    );
+    assert_eq!(
+        validate_metric_name("waddle.push.outbox.retry_scheduled"),
+        "waddle.push.outbox.retry_scheduled"
+    );
+    assert_eq!(
+        validate_metric_name("waddle.http2.errors"),
+        "waddle.http2.errors"
+    );
+}
+
+#[test]
+#[should_panic(expected = "dot.case")]
+fn uppercase_metric_name_is_rejected() {
+    let _ = validate_metric_name("waddle.SM.evicted");
+}
+
+#[test]
+#[should_panic(expected = "empty segments")]
+fn doubled_dot_is_rejected() {
+    let _ = validate_metric_name("waddle..evicted");
+}
+
+#[test]
+#[should_panic(expected = "must not end with '.'")]
+fn trailing_dot_is_rejected() {
+    let _ = validate_metric_name("waddle.evicted.");
+}
+
+#[test]
+#[should_panic(expected = "start with a lowercase letter")]
+fn segment_starting_with_digit_is_rejected() {
+    let _ = validate_metric_name("waddle.2fast");
+}
+
+#[test]
+#[should_panic(expected = "_total")]
+fn prometheus_total_suffix_is_rejected() {
+    let _ = validate_metric_name("waddle.messages_total");
+}
+
+#[test]
+fn attribute_enums_expose_stable_keys_and_values() {
+    assert_eq!(MessageKind::Dm.key(), "kind");
+    assert_eq!(MessageKind::MucPm.value(), "muc_pm");
+    assert_eq!(Janitor::PendingDeliveryClaim.key(), "janitor");
+    assert_eq!(
+        Janitor::PendingDeliveryClaim.value(),
+        "pending_delivery_claim"
+    );
+    assert_eq!(SweepOutcome::Failed.key(), "outcome");
+    assert_eq!(SweepOutcome::Failed.value(), "failed");
+    assert_eq!(StanzaErrorCondition::PolicyViolation.key(), "condition");
+    assert_eq!(
+        StanzaErrorCondition::PolicyViolation.value(),
+        "policy-violation"
+    );
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5064c1298188";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=4d51aa0a5164";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=4d51aa0a5164";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=4d51aa0a5164";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=4d51aa0a5164";


### PR DESCRIPTION
Implements **#1325** (telemetry foundation) plus, per review direction, **#1320** (wire the dead metrics), **#1321**, **#1315**, **#1326**, **#1318**, **#1322**, and **#1317** — the observability push from spec #1323, minus alerts-as-code (#1324) and the counter-family migration (#1330), which follow as separate PRs on top of this foundation.

## What's in here

### Telemetry foundation (#1325)
- **Create-at-increment metric macros** (`counter_add!` / `histogram_record!` in `waddle-xmpp::telemetry`): the instrument is created lazily at the first increment behind a `OnceLock`, so a registered-but-never-wired metric cannot exist by construction. Compile-time dot.case name validation (rejects `_total` suffixes), UCUM units on the instrument, and attributes restricted to a sealed enumerated allowlist (`kind`, `condition` — reusing `error::StanzaErrorCondition` — `janitor`, `outcome`). JIDs/room JIDs/stream ids/message ids cannot become metric attributes. Cardinality budget (max two attribute dimensions per instrument) documented next to the macro. `reason` enums are deliberately deferred to #1330, where the first families that need them migrate.
- **In-memory metric-reader test seam** (`telemetry::test_support`, the one seam approved in the spec): process-global delta-temporality `InMemoryMetricExporter`; tests assert exported samples and attributes, never internals; serialized on the existing `metrics_test_lock`.
- **Sampler + environment plumbing**: `OTEL_TRACES_SAMPLER`/`OTEL_TRACES_SAMPLER_ARG` honored (typed `SamplerChoice`; case-insensitive per the OTel env spec; the ratio argument applies only to explicitly selected ratio samplers; unknown names warn after subscriber init; default `parentbased_traceidratio` 1.0). `deployment.environment` flows through standard `OTEL_RESOURCE_ATTRIBUTES` (the SDK's env detector). Chart 0.4.2 models `telemetry.deploymentEnvironment` / `tracesSampler` / `tracesSamplerArg` (a `0` ratio renders instead of being dropped by falsy gating); prod values set in the gitops HelmRelease.
- **Convention freeze**: `server/CLAUDE.md` — new metrics via the macros only; `prometheus.rs` accepts no new families.

### Dead metrics wired (#1320)
Every previously registered-but-never-incremented instrument now has a real call site: flagship `waddle.messages.delivered` (kind ∈ `dm`|`muc`|`muc_pm`, classified once at the delivery choke points via message type + the XEP-0045 §7.5 `muc#user` PM marker; advances `waddle_messages_total` in lockstep), `xmpp.stanzas.processed` + `xmpp.stanza.latency` at the dispatch backstop, `xmpp.muc.messages` at fanout, MUC presence/occupants/rooms gauges (room-JID attributes **removed** per the cardinality budget), `xmpp.connections.active`, `xmpp.auth.attempts` (SCRAM outcome), and extension-enrichment latency/embeds.

### Message-id correlation (#1321)
`xmpp.stanza.dispatch` span carries `message_id` and `room` (groupchat); the fanout span is now `xmpp.muc.fanout` with `message_id` + `recipients`; `waddle.muc.fanout.duration` histogram; dispatch latency histogram via the rewired `xmpp.stanza.latency`.

### Admission-denial telemetry (#1315)
All five managed-channel admission denial paths route through one helper: info log (room, bare user, condition, `members_only`, resolver outcome) + `waddle.muc.admission.denied` counter by condition. XEP-0045 error wire shapes unchanged (29 join-path regression tests). Client `muc-join` failure beacons carry the denied room's **localpart only**.

### Cross-stack correlation (#1326)
Client: XMPP resource in Faro session attributes; W3C `traceparent` as a WS-upgrade query parameter (sanitizer passes it, still scrubs session-bearing params). Server: dispatch span stamps `xmpp.resource` + bare user JID; the upgrade handler parses `traceparent` into an OTel **span link** + `client.trace_id` on the connection-scoped span (garbage/zero ids rejected).

### Call + messaging client telemetry (#1318, #1322)
Exactly-once `chat.call.lifecycle` (setup outcome, end reason, duration bucket, `call_kind`); `call_kind` on the existing call beacons; end-of-call quality summary (RTT/loss bands, quality level, reconnects); device-permission failures as recoverable errors; `reportCallError` reaches Faro. Queue-depth `kind`, displayed-marker failure events with latency band, `chat.xmpp.catchup` `page_failures`, and `xmpp.room_switch` / `xmpp.initial_render` spans.

### LiveKit media-plane scrape (#1317)
LiveKit's native Prometheus listener enabled (chart 0.1.7), NetworkPolicy for the scrape path, endpoints-role Alloy scrape (`job=livekit-sfu`, per-pod `instance`) into the existing Grafana Cloud pipeline, starter call-QoS queries in `infrastructure/waddle.cloud/docs/livekit-metrics.md`. **Operator note:** rollout restarts the single-replica SFU (drops active calls).

## Verification
- Server: `cargo nextest` 7226/7227 (the 1 failure is pre-existing flake #1416, reproduced on clean main), clippy `-D warnings` clean, no allows.
- Chat: `bun test` 3448 pass; knip + tsc clean.
- Infra: helm lint + template render assertions; kustomize builds.
- Reviewed by parallel standards/spec reviewers, an independent gpt-5.6-terra review, and adversarial persona passes; all confirmed findings fixed in-branch.

## Post-deploy checks (not verifiable pre-merge)
- `deployment.environment` on OTLP resources and sampler-ratio dial visible in Grafana (#1325).
- `waddle_messages_total` non-zero in prod (#1320); `livekit_*` series queryable (#1317); resource-attribute search joins Faro ↔ Tempo (#1326).

## XEP review
No XMPP wire behavior changes anywhere: spans, logs, metrics, and beacons only. The WS-upgrade `traceparent` query parameter is HTTP-layer, inside the repo's documented telemetry exception, and carries no XMPP control semantics. Admission-denial handling preserves exact XEP-0045 §7.2 error shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
