### PR TITLE
feat(server): dual-emit reliability counters to OTel + janitor heartbeat (#1330 expand)

### DIFF
--- a/server/crates/waddle-server/src/dnd_reader.rs
+++ b/server/crates/waddle-server/src/dnd_reader.rs
@@ -76,7 +76,7 @@ impl DndReader for PepDndReader {
                     error = %error,
                     "dnd_projection read failed; defaulting recipient to Inactive"
                 );
-                waddle_xmpp::prometheus::increment_dnd_projection_read_errored();
+                waddle_xmpp::telemetry::reliability::increment_dnd_projection_read_errored();
                 return Ok(DndState::Inactive);
             }
         };

--- a/server/crates/waddle-server/src/notification_outbox/drain.rs
+++ b/server/crates/waddle-server/src/notification_outbox/drain.rs
@@ -57,8 +57,8 @@ impl NotificationOutboxStore {
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
-                        waddle_xmpp::prometheus::increment_push_suppressed(
-                            SuppressedReason::Xep0191Blocked.as_db_value(),
+                        waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                            SuppressedReason::Xep0191Blocked.telemetry_reason(),
                         );
                         processed += 1;
                     }
@@ -156,7 +156,9 @@ impl NotificationOutboxStore {
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
-                        waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
+                        waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                            reason.telemetry_reason(),
+                        );
                         processed += 1;
                     }
                     continue;
@@ -250,7 +252,9 @@ impl NotificationOutboxStore {
             let claimed = mark_candidate_outboxed_tx(&mut tx, candidate, now_ms).await?;
             tx.commit().await?;
             if claimed > 0 {
-                waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
+                waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                    reason.telemetry_reason(),
+                );
             }
             return Ok(claimed > 0);
         }

--- a/server/crates/waddle-server/src/notification_outbox/enqueue.rs
+++ b/server/crates/waddle-server/src/notification_outbox/enqueue.rs
@@ -73,10 +73,10 @@ impl NotificationOutboxStore {
             // dedup semantics, the SQL needs an explicit chained
             // `ON CONFLICT (cols) DO NOTHING` for each path
             // (Greptile review on PR #758).
-            waddle_xmpp::prometheus::increment_push_candidate_coalesced();
+            waddle_xmpp::telemetry::reliability::increment_push_candidate_coalesced();
             return Ok(NotificationCandidateInsertOutcome::Duplicate);
         }
-        waddle_xmpp::prometheus::increment_push_candidate_created();
+        waddle_xmpp::telemetry::reliability::increment_push_candidate_created();
         Ok(NotificationCandidateInsertOutcome::Inserted)
     }
 

--- a/server/crates/waddle-server/src/notification_outbox/gate.rs
+++ b/server/crates/waddle-server/src/notification_outbox/gate.rs
@@ -866,8 +866,8 @@ mod tests {
         );
         // Mirror the T0 emission contract: tick the metric, do NOT
         // persist a candidate row.
-        waddle_xmpp::prometheus::increment_push_suppressed(
-            SuppressedReason::Xep0492Never.as_db_value(),
+        waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+            SuppressedReason::Xep0492Never.telemetry_reason(),
         );
 
         // Push surface invariants: no candidate row, no outbox job.
@@ -960,8 +960,8 @@ mod tests {
             ),
             "T0 MUST suppress <on-mention/> miss with typed Xep0492OnMentionMiss; got {outcome:?}"
         );
-        waddle_xmpp::prometheus::increment_push_suppressed(
-            SuppressedReason::Xep0492OnMentionMiss.as_db_value(),
+        waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+            SuppressedReason::Xep0492OnMentionMiss.telemetry_reason(),
         );
 
         assert_eq!(

--- a/server/crates/waddle-server/src/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/src/notification_outbox/publish.rs
@@ -229,17 +229,17 @@ impl NotificationOutboxStore {
             // [`NotificationOutboxPublishOutcome`].
             match &outcome {
                 NotificationOutboxPublishOutcome::Published { .. } => {
-                    waddle_xmpp::prometheus::increment_push_outbox_published();
+                    waddle_xmpp::telemetry::reliability::increment_push_outbox_published();
                 }
                 NotificationOutboxPublishOutcome::RetryScheduled { .. } => {
-                    waddle_xmpp::prometheus::increment_push_outbox_retry_scheduled();
+                    waddle_xmpp::telemetry::reliability::increment_push_outbox_retry_scheduled();
                 }
                 NotificationOutboxPublishOutcome::Failed { .. } => {
-                    waddle_xmpp::prometheus::increment_push_outbox_dead_lettered();
+                    waddle_xmpp::telemetry::reliability::increment_push_outbox_dead_lettered();
                 }
                 NotificationOutboxPublishOutcome::Suppressed { .. } => {
-                    waddle_xmpp::prometheus::increment_push_suppressed(
-                        SuppressedReason::UnreadZeroAtPublish.as_db_value(),
+                    waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                        SuppressedReason::UnreadZeroAtPublish.telemetry_reason(),
                     );
                 }
             }

--- a/server/crates/waddle-server/src/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/src/notification_outbox/publish.rs
@@ -232,7 +232,9 @@ impl NotificationOutboxStore {
                     waddle_xmpp::telemetry::reliability::increment_push_outbox_published();
                 }
                 NotificationOutboxPublishOutcome::RetryScheduled { .. } => {
-                    waddle_xmpp::telemetry::reliability::increment_push_outbox_retry_scheduled();
+                    waddle_xmpp::telemetry::reliability::increment_push_outbox_retry_scheduled(
+                        waddle_xmpp::telemetry::attributes::PushRetryReason::Unknown,
+                    );
                 }
                 NotificationOutboxPublishOutcome::Failed { .. } => {
                     waddle_xmpp::telemetry::reliability::increment_push_outbox_dead_lettered();

--- a/server/crates/waddle-server/src/notification_outbox/types.rs
+++ b/server/crates/waddle-server/src/notification_outbox/types.rs
@@ -258,6 +258,31 @@ impl SuppressedReason {
         }
     }
 
+    /// Convert the persisted audit reason into the metric-facing closed set.
+    /// Exhaustive matching keeps the boundary typed and makes new variants a
+    /// compile-time decision for telemetry as well as storage.
+    pub(crate) fn telemetry_reason(self) -> waddle_xmpp::telemetry::attributes::PushSuppressReason {
+        use waddle_xmpp::telemetry::attributes::PushSuppressReason as MetricReason;
+
+        match self {
+            Self::Xep0357Self => MetricReason::Xep0357Self,
+            Self::Xep0357NoRegistration => MetricReason::Xep0357NoRegistration,
+            Self::Xep0357RegistrationDisabled => MetricReason::Xep0357RegistrationDisabled,
+            Self::Xep0492Never => MetricReason::Xep0492Never,
+            Self::Xep0492OnMentionMiss => MetricReason::Xep0492OnMentionMiss,
+            Self::Xep0191Blocked => MetricReason::Xep0191Blocked,
+            Self::Xep0513Noping => MetricReason::Xep0513Noping,
+            Self::Xep0513ActiveMiss => MetricReason::Xep0513ActiveMiss,
+            Self::WaddleDnd => MetricReason::WaddleDnd,
+            Self::ProviderRejected => MetricReason::ProviderRejected,
+            Self::ProviderTokenExpired => MetricReason::ProviderTokenExpired,
+            Self::Xep0357PushServiceDegraded => MetricReason::Xep0357PushServiceDegraded,
+            Self::UnreadZeroAtPublish => MetricReason::UnreadZeroAtPublish,
+            Self::PolicyRetriesExhausted => MetricReason::PolicyRetriesExhausted,
+            Self::Xep0444Reaction => MetricReason::Xep0444Reaction,
+        }
+    }
+
     pub(crate) fn from_db_value(value: &str) -> Result<Self, NotificationOutboxError> {
         // Iterate the closed `ALL` set rather than re-listing the
         // variants in a `match` arm — keeps the audit shape, the
@@ -567,36 +592,32 @@ mod tests {
         ));
     }
 
-    /// Wire-contract lockstep guard: every `SuppressedReason` variant
-    /// MUST have its `as_db_value()` listed in
-    /// `waddle_xmpp::prometheus::push_suppressed_reasons()`. The
-    /// prometheus parallel constant lives upstream of this enum (in
-    /// `waddle-xmpp`) and cannot import the typed enum, so the
-    /// invariant is enforced from this side. Drift here means an
-    /// `increment_push_suppressed(...)` call for the missing variant
-    /// would hit the `waddle_push_suppressed_unknown_reason_total`
-    /// catch-all instead of the typed counter — observable but
-    /// incorrect.
+    /// Cross-crate lockstep guard: every persisted `SuppressedReason` maps
+    /// exhaustively to a metric `PushSuppressReason`, and both typed enums
+    /// retain byte-identical values. The Prometheus view is derived from the
+    /// metric enum, so the reverse check also prevents metric-only labels.
     #[test]
-    fn suppressed_reason_wire_contract_matches_prometheus_parallel_constant() {
+    fn suppressed_reason_values_match_the_typed_metric_enum() {
         let wire = waddle_xmpp::prometheus::push_suppressed_reasons();
         for reason in SuppressedReason::ALL.iter().copied() {
             let db = reason.as_db_value();
+            assert_eq!(
+                reason.telemetry_reason().as_str(),
+                db,
+                "typed telemetry mapping drifted for {reason:?}"
+            );
             assert!(
                 wire.contains(&db),
                 "`SuppressedReason::{reason:?}` (db value `{db}`) is missing from \
-                 `waddle_xmpp::prometheus::PUSH_SUPPRESSED_REASONS`; the parallel \
-                 constant has drifted from the typed enum"
+                 the metric-facing `PushSuppressReason` values"
             );
         }
-        // Reverse direction: any string in the parallel constant that
-        // does NOT round-trip through `SuppressedReason::from_db_value`
-        // is dead weight in the metrics surface.
+        // Reverse direction: any metric label that does not round-trip through
+        // the persisted enum is dead weight in the metrics surface.
         for label in wire.iter().copied() {
             assert!(
                 SuppressedReason::from_db_value(label).is_ok(),
-                "`PUSH_SUPPRESSED_REASONS` entry `{label}` is not a known \
-                 `SuppressedReason::as_db_value()`; the parallel constant has drifted"
+                "metric reason `{label}` is not a known persisted `SuppressedReason` value"
             );
         }
         assert_eq!(

--- a/server/crates/waddle-server/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-server/src/pending_delivery/flush.rs
@@ -187,7 +187,7 @@ where
                     // logs can flag MAM corruption / unexpected
                     // tombstones.
                     outcome.unresolved += 1;
-                    waddle_xmpp::prometheus::increment_pending_delivery_unresolved_poison_pill();
+                    waddle_xmpp::telemetry::reliability::increment_pending_delivery_unresolved_poison_pill();
                     if let Err(error) = storage.delete_row(&row.id).await {
                         warn!(
                             row_id = %row.id,
@@ -215,7 +215,7 @@ where
                     // `deferred_transient > 0` — or via another
                     // recovering resource.
                     outcome.deferred_transient += 1;
-                    waddle_xmpp::prometheus::increment_pending_delivery_archive_lookup_transient_failure();
+                    waddle_xmpp::telemetry::reliability::increment_pending_delivery_archive_lookup_transient_failure();
                     warn!(
                         row_id = %row.id,
                         error = %error,

--- a/server/crates/waddle-server/src/server/dual_registration.rs
+++ b/server/crates/waddle-server/src/server/dual_registration.rs
@@ -142,12 +142,18 @@ pub(crate) async fn mirror_register_outcome(
 /// `Some(token)` prunes only if the actor still holds that session (mirrors
 /// `unregister_if_owner`), `None` prunes unconditionally (mirrors a plain
 /// `unregister`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MirrorUnregisterOutcome {
+    Completed,
+    Failed,
+}
+
 pub(crate) async fn mirror_unregister(
     user_registry: &ActorRef<UserRegistryActor>,
     jid: &FullJid,
     owner: Option<Arc<AtomicBool>>,
-) {
-    if let Err(error) = user_registry
+) -> MirrorUnregisterOutcome {
+    match user_registry
         .tell(UnregisterUserResource {
             jid: jid.clone(),
             owner,
@@ -155,13 +161,17 @@ pub(crate) async fn mirror_unregister(
         .mailbox_timeout(MIRROR_TIMEOUT)
         .await
     {
-        warn!(
-            jid = %jid,
-            %error,
-            "dual-registration: failed to enqueue unregister mirror into \
-             user_registry actor; the actor tree may retain a stale resource \
-             until the next successful mirror"
-        );
+        Ok(()) => MirrorUnregisterOutcome::Completed,
+        Err(error) => {
+            warn!(
+                jid = %jid,
+                %error,
+                "dual-registration: failed to enqueue unregister mirror into \
+                 user_registry actor; the actor tree may retain a stale resource \
+                 until the next successful mirror"
+            );
+            MirrorUnregisterOutcome::Failed
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -180,7 +180,9 @@ use groupchat_archive::{
     apply_groupchat_retraction_tombstone, archive_groupchat_message, project_groupchat_inbox,
     resolve_room_claim_fence, ArchiveGroupchatOutcome,
 };
+#[cfg(test)]
 pub(crate) use groupchat_inbox::reconcile_groupchat_notification_candidates;
+pub(crate) use groupchat_inbox::reconcile_groupchat_notification_candidates_for_sweep;
 use groupchat_inbox::{project_groupchat_inbox_event, ProjectGroupchatInboxEvent};
 use groupchat_validation::{
     bad_request_error, build_message_error_reply, item_not_found_error, remove_framework_envelopes,
@@ -192,7 +194,9 @@ pub use handoff::{
     OrderedRelayHandoffCompletion, OrderedRelayInboundSequence, SmInboundCompletionTracker,
 };
 use offline_delivery::queue_offline_delivery;
+#[cfg(test)]
 pub(crate) use offline_delivery::reconcile_xep0357_notification_candidates;
+pub(crate) use offline_delivery::reconcile_xep0357_notification_candidates_for_sweep;
 use room_dispatch::dispatch_to_room;
 use room_pin::apply_pin_change_event;
 use room_subject::{
@@ -204,6 +208,12 @@ use routing::{
     deliver_peer_to_live_only, deliver_to_detached, run_fanout_recipient_pass,
     run_headless_recipient_pass, FanoutPassResult,
 };
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct NotificationRecoverySweepOutcome {
+    pub(crate) completed: usize,
+    pub(crate) had_failure: bool,
+}
 
 #[cfg(feature = "clustering")]
 pub use deps::OrderedRelayRouteOriginKind;

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -465,7 +465,9 @@ async fn insert_groupchat_notification_candidate(
                 %reason,
                 "ProjectGroupchatInbox: T0 push gate suppressed groupchat candidate; no candidate row persisted"
             );
-            waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
+            waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                reason.telemetry_reason(),
+            );
             return GroupchatNotificationCandidateQueueOutcome::Completed;
         }
         crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
@@ -536,10 +538,20 @@ async fn mark_groupchat_notification_recovery_completed(
     }
 }
 
+#[cfg(test)]
 pub(crate) async fn reconcile_groupchat_notification_candidates(
     state: &WebSocketState,
     batch_size: usize,
 ) -> usize {
+    reconcile_groupchat_notification_candidates_for_sweep(state, batch_size)
+        .await
+        .completed
+}
+
+pub(crate) async fn reconcile_groupchat_notification_candidates_for_sweep(
+    state: &WebSocketState,
+    batch_size: usize,
+) -> super::NotificationRecoverySweepOutcome {
     let batch_size = batch_size.clamp(1, 1_000);
     let recoveries = match state
         .deps
@@ -554,10 +566,14 @@ pub(crate) async fn reconcile_groupchat_notification_candidates(
                 error = %error,
                 "Groupchat notification candidate recovery could not read inbox recovery rows"
             );
-            return 0;
+            return super::NotificationRecoverySweepOutcome {
+                completed: 0,
+                had_failure: true,
+            };
         }
     };
     let mut completed = 0usize;
+    let mut had_failure = false;
     for recovery in recoveries {
         let archive_room = recovery.key.archive_stanza_id.by.to_bare();
         let archived = match state
@@ -578,12 +594,15 @@ pub(crate) async fn reconcile_groupchat_notification_candidates(
                     stanza_id = %recovery.key.archive_stanza_id,
                     "Groupchat notification candidate recovery completed because the committed MAM row is missing"
                 );
-                if mark_recovery_completed_from_state(state, &recovery.key).await {
-                    completed += 1;
+                match mark_recovery_completed_from_state(state, &recovery.key).await {
+                    RecoveryCompletionOutcome::Marked => completed += 1,
+                    RecoveryCompletionOutcome::NotMarked => {}
+                    RecoveryCompletionOutcome::Failed => had_failure = true,
                 }
                 continue;
             }
             Err(error) => {
+                had_failure = true;
                 warn!(
                     recipient = %recovery.key.recipient,
                     room = %recovery.key.room,
@@ -626,19 +645,34 @@ pub(crate) async fn reconcile_groupchat_notification_candidates(
             sender_can_broadcast_channel_mention: recovery.sender_can_broadcast_channel_mention,
         })
         .await;
-        if outcome == GroupchatNotificationCandidateQueueOutcome::Completed
-            && mark_recovery_completed_from_state(state, &recovery.key).await
-        {
-            completed += 1;
+        match outcome {
+            GroupchatNotificationCandidateQueueOutcome::Completed => {
+                match mark_recovery_completed_from_state(state, &recovery.key).await {
+                    RecoveryCompletionOutcome::Marked => completed += 1,
+                    RecoveryCompletionOutcome::NotMarked => {}
+                    RecoveryCompletionOutcome::Failed => had_failure = true,
+                }
+            }
+            GroupchatNotificationCandidateQueueOutcome::RetryLater => had_failure = true,
         }
     }
-    completed
+    super::NotificationRecoverySweepOutcome {
+        completed,
+        had_failure,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryCompletionOutcome {
+    Marked,
+    NotMarked,
+    Failed,
 }
 
 async fn mark_recovery_completed_from_state(
     state: &WebSocketState,
     key: &waddle_xmpp::inbox::storage::GroupchatNotificationRecoveryKey,
-) -> bool {
+) -> RecoveryCompletionOutcome {
     match state
         .deps
         .protocol
@@ -646,7 +680,8 @@ async fn mark_recovery_completed_from_state(
         .mark_groupchat_notification_recovery_completed(key)
         .await
     {
-        Ok(marked) => marked > 0,
+        Ok(marked) if marked > 0 => RecoveryCompletionOutcome::Marked,
+        Ok(_) => RecoveryCompletionOutcome::NotMarked,
         Err(error) => {
             warn!(
                 recipient = %key.recipient,
@@ -655,7 +690,7 @@ async fn mark_recovery_completed_from_state(
                 error = %error,
                 "Groupchat notification recovery completion marker failed"
             );
-            false
+            RecoveryCompletionOutcome::Failed
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -53,7 +53,7 @@ pub(super) async fn queue_offline_delivery(
             }
         }
         Ok(waddle_xmpp::pending_delivery::InsertOutcome::QuotaExceeded) => {
-            waddle_xmpp::prometheus::increment_pending_delivery_quota_exceeded();
+            waddle_xmpp::telemetry::reliability::increment_pending_delivery_quota_exceeded();
             // XEP-0160 §3 step 3 + RFC 6120 §8.3 — return a
             // typed `<service-unavailable/>` bounce that
             // echoes the original payload (RFC 6120 §8.3.4
@@ -446,7 +446,9 @@ async fn enqueue_xep0357_notification_candidate_for_message(
                 %reason,
                 "T0 push gate suppressed XEP-0357 DM candidate; no candidate row persisted"
             );
-            waddle_xmpp::prometheus::increment_push_suppressed(reason.as_db_value());
+            waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                reason.telemetry_reason(),
+            );
             return NotificationCandidateQueueOutcome::Completed;
         }
         crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
@@ -604,21 +606,35 @@ async fn mark_pending_notification_outboxed(
     storage: &dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage,
     row_id: &waddle_xmpp::pending_delivery::PendingRowId,
     recipient: &BareJid,
-) {
-    if let Err(error) = storage.mark_notification_outboxed(row_id).await {
-        warn!(
-            recipient = %recipient,
-            row_id = %row_id,
-            error = %error,
-            "pending_delivery notification outbox marker write failed; janitor will retry"
-        );
+) -> bool {
+    match storage.mark_notification_outboxed(row_id).await {
+        Ok(_) => true,
+        Err(error) => {
+            warn!(
+                recipient = %recipient,
+                row_id = %row_id,
+                error = %error,
+                "pending_delivery notification outbox marker write failed; janitor will retry"
+            );
+            false
+        }
     }
 }
 
+#[cfg(test)]
 pub(crate) async fn reconcile_xep0357_notification_candidates(
     state: &WebSocketState,
     batch_size: usize,
 ) -> usize {
+    reconcile_xep0357_notification_candidates_for_sweep(state, batch_size)
+        .await
+        .completed
+}
+
+pub(crate) async fn reconcile_xep0357_notification_candidates_for_sweep(
+    state: &WebSocketState,
+    batch_size: usize,
+) -> super::NotificationRecoverySweepOutcome {
     let batch_size = batch_size.clamp(1, 1_000);
     let pending_storage = state.deps.protocol.pending_delivery_storage.as_ref();
     let rows = match pending_storage.list_unoutboxed_archived(batch_size).await {
@@ -628,10 +644,14 @@ pub(crate) async fn reconcile_xep0357_notification_candidates(
                 error = %error,
                 "XEP-0357 notification candidate recovery could not read pending_delivery rows"
             );
-            return 0;
+            return super::NotificationRecoverySweepOutcome {
+                completed: 0,
+                had_failure: true,
+            };
         }
     };
     let mut completed = 0usize;
+    let mut had_failure = false;
     for row in rows {
         let waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id) =
             &row.payload
@@ -644,12 +664,22 @@ pub(crate) async fn reconcile_xep0357_notification_candidates(
             archive_stanza_id,
         )
         .await;
-        if outcome == NotificationCandidateQueueOutcome::Completed {
-            mark_pending_notification_outboxed(pending_storage, &row.id, &row.recipient).await;
-            completed += 1;
+        match outcome {
+            NotificationCandidateQueueOutcome::Completed => {
+                if !mark_pending_notification_outboxed(pending_storage, &row.id, &row.recipient)
+                    .await
+                {
+                    had_failure = true;
+                }
+                completed += 1;
+            }
+            NotificationCandidateQueueOutcome::RetryLater => had_failure = true,
         }
     }
-    completed
+    super::NotificationRecoverySweepOutcome {
+        completed,
+        had_failure,
+    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -585,7 +585,7 @@ async fn deliver_one_via_actor(
         // backstop / closed-channel eviction, not by a transient full
         // window.
         Ok(waddle_xmpp::registry::BroadcastOutcome::DroppedFull) => {
-            waddle_xmpp::prometheus::increment_delivery_retry_exhausted_drop();
+            waddle_xmpp::telemetry::reliability::increment_delivery_retry_exhausted_drop();
             warn!(
                 jid = %target,
                 retries = DROPPED_FULL_RETRY_DELAYS.len(),
@@ -617,7 +617,7 @@ async fn deliver_one_via_actor(
         // the other broadcast drop reasons (the one drop path `try_deliver`
         // does not itself account for).
         Err((ActorSendFailure::MaybeEnqueued, error)) => {
-            waddle_xmpp::prometheus::increment_delivery_terminal_error_drop();
+            waddle_xmpp::telemetry::reliability::increment_delivery_terminal_error_drop();
             warn!(
                 jid = %target,
                 %error,
@@ -773,7 +773,7 @@ pub(super) async fn deliver_peer_to_live_only(
                 FullJidDeliveryOutcome::Unavailable
             }
             ActorSendFailure::MaybeEnqueued => {
-                waddle_xmpp::prometheus::increment_delivery_terminal_error_drop();
+                waddle_xmpp::telemetry::reliability::increment_delivery_terminal_error_drop();
                 warn!(
                     jid = %target,
                     error = %error,

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -245,7 +245,7 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
-    waddle_xmpp::prometheus::increment_sm_send_window_pause();
+    waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause();
     let deadline = tokio::time::Instant::now() + SEND_WINDOW_PAUSE_DEADLINE;
     // Elicit an ack immediately — nothing more is being written until the
     // window recovers, so the client must be prompted.
@@ -268,7 +268,7 @@ where
         let next = match tokio::time::timeout_at(deadline, reader.next()).await {
             Ok(next) => next,
             Err(_) => {
-                waddle_xmpp::prometheus::increment_sm_send_window_pause_timeout();
+                waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause_timeout();
                 warn!(
                     stream_id = conn.sm_state.stream_id.as_deref().unwrap_or("<unset>"),
                     deadline_secs = SEND_WINDOW_PAUSE_DEADLINE.as_secs(),

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -161,9 +161,22 @@ pub(crate) async fn broadcast_muc_muji_clear_to_remaining(
 /// Public alias for the MUC-presence cleanup used by the SM expired-session
 /// janitor in `server::mod`. Thin passthrough so the janitor doesn't need
 /// to reimplement the room traversal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MucCleanupOutcome {
+    Completed,
+    Failed,
+}
+
 #[cfg(any(not(feature = "clustering"), test))]
-pub async fn cleanup_muc_presence_for_jid(state: &WebSocketState, jid: &FullJid) {
-    cleanup_muc_presence(state, jid).await
+pub async fn cleanup_muc_presence_for_jid(
+    state: &WebSocketState,
+    jid: &FullJid,
+) -> MucCleanupOutcome {
+    if cleanup_muc_presence(state, jid).await {
+        MucCleanupOutcome::Completed
+    } else {
+        MucCleanupOutcome::Failed
+    }
 }
 
 /// Same cleanup path, but with explicit ordered-relay origin provenance for
@@ -173,8 +186,12 @@ pub async fn cleanup_muc_presence_for_jid_with_origin(
     state: &WebSocketState,
     jid: &FullJid,
     origin: crate::server::routes::interpret::OrderedRelayRouteOrigin,
-) {
-    cleanup_muc_presence_with_origin(state, jid, Some(&origin)).await
+) -> MucCleanupOutcome {
+    if cleanup_muc_presence_with_origin(state, jid, Some(&origin)).await {
+        MucCleanupOutcome::Completed
+    } else {
+        MucCleanupOutcome::Failed
+    }
 }
 
 /// #1249: re-drive the MUC cleanup for a session that no longer exists
@@ -199,8 +216,15 @@ pub async fn cleanup_muc_presence_for_jid_with_origin(
 /// until that claim is released — the ghost heals when the other
 /// device disconnects or the claim expires, not before.
 #[cfg(feature = "clustering")]
-pub(crate) async fn redrive_remote_muc_cleanup(state: &WebSocketState, jid: &FullJid) {
-    cleanup_muc_presence_with_origin(state, jid, None).await;
+pub(crate) async fn redrive_remote_muc_cleanup(
+    state: &WebSocketState,
+    jid: &FullJid,
+) -> MucCleanupOutcome {
+    if cleanup_muc_presence_with_origin(state, jid, None).await {
+        MucCleanupOutcome::Completed
+    } else {
+        MucCleanupOutcome::Failed
+    }
 }
 
 /// If `outcome` represents the final occupant leaving a
@@ -217,18 +241,17 @@ pub(crate) async fn redrive_remote_muc_cleanup(state: &WebSocketState, jid: &Ful
 /// their actor across this PR; the residual growth they cause is
 /// the next state-inventory-driven follow-up.
 ///
-/// Errors here are logged and swallowed — the leave itself has
-/// already succeeded on the wire; failing the response because the
-/// eviction round-trip flaked would be a worse user-visible
-/// outcome than letting the registry janitor catch this on the
-/// next dead-actor sweep.
+/// Errors here are logged and returned to sweep callers. Interactive leave
+/// paths intentionally ignore the status because the leave itself has already
+/// succeeded on the wire; failing that response would be worse than letting
+/// the registry janitor catch the room on its next dead-actor sweep.
 pub(crate) async fn maybe_evict_empty_room(
     state: &WebSocketState,
     room_jid: &BareJid,
     outcome: &LeaveOutcome,
-) {
+) -> bool {
     if !(outcome.removed_last_session && outcome.occupant_count == 0 && !outcome.is_persistent) {
-        return;
+        return true;
     }
     // #1108: revision-guarded destroy. The registry asks the room actor
     // to seal itself only if it is still empty at the occupancy revision
@@ -246,7 +269,7 @@ pub(crate) async fn maybe_evict_empty_room(
         Ok(destroyed) => destroyed,
         Err(error) => {
             warn!(room = %room_jid, error = %error, "Failed guarded destroy of empty room");
-            false
+            return false;
         }
     };
     if destroyed {
@@ -255,15 +278,15 @@ pub(crate) async fn maybe_evict_empty_room(
             "Evicted empty non-persistent MUC room from registry"
         );
     } else {
-        // Either the room was already absent (race with another leave
-        // path), a new occupant was admitted after this leave, or the
-        // registry ask failed (logged). Either way we don't want to
-        // fail the user's leave on this.
+        // Either the room was already absent (race with another leave path) or
+        // a new occupant was admitted after this leave. Either way we don't
+        // want to fail the user's leave on this.
         debug!(
             room = %room_jid,
-            "Guarded eviction returned false; room re-admitted an occupant, was already cleared, or ask failed (logged)"
+            "Guarded eviction returned false; room re-admitted an occupant or was already cleared"
         );
     }
+    true
 }
 
 /// Whether [`cleanup_connection_shutdown`] actually persisted a detached,
@@ -667,9 +690,9 @@ pub(crate) async fn broadcast_unavailable_if_no_replacement(
     state: &WebSocketState,
     jid: &FullJid,
     was_presence_available: bool,
-) {
+) -> handlers::presence::TerminatedPresenceBroadcastOutcome {
     if !was_presence_available {
-        return;
+        return handlers::presence::TerminatedPresenceBroadcastOutcome::Completed;
     }
     if state
         .deps
@@ -682,25 +705,42 @@ pub(crate) async fn broadcast_unavailable_if_no_replacement(
             jid = %jid,
             "Suppressed terminated-session unavailable: an available replacement connection is live"
         );
-        return;
+        return handlers::presence::TerminatedPresenceBroadcastOutcome::Completed;
     }
-    handlers::presence::broadcast_unavailable_for_terminated_session(state, jid).await;
+    handlers::presence::broadcast_unavailable_for_terminated_session(state, jid).await
 }
 
-async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
-    cleanup_muc_presence_with_origin(state, jid, None).await;
+async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) -> bool {
+    cleanup_muc_presence_with_origin(state, jid, None).await
 }
 
 async fn cleanup_muc_presence_with_origin(
     state: &WebSocketState,
     jid: &FullJid,
     origin: Option<&crate::server::routes::interpret::OrderedRelayRouteOrigin>,
-) {
-    cleanup_remote_muc_presence(state, jid, origin).await;
+) -> bool {
+    let mut completed = cleanup_remote_muc_presence(state, jid, origin).await;
 
-    for room_jid in list_room_jids(state).await {
-        let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-            continue;
+    let room_jids = match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .list_rooms()
+        .await
+    {
+        Ok(room_jids) => room_jids,
+        Err(error) => {
+            completed = false;
+            warn!(error = %error, "Failed to list room actors");
+            Vec::new()
+        }
+    };
+    for room_jid in room_jids {
+        let room_actor = match get_room_actor_result(state, &room_jid).await {
+            Ok(Some(room_actor)) => room_actor,
+            Ok(None) => continue,
+            Err(error) => {
+                completed = false;
+                warn!(room = %room_jid, error = %error, "Failed to get room actor");
+                continue;
+            }
         };
         let leave_result = room_actor
             .ask(LeaveByRealJid {
@@ -738,10 +778,13 @@ async fn cleanup_muc_presence_with_origin(
                 // session ended.
                 broadcast_muc_leave_to_remaining(state, &room_jid, jid, &outcome).await;
                 broadcast_muc_muji_clear_to_remaining(state, &room_jid, jid, &outcome).await;
-                maybe_evict_empty_room(state, &room_jid, &outcome).await;
+                if !maybe_evict_empty_room(state, &room_jid, &outcome).await {
+                    completed = false;
+                }
             }
             Ok(None) => {}
             Err(error) => {
+                completed = false;
                 warn!(
                     room = %room_jid,
                     jid = %jid,
@@ -751,6 +794,7 @@ async fn cleanup_muc_presence_with_origin(
             }
         }
     }
+    completed
 }
 
 #[cfg(feature = "clustering")]
@@ -758,14 +802,14 @@ async fn cleanup_remote_muc_presence(
     state: &WebSocketState,
     jid: &FullJid,
     cleanup_origin: Option<&crate::server::routes::interpret::OrderedRelayRouteOrigin>,
-) {
+) -> bool {
     let memberships = state
         .deps
         .protocol
         .remote_muc_memberships
         .take_for_occupant(jid);
     if memberships.is_empty() {
-        return;
+        return true;
     }
     let Some(bridge) = state
         .deps
@@ -781,7 +825,7 @@ async fn cleanup_remote_muc_presence(
                 .remote_muc_memberships
                 .restore_snapshot_if_current(membership);
         }
-        return;
+        return false;
     };
     let acquired_user_actor_origin = cleanup_origin.is_none();
     let origin = match cleanup_origin.cloned() {
@@ -795,11 +839,12 @@ async fn cleanup_remote_muc_presence(
                         .remote_muc_memberships
                         .restore_snapshot_if_current(membership);
                 }
-                return;
+                return false;
             };
             origin
         }
     };
+    let mut completed = true;
     for membership in memberships {
         let room_jid = membership.room().clone();
         let nick = membership.nick().to_string();
@@ -809,6 +854,7 @@ async fn cleanup_remote_muc_presence(
             .ok()
             .map(jid::Jid::from)
         else {
+            completed = false;
             state
                 .deps
                 .protocol
@@ -887,6 +933,7 @@ async fn cleanup_remote_muc_presence(
                     .forget_snapshot_if_current(&membership);
             }
             RemoteMucCleanupDisposition::UncertainCommit => {
+                completed = false;
                 debug!(
                     room = %room_jid,
                     nick = %nick,
@@ -905,6 +952,7 @@ async fn cleanup_remote_muc_presence(
             // node/claim recovers — the cleanup is now convergent instead
             // of one-shot.
             RemoteMucCleanupDisposition::RetryableFailure => {
+                completed = false;
                 // Log-level split (race review P2 on PR #1277):
                 // `OriginUnavailable` is the EXPECTED steady state while
                 // the user's other device holds the `UserActor` claim on
@@ -942,8 +990,9 @@ async fn cleanup_remote_muc_presence(
         }
     }
     if acquired_user_actor_origin {
-        reap_remote_muc_cleanup_origin_if_empty(state, jid).await;
+        completed &= reap_remote_muc_cleanup_origin_if_empty(state, jid).await;
     }
+    completed
 }
 
 /// How the disconnect-cleanup pass converges one remote MUC membership
@@ -1093,20 +1142,24 @@ async fn acquire_remote_muc_cleanup_origin(
 }
 
 #[cfg(feature = "clustering")]
-async fn reap_remote_muc_cleanup_origin_if_empty(state: &WebSocketState, jid: &FullJid) {
+async fn reap_remote_muc_cleanup_origin_if_empty(state: &WebSocketState, jid: &FullJid) -> bool {
     let bare_jid = jid.to_bare();
-    if let Err(error) = state
+    match state
         .deps
         .protocol
         .user_registry
         .ask(waddle_xmpp::registry::ReapUserIfEmpty { bare_jid })
         .await
     {
-        warn!(
-            jid = %jid,
-            error = ?error,
-            "failed to reap empty UserActor after remote MUC cleanup"
-        );
+        Ok(_) => true,
+        Err(error) => {
+            warn!(
+                jid = %jid,
+                error = ?error,
+                "failed to reap empty UserActor after remote MUC cleanup"
+            );
+            false
+        }
     }
 }
 
@@ -1115,7 +1168,8 @@ async fn cleanup_remote_muc_presence(
     _state: &WebSocketState,
     _jid: &FullJid,
     _cleanup_origin: Option<&crate::server::routes::interpret::OrderedRelayRouteOrigin>,
-) {
+) -> bool {
+    true
 }
 
 pub(super) async fn cleanup_invalidated_detached_session(
@@ -1276,19 +1330,6 @@ pub(crate) async fn get_or_create_room_actor(
                 warn!(room = %room_jid, %error, "Failed to get or create room actor");
             }
         })
-}
-
-pub(crate) async fn list_room_jids(state: &WebSocketState) -> Vec<BareJid> {
-    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
-        .list_rooms()
-        .await
-    {
-        Ok(rooms) => rooms,
-        Err(error) => {
-            warn!(error = %error, "Failed to list room actors");
-            Vec::new()
-        }
-    }
 }
 
 pub(crate) async fn is_muc_room_jid(state: &WebSocketState, room_jid: &BareJid) -> bool {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -223,7 +223,7 @@ async fn handle_xmpp_websocket(
             if rising_edge {
                 conn.send_window_pause_deadline =
                     Some(tokio::time::Instant::now() + SEND_WINDOW_LOOP_PAUSE_DEADLINE);
-                waddle_xmpp::prometheus::increment_sm_send_window_pause();
+                waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause();
             }
             // Prompt an ack on the rising edge, and AGAIN whenever the client
             // has acked since our last prompt but not yet recovered the
@@ -580,7 +580,7 @@ async fn handle_xmpp_websocket(
                     None => std::future::pending().await,
                 }
             }, if send_window_paused => {
-                waddle_xmpp::prometheus::increment_sm_send_window_pause_timeout();
+                waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause_timeout();
                 warn!(
                     jid = ?conn.phase.bound_jid(),
                     deadline_secs = SEND_WINDOW_LOOP_PAUSE_DEADLINE.as_secs(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -52,7 +52,9 @@ pub use muc::{
 pub(crate) use muc_update::try_handle_muc_presence_update;
 use probe::handle_presence_probe;
 use regular::handle_regular_presence_update;
-pub use subscription::broadcast_unavailable_for_terminated_session;
+pub use subscription::{
+    broadcast_unavailable_for_terminated_session, TerminatedPresenceBroadcastOutcome,
+};
 use subscription::{
     handle_directed_presence, handle_subscription_presence, try_handle_remote_subscription_presence,
 };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -374,7 +374,7 @@ pub(crate) async fn route_room_presence_to_occupant(
                     retried = true;
                     continue;
                 }
-                waddle_xmpp::prometheus::increment_delivery_retry_exhausted_drop();
+                waddle_xmpp::telemetry::reliability::increment_delivery_retry_exhausted_drop();
                 warn!(
                     room = %room_jid,
                     recipient = %recipient,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -355,10 +355,12 @@ fn spawn_session_recovery_delivery(
                 )
                 .await;
                 if outcome.batches > 0 {
-                    waddle_xmpp::prometheus::add_pending_flush_batches(u64::from(outcome.batches));
+                    waddle_xmpp::telemetry::reliability::add_pending_flush_batches(u64::from(
+                        outcome.batches,
+                    ));
                 }
                 if outcome.pushed > 0 {
-                    waddle_xmpp::prometheus::add_pending_flush_rows_pushed(u64::from(
+                    waddle_xmpp::telemetry::reliability::add_pending_flush_rows_pushed(u64::from(
                         outcome.pushed,
                     ));
                 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription.rs
@@ -5,9 +5,11 @@ mod directed;
 mod roster_state;
 mod storage;
 
-pub use delivery::broadcast_unavailable_for_terminated_session;
 pub(super) use delivery::record_stanza_for_detached_available_resources_excluding;
 pub(super) use delivery::try_route_presence_to_bare_remote;
+pub use delivery::{
+    broadcast_unavailable_for_terminated_session, TerminatedPresenceBroadcastOutcome,
+};
 pub(in crate::server::routes::websocket::handlers) use delivery::{
     send_current_presence_from_user_to_jid, send_current_presence_from_user_to_user,
     send_unavailable_presence_from_user_to_jid, send_unavailable_presence_from_user_to_user,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
@@ -283,16 +283,25 @@ async fn send_presence_stanza_to_jid(
 /// session expiry/invalidation and the unclean disconnect of a non-SM
 /// session (issue #1105). Callers gate on the session having actually
 /// been presence-available.
-pub async fn broadcast_unavailable_for_terminated_session(state: &WebSocketState, from: &FullJid) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminatedPresenceBroadcastOutcome {
+    Completed,
+    Failed,
+}
+
+pub async fn broadcast_unavailable_for_terminated_session(
+    state: &WebSocketState,
+    from: &FullJid,
+) -> TerminatedPresenceBroadcastOutcome {
     let Some(storage) = roster_storage(state).await else {
-        return;
+        return TerminatedPresenceBroadcastOutcome::Failed;
     };
     let from_bare = from.to_bare();
     let subscribers = match storage.get_presence_subscribers(&from_bare).await {
         Ok(subscribers) => subscribers,
         Err(error) => {
             warn!(error = %error, from = %from, "Failed to load presence subscribers for expired detached session");
-            return;
+            return TerminatedPresenceBroadcastOutcome::Failed;
         }
     };
 
@@ -325,6 +334,7 @@ pub async fn broadcast_unavailable_for_terminated_session(state: &WebSocketState
         None,
     )
     .await;
+    TerminatedPresenceBroadcastOutcome::Completed
 }
 
 async fn available_live_and_detached_resources_for_user(

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -100,6 +100,7 @@ pub use cleanup::cleanup_muc_presence_for_jid;
 pub use cleanup::cleanup_muc_presence_for_jid_with_origin;
 #[cfg(feature = "clustering")]
 pub(crate) use cleanup::redrive_remote_muc_cleanup;
+pub use cleanup::MucCleanupOutcome;
 pub use connection::router;
 pub use state::{
     ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore, PendingDmCallOffer, ProtocolServices,

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -238,7 +238,8 @@ impl ResolverAffiliationSyncScheduler {
             return ResolverAffiliationSyncSchedule::Stale;
         }
         if state.workers.len() >= state.max_workers {
-            waddle_xmpp::prometheus::increment_resolver_affiliation_sync_capacity_drop();
+            waddle_xmpp::telemetry::reliability::increment_resolver_affiliation_sync_capacity_drop(
+            );
             return ResolverAffiliationSyncSchedule::AtCapacity;
         }
         let effective_admission_revision =

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -578,7 +578,7 @@ async fn handle_sm_enable(
     let max_resume_secs = max_resume_secs_from_env();
     let max = match enable.max {
         Some(m) if m > max_resume_secs => {
-            waddle_xmpp::prometheus::increment_sm_resume_window_clamped();
+            waddle_xmpp::telemetry::reliability::increment_sm_resume_window_clamped();
             max_resume_secs
         }
         Some(m) => m,

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -4,6 +4,7 @@ use crate::server::routes::websocket::WebSocketState;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
+use waddle_xmpp::telemetry::attributes::{Janitor, SweepOutcome};
 
 /// Default interval for the auth-state TTL janitor.
 const AUTH_JANITOR_INTERVAL: Duration = Duration::from_secs(60);
@@ -155,6 +156,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            let mut sweep_failed = false;
             let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
                 .deps
                 .protocol
@@ -164,6 +166,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
             {
                 Ok(sessions) => sessions,
                 Err(err) => {
+                    sweep_failed = true;
                     warn!(error = %err, "SM janitor: drain_expired failed");
                     Vec::new()
                 }
@@ -193,7 +196,8 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 {
                     Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
                     Err(error) => {
-                        waddle_xmpp::prometheus::increment_sm_promotion_blocklist_failed();
+                        sweep_failed = true;
+                        waddle_xmpp::telemetry::reliability::increment_sm_promotion_blocklist_failed();
                         let attempts = match state
                             .deps
                             .protocol
@@ -223,7 +227,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                             }
                         };
                         if attempts >= max_promotion_attempts_from_env() {
-                            waddle_xmpp::prometheus::increment_sm_promotion_dead_lettered();
+                            waddle_xmpp::telemetry::reliability::increment_sm_promotion_dead_lettered();
                             error!(
                                 jid = %session.jid,
                                 stream_id = %session.stream_id,
@@ -271,10 +275,16 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 // recent-tombstone record PER SESSION, immediately
                 // before this session's promotion, so even a retraction
                 // landing mid-batch is still seen.
-                let recent_tombstones = crate::sm_promotion::recent_tombstones_for_promotion(
+                let recent_tombstones = match crate::sm_promotion::recent_tombstones_for_promotion(
                     &state.deps.protocol.sm_session_registry,
                     "SM janitor",
-                );
+                ) {
+                    Ok(records) => records,
+                    Err(_) => {
+                        sweep_failed = true;
+                        Vec::new()
+                    }
+                };
                 let summary = crate::sm_promotion::promote_session_unacked(
                     &session,
                     &state.deps.protocol.connection_registry,
@@ -289,13 +299,17 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 // retraction recorded after the snapshot above raced
                 // this session's promotion — re-scrub the pending rows
                 // it may have just inserted BEFORE confirm_drained.
-                crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
+                if crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
                     &state.deps.protocol.sm_session_registry,
                     &state.deps.protocol.pending_delivery_storage,
                     &recent_tombstones,
                     "SM janitor",
                 )
-                .await;
+                .await
+                    == crate::sm_promotion::PromotionScrubOutcome::Failed
+                {
+                    sweep_failed = true;
+                }
                 if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
                     > 0
                     || summary.storage_failed > 0
@@ -314,9 +328,10 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     );
                 }
                 if summary.has_storage_failure() {
-                    waddle_xmpp::prometheus::add_sm_promotion_storage_failed(u64::from(
-                        summary.storage_failed,
-                    ));
+                    sweep_failed = true;
+                    waddle_xmpp::telemetry::reliability::add_sm_promotion_storage_failed(
+                        u64::from(summary.storage_failed),
+                    );
                     let attempts = match state
                         .deps
                         .protocol
@@ -345,7 +360,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         }
                     };
                     if attempts >= max_promotion_attempts_from_env() {
-                        waddle_xmpp::prometheus::increment_sm_promotion_dead_lettered();
+                        waddle_xmpp::telemetry::reliability::increment_sm_promotion_dead_lettered();
                         error!(
                             jid = %session.jid,
                             stream_id = %session.stream_id,
@@ -392,6 +407,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 {
                     promotion_guard.complete();
                 } else {
+                    sweep_failed = true;
                     continue;
                 }
                 let session_id =
@@ -402,12 +418,16 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 // detached session broadcasts its own presence, so a
                 // late unavailable would pin subscribers on offline for
                 // an online JID.
-                routes::websocket::broadcast_unavailable_if_no_replacement(
+                if routes::websocket::broadcast_unavailable_if_no_replacement(
                     &state,
                     &session.jid,
                     session.presence_available,
                 )
-                .await;
+                .await
+                    == routes::websocket::handlers::presence::TerminatedPresenceBroadcastOutcome::Failed
+                {
+                    sweep_failed = true;
+                }
                 state
                     .deps
                     .protocol
@@ -442,12 +462,16 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 // removed entry is guaranteed to be S1's, so its token cannot
                 // evict a replacement.
                 if let Some(entry) = removed_entry {
-                    crate::server::dual_registration::mirror_unregister(
+                    if crate::server::dual_registration::mirror_unregister(
                         &state.deps.protocol.user_registry,
                         &session.jid,
                         Some(std::sync::Arc::clone(&entry.carbons_enabled)),
                     )
-                    .await;
+                    .await
+                        == crate::server::dual_registration::MirrorUnregisterOutcome::Failed
+                    {
+                        sweep_failed = true;
+                    }
                 }
                 // PR #438 review (Qodo issue #2): the periodic SM expiry
                 // janitor takes its own cleanup path; without this drop
@@ -489,16 +513,25 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                                 inbound_sequence: 0,
                                 handoff: None,
                             };
-                        routes::websocket::cleanup_muc_presence_for_jid_with_origin(
+                        if routes::websocket::cleanup_muc_presence_for_jid_with_origin(
                             &state,
                             &session.jid,
                             cleanup_origin,
                         )
-                        .await;
+                        .await
+                            == routes::websocket::MucCleanupOutcome::Failed
+                        {
+                            sweep_failed = true;
+                        }
                     }
                     #[cfg(not(feature = "clustering"))]
                     {
-                        routes::websocket::cleanup_muc_presence_for_jid(&state, &session.jid).await;
+                        if routes::websocket::cleanup_muc_presence_for_jid(&state, &session.jid)
+                            .await
+                            == routes::websocket::MucCleanupOutcome::Failed
+                        {
+                            sweep_failed = true;
+                        }
                     }
                 }
                 if let Err(error) = state
@@ -508,6 +541,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     .release_claim(&session_id)
                     .await
                 {
+                    sweep_failed = true;
                     warn!(
                         jid = %session.jid,
                         stream_id = %session.stream_id,
@@ -517,12 +551,22 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     );
                 }
             }
-            retry_pending_sm_ownership(&state).await;
+            if !retry_pending_sm_ownership(&state).await {
+                sweep_failed = true;
+            }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::SmExpiry,
+                if sweep_failed {
+                    SweepOutcome::Failed
+                } else {
+                    SweepOutcome::Completed
+                },
+            );
         }
     });
 }
 
-async fn retry_pending_sm_ownership(state: &WebSocketState) {
+async fn retry_pending_sm_ownership(state: &WebSocketState) -> bool {
     const COMBINED_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
     let registry = &state.deps.protocol.sm_session_registry;
     let hydration = async {
@@ -531,12 +575,14 @@ async fn retry_pending_sm_ownership(state: &WebSocketState) {
     let releases = async {
         registry.retry_pending_claim_releases(64).await;
     };
-    if !run_sm_retries_with_budget(COMBINED_RETRY_BUDGET, hydration, releases).await {
+    let completed = run_sm_retries_with_budget(COMBINED_RETRY_BUDGET, hydration, releases).await;
+    if !completed {
         warn!(
             budget = ?COMBINED_RETRY_BUDGET,
             "SM janitor: ownership reconciliation exhausted its post-expiry tick budget"
         );
     }
+    completed
 }
 
 async fn run_sm_retries_with_budget<H, R>(
@@ -655,36 +701,52 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     error!("orphan reaper worker exited; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                     if supervisor.workers.fatal_fence.is_cancelled() {
+                        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                            Janitor::OrphanReaper,
+                            SweepOutcome::Failed,
+                        );
                         break;
                     }
                 }
                 let Some(state) = weak_state.upgrade() else {
                     break;
                 };
-                match supervise_orphan_reaper_sweep(
+                let sweep_outcome = supervise_orphan_reaper_sweep(
                     &supervisor.workers.cancel,
                     &supervisor.workers.fatal_fence,
                     ORPHAN_REAPER_SWEEP_TIMEOUT,
                     run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
                 )
-                .await
-                {
-                    OrphanSweepOutcome::Completed => {}
-                    OrphanSweepOutcome::Cancelled => break,
+                .await;
+                let mut workers_healthy = supervisor.is_healthy();
+                let mut stop_after_sweep = false;
+                match sweep_outcome {
+                    OrphanSweepOutcome::Completed | OrphanSweepOutcome::Failed => {}
+                    OrphanSweepOutcome::Cancelled => {
+                        stop_after_sweep = true;
+                    }
                     OrphanSweepOutcome::TimedOut => {
                         error!(
                             timeout = ?ORPHAN_REAPER_SWEEP_TIMEOUT,
                             "orphan reaper sweep timed out; self-fencing node because claim handoff state may be uncertain"
                         );
-                        break;
+                        stop_after_sweep = true;
                     }
                 }
-                if !supervisor.is_healthy() {
+                if !stop_after_sweep && !workers_healthy {
                     error!("orphan reaper worker exited during sweep; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                     if supervisor.workers.fatal_fence.is_cancelled() {
-                        break;
+                        stop_after_sweep = true;
                     }
+                    workers_healthy = false;
+                }
+                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                    Janitor::OrphanReaper,
+                    orphan_sweep_heartbeat_outcome(sweep_outcome, workers_healthy),
+                );
+                if stop_after_sweep {
+                    break;
                 }
             }
             // Snapshot and stop SM/release workers before any other terminal
@@ -723,8 +785,21 @@ pub(crate) fn spawn_orphan_reaper_janitor(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OrphanSweepOutcome {
     Completed,
+    Failed,
     Cancelled,
     TimedOut,
+}
+
+#[cfg(feature = "clustering")]
+fn orphan_sweep_heartbeat_outcome(
+    outcome: OrphanSweepOutcome,
+    workers_healthy: bool,
+) -> SweepOutcome {
+    if outcome == OrphanSweepOutcome::Completed && workers_healthy {
+        SweepOutcome::Completed
+    } else {
+        SweepOutcome::Failed
+    }
 }
 
 /// Bound and cancellation-arm the complete outer sweep, not only its worker
@@ -739,14 +814,15 @@ async fn supervise_orphan_reaper_sweep<F>(
     sweep: F,
 ) -> OrphanSweepOutcome
 where
-    F: std::future::Future<Output = ()>,
+    F: std::future::Future<Output = bool>,
 {
     tokio::select! {
         biased;
         _ = cancel.cancelled() => OrphanSweepOutcome::Cancelled,
         _ = fatal_fence.cancelled() => OrphanSweepOutcome::Cancelled,
         result = tokio::time::timeout(timeout, sweep) => match result {
-            Ok(()) => OrphanSweepOutcome::Completed,
+            Ok(true) => OrphanSweepOutcome::Completed,
+            Ok(false) => OrphanSweepOutcome::Failed,
             Err(_) => {
                 fatal_fence.cancel();
                 crate::clustering::metrics::record_orphan_worker_failure("sweep", "timeout");
@@ -759,6 +835,30 @@ where
 #[cfg(all(test, feature = "clustering"))]
 mod orphan_sweep_supervision_tests {
     use super::*;
+
+    #[test]
+    fn heartbeat_fails_for_aborted_or_unhealthy_sweeps() {
+        assert_eq!(
+            orphan_sweep_heartbeat_outcome(OrphanSweepOutcome::Failed, true),
+            SweepOutcome::Failed
+        );
+        assert_eq!(
+            orphan_sweep_heartbeat_outcome(OrphanSweepOutcome::Completed, true),
+            SweepOutcome::Completed
+        );
+        assert_eq!(
+            orphan_sweep_heartbeat_outcome(OrphanSweepOutcome::Completed, false),
+            SweepOutcome::Failed
+        );
+        assert_eq!(
+            orphan_sweep_heartbeat_outcome(OrphanSweepOutcome::Cancelled, true),
+            SweepOutcome::Failed
+        );
+        assert_eq!(
+            orphan_sweep_heartbeat_outcome(OrphanSweepOutcome::TimedOut, true),
+            SweepOutcome::Failed
+        );
+    }
 
     #[tokio::test]
     async fn timed_out_outer_sweep_self_fences_uncertain_claim_handoffs() {
@@ -809,6 +909,7 @@ mod orphan_sweep_supervision_tests {
             Duration::from_secs(1),
             async move {
                 entered_by_sweep.store(true, std::sync::atomic::Ordering::SeqCst);
+                true
             },
         )
         .await;
@@ -3297,23 +3398,25 @@ fn failed_sm_candidate_scan_is_an_empty_batch_not_a_sweep_abort() {
 async fn run_orphan_reaper_sweep_with_workers(
     state: &Arc<WebSocketState>,
     workers: &OrphanReaperWorkers,
-) {
+) -> bool {
     use waddle_xmpp::ownership::ClaimError;
+
+    let mut sweep_failed = false;
 
     let clustering = &state.deps.app_state.clustering_claims;
     let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
-        return;
+        return true;
     };
     let Some(node_lease) = clustering.node_lease.clone() else {
-        return;
+        return true;
     };
     let Some(lease_ttl) = clustering.lease_ttl else {
-        return;
+        return true;
     };
 
     let me = identity_handle.current();
     if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "start").await {
-        return;
+        return false;
     }
 
     match node_lease
@@ -3332,7 +3435,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                         node_epoch = %me.node_epoch,
                         "orphan reaper: stale-node watchdog found this node's own heartbeat stale; aborting sweep"
                     );
-                    return;
+                    return false;
                 }
                 match node_lease.expire(&stale_node, lease_ttl).await {
                     Ok(true) => expired_nodes += 1,
@@ -3364,6 +3467,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 );
             }
             if failed_nodes > 0 {
+                sweep_failed = true;
                 warn!(
                     failed_nodes,
                     candidate_count,
@@ -3372,6 +3476,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             }
         }
         Err(error) => {
+            sweep_failed = true;
             warn!(%error, "orphan reaper: stale-node watchdog candidate scan failed");
         }
     }
@@ -3379,7 +3484,7 @@ async fn run_orphan_reaper_sweep_with_workers(
     if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "post-watchdog")
         .await
     {
-        return;
+        return false;
     }
 
     // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
@@ -3396,6 +3501,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             current_generation.as_deref(),
         ),
         Err(error) => {
+            sweep_failed = true;
             debug!(%error, "orphan reaper: current_generation lookup failed; proceeding without backoff");
             std::time::Duration::ZERO
         }
@@ -3414,6 +3520,7 @@ async fn run_orphan_reaper_sweep_with_workers(
     // reaper cadence, but retry one exact fence per sweep so a slow ownership
     // backend cannot monopolize the registry mailbox.
     if let Err(error) = room_registry.retry_pending_room_releases(1).await {
+        sweep_failed = true;
         debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
     }
 
@@ -3454,7 +3561,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                     }
                     Err(error) => {
                         debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
-                        return;
+                        return false;
                     }
                 }
             }
@@ -3462,7 +3569,7 @@ async fn run_orphan_reaper_sweep_with_workers(
         Err(error) => {
             debug!(%error, "orphan reaper: pending RoomActor listing failed");
             workers.fatal_fence.cancel();
-            return;
+            return false;
         }
     }
     if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
@@ -3507,7 +3614,7 @@ async fn run_orphan_reaper_sweep_with_workers(
     let mut room_page_processed = true;
     for candidate in room_candidates {
         if workers.cancel.is_cancelled() {
-            return;
+            return false;
         }
         if !workers.has_release_capacity() {
             room_page_processed = false;
@@ -3547,7 +3654,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             let _ = room_registry
                 .cancel_pending_reclaimed_room_reservation(room_jid.clone())
                 .await;
-            return;
+            return false;
         }
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
             room_page_processed = false;
@@ -3569,7 +3676,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             let _ = room_registry
                 .cancel_pending_reclaimed_room_reservation(room_jid.clone())
                 .await;
-            return;
+            return false;
         }
         match node_lease
             .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
@@ -3639,6 +3746,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                             )
                             .await
                         {
+                            sweep_failed = true;
                             debug!(
                                 room = %room_jid,
                                 %error,
@@ -3669,15 +3777,19 @@ async fn run_orphan_reaper_sweep_with_workers(
                             %error,
                             "orphan reaper: reclaimed-room registry adoption ask failed; node self-fenced"
                         );
-                        return;
+                        return false;
                     }
                 }
             }
             Err(ClaimError::Conflict) => {
                 room_lost_race += 1;
-                let _ = room_registry
+                if let Err(error) = room_registry
                     .cancel_pending_reclaimed_room_reservation(room_jid.clone())
-                    .await;
+                    .await
+                {
+                    sweep_failed = true;
+                    debug!(room = %room_jid, %error, "orphan reaper: failed to cancel lost-race room adoption reservation");
+                }
             }
             Err(error) => {
                 room_page_processed = false;
@@ -3706,8 +3818,12 @@ async fn run_orphan_reaper_sweep_with_workers(
             )
             .await
         {
+            sweep_failed = true;
             warn!(%error, "orphan reaper: failed to persist RoomActor scan cursor");
         }
+    }
+    if !room_scan_succeeded || room_failed > 0 {
+        sweep_failed = true;
     }
     for (outcome, count) in [
         ("hydrated", room_hydrated),
@@ -3821,13 +3937,14 @@ async fn run_orphan_reaper_sweep_with_workers(
                 .protocol
                 .sm_session_registry
                 .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            return;
+            return false;
         }
         // Element 9's ordering requirement: commit the expire CAS on the
         // dead owner's row FIRST. Idempotent/best-effort — a failure here
         // just means the steal below is also likely to lose (the owner
         // row is not yet committed-expired), retried next sweep.
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            sweep_failed = true;
             page_processed = false;
             workers.cancel_hydration_reservation(&candidate.entity);
             debug!(
@@ -3858,7 +3975,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 .protocol
                 .sm_session_registry
                 .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            return;
+            return false;
         }
         match node_lease
             .steal_orphaned_sm_session_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
@@ -3893,6 +4010,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 // renewed concurrently — safe, no-op.
             }
             Err(error) => {
+                sweep_failed = true;
                 page_processed = false;
                 workers.cancel_hydration_reservation(&candidate.entity);
                 state
@@ -3921,8 +4039,12 @@ async fn run_orphan_reaper_sweep_with_workers(
             )
             .await
         {
+            sweep_failed = true;
             warn!(%error, "orphan reaper: failed to persist SM-session scan cursor");
         }
+    }
+    if !scan_succeeded {
+        sweep_failed = true;
     }
     if stolen > 0 {
         info!(
@@ -3953,9 +4075,11 @@ async fn run_orphan_reaper_sweep_with_workers(
             }
             Ok(Ok(_)) => {}
             Ok(Err(error)) => {
+                sweep_failed = true;
                 warn!(%error, "orphan reaper: ISR token sweep failed");
             }
             Err(_timeout) => {
+                sweep_failed = true;
                 warn!(
                     timeout = ?ISR_TOKEN_SWEEP_TIMEOUT,
                     "orphan reaper: ISR token sweep timed out"
@@ -3963,6 +4087,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             }
         }
     }
+    !sweep_failed
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -4529,6 +4654,7 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            let mut sweep_failed = false;
             let detached_live: Option<Vec<waddle_xmpp::pending_delivery::SmSessionId>> = state
                 .deps
                 .protocol
@@ -4545,6 +4671,10 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                     warn!(
                         "claim-expiry janitor: SM session registry locks poisoned; \
                          skipping sweep to avoid mass-release"
+                    );
+                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                        Janitor::PendingDeliveryClaim,
+                        SweepOutcome::Failed,
                     );
                     continue;
                 }
@@ -4591,6 +4721,7 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(error = %error, "claim-expiry janitor: stamp_unstamped_claims failed");
                 }
             }
@@ -4616,6 +4747,7 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                             Ok(0) => skipped_reclaimed += 1,
                             Ok(_) => released += 1,
                             Err(error) => {
+                                sweep_failed = true;
                                 warn!(
                                     row_id = %row_id,
                                     session = %session,
@@ -4632,10 +4764,11 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                         skipped_reclaimed,
                         "claim-expiry janitor: released orphaned pending_delivery claims"
                     );
-                    waddle_xmpp::prometheus::add_pending_delivery_orphan_claims_released(released);
+                    waddle_xmpp::telemetry::reliability::add_pending_delivery_orphan_claims_released(released);
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(error = %error, "claim-expiry janitor: list_orphaned_claims failed");
                 }
             }
@@ -4663,7 +4796,7 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
             {
                 Ok(0) => {}
                 Ok(removed) => {
-                    waddle_xmpp::prometheus::add_pending_delivery_aged_out(removed);
+                    waddle_xmpp::telemetry::reliability::add_pending_delivery_aged_out(removed);
                     info!(
                         removed,
                         cutoff = %cutoff,
@@ -4672,6 +4805,7 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                     );
                 }
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(
                         %error,
                         "pending_delivery aging janitor: delete_older_than failed; \
@@ -4679,6 +4813,14 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                     );
                 }
             }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::PendingDeliveryClaim,
+                if sweep_failed {
+                    SweepOutcome::Failed
+                } else {
+                    SweepOutcome::Completed
+                },
+            );
         }
     });
 }
@@ -4703,7 +4845,7 @@ pub(crate) fn spawn_push_service_publish_job_janitor(websocket_state: &Arc<WebSo
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            match state
+            let outcome = match state
                 .deps
                 .protocol
                 .push_service
@@ -4715,15 +4857,21 @@ pub(crate) fn spawn_push_service_publish_job_janitor(websocket_state: &Arc<WebSo
                         drained = results.len(),
                         "Push Service publish-job janitor drained queued XEP-0357 jobs"
                     );
+                    SweepOutcome::Completed
                 }
-                Ok(_) => {}
+                Ok(_) => SweepOutcome::Completed,
                 Err(error) => {
                     warn!(
                         error = %error,
                         "Push Service publish-job janitor failed; queued jobs remain durable"
                     );
+                    SweepOutcome::Failed
                 }
-            }
+            };
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::PushPublishJob,
+                outcome,
+            );
         }
     });
 }
@@ -4770,6 +4918,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            let mut sweep_failed = false;
             let first_party_service_jid = match state.deps.service_domains.push.parse() {
                 Ok(jid) => jid,
                 Err(error) => {
@@ -4778,29 +4927,35 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                         push_service = %state.deps.service_domains.push,
                         "Notification outbox janitor cannot parse first-party Push Service JID"
                     );
+                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                        Janitor::NotificationOutbox,
+                        SweepOutcome::Failed,
+                    );
                     continue;
                 }
             };
-            let recovered = routes::interpret::reconcile_xep0357_notification_candidates(
+            let recovered = routes::interpret::reconcile_xep0357_notification_candidates_for_sweep(
                 state.as_ref(),
                 batch_size,
             )
             .await;
-            if recovered > 0 {
+            sweep_failed |= recovered.had_failure;
+            if recovered.completed > 0 {
                 debug!(
-                    recovered,
+                    recovered = recovered.completed,
                     "Notification outbox janitor recovered XEP-0357 candidates from pending_delivery"
                 );
             }
             let recovered_groupchat =
-                routes::interpret::reconcile_groupchat_notification_candidates(
+                routes::interpret::reconcile_groupchat_notification_candidates_for_sweep(
                     state.as_ref(),
                     batch_size,
                 )
                 .await;
-            if recovered_groupchat > 0 {
+            sweep_failed |= recovered_groupchat.had_failure;
+            if recovered_groupchat.completed > 0 {
                 debug!(
-                    recovered = recovered_groupchat,
+                    recovered = recovered_groupchat.completed,
                     "Notification outbox janitor recovered XEP-0357 groupchat candidates from inbox projections"
                 );
             }
@@ -4839,6 +4994,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(
                         error = %error,
                         "Notification outbox janitor failed to process candidates; candidates remain durable"
@@ -4867,6 +5023,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(
                         error = %error,
                         "Notification outbox janitor failed; outbox jobs remain durable"
@@ -4891,6 +5048,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(
                         error = %error,
                         "Notification outbox janitor prune failed; completed rows remain durable"
@@ -4912,12 +5070,21 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    sweep_failed = true;
                     warn!(
                         error = %error,
                         "Notification outbox janitor failed to prune completed groupchat notification recovery rows"
                     );
                 }
             }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::NotificationOutbox,
+                if sweep_failed {
+                    SweepOutcome::Failed
+                } else {
+                    SweepOutcome::Completed
+                },
+            );
         }
     });
 }
@@ -5014,7 +5181,7 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         let mut total_drained = 0usize;
         loop {
             if std::time::Instant::now() >= drain_deadline {
-                waddle_xmpp::prometheus::increment_sm_drain_timeout();
+                waddle_xmpp::telemetry::reliability::increment_sm_drain_timeout();
                 // ADR-0017 Phase 3 Slice 10: whatever this node still
                 // believes it owns at the timeout never even reached
                 // `drain_all_for_shutdown` this pass — abandoned, same as
@@ -5116,10 +5283,13 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                 // Round-2 review R2 + round-3 finding 1: per-session
                 // recent-tombstone fetch so a retraction landing
                 // mid-batch during the shutdown drain is still seen.
-                let recent_tombstones = crate::sm_promotion::recent_tombstones_for_promotion(
+                let mut recent_tombstones = Vec::new();
+                if let Ok(records) = crate::sm_promotion::recent_tombstones_for_promotion(
                     &websocket_state.deps.protocol.sm_session_registry,
                     "Graceful shutdown",
-                );
+                ) {
+                    recent_tombstones = records;
+                }
                 let summary = crate::sm_promotion::promote_session_unacked(
                     session,
                     &websocket_state.deps.protocol.connection_registry,
@@ -5133,13 +5303,14 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                 // Finding B: same TOCTOU close-out as the SM janitor —
                 // re-scrub pending rows for tombstones recorded during
                 // this session's promotion window before confirming.
-                crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
-                    &websocket_state.deps.protocol.sm_session_registry,
-                    &websocket_state.deps.protocol.pending_delivery_storage,
-                    &recent_tombstones,
-                    "Graceful shutdown",
-                )
-                .await;
+                let _ =
+                    crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
+                        &websocket_state.deps.protocol.sm_session_registry,
+                        &websocket_state.deps.protocol.pending_delivery_storage,
+                        &recent_tombstones,
+                        "Graceful shutdown",
+                    )
+                    .await;
                 info!(
                     jid = %session.jid,
                     redelivered = summary.redelivered,
@@ -5307,6 +5478,10 @@ pub(crate) fn spawn_auth_state_janitor(websocket_state: &Arc<WebSocketState>) {
                 Ok(counts) => counts,
                 Err(error) => {
                     warn!(error = %error, "auth janitor: sweep failed; will retry next tick");
+                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                        Janitor::AuthState,
+                        SweepOutcome::Failed,
+                    );
                     continue;
                 }
             };
@@ -5329,6 +5504,10 @@ pub(crate) fn spawn_auth_state_janitor(websocket_state: &Arc<WebSocketState>) {
                     "auth janitor: no expired entries"
                 );
             }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::AuthState,
+                SweepOutcome::Completed,
+            );
         }
     });
 }
@@ -5339,6 +5518,7 @@ pub(crate) struct DormancySweepCounts {
     pub evicted: usize,
     pub examined: usize,
     pub remaining: usize,
+    failed: bool,
 }
 
 /// Walk every registered MUC room and destroy the ones that report
@@ -5360,6 +5540,7 @@ pub(crate) async fn sweep_dormant_rooms_once(
     {
         Ok(list) => list,
         Err(error) => {
+            counts.failed = true;
             warn!(error = ?error, "room dormancy janitor: ListRooms ask failed");
             return counts;
         }
@@ -5378,6 +5559,7 @@ pub(crate) async fn sweep_dormant_rooms_once(
             Ok(Some(actor)) => actor,
             Ok(None) => continue,
             Err(error) => {
+                counts.failed = true;
                 warn!(
                     room = %room_jid,
                     error = ?error,
@@ -5393,6 +5575,7 @@ pub(crate) async fn sweep_dormant_rooms_once(
         let status = match actor.ask(IsDormant).reply_timeout(REAPER_ASK_TIMEOUT).await {
             Ok(value) => value,
             Err(error) => {
+                counts.failed = true;
                 warn!(
                     room = %room_jid,
                     error = ?error,
@@ -5426,6 +5609,7 @@ pub(crate) async fn sweep_dormant_rooms_once(
             }
             Ok(false) => {}
             Err(error) => {
+                counts.failed = true;
                 warn!(
                     room = %room_jid,
                     error = ?error,
@@ -5434,13 +5618,20 @@ pub(crate) async fn sweep_dormant_rooms_once(
             }
         }
     }
-    counts.remaining = websocket_state
+    counts.remaining = match websocket_state
         .deps
         .protocol
         .room_registry
         .ask(RoomCount)
         .await
-        .unwrap_or(0);
+    {
+        Ok(remaining) => remaining,
+        Err(error) => {
+            counts.failed = true;
+            warn!(error = ?error, "room dormancy janitor: RoomCount ask failed");
+            0
+        }
+    };
     counts
 }
 
@@ -5468,23 +5659,35 @@ pub(crate) fn spawn_room_dormancy_janitor(websocket_state: &Arc<WebSocketState>)
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let counts = sweep_dormant_rooms_once(&state).await;
-            if counts.evicted > 0 {
-                info!(
-                    examined = counts.examined,
-                    evicted = counts.evicted,
-                    remaining = counts.remaining,
-                    "room dormancy janitor: evicted dormant rooms"
-                );
-            } else {
-                debug!(
-                    examined = counts.examined,
-                    remaining = counts.remaining,
-                    "room dormancy janitor: no dormant rooms"
-                );
-            }
+            run_room_dormancy_sweep(&state).await;
         }
     });
+}
+
+async fn run_room_dormancy_sweep(state: &WebSocketState) {
+    let counts = sweep_dormant_rooms_once(state).await;
+    if counts.evicted > 0 {
+        info!(
+            examined = counts.examined,
+            evicted = counts.evicted,
+            remaining = counts.remaining,
+            "room dormancy janitor: evicted dormant rooms"
+        );
+    } else {
+        debug!(
+            examined = counts.examined,
+            remaining = counts.remaining,
+            "room dormancy janitor: no dormant rooms"
+        );
+    }
+    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+        Janitor::RoomDormancy,
+        if counts.failed {
+            SweepOutcome::Failed
+        } else {
+            SweepOutcome::Completed
+        },
+    );
 }
 
 /// Per-sweep counts returned by [`sweep_empty_user_actors_once`].
@@ -5493,6 +5696,7 @@ pub(crate) struct UserReaperSweepCounts {
     pub reaped: usize,
     pub examined: usize,
     pub remaining: usize,
+    failed: bool,
 }
 
 /// Walk every registered `UserActor` and reap the ones that report zero
@@ -5524,6 +5728,7 @@ pub(crate) async fn sweep_empty_user_actors_once(
     {
         Ok(list) => list,
         Err(error) => {
+            counts.failed = true;
             warn!(error = ?error, "user actor reaper: ListUsers ask failed");
             return counts;
         }
@@ -5540,11 +5745,12 @@ pub(crate) async fn sweep_empty_user_actors_once(
         {
             Ok(true) => {
                 counts.reaped += 1;
-                waddle_xmpp::prometheus::increment_user_actor_reaped();
+                waddle_xmpp::telemetry::reliability::increment_user_actor_reaped();
                 debug!(jid = %bare_jid, "user actor reaper: reaped empty UserActor");
             }
             Ok(false) => {}
             Err(error) => {
+                counts.failed = true;
                 warn!(
                     jid = %bare_jid,
                     error = ?error,
@@ -5561,6 +5767,7 @@ pub(crate) async fn sweep_empty_user_actors_once(
     {
         Ok(count) => count,
         Err(error) => {
+            counts.failed = true;
             // The closing count is a log-only diagnostic, so a failure is not
             // fatal — but surface it rather than reporting a misleading `0
             // remaining` that reads as "everything was reaped".
@@ -5611,13 +5818,21 @@ pub(crate) fn spawn_user_actor_reaper(websocket_state: &Arc<WebSocketState>) {
                     "user actor reaper: no empty UserActors"
                 );
             }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::UserActorReaper,
+                if counts.failed {
+                    SweepOutcome::Failed
+                } else {
+                    SweepOutcome::Completed
+                },
+            );
         }
     });
 }
 
 #[cfg(test)]
 mod room_dormancy_tests {
-    use super::sweep_dormant_rooms_once;
+    use super::{run_room_dormancy_sweep, sweep_dormant_rooms_once};
     use crate::server::routes::websocket::tests::create_test_websocket_state;
     use waddle_xmpp::muc::{
         room_actor::{
@@ -5636,6 +5851,21 @@ mod room_dormancy_tests {
         format!("{local}@muc.example.com")
             .parse()
             .expect("bare jid")
+    }
+
+    #[tokio::test]
+    async fn zero_work_room_dormancy_sweep_records_completed_heartbeat() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let state = create_test_websocket_state().await;
+        run_room_dormancy_sweep(&state).await;
+
+        assert_eq!(
+            metrics.counter_sum(
+                "waddle.janitor.sweeps",
+                &[("janitor", "room_dormancy"), ("outcome", "completed")],
+            ),
+            Some(1),
+        );
     }
 
     #[tokio::test]
@@ -5998,6 +6228,15 @@ mod user_reaper_tests {
 #[cfg(feature = "clustering")]
 const REMOTE_MUC_MEMBERSHIP_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
+#[cfg(feature = "clustering")]
+fn remote_muc_sweep_outcome(had_failure: bool) -> SweepOutcome {
+    if had_failure {
+        SweepOutcome::Failed
+    } else {
+        SweepOutcome::Completed
+    }
+}
+
 /// Collect the occupants whose remote MUC memberships need a cleanup
 /// re-drive (#1249): an ACTIVE membership entry whose occupant full JID
 /// has no live connection-registry entry here and no resumable
@@ -6012,8 +6251,17 @@ const REMOTE_MUC_MEMBERSHIP_RECONCILE_INTERVAL: Duration = Duration::from_secs(3
 /// candidate; SM expiry runs its own cleanup pass which restores the
 /// membership on failure and thereby feeds this janitor.
 #[cfg(feature = "clustering")]
-async fn collect_remote_muc_reconcile_candidates(state: &WebSocketState) -> Vec<jid::FullJid> {
+struct RemoteMucReconcileCandidates {
+    occupants: Vec<jid::FullJid>,
+    had_failure: bool,
+}
+
+#[cfg(feature = "clustering")]
+async fn collect_remote_muc_reconcile_candidates(
+    state: &WebSocketState,
+) -> RemoteMucReconcileCandidates {
     let mut candidates = Vec::new();
+    let mut had_failure = false;
     for occupant in state
         .deps
         .protocol
@@ -6035,18 +6283,26 @@ async fn collect_remote_muc_reconcile_candidates(state: &WebSocketState) -> Vec<
         // node) proves the occupancy is still legitimately resumable.
         // The probe checks this node's memory AND the shared durable
         // store, and fails closed on read errors.
-        if state
+        match state
             .deps
             .protocol
             .sm_session_registry
-            .any_resumable_session_for_full_jid(&occupant)
+            .probe_resumable_session_for_full_jid(&occupant)
             .await
         {
-            continue;
+            waddle_xmpp::stream_management::ResumableSessionProbe::Present => continue,
+            waddle_xmpp::stream_management::ResumableSessionProbe::Absent => {}
+            waddle_xmpp::stream_management::ResumableSessionProbe::Failed => {
+                had_failure = true;
+                continue;
+            }
         }
         candidates.push(occupant);
     }
-    candidates
+    RemoteMucReconcileCandidates {
+        occupants: candidates,
+        had_failure,
+    }
 }
 
 /// #1249: periodically re-drive remote MUC unavailable relays whose
@@ -6073,14 +6329,19 @@ pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSo
                 break;
             };
             let candidates = collect_remote_muc_reconcile_candidates(&state).await;
-            if candidates.is_empty() {
+            if candidates.occupants.is_empty() {
+                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                    Janitor::RemoteMucMembership,
+                    remote_muc_sweep_outcome(candidates.had_failure),
+                );
                 continue;
             }
             info!(
-                candidates = candidates.len(),
+                candidates = candidates.occupants.len(),
                 "remote MUC reconciler: re-driving unavailable relays for departed occupants"
             );
-            for occupant in candidates {
+            let mut sweep_failed = candidates.had_failure;
+            for occupant in candidates.occupants {
                 // Re-check liveness IMMEDIATELY before the re-drive
                 // (codex review P1 on PR #1277): the candidate list was
                 // collected before earlier awaited re-drives, and the
@@ -6098,17 +6359,26 @@ pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSo
                 {
                     continue;
                 }
-                routes::websocket::redrive_remote_muc_cleanup(&state, &occupant).await;
+                if routes::websocket::redrive_remote_muc_cleanup(&state, &occupant).await
+                    == routes::websocket::MucCleanupOutcome::Failed
+                {
+                    sweep_failed = true;
+                }
             }
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::RemoteMucMembership,
+                remote_muc_sweep_outcome(sweep_failed),
+            );
         }
     });
 }
 
 #[cfg(all(test, feature = "clustering"))]
 mod remote_muc_reconciler_tests {
-    use super::collect_remote_muc_reconcile_candidates;
+    use super::{collect_remote_muc_reconcile_candidates, remote_muc_sweep_outcome};
     use crate::server::routes::websocket::tests::create_test_websocket_state;
     use waddle_xmpp::stream_management::{DetachedSession, SmSessionRegistry};
+    use waddle_xmpp::telemetry::attributes::SweepOutcome;
 
     fn room(local: &str) -> jid::BareJid {
         format!("{local}@muc.example.com")
@@ -6138,6 +6408,32 @@ mod remote_muc_reconciler_tests {
             presence_payloads: Vec::new(),
             pending_subscribes_flushed: false,
         }
+    }
+
+    #[tokio::test]
+    async fn missing_relay_bridge_restores_membership_and_fails_the_sweep() {
+        let state = create_test_websocket_state().await;
+        let occupant: jid::FullJid = "ghost@example.com/web".parse().expect("occupant");
+        state.deps.protocol.remote_muc_memberships.record_join(
+            &occupant,
+            &room("bridge-missing"),
+            "ghost",
+        );
+
+        let cleanup =
+            crate::server::routes::websocket::redrive_remote_muc_cleanup(&state, &occupant).await;
+
+        assert_eq!(
+            cleanup,
+            crate::server::routes::websocket::MucCleanupOutcome::Failed
+        );
+        assert!(state
+            .deps
+            .protocol
+            .remote_muc_memberships
+            .occupants_with_active_memberships()
+            .contains(&occupant));
+        assert_eq!(remote_muc_sweep_outcome(true), SweepOutcome::Failed);
     }
 
     /// #1249: an ACTIVE remote membership whose occupant has neither a
@@ -6183,8 +6479,9 @@ mod remote_muc_reconciler_tests {
         assert_eq!(taken.len(), 1);
 
         let candidates = collect_remote_muc_reconcile_candidates(&state).await;
+        assert!(!candidates.had_failure);
         assert_eq!(
-            candidates,
+            candidates.occupants,
             vec![ghost],
             "only the fully departed occupant is re-driven"
         );

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -741,10 +741,16 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     }
                     workers_healthy = false;
                 }
-                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                    Janitor::OrphanReaper,
-                    orphan_sweep_heartbeat_outcome(sweep_outcome, workers_healthy),
-                );
+                // A shutdown-cancelled sweep is neither completed nor failed;
+                // skipping the heartbeat keeps routine deploys from
+                // registering failed sweeps (an absent heartbeat during
+                // shutdown is the honest signal).
+                if sweep_outcome != OrphanSweepOutcome::Cancelled {
+                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                        Janitor::OrphanReaper,
+                        orphan_sweep_heartbeat_outcome(sweep_outcome, workers_healthy),
+                    );
+                }
                 if stop_after_sweep {
                     break;
                 }
@@ -822,6 +828,11 @@ where
         _ = fatal_fence.cancelled() => OrphanSweepOutcome::Cancelled,
         result = tokio::time::timeout(timeout, sweep) => match result {
             Ok(true) => OrphanSweepOutcome::Completed,
+            // The sweep observed the cancellation token itself before the
+            // biased select arms fired — that's a shutdown, not a failure.
+            Ok(false) if cancel.is_cancelled() || fatal_fence.is_cancelled() => {
+                OrphanSweepOutcome::Cancelled
+            }
             Ok(false) => OrphanSweepOutcome::Failed,
             Err(_) => {
                 fatal_fence.cancel();

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -363,9 +363,12 @@ pub async fn prune_promoted_then_reinsert_for_retry(
 pub fn recent_tombstones_for_promotion(
     sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
     context: &'static str,
-) -> Vec<waddle_xmpp::stream_management::RecentTombstoneRecord> {
+) -> Result<
+    Vec<waddle_xmpp::stream_management::RecentTombstoneRecord>,
+    waddle_xmpp::stream_management::SmRegistryError,
+> {
     match sm_registry.recent_tombstones() {
-        Ok(records) => records,
+        Ok(records) => Ok(records),
         Err(error) => {
             tracing::warn!(
                 %error,
@@ -373,7 +376,7 @@ pub fn recent_tombstones_for_promotion(
                 "recent-tombstone read failed; proceeding without the \
                  promotion-time tombstone re-check"
             );
-            Vec::new()
+            Err(error)
         }
     }
 }
@@ -394,12 +397,18 @@ pub fn recent_tombstones_for_promotion(
 /// just-inserted rows are removed again. Idempotent and best-effort —
 /// a scrub failure is logged; the row also stays covered by the
 /// interpret-layer scrub retry semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromotionScrubOutcome {
+    Completed,
+    Failed,
+}
+
 pub async fn scrub_pending_for_tombstones_recorded_during_promotion(
     sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
     pending_storage: &Arc<dyn PendingDeliveryStorage>,
     pre_promotion: &[waddle_xmpp::stream_management::RecentTombstoneRecord],
     context: &'static str,
-) {
+) -> PromotionScrubOutcome {
     let post_promotion = match sm_registry.recent_tombstones() {
         Ok(records) => records,
         Err(error) => {
@@ -409,9 +418,10 @@ pub async fn scrub_pending_for_tombstones_recorded_during_promotion(
                 "post-promotion recent-tombstone read failed; a retraction that \
                  raced this promotion window may deliver at next login"
             );
-            return;
+            return PromotionScrubOutcome::Failed;
         }
     };
+    let mut completed = true;
     for record in post_promotion
         .iter()
         .filter(|record| !pre_promotion.contains(record))
@@ -429,6 +439,7 @@ pub async fn scrub_pending_for_tombstones_recorded_during_promotion(
             }
             Ok(_) => {}
             Err(error) => {
+                completed = false;
                 tracing::warn!(
                     target = record.key.id(),
                     archive = %record.key.archive_jid(),
@@ -439,6 +450,11 @@ pub async fn scrub_pending_for_tombstones_recorded_during_promotion(
                 );
             }
         }
+    }
+    if completed {
+        PromotionScrubOutcome::Completed
+    } else {
+        PromotionScrubOutcome::Failed
     }
 }
 
@@ -457,7 +473,7 @@ pub async fn promote_displaced_sessions(
         {
             Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
             Err(error) => {
-                waddle_xmpp::prometheus::increment_sm_promotion_blocklist_failed();
+                waddle_xmpp::telemetry::reliability::increment_sm_promotion_blocklist_failed();
                 if let Err(record_error) = deps
                     .sm_registry
                     .record_promotion_failure(&session.stream_id)
@@ -494,8 +510,12 @@ pub async fn promote_displaced_sessions(
         // session's promotion, so a retraction racing the displacement
         // drain — even one landing mid-batch — still scrubs the
         // in-flight copies.
-        let recent_tombstones =
-            recent_tombstones_for_promotion(deps.sm_registry, "displaced SM promotion");
+        let mut recent_tombstones = Vec::new();
+        if let Ok(records) =
+            recent_tombstones_for_promotion(deps.sm_registry, "displaced SM promotion")
+        {
+            recent_tombstones = records;
+        }
         let summary = promote_session_unacked(
             &session,
             deps.connection_registry,
@@ -517,7 +537,7 @@ pub async fn promote_displaced_sessions(
         )
         .await;
         if summary.has_storage_failure() {
-            waddle_xmpp::prometheus::add_sm_promotion_storage_failed(u64::from(
+            waddle_xmpp::telemetry::reliability::add_sm_promotion_storage_failed(u64::from(
                 summary.storage_failed,
             ));
             if let Err(error) = deps
@@ -618,7 +638,7 @@ async fn promote_one(
     mut ctx: PromotionContext<'_>,
 ) -> PromotedOutcome {
     if waddle_xmpp_core::mam::is_mam_query_response_message(&message) {
-        waddle_xmpp::prometheus::increment_sm_promotion_not_promotable();
+        waddle_xmpp::telemetry::reliability::increment_sm_promotion_not_promotable();
         return PromotedOutcome::NotPromotable;
     }
 

--- a/server/crates/waddle-server/src/sm_promotion/pending.rs
+++ b/server/crates/waddle-server/src/sm_promotion/pending.rs
@@ -80,7 +80,7 @@ pub(super) async fn insert_pending(
             // typed StanzaError builder the routing layer uses for
             // intake-time quota overflow so the wire shape is
             // identical.
-            waddle_xmpp::prometheus::increment_pending_delivery_quota_exceeded();
+            waddle_xmpp::telemetry::reliability::increment_pending_delivery_quota_exceeded();
             send_quota_bounce(original_message, &recipient, delivery).await;
             PromotedOutcome::Bounced
         }

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -559,6 +559,15 @@ fn render_push_suppressed_lines(out: &mut String) {
         out.push_str(&value.to_string());
         out.push('\n');
     }
+    // Frozen at 0 through the expand phase: the sealed
+    // `PushSuppressReason` enum makes an unmapped reason a compile
+    // error, so nothing can increment this series any more — but the
+    // expand release must not change the text renderer's output shape.
+    // Absence-sensitive queries keep answering until the contract PR
+    // deletes the family wholesale.
+    out.push_str("# HELP waddle_push_suppressed_unknown_reason_total Push suppression events that arrived with a reason outside the typed allowlist. Structurally unreachable since the reason set became a sealed enum; frozen at 0 until the family's contract-phase deletion.\n");
+    out.push_str("# TYPE waddle_push_suppressed_unknown_reason_total counter\n");
+    out.push_str("waddle_push_suppressed_unknown_reason_total 0\n");
 }
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -260,9 +260,9 @@ static DND_PROJECTION_READ_ERRORED: AtomicU64 = AtomicU64::new(0);
 // values remain byte-identical.
 //
 // Storage is a fixed `[AtomicU64; N]` array indexed by the typed reason.
-// No mutex, no allocations, no cardinality growth at runtime. Inputs that
-// cannot be mapped into the typed allowlist use the separate
-// `PUSH_SUPPRESSED_UNKNOWN_REASON` catch-all before reaching this boundary.
+// No mutex, no allocations, no cardinality growth at runtime. The sealed
+// `PushSuppressReason` enum makes an unmapped reason a compile error, so
+// no unknown-reason catch-all exists (deleted with #1330's typed plumbing).
 pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &PushSuppressReason::VALUES;
 
 const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
@@ -299,10 +299,6 @@ const _: () = assert!(
     PUSH_SUPPRESSED_REASONS.len() == PUSH_SUPPRESSED_COUNTERS_LEN,
     "PUSH_SUPPRESSED_REASONS and PUSH_SUPPRESSED_COUNTERS must stay the same length"
 );
-
-// Catch-all counter for reason values that cannot be mapped into the typed
-// allowlist. Normal typed suppression cannot increment it.
-static PUSH_SUPPRESSED_UNKNOWN_REASON: AtomicU64 = AtomicU64::new(0);
 
 /// Public read-only view of the metric reason values. The
 /// `waddle-server` test suite uses this to assert that every
@@ -551,13 +547,6 @@ pub(crate) fn increment_push_suppressed(reason: PushSuppressReason) {
     PUSH_SUPPRESSED_COUNTERS[reason.index()].fetch_add(1, Ordering::Relaxed);
 }
 
-/// Increment the frozen legacy catch-all for an upstream reason that could not
-/// be mapped into [`PushSuppressReason`]. Normal typed emission cannot reach
-/// this counter.
-pub(crate) fn increment_push_suppressed_unknown_reason() {
-    PUSH_SUPPRESSED_UNKNOWN_REASON.fetch_add(1, Ordering::Relaxed);
-}
-
 /// Snapshot of every push-suppressed counter for rendering.
 fn render_push_suppressed_lines(out: &mut String) {
     out.push_str("# HELP waddle_push_suppressed_total XEP-0357 push notification candidates suppressed by a XEP/Waddle rule. Labeled by the typed `SuppressedReason` enum.\n");
@@ -570,12 +559,6 @@ fn render_push_suppressed_lines(out: &mut String) {
         out.push_str(&value.to_string());
         out.push('\n');
     }
-    let unknown = PUSH_SUPPRESSED_UNKNOWN_REASON.load(Ordering::Relaxed);
-    out.push_str("# HELP waddle_push_suppressed_unknown_reason_total Push suppression events that arrived with a reason string not present in the parallel `PUSH_SUPPRESSED_REASONS` wire-contract constant. A non-zero sample indicates the constant has drifted from `SuppressedReason::as_db_value`.\n");
-    out.push_str("# TYPE waddle_push_suppressed_unknown_reason_total counter\n");
-    out.push_str("waddle_push_suppressed_unknown_reason_total ");
-    out.push_str(&unknown.to_string());
-    out.push('\n');
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -614,7 +597,6 @@ pub fn reset_metrics_for_test() {
     for counter in PUSH_SUPPRESSED_COUNTERS.iter() {
         counter.store(0, Ordering::Release);
     }
-    PUSH_SUPPRESSED_UNKNOWN_REASON.store(0, Ordering::Release);
     PUSH_CANDIDATE_CREATED.store(0, Ordering::Release);
     PUSH_CANDIDATE_COALESCED.store(0, Ordering::Release);
     PUSH_OUTBOX_PUBLISHED.store(0, Ordering::Release);

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -7,6 +7,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(any(test, feature = "test-utils"))]
 use std::sync::OnceLock;
 
+use crate::telemetry::attributes::PushSuppressReason;
+
 static CONNECTED_USERS: AtomicU64 = AtomicU64::new(0);
 static ROOM_COUNT: AtomicU64 = AtomicU64::new(0);
 static MESSAGES_TOTAL: AtomicU64 = AtomicU64::new(0);
@@ -252,36 +254,16 @@ static DND_PROJECTION_READ_ERRORED: AtomicU64 = AtomicU64::new(0);
 // time a XEP-0357 push candidate is suppressed at either T0 emission
 // or the T1 drain. Labeled by the typed `SuppressedReason` enum.
 //
-// **Wire contract**: [`PUSH_SUPPRESSED_REASONS`] is the source-of-truth
-// parallel constant of every label string the caller is allowed to
-// pass. It MUST stay in lockstep with `SuppressedReason::as_db_value`
-// in `waddle_server::notification_outbox` (i.e. every entry in
-// `SuppressedReason::ALL.iter().map(as_db_value)` MUST appear here,
-// in declaration order). The `waddle-server` test suite enforces this
-// invariant — `waddle-xmpp` is upstream and cannot import the enum.
+// **Wire contract**: [`PUSH_SUPPRESSED_REASONS`] is compiled directly
+// from [`PushSuppressReason::VALUES`]. `waddle-server` exhaustively maps
+// its persisted audit enum into that metric enum and tests that its DB
+// values remain byte-identical.
 //
-// Storage is a fixed `[AtomicU64; N]` array indexed by the position
-// of the reason string in `PUSH_SUPPRESSED_REASONS`. No mutex, no
-// allocations, no cardinality growth at runtime. An unknown label
-// (contract drift) increments `PUSH_SUPPRESSED_UNKNOWN_REASON` and
-// emits a `warn!` so the failure is observable.
-pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &[
-    "xep0357_self",
-    "xep0357_no_registration",
-    "xep0357_registration_disabled",
-    "xep0492_never",
-    "xep0492_on_mention_miss",
-    "xep0191_blocked",
-    "xep0513_noping",
-    "xep0513_active_miss",
-    "waddle_dnd",
-    "provider_rejected",
-    "provider_token_expired",
-    "xep0357_push_service_degraded",
-    "unread_zero_at_publish",
-    "policy_retries_exhausted",
-    "xep0444_reaction",
-];
+// Storage is a fixed `[AtomicU64; N]` array indexed by the typed reason.
+// No mutex, no allocations, no cardinality growth at runtime. Inputs that
+// cannot be mapped into the typed allowlist use the separate
+// `PUSH_SUPPRESSED_UNKNOWN_REASON` catch-all before reaching this boundary.
+pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &PushSuppressReason::VALUES;
 
 const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
 
@@ -318,25 +300,15 @@ const _: () = assert!(
     "PUSH_SUPPRESSED_REASONS and PUSH_SUPPRESSED_COUNTERS must stay the same length"
 );
 
-// Catch-all gauge for caller/contract drift: any
-// `increment_push_suppressed` call site passing a value that is NOT
-// in `PUSH_SUPPRESSED_REASONS` increments this and emits a `warn!`.
-// A non-zero sample at scrape time means the parallel constant has
-// drifted from `SuppressedReason::as_db_value` and needs a same-PR
-// fix.
+// Catch-all counter for reason values that cannot be mapped into the typed
+// allowlist. Normal typed suppression cannot increment it.
 static PUSH_SUPPRESSED_UNKNOWN_REASON: AtomicU64 = AtomicU64::new(0);
 
-/// Public read-only view of the parallel reason list. The
+/// Public read-only view of the metric reason values. The
 /// `waddle-server` test suite uses this to assert that every
 /// `SuppressedReason::as_db_value()` appears in the wire contract.
 pub fn push_suppressed_reasons() -> &'static [&'static str] {
     PUSH_SUPPRESSED_REASONS
-}
-
-/// Returns the index of `reason` in `PUSH_SUPPRESSED_REASONS`, or
-/// `None` if the reason is not a recognized wire-contract value.
-fn push_suppressed_index(reason: &str) -> Option<usize> {
-    PUSH_SUPPRESSED_REASONS.iter().position(|r| *r == reason)
 }
 
 /// Serializes unit tests that mutate process-global metrics.
@@ -402,31 +374,31 @@ pub fn record_message_processed() {
     CURRENT_SECOND_MESSAGES.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_broadcast_delivered() {
+pub(crate) fn increment_broadcast_delivered() {
     BROADCAST_DELIVERED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_broadcast_not_connected() {
+pub(crate) fn increment_broadcast_not_connected() {
     BROADCAST_NOT_CONNECTED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_broadcast_dropped_full() {
+pub(crate) fn increment_broadcast_dropped_full() {
     BROADCAST_DROPPED_FULL.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_broadcast_dropped_closed() {
+pub(crate) fn increment_broadcast_dropped_closed() {
     BROADCAST_DROPPED_CLOSED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_delivery_terminal_error_drop() {
+pub(crate) fn increment_delivery_terminal_error_drop() {
     DELIVERY_TERMINAL_ERROR_DROP.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_delivery_retry_exhausted_drop() {
+pub(crate) fn increment_delivery_retry_exhausted_drop() {
     DELIVERY_RETRY_EXHAUSTED_DROP.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_resolver_affiliation_sync_capacity_drop() {
+pub(crate) fn increment_resolver_affiliation_sync_capacity_drop() {
     RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -440,92 +412,92 @@ pub fn delivery_retry_exhausted_drop_count() -> u64 {
     DELIVERY_RETRY_EXHAUSTED_DROP.load(Ordering::Relaxed)
 }
 
-pub fn increment_user_actor_reaped() {
+pub(crate) fn increment_user_actor_reaped() {
     USER_ACTOR_REAPED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_sm_unacked_evicted() {
+pub(crate) fn increment_sm_unacked_evicted() {
     SM_UNACKED_EVICTED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_pending_delivery_quota_exceeded() {
+pub(crate) fn increment_pending_delivery_quota_exceeded() {
     PENDING_DELIVERY_QUOTA_EXCEEDED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn add_pending_delivery_orphan_claims_released(n: u64) {
+pub(crate) fn add_pending_delivery_orphan_claims_released(n: u64) {
     PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.fetch_add(n, Ordering::Relaxed);
 }
 
-pub fn add_pending_delivery_aged_out(n: u64) {
+pub(crate) fn add_pending_delivery_aged_out(n: u64) {
     PENDING_DELIVERY_AGED_OUT.fetch_add(n, Ordering::Relaxed);
 }
 
-pub fn increment_pending_delivery_unresolved_poison_pill() {
+pub(crate) fn increment_pending_delivery_unresolved_poison_pill() {
     PENDING_DELIVERY_UNRESOLVED_POISON_PILL.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_pending_delivery_archive_lookup_transient_failure() {
+pub(crate) fn increment_pending_delivery_archive_lookup_transient_failure() {
     PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn add_sm_promotion_storage_failed(n: u64) {
+pub(crate) fn add_sm_promotion_storage_failed(n: u64) {
     SM_PROMOTION_STORAGE_FAILED.fetch_add(n, Ordering::Relaxed);
 }
 
-pub fn increment_sm_promotion_not_promotable() {
+pub(crate) fn increment_sm_promotion_not_promotable() {
     SM_PROMOTION_NOT_PROMOTABLE.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_sm_promotion_blocklist_failed() {
+pub(crate) fn increment_sm_promotion_blocklist_failed() {
     SM_PROMOTION_BLOCKLIST_FAILED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_sm_promotion_dead_lettered() {
+pub(crate) fn increment_sm_promotion_dead_lettered() {
     SM_PROMOTION_DEAD_LETTERED.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_sm_drain_timeout() {
+pub(crate) fn increment_sm_drain_timeout() {
     SM_DRAIN_TIMEOUT.fetch_add(1, Ordering::Relaxed);
 }
 
-pub fn increment_sm_resume_window_clamped() {
+pub(crate) fn increment_sm_resume_window_clamped() {
     SM_RESUME_WINDOW_CLAMPED.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `waddle_sm_send_window_pauses_total` — a wire-write path
 /// engaged the XEP-0198 send-window pause (issue #1219).
-pub fn increment_sm_send_window_pause() {
+pub(crate) fn increment_sm_send_window_pause() {
     SM_SEND_WINDOW_PAUSES.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `waddle_sm_send_window_pause_timeouts_total` — a send-window
 /// pause outlived its deadline with no recovering ack (issue #1219).
-pub fn increment_sm_send_window_pause_timeout() {
+pub(crate) fn increment_sm_send_window_pause_timeout() {
     SM_SEND_WINDOW_PAUSE_TIMEOUTS.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment `waddle_sm_detached_unacked_evicted_total` — a detached
 /// session's unacked queue evicted an entry at capacity while awaiting
 /// resume (issue #1219; previously silent).
-pub fn increment_sm_detached_unacked_evicted() {
+pub(crate) fn increment_sm_detached_unacked_evicted() {
     SM_DETACHED_UNACKED_EVICTED.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Add to `waddle_pending_flush_batches_total` — batches drained by the
 /// batched offline flush (issue #1220).
-pub fn add_pending_flush_batches(n: u64) {
+pub(crate) fn add_pending_flush_batches(n: u64) {
     PENDING_FLUSH_BATCHES.fetch_add(n, Ordering::Relaxed);
 }
 
 /// Add to `waddle_pending_flush_rows_pushed_total` — replay stanzas pushed
 /// to recovering resources by the offline flush (issue #1220).
-pub fn add_pending_flush_rows_pushed(n: u64) {
+pub(crate) fn add_pending_flush_rows_pushed(n: u64) {
     PENDING_FLUSH_ROWS_PUSHED.fetch_add(n, Ordering::Relaxed);
 }
 
 /// Increment the `waddle_push_candidate_created_total` counter. Call
 /// from the `Inserted` arm of `notification_outbox::insert_candidate`.
-pub fn increment_push_candidate_created() {
+pub(crate) fn increment_push_candidate_created() {
     PUSH_CANDIDATE_CREATED.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -534,14 +506,14 @@ pub fn increment_push_candidate_created() {
 /// `notification_outbox::insert_candidate` — a candidate row already
 /// existed for this `(recipient, conversation, thread, stanza_id,
 /// class)` tuple.
-pub fn increment_push_candidate_coalesced() {
+pub(crate) fn increment_push_candidate_coalesced() {
     PUSH_CANDIDATE_COALESCED.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment the `waddle_push_outbox_published_total` counter. Call
 /// from the `Published` outcome of `publish_claimed_job` — the
 /// XEP-0357 publish made it past the Push Service boundary.
-pub fn increment_push_outbox_published() {
+pub(crate) fn increment_push_outbox_published() {
     PUSH_OUTBOX_PUBLISHED.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -549,7 +521,7 @@ pub fn increment_push_outbox_published() {
 /// Call from the `RetryScheduled` outcome of
 /// `retry_or_fail_outcome_for_claimed_job` — the job failed
 /// transiently and a future retry is queued.
-pub fn increment_push_outbox_retry_scheduled() {
+pub(crate) fn increment_push_outbox_retry_scheduled() {
     PUSH_OUTBOX_RETRY_SCHEDULED.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -557,7 +529,7 @@ pub fn increment_push_outbox_retry_scheduled() {
 /// Call from the `Failed` outcome of
 /// `retry_or_fail_outcome_for_claimed_job` — the job hit the
 /// permanent-failure threshold and was flipped to `failed` status.
-pub fn increment_push_outbox_dead_lettered() {
+pub(crate) fn increment_push_outbox_dead_lettered() {
     PUSH_OUTBOX_DEAD_LETTERED.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -567,39 +539,23 @@ pub fn increment_push_outbox_dead_lettered() {
 /// the projection read fails and the recipient is defaulted to
 /// `Inactive` — i.e. a user who was in DND silently becomes
 /// un-DND'd at the push gate. Non-zero rate is alert-worthy.
-pub fn increment_dnd_projection_read_errored() {
+pub(crate) fn increment_dnd_projection_read_errored() {
     DND_PROJECTION_READ_ERRORED.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Increment the `waddle_push_suppressed_total{reason}` counter.
 ///
-/// `reason` is a wire-contract value drawn from
-/// [`PUSH_SUPPRESSED_REASONS`], populated in lockstep with
-/// `SuppressedReason::as_db_value` over in
-/// `waddle_server::notification_outbox` (the `waddle-server` test
-/// suite enforces the bijection; `waddle-xmpp` is upstream of the
-/// enum). The bound is `&'static str` so no dynamic labels exist at
-/// runtime; cardinality is bounded by the parallel constant.
-///
-/// Lookup is a linear scan over `PUSH_SUPPRESSED_REASONS` (small N,
-/// closed set) followed by an `AtomicU64::fetch_add` on a fixed slot
-/// — no mutex, no allocation, no async-hot-path stalls. A value not
-/// present in the parallel constant is a contract-drift bug: the
-/// catch-all [`PUSH_SUPPRESSED_UNKNOWN_REASON`] counter is bumped and
-/// a `warn!` fires so the drift is observable both in metrics and in
-/// logs.
-pub fn increment_push_suppressed(reason: &'static str) {
-    if let Some(idx) = push_suppressed_index(reason) {
-        PUSH_SUPPRESSED_COUNTERS[idx].fetch_add(1, Ordering::Relaxed);
-        return;
-    }
+/// The typed reason indexes a fixed atomic slot directly: no allocation,
+/// lookup, or unbounded label can enter the legacy renderer.
+pub(crate) fn increment_push_suppressed(reason: PushSuppressReason) {
+    PUSH_SUPPRESSED_COUNTERS[reason.index()].fetch_add(1, Ordering::Relaxed);
+}
+
+/// Increment the frozen legacy catch-all for an upstream reason that could not
+/// be mapped into [`PushSuppressReason`]. Normal typed emission cannot reach
+/// this counter.
+pub(crate) fn increment_push_suppressed_unknown_reason() {
     PUSH_SUPPRESSED_UNKNOWN_REASON.fetch_add(1, Ordering::Relaxed);
-    tracing::warn!(
-        reason,
-        "push suppressed counter received an unknown reason; \
-         waddle_xmpp::prometheus::PUSH_SUPPRESSED_REASONS has drifted \
-         from waddle_server::notification_outbox::SuppressedReason"
-    );
 }
 
 /// Snapshot of every push-suppressed counter for rendering.

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -189,7 +189,7 @@ impl ConnectionRegistry {
         let sender = match self.connections.get(jid) {
             Some(entry) => entry.value().sender.clone(),
             None => {
-                prometheus::increment_broadcast_not_connected();
+                crate::telemetry::reliability::increment_broadcast_not_connected();
                 return BroadcastOutcome::NotConnected;
             }
         };
@@ -197,14 +197,14 @@ impl ConnectionRegistry {
         let delivered_kind = crate::telemetry::messages::delivered_message_kind(&stanza);
         match sender.try_send(OutboundStanza::new(stanza)) {
             Ok(()) => {
-                prometheus::increment_broadcast_delivered();
+                crate::telemetry::reliability::increment_broadcast_delivered();
                 if let Some(kind) = delivered_kind {
                     crate::telemetry::messages::record_delivered_message(kind);
                 }
                 BroadcastOutcome::Delivered
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                prometheus::increment_broadcast_dropped_full();
+                crate::telemetry::reliability::increment_broadcast_dropped_full();
                 // Keep per-recipient detail at debug only — the
                 // aggregated broadcast log at the call site already
                 // reports a per-send `dropped_full` total, and
@@ -219,7 +219,7 @@ impl ConnectionRegistry {
                 BroadcastOutcome::DroppedFull
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                prometheus::increment_broadcast_dropped_closed();
+                crate::telemetry::reliability::increment_broadcast_dropped_closed();
                 self.remove_if_sender_closed(jid);
                 BroadcastOutcome::DroppedClosed
             }
@@ -245,7 +245,7 @@ impl ConnectionRegistry {
                 entry.value().sender.clone()
             }
             _ => {
-                prometheus::increment_broadcast_not_connected();
+                crate::telemetry::reliability::increment_broadcast_not_connected();
                 return BroadcastOutcome::NotConnected;
             }
         };
@@ -260,15 +260,15 @@ impl ConnectionRegistry {
         // Counting here would double every cross-node delivery.
         match sender.try_send(outbound) {
             Ok(()) => {
-                prometheus::increment_broadcast_delivered();
+                crate::telemetry::reliability::increment_broadcast_delivered();
                 BroadcastOutcome::Delivered
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                prometheus::increment_broadcast_dropped_full();
+                crate::telemetry::reliability::increment_broadcast_dropped_full();
                 BroadcastOutcome::DroppedFull
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                prometheus::increment_broadcast_dropped_closed();
+                crate::telemetry::reliability::increment_broadcast_dropped_closed();
                 self.remove_if_sender_closed_owner(jid, &sender);
                 BroadcastOutcome::DroppedClosed
             }

--- a/server/crates/waddle-xmpp/src/registry/user_actor/delivery.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor/delivery.rs
@@ -37,7 +37,6 @@ use kameo::message::Context;
 use tokio::sync::mpsc::error::TrySendError;
 
 use super::UserActor;
-use crate::prometheus;
 use crate::registry::connection_registry::{BroadcastOutcome, ConnectionEntry, OutboundStanza};
 use crate::Stanza;
 
@@ -48,24 +47,24 @@ impl UserActor {
     /// place (mirrors `ConnectionRegistry::try_send_to_with_kind`).
     fn try_deliver(&mut self, jid: &FullJid, outbound: OutboundStanza) -> BroadcastOutcome {
         let Some(entry) = self.connections.get(jid) else {
-            prometheus::increment_broadcast_not_connected();
+            crate::telemetry::reliability::increment_broadcast_not_connected();
             return BroadcastOutcome::NotConnected;
         };
         let delivered_kind = crate::telemetry::messages::delivered_message_kind(&outbound.stanza);
         match entry.sender.try_send(outbound) {
             Ok(()) => {
-                prometheus::increment_broadcast_delivered();
+                crate::telemetry::reliability::increment_broadcast_delivered();
                 if let Some(kind) = delivered_kind {
                     crate::telemetry::messages::record_delivered_message(kind);
                 }
                 BroadcastOutcome::Delivered
             }
             Err(TrySendError::Full(_)) => {
-                prometheus::increment_broadcast_dropped_full();
+                crate::telemetry::reliability::increment_broadcast_dropped_full();
                 BroadcastOutcome::DroppedFull
             }
             Err(TrySendError::Closed(_)) => {
-                prometheus::increment_broadcast_dropped_closed();
+                crate::telemetry::reliability::increment_broadcast_dropped_closed();
                 // The actor serializes register against send, so unlike the
                 // DashMap path there is no concurrent-replacement window: if
                 // the stored entry's channel is closed it is genuinely dead

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -38,8 +38,8 @@ pub use session_registry::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, DetachedPresenceState, DetachedSession,
     DetachedUnackedStanza, InMemorySmSessionRegistry, RecentTombstoneRecord,
     ReclaimedClaimReservation, ReclaimedHydrationOutcome, RemoteResumeAskOutcome,
-    RemoteResumeAsker, SmClaimCompletion, SmRegistryError, SmSessionRegistry, StealTicket,
-    DEFAULT_MAX_SESSIONS, TOMBSTONE_CLOCK_SKEW_SLACK,
+    RemoteResumeAsker, ResumableSessionProbe, SmClaimCompletion, SmRegistryError,
+    SmSessionRegistry, StealTicket, DEFAULT_MAX_SESSIONS, TOMBSTONE_CLOCK_SKEW_SLACK,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -23,7 +23,7 @@ pub use cross_node_resume::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, RemoteResumeAskOutcome, RemoteResumeAsker,
     StealTicket,
 };
-pub use resources::DetachedPresenceState;
+pub use resources::{DetachedPresenceState, ResumableSessionProbe};
 pub use session::{DetachedSession, DetachedUnackedStanza};
 pub use tombstones::{RecentTombstoneRecord, TOMBSTONE_CLOCK_SKEW_SLACK};
 pub use traits::{SmClaimCompletion, SmRegistryError, SmSessionRegistry};

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/resources.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/resources.rs
@@ -7,6 +7,14 @@ use super::session::DetachedSession;
 use super::SmRegistryError;
 use crate::Stanza;
 
+/// Outcome of probing whether a full JID still owns resumable XEP-0198 state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumableSessionProbe {
+    Present,
+    Absent,
+    Failed,
+}
+
 /// Last broadcast rich presence of a detached available resource.
 ///
 /// `payloads` are the resource's own presence extension elements
@@ -267,6 +275,18 @@ impl InMemorySmSessionRegistry {
     /// evicted. Fail-closed: a durable read error reports `true` so the
     /// caller skips the eviction.
     pub async fn any_resumable_session_for_full_jid(&self, jid: &FullJid) -> bool {
+        matches!(
+            self.probe_resumable_session_for_full_jid(jid).await,
+            ResumableSessionProbe::Present | ResumableSessionProbe::Failed
+        )
+    }
+
+    /// Typed variant of [`Self::any_resumable_session_for_full_jid`] for
+    /// sweep callers that must distinguish fail-closed reads from live state.
+    pub async fn probe_resumable_session_for_full_jid(
+        &self,
+        jid: &FullJid,
+    ) -> ResumableSessionProbe {
         let in_memory = {
             let matches_memory =
                 |sessions: &std::collections::HashMap<String, super::super::DetachedSession>| {
@@ -281,23 +301,27 @@ impl InMemorySmSessionRegistry {
                     matches_memory(&sessions) || matches_memory(&claimed)
                 }
                 // Poisoned lock: fail closed.
-                _ => return true,
+                _ => return ResumableSessionProbe::Failed,
             }
         };
         if in_memory {
-            return true;
+            return ResumableSessionProbe::Present;
         }
         let Some(persistence) = self.persistence.as_ref() else {
-            return false;
+            return ResumableSessionProbe::Absent;
         };
         match persistence.list_all_sessions().await {
             Ok(rows) => {
                 let now = chrono::Utc::now();
-                rows.iter().any(|row| {
+                if rows.iter().any(|row| {
                     row.jid == *jid
                         && now.signed_duration_since(row.detached_at).to_std().ok()
                             <= Some(row.max_resume_duration)
-                })
+                }) {
+                    ResumableSessionProbe::Present
+                } else {
+                    ResumableSessionProbe::Absent
+                }
             }
             Err(error) => {
                 tracing::warn!(
@@ -305,7 +329,7 @@ impl InMemorySmSessionRegistry {
                     %error,
                     "any_resumable_session_for_full_jid: durable read failed; failing closed"
                 );
-                true
+                ResumableSessionProbe::Failed
             }
         }
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/session.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/session.rs
@@ -232,7 +232,7 @@ impl DetachedSession {
     /// path (it comes from presence relay / Q6 recording, not MAM
     /// catch-up), so this is not coalesced.
     fn note_detached_eviction(&self, evicted_sequence: u32) {
-        crate::prometheus::increment_sm_detached_unacked_evicted();
+        crate::telemetry::reliability::increment_sm_detached_unacked_evicted();
         tracing::warn!(
             stream_id = %self.stream_id,
             evicted_sequence,

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -5398,6 +5398,7 @@ async fn reinsert_for_retry_keeps_queue_when_session_was_never_persisted() {
 struct FailingSnapshotPersistence {
     inner: super::super::persistence::InMemorySmPersistence,
     fail_snapshots: std::sync::atomic::AtomicBool,
+    fail_reads: std::sync::atomic::AtomicBool,
 }
 
 impl FailingSnapshotPersistence {
@@ -5405,6 +5406,7 @@ impl FailingSnapshotPersistence {
         Self {
             inner: super::super::persistence::InMemorySmPersistence::new(),
             fail_snapshots: std::sync::atomic::AtomicBool::new(false),
+            fail_reads: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -5484,6 +5486,11 @@ impl super::super::persistence::SmPersistenceStorage for FailingSnapshotPersiste
         Vec<super::super::persistence::PersistedSession>,
         super::super::persistence::SmPersistenceError,
     > {
+        if self.fail_reads.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(super::super::persistence::SmPersistenceError::Other(
+                "simulated session-list failure".into(),
+            ));
+        }
         self.inner.list_all_sessions().await
     }
 
@@ -6612,4 +6619,20 @@ async fn any_resumable_session_probe_covers_durable_rows_and_fails_closed() {
         .await
         .expect("upsert row");
     assert!(!registry.any_resumable_session_for_full_jid(&other).await);
+}
+
+#[tokio::test]
+async fn typed_resumable_session_probe_surfaces_durable_read_failure() {
+    let storage = std::sync::Arc::new(FailingSnapshotPersistence::new());
+    storage
+        .fail_reads
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage);
+    let jid: FullJid = "roamer@example.com/laptop".parse().expect("jid");
+
+    assert_eq!(
+        registry.probe_resumable_session_for_full_jid(&jid).await,
+        super::ResumableSessionProbe::Failed
+    );
+    assert!(registry.any_resumable_session_for_full_jid(&jid).await);
 }

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -2,8 +2,6 @@ use std::time::Instant;
 
 use tracing::warn;
 
-use crate::prometheus;
-
 use super::unacked_queue::sequence_gt;
 use super::{
     DetachedSession, UnackedPushResult, UnackedQueue, DEFAULT_ACK_REQUEST_THRESHOLD,
@@ -245,7 +243,7 @@ impl StreamManagementState {
             UnackedPushResult::Accepted => {}
             UnackedPushResult::Evicted(evicted) => {
                 self.mark_replay_gap_through(evicted.sequence);
-                prometheus::increment_sm_unacked_evicted();
+                crate::telemetry::reliability::increment_sm_unacked_evicted();
                 self.note_eviction_for_throttled_warn(evicted.sequence);
             }
         }

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -252,6 +252,32 @@ impl MetricAttribute for PushSuppressReason {
     }
 }
 
+/// `reason` — why an XEP-0357 push outbox job was scheduled for retry.
+///
+/// The legacy text family only ever rendered
+/// `waddle_push_outbox_retry_scheduled_total{reason="unknown"}`, so the
+/// OTel successor carries the same closed label shape through the alias
+/// cutover. Gains real variants if the outbox ever classifies retry
+/// causes; until then `Unknown` is the whole set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushRetryReason {
+    /// The retry cause was not classified.
+    Unknown,
+}
+
+impl sealed::Sealed for PushRetryReason {}
+impl MetricAttribute for PushRetryReason {
+    fn key(&self) -> &'static str {
+        "reason"
+    }
+
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 /// `condition` — the RFC 6120 §8.3.3 defined stanza-error conditions,
 /// reusing the crate's existing typed enum (its `as_str()` already
 /// yields the hyphenated wire names). Re-exported here so metric call

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -120,6 +120,138 @@ impl MetricAttribute for SweepOutcome {
     }
 }
 
+/// `reason` — why an XEP-0357 push notification was suppressed.
+///
+/// This is the metric-facing closed set. `waddle-server` converts its
+/// persisted `SuppressedReason` audit value into this enum before emitting,
+/// so metric labels never cross the crate boundary as strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushSuppressReason {
+    /// The notification would target its sender.
+    Xep0357Self,
+    /// The recipient has no push registration.
+    Xep0357NoRegistration,
+    /// The recipient's push registration is disabled.
+    Xep0357RegistrationDisabled,
+    /// XEP-0492 resolved to `<never/>`.
+    Xep0492Never,
+    /// XEP-0492 `<on-mention/>` did not match.
+    Xep0492OnMentionMiss,
+    /// XEP-0191 blocked the sender or conversation.
+    Xep0191Blocked,
+    /// XEP-0513 `<noping/>` opted out of notification.
+    Xep0513Noping,
+    /// XEP-0513 `<active/>` did not match.
+    Xep0513ActiveMiss,
+    /// Waddle DND is active for the recipient.
+    WaddleDnd,
+    /// The downstream push provider rejected the notification.
+    ProviderRejected,
+    /// The downstream push provider reported an expired token.
+    ProviderTokenExpired,
+    /// The XEP-0357 push service is degraded.
+    Xep0357PushServiceDegraded,
+    /// The unread count reached zero before publish.
+    UnreadZeroAtPublish,
+    /// Policy evaluation exhausted its retry budget.
+    PolicyRetriesExhausted,
+    /// The message is an XEP-0444 reaction-only notification.
+    Xep0444Reaction,
+}
+
+impl PushSuppressReason {
+    /// Every allowed value, in stable legacy-renderer order.
+    pub const ALL: [Self; 15] = [
+        Self::Xep0357Self,
+        Self::Xep0357NoRegistration,
+        Self::Xep0357RegistrationDisabled,
+        Self::Xep0492Never,
+        Self::Xep0492OnMentionMiss,
+        Self::Xep0191Blocked,
+        Self::Xep0513Noping,
+        Self::Xep0513ActiveMiss,
+        Self::WaddleDnd,
+        Self::ProviderRejected,
+        Self::ProviderTokenExpired,
+        Self::Xep0357PushServiceDegraded,
+        Self::UnreadZeroAtPublish,
+        Self::PolicyRetriesExhausted,
+        Self::Xep0444Reaction,
+    ];
+
+    /// Every allowed label value, in stable legacy-renderer order.
+    pub const VALUES: [&'static str; 15] = [
+        Self::Xep0357Self.as_str(),
+        Self::Xep0357NoRegistration.as_str(),
+        Self::Xep0357RegistrationDisabled.as_str(),
+        Self::Xep0492Never.as_str(),
+        Self::Xep0492OnMentionMiss.as_str(),
+        Self::Xep0191Blocked.as_str(),
+        Self::Xep0513Noping.as_str(),
+        Self::Xep0513ActiveMiss.as_str(),
+        Self::WaddleDnd.as_str(),
+        Self::ProviderRejected.as_str(),
+        Self::ProviderTokenExpired.as_str(),
+        Self::Xep0357PushServiceDegraded.as_str(),
+        Self::UnreadZeroAtPublish.as_str(),
+        Self::PolicyRetriesExhausted.as_str(),
+        Self::Xep0444Reaction.as_str(),
+    ];
+
+    /// The byte-stable legacy label value.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Xep0357Self => "xep0357_self",
+            Self::Xep0357NoRegistration => "xep0357_no_registration",
+            Self::Xep0357RegistrationDisabled => "xep0357_registration_disabled",
+            Self::Xep0492Never => "xep0492_never",
+            Self::Xep0492OnMentionMiss => "xep0492_on_mention_miss",
+            Self::Xep0191Blocked => "xep0191_blocked",
+            Self::Xep0513Noping => "xep0513_noping",
+            Self::Xep0513ActiveMiss => "xep0513_active_miss",
+            Self::WaddleDnd => "waddle_dnd",
+            Self::ProviderRejected => "provider_rejected",
+            Self::ProviderTokenExpired => "provider_token_expired",
+            Self::Xep0357PushServiceDegraded => "xep0357_push_service_degraded",
+            Self::UnreadZeroAtPublish => "unread_zero_at_publish",
+            Self::PolicyRetriesExhausted => "policy_retries_exhausted",
+            Self::Xep0444Reaction => "xep0444_reaction",
+        }
+    }
+
+    pub(crate) const fn index(self) -> usize {
+        match self {
+            Self::Xep0357Self => 0,
+            Self::Xep0357NoRegistration => 1,
+            Self::Xep0357RegistrationDisabled => 2,
+            Self::Xep0492Never => 3,
+            Self::Xep0492OnMentionMiss => 4,
+            Self::Xep0191Blocked => 5,
+            Self::Xep0513Noping => 6,
+            Self::Xep0513ActiveMiss => 7,
+            Self::WaddleDnd => 8,
+            Self::ProviderRejected => 9,
+            Self::ProviderTokenExpired => 10,
+            Self::Xep0357PushServiceDegraded => 11,
+            Self::UnreadZeroAtPublish => 12,
+            Self::PolicyRetriesExhausted => 13,
+            Self::Xep0444Reaction => 14,
+        }
+    }
+}
+
+impl sealed::Sealed for PushSuppressReason {}
+impl MetricAttribute for PushSuppressReason {
+    fn key(&self) -> &'static str {
+        "reason"
+    }
+
+    fn value(&self) -> &'static str {
+        self.as_str()
+    }
+}
+
 /// `condition` — the RFC 6120 §8.3.3 defined stanza-error conditions,
 /// reusing the crate's existing typed enum (its `as_str()` already
 /// yields the hyphenated wire names). Re-exported here so metric call

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -49,6 +49,7 @@
 
 pub mod attributes;
 pub mod messages;
+pub mod reliability;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -407,4 +407,247 @@ mod tests {
             .collect();
         assert_eq!(enum_values, crate::prometheus::PUSH_SUPPRESSED_REASONS);
     }
+
+    /// One dual-emit contract case: drive `emit`, then expect the OTel
+    /// counter `otel` and the legacy text line `legacy` to both read
+    /// `expected`.
+    struct DualEmitCase {
+        otel: &'static str,
+        legacy: &'static str,
+        expected: u64,
+        emit: fn(),
+    }
+
+    /// #1330 acceptance: metric-reader-seam coverage for EVERY migrated
+    /// counter, not a per-family sample. Each helper is driven once and
+    /// both halves of the dual emit are asserted — the exported OTel
+    /// sample under the new `xmpp.*` name and the legacy `waddle_*`
+    /// text line the recording-rule aliases will later map from.
+    #[tokio::test]
+    async fn every_migrated_counter_dual_emits() {
+        let cases: &[DualEmitCase] = &[
+            // Stream-management family.
+            DualEmitCase {
+                otel: "xmpp.sm.unacked_evicted",
+                legacy: "waddle_sm_unacked_evicted_total",
+                expected: 1,
+                emit: increment_sm_unacked_evicted,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.promotion_storage_failed",
+                legacy: "waddle_sm_promotion_storage_failed_total",
+                expected: 3,
+                emit: || add_sm_promotion_storage_failed(3),
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.promotion_not_promotable",
+                legacy: "waddle_sm_promotion_not_promotable_total",
+                expected: 1,
+                emit: increment_sm_promotion_not_promotable,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.promotion_blocklist_failed",
+                legacy: "waddle_sm_promotion_blocklist_failed_total",
+                expected: 1,
+                emit: increment_sm_promotion_blocklist_failed,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.promotion_dead_lettered",
+                legacy: "waddle_sm_promotion_dead_lettered_total",
+                expected: 1,
+                emit: increment_sm_promotion_dead_lettered,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.drain_timeout",
+                legacy: "waddle_sm_drain_timeout_total",
+                expected: 1,
+                emit: increment_sm_drain_timeout,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.resume_window_clamped",
+                legacy: "waddle_sm_resume_window_clamped_total",
+                expected: 1,
+                emit: increment_sm_resume_window_clamped,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.send_window_pauses",
+                legacy: "waddle_sm_send_window_pauses_total",
+                expected: 1,
+                emit: increment_sm_send_window_pause,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.send_window_pause_timeouts",
+                legacy: "waddle_sm_send_window_pause_timeouts_total",
+                expected: 1,
+                emit: increment_sm_send_window_pause_timeout,
+            },
+            DualEmitCase {
+                otel: "xmpp.sm.detached_unacked_evicted",
+                legacy: "waddle_sm_detached_unacked_evicted_total",
+                expected: 1,
+                emit: increment_sm_detached_unacked_evicted,
+            },
+            // Push family (reason-carrying helpers asserted separately below).
+            DualEmitCase {
+                otel: "xmpp.push.candidate_created",
+                legacy: "waddle_push_candidate_created_total",
+                expected: 1,
+                emit: increment_push_candidate_created,
+            },
+            DualEmitCase {
+                otel: "xmpp.push.candidate_coalesced",
+                legacy: "waddle_push_candidate_coalesced_total",
+                expected: 1,
+                emit: increment_push_candidate_coalesced,
+            },
+            DualEmitCase {
+                otel: "xmpp.push.outbox_published",
+                legacy: "waddle_push_outbox_published_total",
+                expected: 1,
+                emit: increment_push_outbox_published,
+            },
+            DualEmitCase {
+                otel: "xmpp.push.outbox_dead_lettered",
+                legacy: "waddle_push_outbox_dead_lettered_total",
+                expected: 1,
+                emit: increment_push_outbox_dead_lettered,
+            },
+            // Pending-delivery family.
+            DualEmitCase {
+                otel: "xmpp.pending_delivery.quota_exceeded",
+                legacy: "waddle_pending_delivery_quota_exceeded_total",
+                expected: 1,
+                emit: increment_pending_delivery_quota_exceeded,
+            },
+            DualEmitCase {
+                otel: "xmpp.pending_delivery.orphan_claims_released",
+                legacy: "waddle_pending_delivery_orphan_claims_released_total",
+                expected: 4,
+                emit: || add_pending_delivery_orphan_claims_released(4),
+            },
+            DualEmitCase {
+                otel: "xmpp.pending_delivery.aged_out",
+                legacy: "waddle_pending_delivery_aged_out_total",
+                expected: 2,
+                emit: || add_pending_delivery_aged_out(2),
+            },
+            DualEmitCase {
+                otel: "xmpp.pending_delivery.unresolved_poison_pill",
+                legacy: "waddle_pending_delivery_unresolved_poison_pill_total",
+                expected: 1,
+                emit: increment_pending_delivery_unresolved_poison_pill,
+            },
+            DualEmitCase {
+                otel: "xmpp.pending_delivery.archive_lookup_transient_failure",
+                legacy: "waddle_pending_delivery_archive_lookup_transient_failure_total",
+                expected: 1,
+                emit: increment_pending_delivery_archive_lookup_transient_failure,
+            },
+            DualEmitCase {
+                otel: "xmpp.pending.flush_batches",
+                legacy: "waddle_pending_flush_batches_total",
+                expected: 2,
+                emit: || add_pending_flush_batches(2),
+            },
+            DualEmitCase {
+                otel: "xmpp.pending.flush_rows_pushed",
+                legacy: "waddle_pending_flush_rows_pushed_total",
+                expected: 5,
+                emit: || add_pending_flush_rows_pushed(5),
+            },
+            // Broadcast family.
+            DualEmitCase {
+                otel: "xmpp.broadcast.delivered",
+                legacy: "waddle_broadcast_delivered_total",
+                expected: 1,
+                emit: increment_broadcast_delivered,
+            },
+            DualEmitCase {
+                otel: "xmpp.broadcast.not_connected",
+                legacy: "waddle_broadcast_not_connected_total",
+                expected: 1,
+                emit: increment_broadcast_not_connected,
+            },
+            DualEmitCase {
+                otel: "xmpp.broadcast.dropped_full",
+                legacy: "waddle_broadcast_dropped_full_total",
+                expected: 1,
+                emit: increment_broadcast_dropped_full,
+            },
+            DualEmitCase {
+                otel: "xmpp.broadcast.dropped_closed",
+                legacy: "waddle_broadcast_dropped_closed_total",
+                expected: 1,
+                emit: increment_broadcast_dropped_closed,
+            },
+            // Delivery-loss family.
+            DualEmitCase {
+                otel: "xmpp.delivery.terminal_error_drop",
+                legacy: "waddle_delivery_terminal_error_drop_total",
+                expected: 1,
+                emit: increment_delivery_terminal_error_drop,
+            },
+            DualEmitCase {
+                otel: "xmpp.delivery.retry_exhausted_drop",
+                legacy: "waddle_delivery_retry_exhausted_drop_total",
+                expected: 1,
+                emit: increment_delivery_retry_exhausted_drop,
+            },
+            DualEmitCase {
+                otel: "xmpp.resolver.affiliation_sync_capacity_drop",
+                legacy: "waddle_resolver_affiliation_sync_capacity_drop_total",
+                expected: 1,
+                emit: increment_resolver_affiliation_sync_capacity_drop,
+            },
+            DualEmitCase {
+                otel: "xmpp.user_actor.reaped",
+                legacy: "waddle_user_actor_reaped_total",
+                expected: 1,
+                emit: increment_user_actor_reaped,
+            },
+            // DND.
+            DualEmitCase {
+                otel: "xmpp.dnd.projection_read_errored",
+                legacy: "waddle_dnd_projection_read_errored_total",
+                expected: 1,
+                emit: increment_dnd_projection_read_errored,
+            },
+        ];
+
+        let guard = setup().await;
+        for case in cases {
+            (case.emit)();
+        }
+        increment_push_outbox_retry_scheduled(super::PushRetryReason::Unknown);
+        increment_push_suppressed(PushSuppressReason::WaddleDnd);
+
+        let rendered = crate::prometheus::render_metrics();
+        for case in cases {
+            assert_eq!(
+                guard.counter_sum(case.otel, &[]),
+                Some(case.expected),
+                "OTel sample missing or wrong for {}",
+                case.otel
+            );
+            assert!(
+                rendered.contains(&format!("{} {}\n", case.legacy, case.expected)),
+                "legacy text line missing or wrong for {}",
+                case.legacy
+            );
+        }
+        // The two reason-carrying helpers keep their label shape on both
+        // halves.
+        assert_eq!(
+            guard.counter_sum("xmpp.push.outbox_retry_scheduled", &[("reason", "unknown")]),
+            Some(1)
+        );
+        assert!(
+            rendered.contains("waddle_push_outbox_retry_scheduled_total{reason=\"unknown\"} 1\n")
+        );
+        assert_eq!(
+            guard.counter_sum("xmpp.push.suppressed", &[("reason", "waddle_dnd")]),
+            Some(1)
+        );
+        assert!(rendered.contains("waddle_push_suppressed_total{reason=\"waddle_dnd\"} 1\n"));
+    }
 }

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -146,13 +146,11 @@ pub fn increment_push_suppressed(reason: PushSuppressReason) {
     );
 }
 
-dual_increment!(
-    increment_push_suppressed_unknown_reason,
-    crate::prometheus::increment_push_suppressed_unknown_reason,
-    "xmpp.push.suppressed_unknown_reason",
-    "{notification}",
-    "Push suppression events that could not be mapped to the bounded reason set."
-);
+// No dual helper for the legacy unknown-reason catch-all: the sealed
+// `PushSuppressReason` enum makes an unmapped reason a compile error,
+// so the catch-all is structurally unreachable. Its frozen text
+// counter stays rendered (permanently 0) until the contract PR
+// deletes the family.
 
 dual_increment!(
     increment_pending_delivery_quota_exceeded,

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -1,0 +1,403 @@
+//! Reliability counters dual-emitted to the frozen legacy text renderer and
+//! their OpenTelemetry successors.
+//!
+//! OTel names deliberately start with `xmpp`, not `waddle`: after Prometheus
+//! export, `xmpp.<rest>` becomes `xmpp_<rest>_total`, leaving the live
+//! `waddle_<rest>_total` scrape distinct until recording-rule aliases cut over.
+
+use super::attributes::{Janitor, PushSuppressReason, SweepOutcome};
+
+macro_rules! dual_increment {
+    ($helper:ident, $legacy:path, $name:literal, $unit:literal, $description:literal) => {
+        #[doc = concat!("Increment legacy reliability counter and OTel `", $name, "`.")]
+        pub fn $helper() {
+            $legacy();
+            crate::counter_add!($name, $unit, $description, 1);
+        }
+    };
+}
+
+macro_rules! dual_add {
+    ($helper:ident, $legacy:path, $name:literal, $unit:literal, $description:literal) => {
+        #[doc = concat!("Add to the legacy reliability counter and OTel `", $name, "`.")]
+        pub fn $helper(count: u64) {
+            $legacy(count);
+            crate::counter_add!($name, $unit, $description, count);
+        }
+    };
+}
+
+dual_increment!(
+    increment_sm_unacked_evicted,
+    crate::prometheus::increment_sm_unacked_evicted,
+    "xmpp.sm.unacked_evicted",
+    "{stanza}",
+    "XEP-0198 unacked stanzas evicted from an attached session replay window."
+);
+dual_add!(
+    add_sm_promotion_storage_failed,
+    crate::prometheus::add_sm_promotion_storage_failed,
+    "xmpp.sm.promotion_storage_failed",
+    "{stanza}",
+    "Unacked stanzas whose XEP-0160 promotion storage write failed."
+);
+dual_increment!(
+    increment_sm_promotion_not_promotable,
+    crate::prometheus::increment_sm_promotion_not_promotable,
+    "xmpp.sm.promotion_not_promotable",
+    "{stanza}",
+    "Unacked stanzas that were not XEP-0160 promotion candidates."
+);
+dual_increment!(
+    increment_sm_promotion_blocklist_failed,
+    crate::prometheus::increment_sm_promotion_blocklist_failed,
+    "xmpp.sm.promotion_blocklist_failed",
+    "{session}",
+    "XEP-0198 promotion sessions skipped because blocklist loading failed."
+);
+dual_increment!(
+    increment_sm_promotion_dead_lettered,
+    crate::prometheus::increment_sm_promotion_dead_lettered,
+    "xmpp.sm.promotion_dead_lettered",
+    "{session}",
+    "XEP-0198 promotion sessions dead-lettered after exhausting retries."
+);
+dual_increment!(
+    increment_sm_drain_timeout,
+    crate::prometheus::increment_sm_drain_timeout,
+    "xmpp.sm.drain_timeout",
+    "{event}",
+    "Graceful-shutdown XEP-0198 drains that exceeded their deadline."
+);
+dual_increment!(
+    increment_sm_resume_window_clamped,
+    crate::prometheus::increment_sm_resume_window_clamped,
+    "xmpp.sm.resume_window_clamped",
+    "{session}",
+    "XEP-0198 sessions whose requested resume window was clamped."
+);
+dual_increment!(
+    increment_sm_send_window_pause,
+    crate::prometheus::increment_sm_send_window_pause,
+    "xmpp.sm.send_window_pauses",
+    "{event}",
+    "XEP-0198 wire-write pauses engaged at the send-window high watermark."
+);
+dual_increment!(
+    increment_sm_send_window_pause_timeout,
+    crate::prometheus::increment_sm_send_window_pause_timeout,
+    "xmpp.sm.send_window_pause_timeouts",
+    "{event}",
+    "XEP-0198 send-window pauses that exceeded their acknowledgement deadline."
+);
+dual_increment!(
+    increment_sm_detached_unacked_evicted,
+    crate::prometheus::increment_sm_detached_unacked_evicted,
+    "xmpp.sm.detached_unacked_evicted",
+    "{stanza}",
+    "Unacked stanzas evicted from a detached XEP-0198 session replay window."
+);
+
+dual_increment!(
+    increment_push_candidate_created,
+    crate::prometheus::increment_push_candidate_created,
+    "xmpp.push.candidate_created",
+    "{notification}",
+    "XEP-0357 notification candidates inserted into the durable pipeline."
+);
+dual_increment!(
+    increment_push_candidate_coalesced,
+    crate::prometheus::increment_push_candidate_coalesced,
+    "xmpp.push.candidate_coalesced",
+    "{notification}",
+    "Duplicate XEP-0357 notification candidates coalesced at insertion."
+);
+dual_increment!(
+    increment_push_outbox_published,
+    crate::prometheus::increment_push_outbox_published,
+    "xmpp.push.outbox_published",
+    "{notification}",
+    "XEP-0357 notification outbox jobs accepted by the Push Service."
+);
+dual_increment!(
+    increment_push_outbox_retry_scheduled,
+    crate::prometheus::increment_push_outbox_retry_scheduled,
+    "xmpp.push.outbox_retry_scheduled",
+    "{notification}",
+    "XEP-0357 notification outbox jobs scheduled for retry."
+);
+dual_increment!(
+    increment_push_outbox_dead_lettered,
+    crate::prometheus::increment_push_outbox_dead_lettered,
+    "xmpp.push.outbox_dead_lettered",
+    "{notification}",
+    "XEP-0357 notification outbox jobs terminally dead-lettered."
+);
+
+/// Record one typed push suppression in both telemetry systems.
+pub fn increment_push_suppressed(reason: PushSuppressReason) {
+    crate::prometheus::increment_push_suppressed(reason);
+    crate::counter_add!(
+        "xmpp.push.suppressed",
+        "{notification}",
+        "XEP-0357 notification candidates suppressed by a bounded policy reason.",
+        1,
+        reason,
+    );
+}
+
+dual_increment!(
+    increment_push_suppressed_unknown_reason,
+    crate::prometheus::increment_push_suppressed_unknown_reason,
+    "xmpp.push.suppressed_unknown_reason",
+    "{notification}",
+    "Push suppression events that could not be mapped to the bounded reason set."
+);
+
+dual_increment!(
+    increment_pending_delivery_quota_exceeded,
+    crate::prometheus::increment_pending_delivery_quota_exceeded,
+    "xmpp.pending_delivery.quota_exceeded",
+    "{message}",
+    "Offline messages rejected because the recipient pending-delivery quota was full."
+);
+dual_add!(
+    add_pending_delivery_orphan_claims_released,
+    crate::prometheus::add_pending_delivery_orphan_claims_released,
+    "xmpp.pending_delivery.orphan_claims_released",
+    "{claim}",
+    "Orphaned pending-delivery claims released by the claim janitor."
+);
+dual_add!(
+    add_pending_delivery_aged_out,
+    crate::prometheus::add_pending_delivery_aged_out,
+    "xmpp.pending_delivery.aged_out",
+    "{row}",
+    "Pending-delivery rows removed after exceeding the configured maximum age."
+);
+dual_increment!(
+    increment_pending_delivery_unresolved_poison_pill,
+    crate::prometheus::increment_pending_delivery_unresolved_poison_pill,
+    "xmpp.pending_delivery.unresolved_poison_pill",
+    "{row}",
+    "Pending-delivery rows dropped because their archived payload could not be resolved."
+);
+dual_increment!(
+    increment_pending_delivery_archive_lookup_transient_failure,
+    crate::prometheus::increment_pending_delivery_archive_lookup_transient_failure,
+    "xmpp.pending_delivery.archive_lookup_transient_failure",
+    "{event}",
+    "Pending-delivery flushes aborted by a transient archive lookup failure."
+);
+dual_add!(
+    add_pending_flush_batches,
+    crate::prometheus::add_pending_flush_batches,
+    "xmpp.pending.flush_batches",
+    "{event}",
+    "Pending-delivery batches drained by offline-message flushes."
+);
+dual_add!(
+    add_pending_flush_rows_pushed,
+    crate::prometheus::add_pending_flush_rows_pushed,
+    "xmpp.pending.flush_rows_pushed",
+    "{row}",
+    "Pending-delivery rows pushed to recovering resources."
+);
+
+dual_increment!(
+    increment_broadcast_delivered,
+    crate::prometheus::increment_broadcast_delivered,
+    "xmpp.broadcast.delivered",
+    "{stanza}",
+    "Non-blocking broadcast attempts enqueued to a recipient."
+);
+dual_increment!(
+    increment_broadcast_not_connected,
+    crate::prometheus::increment_broadcast_not_connected,
+    "xmpp.broadcast.not_connected",
+    "{stanza}",
+    "Non-blocking broadcast attempts with no connected recipient."
+);
+dual_increment!(
+    increment_broadcast_dropped_full,
+    crate::prometheus::increment_broadcast_dropped_full,
+    "xmpp.broadcast.dropped_full",
+    "{stanza}",
+    "Non-blocking broadcast attempts dropped because the recipient channel was full."
+);
+dual_increment!(
+    increment_broadcast_dropped_closed,
+    crate::prometheus::increment_broadcast_dropped_closed,
+    "xmpp.broadcast.dropped_closed",
+    "{stanza}",
+    "Non-blocking broadcast attempts dropped because the recipient channel was closed."
+);
+
+dual_increment!(
+    increment_delivery_terminal_error_drop,
+    crate::prometheus::increment_delivery_terminal_error_drop,
+    "xmpp.delivery.terminal_error_drop",
+    "{stanza}",
+    "Actor-path deliveries dropped after an enqueue-uncertain terminal error."
+);
+dual_increment!(
+    increment_delivery_retry_exhausted_drop,
+    crate::prometheus::increment_delivery_retry_exhausted_drop,
+    "xmpp.delivery.retry_exhausted_drop",
+    "{stanza}",
+    "Deliveries dropped after bounded full-channel retries were exhausted."
+);
+dual_increment!(
+    increment_resolver_affiliation_sync_capacity_drop,
+    crate::prometheus::increment_resolver_affiliation_sync_capacity_drop,
+    "xmpp.resolver.affiliation_sync_capacity_drop",
+    "{event}",
+    "Resolver-affiliation synchronization jobs dropped at scheduler capacity."
+);
+dual_increment!(
+    increment_user_actor_reaped,
+    crate::prometheus::increment_user_actor_reaped,
+    "xmpp.user_actor.reaped",
+    "{session}",
+    "Empty user actors removed by the periodic reaper."
+);
+
+dual_increment!(
+    increment_dnd_projection_read_errored,
+    crate::prometheus::increment_dnd_projection_read_errored,
+    "xmpp.dnd.projection_read_errored",
+    "{event}",
+    "DND projection reads that failed open to inactive."
+);
+
+/// Record one periodic janitor sweep outcome.
+pub fn record_janitor_sweep(janitor: Janitor, outcome: SweepOutcome) {
+    crate::counter_add!(
+        "waddle.janitor.sweeps",
+        "{sweep}",
+        "Periodic janitor sweep ticks by janitor and outcome.",
+        1,
+        janitor,
+        outcome,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::attributes::MetricAttribute;
+
+    async fn setup() -> crate::telemetry::test_support::MetricsTestGuard {
+        let guard = crate::telemetry::test_support::acquire().await;
+        crate::prometheus::reset_metrics_for_test();
+        guard
+    }
+
+    #[tokio::test]
+    async fn sm_helper_dual_emits() {
+        let guard = setup().await;
+        add_sm_promotion_storage_failed(3);
+        assert_eq!(
+            guard.counter_sum("xmpp.sm.promotion_storage_failed", &[]),
+            Some(3)
+        );
+        assert!(crate::prometheus::render_metrics()
+            .contains("waddle_sm_promotion_storage_failed_total 3"));
+    }
+
+    #[tokio::test]
+    async fn push_helper_dual_emits_with_typed_reason() {
+        let guard = setup().await;
+        increment_push_suppressed(PushSuppressReason::Xep0492Never);
+        assert_eq!(
+            guard.counter_sum("xmpp.push.suppressed", &[("reason", "xep0492_never")]),
+            Some(1)
+        );
+        assert!(crate::prometheus::render_metrics()
+            .contains("waddle_push_suppressed_total{reason=\"xep0492_never\"} 1"));
+    }
+
+    #[tokio::test]
+    async fn pending_delivery_helper_dual_emits() {
+        let guard = setup().await;
+        add_pending_delivery_aged_out(4);
+        assert_eq!(
+            guard.counter_sum("xmpp.pending_delivery.aged_out", &[]),
+            Some(4)
+        );
+        assert!(crate::prometheus::render_metrics()
+            .contains("waddle_pending_delivery_aged_out_total 4"));
+    }
+
+    #[tokio::test]
+    async fn broadcast_helper_dual_emits() {
+        let guard = setup().await;
+        increment_broadcast_dropped_full();
+        assert_eq!(
+            guard.counter_sum("xmpp.broadcast.dropped_full", &[]),
+            Some(1)
+        );
+        assert!(
+            crate::prometheus::render_metrics().contains("waddle_broadcast_dropped_full_total 1")
+        );
+    }
+
+    #[tokio::test]
+    async fn delivery_loss_helper_dual_emits() {
+        let guard = setup().await;
+        increment_delivery_retry_exhausted_drop();
+        assert_eq!(
+            guard.counter_sum("xmpp.delivery.retry_exhausted_drop", &[]),
+            Some(1)
+        );
+        assert!(crate::prometheus::render_metrics()
+            .contains("waddle_delivery_retry_exhausted_drop_total 1"));
+    }
+
+    #[tokio::test]
+    async fn dnd_helper_dual_emits() {
+        let guard = setup().await;
+        increment_dnd_projection_read_errored();
+        assert_eq!(
+            guard.counter_sum("xmpp.dnd.projection_read_errored", &[]),
+            Some(1)
+        );
+        assert!(crate::prometheus::render_metrics()
+            .contains("waddle_dnd_projection_read_errored_total 1"));
+    }
+
+    #[tokio::test]
+    async fn janitor_completed_heartbeat_records() {
+        let guard = setup().await;
+        record_janitor_sweep(Janitor::RoomDormancy, SweepOutcome::Completed);
+        assert_eq!(
+            guard.counter_sum(
+                "waddle.janitor.sweeps",
+                &[("janitor", "room_dormancy"), ("outcome", "completed")]
+            ),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn janitor_failed_heartbeat_records() {
+        let guard = setup().await;
+        record_janitor_sweep(Janitor::AuthState, SweepOutcome::Failed);
+        assert_eq!(
+            guard.counter_sum(
+                "waddle.janitor.sweeps",
+                &[("janitor", "auth_state"), ("outcome", "failed")]
+            ),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn push_suppress_reason_exactly_covers_legacy_reason_list() {
+        let enum_values: Vec<_> = PushSuppressReason::ALL
+            .iter()
+            .map(MetricAttribute::value)
+            .collect();
+        assert_eq!(enum_values, crate::prometheus::PUSH_SUPPRESSED_REASONS);
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -5,7 +5,7 @@
 //! export, `xmpp.<rest>` becomes `xmpp_<rest>_total`, leaving the live
 //! `waddle_<rest>_total` scrape distinct until recording-rule aliases cut over.
 
-use super::attributes::{Janitor, PushSuppressReason, SweepOutcome};
+use super::attributes::{Janitor, PushRetryReason, PushSuppressReason, SweepOutcome};
 
 macro_rules! dual_increment {
     ($helper:ident, $legacy:path, $name:literal, $unit:literal, $description:literal) => {
@@ -119,13 +119,22 @@ dual_increment!(
     "{notification}",
     "XEP-0357 notification outbox jobs accepted by the Push Service."
 );
-dual_increment!(
-    increment_push_outbox_retry_scheduled,
-    crate::prometheus::increment_push_outbox_retry_scheduled,
-    "xmpp.push.outbox_retry_scheduled",
-    "{notification}",
-    "XEP-0357 notification outbox jobs scheduled for retry."
-);
+/// Dual-emit for outbox retry scheduling. Hand-written (not
+/// `dual_increment!`) because the OTel successor must carry the same
+/// `reason` label shape the legacy text family renders
+/// (`waddle_push_outbox_retry_scheduled_total{reason="unknown"}`) —
+/// otherwise PromQL filtering or grouping by `reason` would stop
+/// matching at the alias cutover.
+pub fn increment_push_outbox_retry_scheduled(reason: PushRetryReason) {
+    crate::prometheus::increment_push_outbox_retry_scheduled();
+    crate::counter_add!(
+        "xmpp.push.outbox_retry_scheduled",
+        "{notification}",
+        "XEP-0357 notification outbox jobs scheduled for retry.",
+        1,
+        reason,
+    );
+}
 dual_increment!(
     increment_push_outbox_dead_lettered,
     crate::prometheus::increment_push_outbox_dead_lettered,


### PR DESCRIPTION
Implements the **expand phase** of #1330 (reliability-counter migration), stacked on #1417 (alerts pipeline) and #1415 (telemetry foundation).

## Plan

1. **Dual-emit per family** (SM → push → pending-delivery → broadcast + delivery-loss): every live reliability counter gains a typed helper in `waddle_xmpp::telemetry::reliability` that emits the new OTel macro metric (`xmpp.*` dot.case names per the spec's alias examples, so exported names do not collide with the legacy `waddle_*` scrape during dual-emit) AND the legacy Prometheus text counter. Call sites route through the new helpers; `prometheus.rs` increment helpers stay only as the legacy half of dual-emit.
2. **Push-suppression `reason` enum**: the 15 static suppression reasons become a typed `MetricAttribute` enum (the `reason` attribute set deferred from #1325).
3. **Janitor heartbeat**: `waddle.janitor.sweeps` counter (`janitor` × `outcome`), emitted by every janitor loop on every sweep including zero-work sweeps, so a wedged loop is distinguishable from an idle one.
4. **Metric-reader-seam tests** for every migrated counter and the heartbeat.

## Deliberately deferred to the contract PR (after one dual-emit release is verified in prod)

- Mimir recording-rule aliases (`waddle_*_total = sum(...) (xmpp_*_total)`): recording an alias while the text scrape still ingests the same name would double-populate the series — the alias lands in the same merge that deletes each family's text renderer.
- Text-renderer deletion per family and shrinking `/metrics` to the scrape-liveness stub.
- "Old query names verified against prod before and after" — requires the deployed dual-emit release.

## XEP review

No XMPP wire behavior changes — metric emission only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
