### PR TITLE
feat(server): observability gap closure — message/cross-stack correlation, HTTP/auth/call/push telemetry, MUC admission denials, chat call lifecycle (#1321 #1326 #1329 #1328 #1319 #1318 #1315 #531)

### DIFF
--- a/chat/src/lib/calls/call-effects.ts
+++ b/chat/src/lib/calls/call-effects.ts
@@ -10,7 +10,10 @@ import {
   isSameCallBareJid,
 } from "./tie-break";
 import type { CallEvent, CallState } from "./types";
-import { reportDeclinedCallAttempt } from "./call-lifecycle-telemetry";
+import {
+  reportDeclinedCallAttempt,
+  reportFailedCallAttempt,
+} from "./call-lifecycle-telemetry";
 
 /**
  * Side-effect handler invoked by the chat-side `on_call` wrapper
@@ -70,6 +73,7 @@ export async function handleCallEventSideEffect(
         await outboundCalls.rejectTieBreak(sender, event.from, event.sid);
       }
     } catch (err) {
+      reportFailedCallAttempt(event.sid, "dm");
       reportCallError(err);
     }
     return;
@@ -92,6 +96,7 @@ export async function handleCallEventSideEffect(
         .sessionTerminate(sender, prev.peer, prev.sid, "expired")
         .catch((err) => reportCallError(err));
     } catch (err) {
+      reportFailedCallAttempt(event.sid, "dm");
       failCallState(err, prev.sid);
     }
     return;

--- a/chat/src/lib/calls/call-lifecycle-telemetry.ts
+++ b/chat/src/lib/calls/call-lifecycle-telemetry.ts
@@ -46,7 +46,6 @@ const QUALITY_SEVERITY: Record<CallConnectionQuality, number> = {
 
 const attempts = new Map<string, Attempt>();
 const emittedSids = new Set<string>();
-const MAX_EMITTED_SIDS = 256;
 let currentSid: string | null = null;
 
 export function durationBucket(durationMs: number): CallDurationBucket {
@@ -79,9 +78,7 @@ export function reconnectCountBucket(count: number): CallReconnectCountBucket {
 
 export function beginCallAttempt(sid: string, callKind: CallKind): void {
   if (!sid) return;
-  // An explicit begin is a new attempt even when a restored call reuses the
-  // same protocol sid after a prior disconnect in this SPA lifetime.
-  emittedSids.delete(sid);
+  if (emittedSids.has(sid)) return;
   if (currentSid && currentSid !== sid) {
     const current = attempts.get(currentSid);
     finishCallAttempt(currentSid, {
@@ -175,7 +172,6 @@ export function finishCallAttempt(
     reconnectCount: reconnectCountBucket(attempt.reconnectCount),
   };
   emittedSids.add(sid);
-  trimEmittedSids();
   attempts.delete(sid);
   if (currentSid === sid) currentSid = null;
   reportCallLifecycle(payload);
@@ -186,7 +182,6 @@ export function finishCallAttempt(
 export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"): void {
   if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
   emittedSids.add(sid);
-  trimEmittedSids();
   reportCallLifecycle({
     setupOutcome: "declined",
     endReason: "hangup",
@@ -203,7 +198,6 @@ export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"
 export function reportFailedCallAttempt(sid: string, callKind: CallKind): void {
   if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
   emittedSids.add(sid);
-  trimEmittedSids();
   reportCallLifecycle({
     setupOutcome: "failed",
     endReason: "error",
@@ -214,12 +208,6 @@ export function reportFailedCallAttempt(sid: string, callKind: CallKind): void {
     connectionQuality: "unknown",
     reconnectCount: "none",
   });
-}
-
-function trimEmittedSids(): void {
-  if (emittedSids.size <= MAX_EMITTED_SIDS) return;
-  const oldest = emittedSids.values().next().value;
-  if (oldest) emittedSids.delete(oldest);
 }
 
 function currentAttempt(): Attempt | undefined {

--- a/chat/src/lib/calls/call-lifecycle-telemetry.ts
+++ b/chat/src/lib/calls/call-lifecycle-telemetry.ts
@@ -90,6 +90,20 @@ export function reconnectCountBucket(count: number): CallReconnectCountBucket {
   return "multiple";
 }
 
+/**
+ * Re-open lifecycle telemetry for a recovered media session whose sid
+ * already emitted a terminal event (e.g. transport loss before the tab
+ * resumed the call from cached activity). Unlike `beginCallAttempt`,
+ * this deliberately lifts the sid's exactly-once guard: the recovered
+ * segment is a distinct attempt whose duration/quality would otherwise
+ * go dark. Only the resume paths may call it.
+ */
+export function resumeCallAttempt(sid: string, callKind: CallKind): void {
+  if (!sid) return;
+  emittedSids.delete(sid);
+  beginCallAttempt(sid, callKind);
+}
+
 export function beginCallAttempt(sid: string, callKind: CallKind): void {
   if (!sid) return;
   if (emittedSids.has(sid)) return;

--- a/chat/src/lib/calls/call-lifecycle-telemetry.ts
+++ b/chat/src/lib/calls/call-lifecycle-telemetry.ts
@@ -45,8 +45,22 @@ const QUALITY_SEVERITY: Record<CallConnectionQuality, number> = {
 };
 
 const attempts = new Map<string, Attempt>();
+// Insertion-ordered dedupe window: exactly-once per sid holds for the
+// most recent MAX_EMITTED_SIDS call attempts. Bounded so a hostile
+// stream of inbound proposals cannot grow memory for the tab's
+// lifetime; a sid old enough to be evicted re-emitting is acceptable.
+const MAX_EMITTED_SIDS = 4096;
 const emittedSids = new Set<string>();
 let currentSid: string | null = null;
+
+function markEmitted(sid: string): void {
+  emittedSids.add(sid);
+  if (emittedSids.size <= MAX_EMITTED_SIDS) return;
+  for (const oldest of emittedSids) {
+    emittedSids.delete(oldest);
+    if (emittedSids.size <= MAX_EMITTED_SIDS) break;
+  }
+}
 
 export function durationBucket(durationMs: number): CallDurationBucket {
   if (durationMs <= 0) return "none";
@@ -171,7 +185,7 @@ export function finishCallAttempt(
     connectionQuality: attempt.worstConnectionQuality,
     reconnectCount: reconnectCountBucket(attempt.reconnectCount),
   };
-  emittedSids.add(sid);
+  markEmitted(sid);
   attempts.delete(sid);
   if (currentSid === sid) currentSid = null;
   reportCallLifecycle(payload);
@@ -181,7 +195,7 @@ export function finishCallAttempt(
 /** Emit a declined inbound proposal that never occupied the single call slot. */
 export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"): void {
   if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
-  emittedSids.add(sid);
+  markEmitted(sid);
   reportCallLifecycle({
     setupOutcome: "declined",
     endReason: "hangup",
@@ -197,7 +211,7 @@ export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"
 /** Emit a failed setup that ended before it could occupy the call store. */
 export function reportFailedCallAttempt(sid: string, callKind: CallKind): void {
   if (!sid || attempts.has(sid) || emittedSids.has(sid)) return;
-  emittedSids.add(sid);
+  markEmitted(sid);
   reportCallLifecycle({
     setupOutcome: "failed",
     endReason: "error",

--- a/chat/src/lib/calls/call-lifecycle-telemetry.ts
+++ b/chat/src/lib/calls/call-lifecycle-telemetry.ts
@@ -10,16 +10,17 @@ export type CallEndReason = "hangup" | "peer-left" | "error" | "reconnect-exhaus
 export type CallDurationBucket = "none" | "under-1m" | "1m-10m" | "10m-60m" | "over-60m";
 export type CallRttBand = "unknown" | "under-100ms" | "100ms-300ms" | "over-300ms";
 export type CallPacketLossBand = "unknown" | "under-1pct" | "1pct-5pct" | "over-5pct";
+export type CallReconnectCountBucket = "none" | "once" | "multiple";
 
 export type CallLifecyclePayload = {
   setupOutcome: CallSetupOutcome;
-  endReason?: CallEndReason;
+  endReason: CallEndReason;
   durationBucket: CallDurationBucket;
   callKind: CallKind;
   rttBand: CallRttBand;
   packetLossBand: CallPacketLossBand;
   connectionQuality: CallConnectionQuality;
-  reconnectCount: number;
+  reconnectCount: CallReconnectCountBucket;
 };
 
 type Attempt = {
@@ -70,6 +71,12 @@ export function packetLossBand(packetLossPct: number | null): CallPacketLossBand
   return "over-5pct";
 }
 
+export function reconnectCountBucket(count: number): CallReconnectCountBucket {
+  if (count <= 0) return "none";
+  if (count === 1) return "once";
+  return "multiple";
+}
+
 export function beginCallAttempt(sid: string, callKind: CallKind): void {
   if (!sid) return;
   // An explicit begin is a new attempt even when a restored call reuses the
@@ -79,7 +86,7 @@ export function beginCallAttempt(sid: string, callKind: CallKind): void {
     const current = attempts.get(currentSid);
     finishCallAttempt(currentSid, {
       setupOutcome: "proposed",
-      ...(current?.accepted ? { endReason: "error" as const } : {}),
+      endReason: current?.accepted ? "error" : "hangup",
     });
   }
   if (!attempts.has(sid)) {
@@ -151,7 +158,7 @@ export function observeCallConnectionPhase(phase: CallConnectionPhase): void {
 
 export function finishCallAttempt(
   sid: string,
-  terminal: { setupOutcome?: CallSetupOutcome; endReason?: CallEndReason },
+  terminal: { setupOutcome?: CallSetupOutcome; endReason: CallEndReason },
   now: number = Date.now(),
 ): CallLifecyclePayload | null {
   if (emittedSids.has(sid)) return null;
@@ -159,13 +166,13 @@ export function finishCallAttempt(
   if (!attempt) return null;
   const payload: CallLifecyclePayload = {
     setupOutcome: attempt.accepted ? "accepted" : (terminal.setupOutcome ?? "proposed"),
-    ...(terminal.endReason ? { endReason: terminal.endReason } : {}),
+    endReason: terminal.endReason,
     durationBucket: durationBucket(attempt.acceptedAtMs === null ? 0 : now - attempt.acceptedAtMs),
     callKind: attempt.callKind,
     rttBand: rttBand(attempt.maxRttMs),
     packetLossBand: packetLossBand(attempt.maxPacketLossPct),
     connectionQuality: attempt.worstConnectionQuality,
-    reconnectCount: attempt.reconnectCount,
+    reconnectCount: reconnectCountBucket(attempt.reconnectCount),
   };
   emittedSids.add(sid);
   trimEmittedSids();
@@ -182,12 +189,13 @@ export function reportDeclinedCallAttempt(sid: string, callKind: CallKind = "dm"
   trimEmittedSids();
   reportCallLifecycle({
     setupOutcome: "declined",
+    endReason: "hangup",
     durationBucket: "none",
     callKind,
     rttBand: "unknown",
     packetLossBand: "unknown",
     connectionQuality: "unknown",
-    reconnectCount: 0,
+    reconnectCount: "none",
   });
 }
 
@@ -198,12 +206,13 @@ export function reportFailedCallAttempt(sid: string, callKind: CallKind): void {
   trimEmittedSids();
   reportCallLifecycle({
     setupOutcome: "failed",
+    endReason: "error",
     durationBucket: "none",
     callKind,
     rttBand: "unknown",
     packetLossBand: "unknown",
     connectionQuality: "unknown",
-    reconnectCount: 0,
+    reconnectCount: "none",
   });
 }
 

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -331,7 +331,11 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
  */
 export function applyCallEvent(
   event: CallEvent,
-  options: { sender?: CallWireSender | null; selfOriginated?: boolean } = {},
+  options: {
+    sender?: CallWireSender | null;
+    selfOriginated?: boolean;
+    selfFullJid?: string;
+  } = {},
 ): void {
   // Route inbound Muji session-accept stanzas to the pending
   // `beginMucCall` Promise BEFORE the 1:1 reducer sees them. A
@@ -376,6 +380,12 @@ export function applyCallEvent(
     && next.phase === "idle"
     && event.kind === "proceed"
     && event.sid === before.sid
+    // A proceed echoed from THIS resource is the local accept — the
+    // attempt continues into session-initiate, so it must not be
+    // finalized here. `selfOriginated` is bare-JID scoped and would
+    // also match a sibling resource's "accepted elsewhere" proceed,
+    // which DOES end this tab's attempt — hence the full-JID check.
+    && event.from !== options.selfFullJid
   ) {
     finishCallAttempt(before.sid, { setupOutcome: "proposed", endReason: "hangup" });
   }

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -331,7 +331,7 @@ export function reduceCallState(current: CallState, event: CallEvent): CallState
  */
 export function applyCallEvent(
   event: CallEvent,
-  options: { sender?: CallWireSender | null } = {},
+  options: { sender?: CallWireSender | null; selfOriginated?: boolean } = {},
 ): void {
   // Route inbound Muji session-accept stanzas to the pending
   // `beginMucCall` Promise BEFORE the 1:1 reducer sees them. A
@@ -355,12 +355,29 @@ export function applyCallEvent(
   }
   if (next.phase === "ended" && (before.phase !== "ended" || before.sid !== next.sid)) {
     if (event.kind === "reject") {
-      finishCallAttempt(next.sid, { setupOutcome: "declined" });
+      finishCallAttempt(next.sid, {
+        setupOutcome: "declined",
+        endReason: signaledCallEndReason(options.selfOriginated),
+      });
     } else if (event.kind === "retract") {
-      finishCallAttempt(next.sid, { setupOutcome: "proposed" });
+      finishCallAttempt(next.sid, {
+        setupOutcome: "proposed",
+        endReason: signaledCallEndReason(options.selfOriginated),
+      });
     } else {
-      finishCallAttempt(next.sid, callLifecycleTerminalForRemoteEnd(before, event, next.reason));
+      finishCallAttempt(
+        next.sid,
+        callLifecycleTerminalForSignaledEnd(before, event, next.reason, options.selfOriginated),
+      );
     }
+  }
+  if (
+    before.phase === "incoming"
+    && next.phase === "idle"
+    && event.kind === "proceed"
+    && event.sid === before.sid
+  ) {
+    finishCallAttempt(before.sid, { setupOutcome: "proposed", endReason: "hangup" });
   }
   if (next !== before) {
     $lastCallError.set(null);
@@ -398,19 +415,36 @@ const CALL_ERROR_REASONS = new Set([
   "error",
 ]);
 
-export function callLifecycleTerminalForRemoteEnd(
+export function callLifecycleTerminalForSignaledEnd(
   before: CallState,
   _event: CallEvent,
   reason: string | null,
-): { setupOutcome?: CallSetupOutcome; endReason?: CallEndReason } {
+  selfOriginated: boolean = false,
+): { setupOutcome?: CallSetupOutcome; endReason: CallEndReason } {
   const isFailure = reason !== null && CALL_ERROR_REASONS.has(reason);
   if (before.phase === "active") {
-    return { endReason: isFailure || reason === "timeout" ? "error" : "peer-left" };
+    return {
+      endReason: isFailure || reason === "timeout"
+        ? "error"
+        : signaledCallEndReason(selfOriginated),
+    };
   }
-  if (reason === "timeout") return { setupOutcome: "timeout" };
-  if (reason === "decline") return { setupOutcome: "declined" };
-  if (isFailure) return { setupOutcome: "failed" };
-  return { setupOutcome: "proposed" };
+  if (reason === "timeout") return { setupOutcome: "timeout", endReason: "error" };
+  if (reason === "decline") {
+    return {
+      setupOutcome: "declined",
+      endReason: signaledCallEndReason(selfOriginated),
+    };
+  }
+  if (isFailure) return { setupOutcome: "failed", endReason: "error" };
+  return {
+    setupOutcome: "proposed",
+    endReason: signaledCallEndReason(selfOriginated),
+  };
+}
+
+function signaledCallEndReason(selfOriginated: boolean | undefined): CallEndReason {
+  return selfOriginated ? "hangup" : "peer-left";
 }
 
 function applyIncomingCallAlerts(before: CallState, next: CallState): void {
@@ -454,11 +488,10 @@ export function clearCallState(terminal: {
   );
   const current = $callState.get();
   if (current.phase !== "idle" && current.phase !== "ended") {
+    const derivedTerminal = callLifecycleTerminalForTeardown(current.phase, "clear");
     finishCallAttempt(current.sid, {
-      setupOutcome: terminal.setupOutcome ?? teardownSetupOutcome(current.phase),
-      ...(terminal.endReason
-        ? { endReason: terminal.endReason }
-        : current.phase === "active" ? { endReason: "error" as const } : {}),
+      setupOutcome: terminal.setupOutcome ?? derivedTerminal.setupOutcome,
+      endReason: terminal.endReason ?? derivedTerminal.endReason,
     });
   }
   if (current.phase === "incoming") {
@@ -598,7 +631,7 @@ export function scheduleOutgoingTimeout(
       .catch((err) => reportCallError(err));
     publishNoAnswerOutcome(s.to, sid, s.media, s.initiator);
     clearDmCallActivity(s.to, sid);
-    finishCallAttempt(sid, { setupOutcome: "timeout" });
+    finishCallAttempt(sid, { setupOutcome: "timeout", endReason: "error" });
     $callState.set({
       phase: "ended",
       sid,
@@ -631,7 +664,7 @@ export function scheduleSessionAcceptTimeout(
       .catch((err) => reportCallError(err));
     publishNoAnswerOutcome(peerFullJid, sid, s.media, s.initiator);
     clearDmCallActivity(peerFullJid, sid);
-    finishCallAttempt(sid, { setupOutcome: "timeout" });
+    finishCallAttempt(sid, { setupOutcome: "timeout", endReason: "error" });
     $callState.set({
       phase: "ended",
       sid,
@@ -739,6 +772,19 @@ export function teardownSetupOutcome(phase: CallState["phase"]): CallSetupOutcom
   }
 }
 
+export function callLifecycleTerminalForTeardown(
+  phase: CallState["phase"],
+  disposition: "clear" | "success" | "gone",
+): { setupOutcome: CallSetupOutcome; endReason: CallEndReason } {
+  const failedSetup = phase === "muc-pending";
+  const terminalFailure = disposition === "gone" || failedSetup
+    || (disposition === "clear" && phase === "active");
+  return {
+    setupOutcome: teardownSetupOutcome(phase),
+    endReason: terminalFailure ? "error" : "hangup",
+  };
+}
+
 export async function tearDownActiveCall(
   sender: CallWireSender | null,
   reason: "success" | "gone",
@@ -746,12 +792,7 @@ export async function tearDownActiveCall(
   cancelCallTimers();
   const s = $callState.get();
   if (s.phase !== "idle" && s.phase !== "ended") {
-    finishCallAttempt(s.sid, {
-      setupOutcome: teardownSetupOutcome(s.phase),
-      ...(s.phase === "active"
-        ? { endReason: reason === "success" ? "hangup" as const : "error" as const }
-        : {}),
-    });
+    finishCallAttempt(s.sid, callLifecycleTerminalForTeardown(s.phase, reason));
   }
   if (sender) {
     try {

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -19,7 +19,7 @@ import {
 import type { CallMedia } from "./types";
 import { barePeerJid } from "../xmpp/jid";
 import {
-  beginCallAttempt,
+  resumeCallAttempt,
   finishCallAttempt,
   markCallAttemptAccepted,
   reportFailedCallAttempt,
@@ -149,7 +149,7 @@ export function resumeDmCallActivity(options: {
     join: activity.join,
     initiator: selfFullJid,
   });
-  beginCallAttempt(activity.sid, "dm");
+  resumeCallAttempt(activity.sid, "dm");
   markCallAttemptAccepted(activity.sid);
   return true;
 }

--- a/chat/src/lib/calls/dm-call-actions.ts
+++ b/chat/src/lib/calls/dm-call-actions.ts
@@ -22,6 +22,7 @@ import {
   beginCallAttempt,
   finishCallAttempt,
   markCallAttemptAccepted,
+  reportFailedCallAttempt,
 } from "./call-lifecycle-telemetry";
 
 export async function startDmCallAction(options: {
@@ -33,10 +34,13 @@ export async function startDmCallAction(options: {
   const current = $callState.get();
   if (current.phase !== "idle" && current.phase !== "ended") return;
 
-  const sender = options.getSender();
-  if (!sender) return;
-
   const sid = newCallSid();
+  const sender = options.getSender();
+  if (!sender) {
+    reportFailedCallAttempt(sid, "dm");
+    return;
+  }
+
   beginOutgoingCall(
     options.peerBareJid,
     sid,

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -60,9 +60,12 @@ export async function startMucCallAction({
   tryResumeFirst = false,
 }: MucCallStartActionOptions): Promise<boolean> {
   if (isBusy()) return false;
-  const sender = getSender();
-  if (!sender) return false;
   const lifecycleAttemptId = crypto.randomUUID();
+  const sender = getSender();
+  if (!sender) {
+    reportFailedCallAttempt(lifecycleAttemptId, "muc");
+    return false;
+  }
   setStarting(true);
   try {
     await ensureJoined?.();

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -10,7 +10,7 @@ import {
 } from "./muc-call-session-cache";
 import type { CallMedia, LiveKitJoin } from "./types";
 import {
-  beginCallAttempt,
+  resumeCallAttempt,
   markCallAttemptAccepted,
   reportFailedCallAttempt,
 } from "./call-lifecycle-telemetry";
@@ -263,7 +263,7 @@ export async function resumeMucCallActivity({
     selfNick,
     selfFullJid,
   });
-  beginCallAttempt(session.sid, "muc");
+  resumeCallAttempt(session.sid, "muc");
   markCallAttemptAccepted(session.sid);
 
   // Best-effort republish of Muji active presence under the current

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -869,9 +869,11 @@ export function setXmppResourceForTelemetry(resource: string): void {
  */
 export function websocketUrlWithTraceparent(value: string): string {
   const activeSpanContext = trace.getSpan(context.active())?.spanContext();
-  const spanContext = activeSpanContext && validSpanContext(activeSpanContext)
-    ? activeSpanContext
-    : randomSpanContext();
+  if (activeSpanContext && validSpanContext(activeSpanContext)) {
+    return websocketUrlWithSpanContext(value, activeSpanContext);
+  }
+  if (typeof globalThis.crypto?.getRandomValues !== "function") return value;
+  const spanContext = randomSpanContext();
   return websocketUrlWithSpanContext(value, spanContext);
 }
 
@@ -890,7 +892,7 @@ function randomSpanContext(): { traceId: string; spanId: string; traceFlags: num
 function randomNonZeroHex(byteLength: number): string {
   let value = "";
   do {
-    value = Array.from(crypto.getRandomValues(new Uint8Array(byteLength)), (byte) =>
+    value = Array.from(globalThis.crypto.getRandomValues(new Uint8Array(byteLength)), (byte) =>
       byte.toString(16).padStart(2, "0")
     ).join("");
   } while (/^0+$/.test(value));

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -868,18 +868,48 @@ export function setXmppResourceForTelemetry(resource: string): void {
  * parameter is the only cross-stack propagation channel available here.
  */
 export function websocketUrlWithTraceparent(value: string): string {
-  const spanContext = trace.getSpan(context.active())?.spanContext();
-  if (!spanContext) return value;
+  const activeSpanContext = trace.getSpan(context.active())?.spanContext();
+  const spanContext = activeSpanContext && validSpanContext(activeSpanContext)
+    ? activeSpanContext
+    : randomSpanContext();
   return websocketUrlWithSpanContext(value, spanContext);
+}
+
+function validSpanContext(spanContext: { traceId: string; spanId: string; traceFlags: number }): boolean {
+  return isValidTraceparent(traceparentFromSpanContext(spanContext));
+}
+
+function randomSpanContext(): { traceId: string; spanId: string; traceFlags: number } {
+  return {
+    traceId: randomNonZeroHex(16),
+    spanId: randomNonZeroHex(8),
+    traceFlags: 0,
+  };
+}
+
+function randomNonZeroHex(byteLength: number): string {
+  let value = "";
+  do {
+    value = Array.from(crypto.getRandomValues(new Uint8Array(byteLength)), (byte) =>
+      byte.toString(16).padStart(2, "0")
+    ).join("");
+  } while (/^0+$/.test(value));
+  return value;
+}
+
+function traceparentFromSpanContext(
+  spanContext: { traceId: string; spanId: string; traceFlags: number },
+): string {
+  return `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff)
+    .toString(16)
+    .padStart(2, "0")}`;
 }
 
 function websocketUrlWithSpanContext(
   value: string,
   spanContext: { traceId: string; spanId: string; traceFlags: number },
 ): string {
-  const traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff)
-    .toString(16)
-    .padStart(2, "0")}`;
+  const traceparent = traceparentFromSpanContext(spanContext);
   if (!isValidTraceparent(traceparent)) return value;
   try {
     const url = new URL(value);
@@ -1148,13 +1178,13 @@ export function reportCallMediaPath(snapshot: CallMediaPathSnapshot, callKind: C
 export function reportCallLifecycle(payload: CallLifecyclePayload): void {
   faro?.api.pushEvent("chat.call.lifecycle", {
     setup_outcome: payload.setupOutcome,
-    ...(payload.endReason ? { end_reason: payload.endReason } : {}),
+    end_reason: payload.endReason,
     duration_bucket: payload.durationBucket,
     call_kind: payload.callKind,
     rtt_band: payload.rttBand,
     packet_loss_band: payload.packetLossBand,
     connection_quality: payload.connectionQuality,
-    reconnect_count: String(payload.reconnectCount),
+    reconnect_count: payload.reconnectCount,
   });
 }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2944,6 +2944,7 @@ export class BrowserXmppClient {
         applyCallEvent(event, {
           sender: xmpp as unknown as CallWireSender,
           selfOriginated: isSelfOriginated,
+          selfFullJid: this.fullJid,
         });
       }
       if (!isSelfOriginated) {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2941,7 +2941,10 @@ export class BrowserXmppClient {
           (event.kind === "finish" && prev.phase === "active" && prev.kind === "dm")
         );
       if (!isSelfOriginated || selfOriginatedEventShouldTouchCurrentCall) {
-        applyCallEvent(event, { sender: xmpp as unknown as CallWireSender });
+        applyCallEvent(event, {
+          sender: xmpp as unknown as CallWireSender,
+          selfOriginated: isSelfOriginated,
+        });
       }
       if (!isSelfOriginated) {
         void handleCallEventSideEffect(event, prev, xmpp as unknown as CallWireSender, this.fullJid);

--- a/chat/tests/call-effects.test.ts
+++ b/chat/tests/call-effects.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   $callState,
   $lastCallError,
@@ -7,6 +7,8 @@ import {
 import { handleCallEventSideEffect } from "../src/lib/calls/call-effects";
 import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "../src/lib/calls/types";
+import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const audioVideo: CallMedia = { audio: true, video: true };
 const audioOnly: CallMedia = { audio: true, video: false };
@@ -32,6 +34,12 @@ function mockSender(): CallWireSender {
     send_call_session_terminate: mock(async () => undefined),
   };
 }
+
+afterEach(() => {
+  clearCallState();
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
+});
 
 describe("handleCallEventSideEffect", () => {
   test("proceed side-effect failure ends outgoing UI and preserves a visible error", async () => {
@@ -338,6 +346,86 @@ describe("handleCallEventSideEffect", () => {
       media: audioVideo,
     });
     clearCallState();
+  });
+
+  test("tie-break retract failure reports the inbound proposal as one failed attempt", async () => {
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          events.push({ name, attributes });
+        },
+        pushError: () => undefined,
+      },
+    } as never);
+    const sender = mockSender();
+    sender.send_call_retract_tie_break = mock(async () => {
+      throw new Error("tie-break retract failed");
+    });
+    const prev: CallState = {
+      phase: "outgoing",
+      to: "dave@waddle.test",
+      sid: "z-outgoing",
+      media: audioVideo,
+    };
+    $callState.set(prev);
+
+    await handleCallEventSideEffect({
+      kind: "propose",
+      from: "dave@waddle.test/phone",
+      sid: "a-incoming",
+      media: audioVideo,
+    }, prev, sender, "alice@waddle.test/web-1");
+
+    expect(events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "failed",
+        end_reason: "error",
+        call_kind: "dm",
+      }),
+    }]);
+  });
+
+  test("active-call migration failure reports the inbound proposal as one failed attempt", async () => {
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          events.push({ name, attributes });
+        },
+        pushError: () => undefined,
+      },
+    } as never);
+    const sender = mockSender();
+    sender.send_call_finish_migrated = mock(async () => {
+      throw new Error("migration finish failed");
+    });
+    const prev: CallState = {
+      phase: "active",
+      peer: "dave@waddle.test/desktop",
+      sid: "old-session",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    };
+    $callState.set(prev);
+
+    await handleCallEventSideEffect({
+      kind: "propose",
+      from: "dave@waddle.test/tablet",
+      sid: "new-session",
+      media: audioVideo,
+    }, prev, sender, "alice@waddle.test/web-1");
+
+    expect(events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "failed",
+        end_reason: "error",
+        call_kind: "dm",
+      }),
+    }]);
   });
 
   test("tie-break: higher inbound propose is rejected and outgoing state stays intact", async () => {

--- a/chat/tests/call-lifecycle-telemetry.test.ts
+++ b/chat/tests/call-lifecycle-telemetry.test.ts
@@ -10,6 +10,7 @@ import {
   observeCallConnectionQuality,
   observeCallStats,
   packetLossBand,
+  reconnectCountBucket,
   reportDeclinedCallAttempt,
   reportFailedCallAttempt,
   rttBand,
@@ -48,6 +49,9 @@ describe("call lifecycle mappings", () => {
     expect(packetLossBand(0.5)).toBe("under-1pct");
     expect(packetLossBand(5)).toBe("1pct-5pct");
     expect(packetLossBand(5.1)).toBe("over-5pct");
+    expect(reconnectCountBucket(0)).toBe("none");
+    expect(reconnectCountBucket(1)).toBe("once");
+    expect(reconnectCountBucket(2)).toBe("multiple");
   });
 
   test("emits one declined DM setup outcome for an unaccepted attempt", () => {
@@ -55,11 +59,20 @@ describe("call lifecycle mappings", () => {
     __setFaroForTesting(stub as never);
     beginCallAttempt("dm-1", "dm");
 
-    const first = finishCallAttempt("dm-1", { setupOutcome: "declined" }, 1_000);
-    const duplicate = finishCallAttempt("dm-1", { setupOutcome: "failed" }, 2_000);
+    const first = finishCallAttempt(
+      "dm-1",
+      { setupOutcome: "declined", endReason: "peer-left" },
+      1_000,
+    );
+    const duplicate = finishCallAttempt(
+      "dm-1",
+      { setupOutcome: "failed", endReason: "error" },
+      2_000,
+    );
 
     expect(first).toMatchObject({
       setupOutcome: "declined",
+      endReason: "peer-left",
       callKind: "dm",
       durationBucket: "none",
     });
@@ -68,12 +81,13 @@ describe("call lifecycle mappings", () => {
       name: "chat.call.lifecycle",
       attributes: {
         setup_outcome: "declined",
+        end_reason: "peer-left",
         duration_bucket: "none",
         call_kind: "dm",
         rtt_band: "unknown",
         packet_loss_band: "unknown",
         connection_quality: "unknown",
-        reconnect_count: "0",
+        reconnect_count: "none",
       },
     }]);
   });
@@ -88,7 +102,11 @@ describe("call lifecycle mappings", () => {
     finishCallAttempt("active", { endReason: "hangup" });
 
     expect(stub.events.map((event) => event.attributes)).toEqual([
-      expect.objectContaining({ setup_outcome: "declined", call_kind: "dm" }),
+      expect.objectContaining({
+        setup_outcome: "declined",
+        end_reason: "hangup",
+        call_kind: "dm",
+      }),
       expect.objectContaining({ setup_outcome: "accepted", end_reason: "hangup" }),
     ]);
   });
@@ -125,7 +143,11 @@ describe("call lifecycle mappings", () => {
     finishCallAttempt("first", { endReason: "hangup" }, 91_000);
 
     beginCallAttempt("second", "dm");
-    const second = finishCallAttempt("second", { setupOutcome: "failed" }, 100_000);
+    const second = finishCallAttempt(
+      "second",
+      { setupOutcome: "failed", endReason: "error" },
+      100_000,
+    );
 
     expect(second).toMatchObject({
       durationBucket: "none",
@@ -141,7 +163,11 @@ describe("call lifecycle mappings", () => {
 
     expect(stub.events).toEqual([{
       name: "chat.call.lifecycle",
-      attributes: expect.objectContaining({ setup_outcome: "failed", call_kind: "muc" }),
+      attributes: expect.objectContaining({
+        setup_outcome: "failed",
+        end_reason: "error",
+        call_kind: "muc",
+      }),
     }]);
   });
 
@@ -171,13 +197,13 @@ describe("call lifecycle mappings", () => {
       rttBand: "over-300ms",
       packetLossBand: "over-5pct",
       connectionQuality: "poor",
-      reconnectCount: 1,
+      reconnectCount: "once",
     });
     expect(stub.events[0]?.attributes).toMatchObject({
       setup_outcome: "accepted",
       end_reason: "hangup",
       call_kind: "muc",
-      reconnect_count: "1",
+      reconnect_count: "once",
     });
   });
 });

--- a/chat/tests/call-lifecycle-telemetry.test.ts
+++ b/chat/tests/call-lifecycle-telemetry.test.ts
@@ -111,20 +111,61 @@ describe("call lifecycle mappings", () => {
     ]);
   });
 
-  test("classifies transport loss from observed reconnect state and permits explicit SID reuse", () => {
-    const stub = createFaroStub();
-    __setFaroForTesting(stub as never);
+  test("classifies transport loss from observed reconnect state", () => {
     beginCallAttempt("restored-sid", "dm");
     markCallAttemptAccepted("restored-sid");
     expect(finishCallAttemptForTransportDisconnect("restored-sid")?.endReason).toBe("error");
 
-    beginCallAttempt("restored-sid", "dm");
-    markCallAttemptAccepted("restored-sid");
+    beginCallAttempt("reconnecting-sid", "dm");
+    markCallAttemptAccepted("reconnecting-sid");
     observeCallConnectionPhase("reconnecting");
-    expect(finishCallAttemptForTransportDisconnect("restored-sid")?.endReason)
+    expect(finishCallAttemptForTransportDisconnect("reconnecting-sid")?.endReason)
       .toBe("reconnect-exhausted");
+  });
+
+  test("emits once for a replayed SID while a new SID retry emits independently", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    beginCallAttempt("replayed-sid", "dm");
+    finishCallAttempt(
+      "replayed-sid",
+      { setupOutcome: "failed", endReason: "error" },
+    );
+
+    beginCallAttempt("replayed-sid", "dm");
+    markCallAttemptAccepted("replayed-sid");
+    expect(finishCallAttempt("replayed-sid", { endReason: "hangup" })).toBeNull();
+
+    beginCallAttempt("retry-sid", "dm");
+    markCallAttemptAccepted("retry-sid");
+    finishCallAttempt("retry-sid", { endReason: "hangup" });
 
     expect(stub.events).toHaveLength(2);
+    expect(stub.events.map((event) => event.attributes?.setup_outcome)).toEqual([
+      "failed",
+      "accepted",
+    ]);
+  });
+
+  test("retains exactly-once history for the whole session", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    for (let index = 0; index < 2_050; index += 1) {
+      const sid = `session-sid-${index}`;
+      beginCallAttempt(sid, "dm");
+      finishCallAttempt(sid, { setupOutcome: "failed", endReason: "error" });
+    }
+
+    beginCallAttempt("session-sid-0", "dm");
+    expect(
+      finishCallAttempt("session-sid-0", {
+        setupOutcome: "accepted",
+        endReason: "hangup",
+      })
+    ).toBeNull();
+    expect(stub.events).toHaveLength(2_050);
   });
 
   test("does not call a later transport loss exhausted after a successful reconnect", () => {

--- a/chat/tests/call-lifecycle-telemetry.test.ts
+++ b/chat/tests/call-lifecycle-telemetry.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   __resetCallLifecycleTelemetryForTesting,
   beginCallAttempt,
+  resumeCallAttempt,
   durationBucket,
   finishCallAttempt,
   finishCallAttemptForTransportDisconnect,
@@ -166,6 +167,35 @@ describe("call lifecycle mappings", () => {
       })
     ).toBeNull();
     expect(stub.events).toHaveLength(2_050);
+  });
+
+  test("a resumed media session re-opens telemetry for an already-emitted sid", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    // First segment ends in a transport loss and emits its terminal.
+    beginCallAttempt("resumed-sid", "dm");
+    markCallAttemptAccepted("resumed-sid");
+    finishCallAttempt("resumed-sid", { setupOutcome: "accepted", endReason: "error" });
+    expect(stub.events).toHaveLength(1);
+
+    // A replayed proposal with the same sid stays deduped...
+    beginCallAttempt("resumed-sid", "dm");
+    expect(
+      finishCallAttempt("resumed-sid", { setupOutcome: "proposed", endReason: "hangup" })
+    ).toBeNull();
+    expect(stub.events).toHaveLength(1);
+
+    // ...but an explicit resume re-opens the sid so the recovered
+    // segment's duration/quality is not dark.
+    resumeCallAttempt("resumed-sid", "dm");
+    markCallAttemptAccepted("resumed-sid");
+    const payload = finishCallAttempt("resumed-sid", {
+      setupOutcome: "accepted",
+      endReason: "hangup",
+    });
+    expect(payload?.setupOutcome).toBe("accepted");
+    expect(stub.events).toHaveLength(2);
   });
 
   test("does not call a later transport loss exhausted after a successful reconnect", () => {

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -17,7 +17,11 @@ import {
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "../src/lib/calls/types";
-import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
+import {
+  __resetCallLifecycleTelemetryForTesting,
+  finishCallAttempt,
+  markCallAttemptAccepted,
+} from "../src/lib/calls/call-lifecycle-telemetry";
 import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const audioVideo: CallMedia = { audio: true, video: true };
@@ -220,6 +224,50 @@ describe("call-store reducer", () => {
       }),
     }]);
 
+  });
+
+  test("local accept proceed does not finalize the attempt (session-initiate follows)", () => {
+    clearCallState();
+    __resetCallLifecycleTelemetryForTesting();
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          events.push({ name, attributes });
+        },
+      },
+    } as never);
+
+    applyCallEvent({
+      kind: "propose",
+      from: "alice@waddle.test/desktop",
+      sid: "local-accept",
+      media: audioVideo,
+    });
+    // The echo of THIS resource's own <proceed/> (local accept): the
+    // attempt must survive so session-initiate can mark it accepted.
+    applyCallEvent(
+      {
+        kind: "proceed",
+        from: "bob@waddle.test/web",
+        sid: "local-accept",
+      },
+      { selfOriginated: true, selfFullJid: "bob@waddle.test/web" },
+    );
+    expect(events).toEqual([]);
+
+    // The attempt is still alive: a later terminal event emits its
+    // lifecycle beacon (accepted via the media path in the real flow).
+    markCallAttemptAccepted("local-accept");
+    finishCallAttempt("local-accept", { endReason: "hangup" });
+    expect(events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "accepted",
+        end_reason: "hangup",
+        call_kind: "dm",
+      }),
+    }]);
   });
 
   test("beginOutgoingCall transitions to the outgoing phase", () => {

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   $callState,
   $lastCallError,
   applyCallEvent,
   beginOutgoingCall,
-  callLifecycleTerminalForRemoteEnd,
+  callLifecycleTerminalForSignaledEnd,
+  callLifecycleTerminalForTeardown,
   clearCallState,
   clearLastCallError,
   reduceCallState,
@@ -16,6 +17,7 @@ import {
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallEvent, CallMedia, CallState, LiveKitJoin } from "../src/lib/calls/types";
+import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
 import { __setFaroForTesting } from "../src/lib/telemetry";
 
 const audioVideo: CallMedia = { audio: true, video: true };
@@ -25,6 +27,13 @@ const join: LiveKitJoin = {
   identity: "bob@waddle.test/desktop",
   token: "eyJhbGc.payload.sig",
 };
+
+afterEach(() => {
+  clearCallState();
+  clearDmCallActivities();
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
+});
 
 describe("call-store reducer", () => {
   test("propose transitions idle → incoming", () => {
@@ -174,6 +183,43 @@ describe("call-store reducer", () => {
     });
     clearCallState();
     expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("sibling proceed finalizes the pending browser attempt exactly once", () => {
+    clearCallState();
+    __resetCallLifecycleTelemetryForTesting();
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          events.push({ name, attributes });
+        },
+      },
+    } as never);
+
+    applyCallEvent({
+      kind: "propose",
+      from: "alice@waddle.test/desktop",
+      sid: "sibling-accepted",
+      media: audioVideo,
+    });
+    applyCallEvent({
+      kind: "proceed",
+      from: "alice@waddle.test/phone",
+      sid: "sibling-accepted",
+    });
+    clearCallState();
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "proposed",
+        end_reason: "hangup",
+        call_kind: "dm",
+      }),
+    }]);
+
   });
 
   test("beginOutgoingCall transitions to the outgoing phase", () => {
@@ -433,14 +479,18 @@ describe("call lifecycle terminal mapping", () => {
   });
 
   test.each([
-    ["failed-transport", "failed"],
-    ["incompatible-parameters", "failed"],
-    ["timeout", "timeout"],
-    ["decline", "declined"],
-    ["success", "proposed"],
-  ])("maps pre-active %s to setup outcome %s", (reason, setupOutcome) => {
-    expect(callLifecycleTerminalForRemoteEnd(incoming, terminate(reason), reason))
-      .toEqual({ setupOutcome });
+    ["failed-transport", "failed", "error"],
+    ["incompatible-parameters", "failed", "error"],
+    ["timeout", "timeout", "error"],
+    ["decline", "declined", "peer-left"],
+    ["success", "proposed", "peer-left"],
+  ])("maps pre-active %s to setup outcome %s and end reason %s", (
+    reason,
+    setupOutcome,
+    endReason,
+  ) => {
+    expect(callLifecycleTerminalForSignaledEnd(incoming, terminate(reason), reason))
+      .toEqual({ setupOutcome, endReason });
   });
 
   test.each([
@@ -459,9 +509,30 @@ describe("call lifecycle terminal mapping", () => {
     ["timeout", "error"],
     ["success", "peer-left"],
   ])("maps active %s to end reason %s", (reason, endReason) => {
-    expect(callLifecycleTerminalForRemoteEnd(active, terminate(reason), reason))
+    expect(callLifecycleTerminalForSignaledEnd(active, terminate(reason), reason))
       .toEqual({ endReason });
   });
+
+  test("maps a proposed-then-retracted attempt to a peer departure", () => {
+    expect(callLifecycleTerminalForSignaledEnd(incoming, {
+      kind: "retract",
+      from: "alice@waddle.test/desktop",
+      sid: "c1",
+    }, "retract")).toEqual({ setupOutcome: "proposed", endReason: "peer-left" });
+  });
+
+  test.each([
+    ["incoming", "clear", "declined", "hangup"],
+    ["outgoing", "success", "proposed", "hangup"],
+    ["muc-pending", "clear", "failed", "error"],
+    ["active", "gone", "accepted", "error"],
+  ] as const)(
+    "maps non-active/local %s %s teardown to %s and %s",
+    (phase, disposition, setupOutcome, endReason) => {
+      expect(callLifecycleTerminalForTeardown(phase, disposition))
+        .toEqual({ setupOutcome, endReason });
+    },
+  );
 });
 
 describe("clearLastCallError", () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -31,6 +31,8 @@ import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import { createIncomingCallAlertController } from "../src/shell/audio-alerts";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
+import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -241,6 +243,8 @@ afterEach(() => {
   // `muc-call-presence.test.ts`) that expect an empty store.
   clearMucCallParticipants();
   clearAllMucCallSessionCacheForTests();
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
 });
 
 describe("DM call outcome feed anchors", () => {
@@ -1327,10 +1331,18 @@ describe("1:1 call event wiring", () => {
   });
 
   test("self-originated sibling reject clears this resource's incoming DM ring", async () => {
+    const telemetryEvents: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          telemetryEvents.push({ name, attributes });
+        },
+      },
+    } as never);
     const sender = mockSender();
     const events = wireClientEvents(sender);
-    $callState.set({
-      phase: "incoming",
+    events.emitCall({
+      kind: "propose",
       from: "bob@waddle.test/desktop",
       sid: "shared-call",
       media: audioVideo,
@@ -1351,6 +1363,51 @@ describe("1:1 call event wiring", () => {
       reason: "reject",
     });
     expect(sender.send_call_reject).not.toHaveBeenCalled();
+    expect(telemetryEvents).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "declined",
+        end_reason: "hangup",
+        call_kind: "dm",
+      }),
+    }]);
+  });
+
+  test("self-originated sibling finish records a local active-call hangup", async () => {
+    const telemetryEvents: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          telemetryEvents.push({ name, attributes });
+        },
+      },
+    } as never);
+    const events = wireClientEvents();
+    beginOutgoingCall("bob@waddle.test", "shared-active-call", audioVideo);
+    events.emitCall({
+      kind: "session-accept",
+      from: "bob@waddle.test/desktop",
+      sid: "shared-active-call",
+      media: audioVideo,
+      join,
+    });
+    events.emitCall({
+      kind: "finish",
+      from: "alice@waddle.test/phone",
+      to: "bob@waddle.test/desktop",
+      sid: "shared-active-call",
+      reason: "success",
+    });
+    await flushCallSideEffects();
+
+    expect(telemetryEvents).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "accepted",
+        end_reason: "hangup",
+        call_kind: "dm",
+      }),
+    }]);
   });
 
   test("real on_call propose event applies lower-sid tie-break and surfaces incoming UI", async () => {
@@ -2119,6 +2176,37 @@ describe("MUC group call", () => {
       kind: "muc",
       selfNick: "alice",
     });
+  });
+
+  test("group-call button reports a missing XMPP sender as one failed MUC preflight", async () => {
+    const telemetryEvents: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          telemetryEvents.push({ name, attributes });
+        },
+      },
+    } as never);
+
+    const started = await startMucCallAction({
+      roomJid: "chan@muc.test",
+      media: audioVideo,
+      isBusy: () => false,
+      setStarting: () => undefined,
+      getSender: () => null,
+      getSelfNick: () => "alice",
+    });
+
+    expect(started).toBe(false);
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(telemetryEvents).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "failed",
+        end_reason: "error",
+        call_kind: "muc",
+      }),
+    }]);
   });
 
   test("BrowserXmppClient.disconnect rejects a pending MUC preparing wait", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -590,6 +590,7 @@ describe("client send readiness", () => {
     expect(errors[0].kind).toBe("muc-join");
     expect(errors[0].condition).toBe("registration-required");
     expect(errors[0].errorType).toBe("auth");
+    expect(errors[0].roomLocalpart).toBe("c1");
     expect(staleJoinVisibleAtEmit).toEqual([false]);
   });
 

--- a/chat/tests/dm-call-actions.test.ts
+++ b/chat/tests/dm-call-actions.test.ts
@@ -16,6 +16,8 @@ import {
   readDmCallActivity,
 } from "../src/lib/calls/dm-call-activity";
 import type { CallWireSender } from "../src/lib/calls/outbound";
+import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
+import { __setFaroForTesting } from "../src/lib/telemetry";
 
 function jwtWithExp(exp: number): string {
   return [
@@ -32,9 +34,38 @@ function base64Url(value: string): string {
 afterEach(() => {
   clearCallState();
   clearDmCallActivities();
+  __resetCallLifecycleTelemetryForTesting();
+  __setFaroForTesting(null);
 });
 
 describe("startDmCallAction", () => {
+  test("reports a missing XMPP sender as one failed DM preflight", async () => {
+    const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+    __setFaroForTesting({
+      api: {
+        pushEvent: (name: string, attributes?: Record<string, string>) => {
+          events.push({ name, attributes });
+        },
+      },
+    } as never);
+
+    await startDmCallAction({
+      peerBareJid: "bob@waddle.test",
+      media: { audio: true, video: false },
+      getSender: () => null,
+    });
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(events).toEqual([{
+      name: "chat.call.lifecycle",
+      attributes: expect.objectContaining({
+        setup_outcome: "failed",
+        end_reason: "error",
+        call_kind: "dm",
+      }),
+    }]);
+  });
+
   test("sends a fresh XEP-0353 propose and marks the peer as ringing", async () => {
     const sender: CallWireSender = {
       send_call_propose: mock(async () => undefined),

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -422,6 +422,22 @@ describe("telemetry module no-op behaviour", () => {
       .toMatch(/^00-(?!0{32})[0-9a-f]{32}-(?!0{16})[0-9a-f]{16}-00$/);
   });
 
+  test("leaves the WebSocket URL unchanged when Web Crypto is unavailable", () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+    const value = "wss://xmpp.example/ws?transport=websocket";
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(websocketUrlWithTraceparent(value)).toBe(value);
+    } finally {
+      if (original) Object.defineProperty(globalThis, "crypto", original);
+      else Reflect.deleteProperty(globalThis, "crypto");
+    }
+  });
+
   test("passes a well-formed traceparent into the XMPP WebSocket configuration", async () => {
     const stub = createFaroStub();
     __setFaroForTesting(stub as never);

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -412,9 +412,54 @@ describe("telemetry module no-op behaviour", () => {
     )).toBe(`wss://xmpp.example/:route?traceparent=${traceparent}`);
   });
 
-  test("leaves WebSocket URLs unchanged when there is no active span", () => {
-    expect(websocketUrlWithTraceparent("wss://xmpp.example/ws?transport=websocket"))
-      .toBe("wss://xmpp.example/ws?transport=websocket");
+  test("generates valid random trace context when there is no active span", () => {
+    const result = new URL(
+      websocketUrlWithTraceparent("wss://xmpp.example/ws?transport=websocket"),
+    );
+
+    expect(result.searchParams.get("transport")).toBe("websocket");
+    expect(result.searchParams.get("traceparent"))
+      .toMatch(/^00-(?!0{32})[0-9a-f]{32}-(?!0{16})[0-9a-f]{16}-00$/);
+  });
+
+  test("passes a well-formed traceparent into the XMPP WebSocket configuration", async () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    let configuredUrl = "";
+
+    class StubConfig {
+      constructor(url: string, ..._args: unknown[]) {
+        configuredUrl = url;
+      }
+    }
+    class StubClient {
+      async connect(): Promise<void> {}
+      async disconnect(): Promise<void> {}
+    }
+
+    const client = new BrowserXmppClient(session({
+      xmpp_websocket_url: "wss://xmpp.example/ws?session_id=secret",
+    }));
+    const state = client as unknown as {
+      connectTimeoutMs: number;
+      loadModule: () => Promise<unknown>;
+      reconnect: { clearTimer: () => void };
+    };
+    state.connectTimeoutMs = 1_000;
+    state.loadModule = async () => ({ WaddleConfig: StubConfig, WaddleClient: StubClient });
+
+    const pendingConnect = client.connect();
+    pendingConnect.catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const configured = new URL(configuredUrl);
+    expect(configured.searchParams.get("session_id")).toBe("secret");
+    expect(configured.searchParams.get("traceparent"))
+      .toMatch(/^00-(?!0{32})[0-9a-f]{32}-(?!0{16})[0-9a-f]{16}-00$/);
+
+    await client.disconnect();
+    await pendingConnect.catch(() => undefined);
+    state.reconnect.clearTimer();
   });
 
   test("appends the active trace context without dropping existing WebSocket query values", () => {
@@ -959,10 +1004,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
         detail: string;
         cause?: unknown;
         condition?: string;
-      errorType?: string;
-      errorText?: string;
-      roomLocalpart?: string;
-        roomLocalpart?: string;
+        errorType?: string;
         errorText?: string;
       }) => void;
     };
@@ -1026,6 +1068,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
         detail: string;
         condition?: string;
         errorType?: string;
+        errorText?: string;
+        roomLocalpart?: string;
       }) => void;
     };
 

--- a/server/crates/waddle-server/src/auth/mod.rs
+++ b/server/crates/waddle-server/src/auth/mod.rs
@@ -64,6 +64,9 @@ pub enum AuthError {
     #[error("HTTP request failed: {0}")]
     HttpError(String),
 
+    #[error("Identity provider unavailable (HTTP {0})")]
+    ProviderUnreachable(reqwest::StatusCode),
+
     #[error("User already exists: {0}")]
     UserAlreadyExists(String),
 

--- a/server/crates/waddle-server/src/auth/oauth2.rs
+++ b/server/crates/waddle-server/src/auth/oauth2.rs
@@ -65,6 +65,9 @@ pub async fn exchange_code(
     if !res.status().is_success() {
         let status = res.status();
         if status.is_server_error() {
+            // Drain the body so the pooled connection is reusable
+            // during a sustained provider outage.
+            let _ = res.text().await;
             return Err(AuthError::ProviderUnreachable(status));
         }
         let body = res.text().await.unwrap_or_default();
@@ -162,6 +165,9 @@ pub async fn fetch_userinfo(
     if !res.status().is_success() {
         let status = res.status();
         if status.is_server_error() {
+            // Drain the body so the pooled connection is reusable
+            // during a sustained provider outage.
+            let _ = res.text().await;
             return Err(AuthError::ProviderUnreachable(status));
         }
         let body = res.text().await.unwrap_or_default();

--- a/server/crates/waddle-server/src/auth/oauth2.rs
+++ b/server/crates/waddle-server/src/auth/oauth2.rs
@@ -64,6 +64,9 @@ pub async fn exchange_code(
 
     if !res.status().is_success() {
         let status = res.status();
+        if status.is_server_error() {
+            return Err(AuthError::ProviderUnreachable(status));
+        }
         let body = res.text().await.unwrap_or_default();
         return Err(AuthError::TokenExchangeFailed(format!(
             "token endpoint {}: {}",
@@ -158,6 +161,9 @@ pub async fn fetch_userinfo(
 
     if !res.status().is_success() {
         let status = res.status();
+        if status.is_server_error() {
+            return Err(AuthError::ProviderUnreachable(status));
+        }
         let body = res.text().await.unwrap_or_default();
         return Err(AuthError::UserInfoFailed(format!(
             "userinfo endpoint {}: {}",
@@ -400,5 +406,90 @@ mod tests {
         assert_eq!(payload_json["htm"], "POST");
         assert_eq!(payload_json["htu"], token_endpoint);
         assert!(payload_json["jti"].as_str().is_some_and(|v| !v.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn exchange_code_distinguishes_provider_outages_from_client_rejections() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/unavailable-token"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/rejected-token"))
+            .respond_with(ResponseTemplate::new(400))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let provider = oidc_provider_for(AuthProviderTokenEndpointAuthMethod::NoAuthentication);
+        let unavailable = exchange_code(
+            &Client::new(),
+            &provider,
+            &format!("{}/unavailable-token", mock_server.uri()),
+            "auth-code",
+            "https://app.example/callback",
+            "pkce-verifier",
+            false,
+        )
+        .await
+        .expect_err("a 5xx token response should fail");
+        assert!(matches!(
+            unavailable,
+            AuthError::ProviderUnreachable(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+        ));
+
+        let rejected = exchange_code(
+            &Client::new(),
+            &provider,
+            &format!("{}/rejected-token", mock_server.uri()),
+            "auth-code",
+            "https://app.example/callback",
+            "pkce-verifier",
+            false,
+        )
+        .await
+        .expect_err("a 4xx token response should fail");
+        assert!(matches!(rejected, AuthError::TokenExchangeFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_userinfo_distinguishes_provider_outages_from_client_rejections() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/unavailable-userinfo"))
+            .respond_with(ResponseTemplate::new(502))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/rejected-userinfo"))
+            .respond_with(ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let unavailable = fetch_userinfo(
+            &Client::new(),
+            &format!("{}/unavailable-userinfo", mock_server.uri()),
+            "access-token",
+        )
+        .await
+        .expect_err("a 5xx userinfo response should fail");
+        assert!(matches!(
+            unavailable,
+            AuthError::ProviderUnreachable(reqwest::StatusCode::BAD_GATEWAY)
+        ));
+
+        let rejected = fetch_userinfo(
+            &Client::new(),
+            &format!("{}/rejected-userinfo", mock_server.uri()),
+            "access-token",
+        )
+        .await
+        .expect_err("a 4xx userinfo response should fail");
+        assert!(matches!(rejected, AuthError::UserInfoFailed(_)));
     }
 }

--- a/server/crates/waddle-server/src/auth/oauth2.rs
+++ b/server/crates/waddle-server/src/auth/oauth2.rs
@@ -60,7 +60,7 @@ pub async fn exchange_code(
     let res = request
         .send()
         .await
-        .map_err(|e| AuthError::TokenExchangeFailed(e.to_string()))?;
+        .map_err(|e| AuthError::HttpError(e.to_string()))?;
 
     if !res.status().is_success() {
         let status = res.status();
@@ -154,7 +154,7 @@ pub async fn fetch_userinfo(
         .bearer_auth(access_token)
         .send()
         .await
-        .map_err(|e| AuthError::UserInfoFailed(e.to_string()))?;
+        .map_err(|e| AuthError::HttpError(e.to_string()))?;
 
     if !res.status().is_success() {
         let status = res.status();

--- a/server/crates/waddle-server/src/auth/oidc.rs
+++ b/server/crates/waddle-server/src/auth/oidc.rs
@@ -26,6 +26,17 @@ pub struct DynamicClientRegistration {
     pub token_endpoint_auth_method: String,
 }
 
+pub enum UserinfoFetchOutcome {
+    NotRequested,
+    Succeeded,
+    Failed(AuthError),
+}
+
+pub struct OidcClaimsOutcome {
+    pub claims: IdentityClaims,
+    pub userinfo: UserinfoFetchOutcome,
+}
+
 #[derive(Debug, Serialize)]
 struct DynamicRegistrationRequest {
     redirect_uris: Vec<String>,
@@ -45,7 +56,7 @@ pub async fn discover(client: &Client, issuer: &str) -> Result<OidcDiscovery, Au
         .get(&url)
         .send()
         .await
-        .map_err(|e| AuthError::AuthorizationFailed(e.to_string()))?;
+        .map_err(|e| AuthError::HttpError(e.to_string()))?;
 
     if !res.status().is_success() {
         let status = res.status();
@@ -129,7 +140,7 @@ pub async fn register_dynamic_client(
         .json(&req)
         .send()
         .await
-        .map_err(|e| AuthError::AuthorizationFailed(e.to_string()))?;
+        .map_err(|e| AuthError::HttpError(e.to_string()))?;
 
     if !res.status().is_success() {
         let status = res.status();
@@ -170,7 +181,7 @@ async fn fetch_jwks(client: &Client, jwks_uri: &str) -> Result<JwkSet, AuthError
         .get(jwks_uri)
         .send()
         .await
-        .map_err(|e| AuthError::JwtError(e.to_string()))?;
+        .map_err(|e| AuthError::HttpError(e.to_string()))?;
 
     if !res.status().is_success() {
         let status = res.status();
@@ -264,7 +275,7 @@ pub async fn claims_from_token_response(
     discovery: &OidcDiscovery,
     token: &OAuthTokenResponse,
     expected_nonce: Option<&str>,
-) -> Result<IdentityClaims, AuthError> {
+) -> Result<OidcClaimsOutcome, AuthError> {
     let id_token = token.id_token.as_deref().ok_or_else(|| {
         AuthError::InvalidRequest("OIDC provider did not return id_token".to_string())
     })?;
@@ -289,21 +300,27 @@ pub async fn claims_from_token_response(
     let mut merged = id_claims.clone();
 
     // If userinfo endpoint exists, merge extra profile claims on top.
-    if let Some(userinfo_endpoint) = provider
+    let userinfo = if let Some(userinfo_endpoint) = provider
         .userinfo_endpoint
         .as_deref()
         .or(discovery.userinfo_endpoint.as_deref())
     {
-        if let Ok(userinfo) = fetch_userinfo(client, userinfo_endpoint, &token.access_token).await {
-            if let Some(obj) = merged.as_object_mut() {
-                if let Some(userinfo_obj) = userinfo.as_object() {
-                    for (k, v) in userinfo_obj {
-                        obj.insert(k.clone(), v.clone());
+        match fetch_userinfo(client, userinfo_endpoint, &token.access_token).await {
+            Ok(userinfo) => {
+                if let Some(obj) = merged.as_object_mut() {
+                    if let Some(userinfo_obj) = userinfo.as_object() {
+                        for (k, v) in userinfo_obj {
+                            obj.insert(k.clone(), v.clone());
+                        }
                     }
                 }
+                UserinfoFetchOutcome::Succeeded
             }
+            Err(error) => UserinfoFetchOutcome::Failed(error),
         }
-    }
+    } else {
+        UserinfoFetchOutcome::NotRequested
+    };
 
     let preferred_username = provider
         .username_claim
@@ -318,15 +335,18 @@ pub async fn claims_from_token_response(
         .and_then(|k| value_string(merged.get(k)))
         .or_else(|| value_string(merged.get("email")));
 
-    Ok(IdentityClaims {
-        subject,
-        issuer: Some(discovery.issuer.clone()),
-        preferred_username,
-        name: value_string(merged.get("name")),
-        email,
-        email_verified: value_bool(merged.get("email_verified")),
-        avatar_url: avatar_url_from_claims(&merged),
-        raw_claims: merged,
+    Ok(OidcClaimsOutcome {
+        claims: IdentityClaims {
+            subject,
+            issuer: Some(discovery.issuer.clone()),
+            preferred_username,
+            name: value_string(merged.get("name")),
+            email,
+            email_verified: value_bool(merged.get("email_verified")),
+            avatar_url: avatar_url_from_claims(&merged),
+            raw_claims: merged,
+        },
+        userinfo,
     })
 }
 

--- a/server/crates/waddle-server/src/auth/oidc.rs
+++ b/server/crates/waddle-server/src/auth/oidc.rs
@@ -185,6 +185,9 @@ async fn fetch_jwks(client: &Client, jwks_uri: &str) -> Result<JwkSet, AuthError
 
     if !res.status().is_success() {
         let status = res.status();
+        if status.is_server_error() {
+            return Err(AuthError::ProviderUnreachable(status));
+        }
         let body = res.text().await.unwrap_or_default();
         return Err(AuthError::JwtError(format!(
             "jwks endpoint {}: {}",
@@ -462,6 +465,42 @@ mod tests {
         .to_string();
 
         assert!(err.contains("dynamic registration returned empty client_secret"));
+    }
+
+    #[tokio::test]
+    async fn fetch_jwks_distinguishes_provider_outages_from_client_rejections() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/unavailable-jwks"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/missing-jwks"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let unavailable = fetch_jwks(
+            &Client::new(),
+            &format!("{}/unavailable-jwks", mock_server.uri()),
+        )
+        .await
+        .expect_err("a 5xx JWKS response should fail");
+        assert!(matches!(
+            unavailable,
+            AuthError::ProviderUnreachable(reqwest::StatusCode::SERVICE_UNAVAILABLE)
+        ));
+
+        let rejected = fetch_jwks(
+            &Client::new(),
+            &format!("{}/missing-jwks", mock_server.uri()),
+        )
+        .await
+        .expect_err("a 4xx JWKS response should fail");
+        assert!(matches!(rejected, AuthError::JwtError(_)));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/auth/oidc.rs
+++ b/server/crates/waddle-server/src/auth/oidc.rs
@@ -186,6 +186,9 @@ async fn fetch_jwks(client: &Client, jwks_uri: &str) -> Result<JwkSet, AuthError
     if !res.status().is_success() {
         let status = res.status();
         if status.is_server_error() {
+            // Drain the body so the pooled connection is reusable
+            // during a sustained provider outage.
+            let _ = res.text().await;
             return Err(AuthError::ProviderUnreachable(status));
         }
         let body = res.text().await.unwrap_or_default();

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -190,6 +190,7 @@ impl ClusteringReadiness {
             .store(ready, std::sync::atomic::Ordering::Release);
     }
 
+    #[cfg(any(test, feature = "clustering"))]
     pub(crate) fn fatal_fence_token(&self) -> CancellationToken {
         self.fatal_fence.clone()
     }

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -67,6 +67,13 @@ const MAX_ORDERED_RELAY_CHANNEL_LOCKS: usize = 4096;
 const MAX_REMOTE_OWNER_REGISTRATION_LOCKS: usize = 4096;
 const REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE: usize = 256;
 
+fn stanza_message_id(stanza: &Stanza) -> &str {
+    match stanza {
+        Stanza::Message(message) => message.id.as_ref().map_or("", |id| id.0.as_str()),
+        Stanza::Iq(_) | Stanza::Presence(_) => "",
+    }
+}
+
 type RemoteDeliveryFuture<'a> =
     Pin<Box<dyn Future<Output = Option<FullJidDeliveryOutcome>> + Send + 'a>>;
 
@@ -257,6 +264,34 @@ fn route_target_stanza_is_iq(target: &RemoteResourceRouteTarget) -> bool {
         RemoteResourceRouteTarget::FullJid { stanza, .. }
         | RemoteResourceRouteTarget::BareJid { stanza, .. }
         | RemoteResourceRouteTarget::MucProxy { stanza, .. } => matches!(stanza.0, Stanza::Iq(_)),
+    }
+}
+
+fn log_remote_resource_route_outcome(
+    target: &RemoteResourceRouteTarget,
+    outcome: FullJidDeliveryOutcome,
+) {
+    match target {
+        RemoteResourceRouteTarget::FullJid { target, stanza } => tracing::debug!(
+            jid = %target,
+            message_id = stanza_message_id(&stanza.0),
+            ?outcome,
+            "ordered-relay full-JID delivery outcome"
+        ),
+        RemoteResourceRouteTarget::BareJid { target, stanza } => tracing::debug!(
+            jid = %target,
+            message_id = stanza_message_id(&stanza.0),
+            ?outcome,
+            "ordered-relay bare-JID delivery outcome"
+        ),
+        RemoteResourceRouteTarget::MucProxy {
+            room_jid, stanza, ..
+        } => tracing::debug!(
+            room = %room_jid,
+            message_id = stanza_message_id(&stanza.0),
+            ?outcome,
+            "ordered-relay MUC proxy delivery outcome"
+        ),
     }
 }
 
@@ -639,16 +674,28 @@ impl OrderedRelayDeliveryBridge {
                 if handoff.mark_deferred() {
                     let bridge = Arc::clone(self);
                     let origin_stanza = stanza.clone();
+                    let outcome_target = target.clone();
+                    let outcome_message_id = match stanza {
+                        Stanza::Message(message) => message.id.clone(),
+                        Stanza::Iq(_) | Stanza::Presence(_) => None,
+                    };
                     tokio::spawn(async move {
-                        let replies = bridge
+                        let delivery_outcome = bridge
                             .deliver_seeded_remote(seed, true)
                             .await
-                            .map(|outcome| {
-                                replies_for_origin_handoff(
-                                    &origin_stanza,
-                                    caller_delivery_outcome(outcome),
-                                )
-                            })
+                            .map(caller_delivery_outcome);
+                        if let Some(outcome) = delivery_outcome {
+                            tracing::debug!(
+                                jid = %outcome_target,
+                                message_id = outcome_message_id
+                                    .as_ref()
+                                    .map_or("", |id| id.0.as_str()),
+                                ?outcome,
+                                "ordered-relay deferred full-JID delivery outcome"
+                            );
+                        }
+                        let replies = delivery_outcome
+                            .map(|outcome| replies_for_origin_handoff(&origin_stanza, outcome))
                             .unwrap_or_default();
                         handoff.complete(replies);
                     });
@@ -656,9 +703,15 @@ impl OrderedRelayDeliveryBridge {
                 }
             }
 
-            Some(caller_delivery_outcome(
-                Arc::clone(self).deliver_seeded_remote(seed, true).await?,
-            ))
+            let outcome =
+                caller_delivery_outcome(Arc::clone(self).deliver_seeded_remote(seed, true).await?);
+            tracing::debug!(
+                jid = %target,
+                message_id = stanza_message_id(stanza),
+                ?outcome,
+                "ordered-relay full-JID delivery outcome"
+            );
+            Some(outcome)
         })
     }
 
@@ -1907,18 +1960,25 @@ impl OrderedRelayDeliveryBridge {
             if handoff.mark_deferred() {
                 let bridge = Arc::clone(&self);
                 let origin_stanza = origin_stanza.clone();
+                let outcome_target = target.clone();
                 tokio::spawn(async move {
                     let outcome = bridge
                         .route_remote_resource_origin_once(remote_origin, target)
                         .await
                         .unwrap_or(FullJidDeliveryOutcome::Dropped);
+                    log_remote_resource_route_outcome(&outcome_target, outcome);
                     handoff.complete(replies_for_origin_handoff(&origin_stanza, outcome));
                 });
                 return Some(FullJidDeliveryOutcome::Delivered);
             }
         }
-        self.route_remote_resource_origin_once(remote_origin, target)
-            .await
+        let outcome = self
+            .route_remote_resource_origin_once(remote_origin, target.clone())
+            .await;
+        if let Some(outcome) = outcome {
+            log_remote_resource_route_outcome(&target, outcome);
+        }
+        outcome
     }
 
     async fn route_remote_resource_origin_once(
@@ -2473,14 +2533,34 @@ impl OrderedRelayDeliveryBridge {
                 {
                     waddle_xmpp::telemetry::messages::record_delivered_message(message_kind);
                 }
+                tracing::debug!(
+                    jid = %target,
+                    message_id = stanza_message_id(stanza),
+                    outcome = ?FullJidDeliveryOutcome::Delivered,
+                    "clustered remote-resource delivery outcome"
+                );
                 Some(FullJidDeliveryOutcome::Delivered)
             }
             Ok(RelayRemoteResourceFrameReply {
                 status: RelayRemoteResourceFrameStatus::Backpressure,
-            }) => Some(FullJidDeliveryOutcome::Dropped),
+            }) => {
+                tracing::debug!(
+                    jid = %target,
+                    message_id = stanza_message_id(stanza),
+                    outcome = ?FullJidDeliveryOutcome::Dropped,
+                    "clustered remote-resource delivery outcome"
+                );
+                Some(FullJidDeliveryOutcome::Dropped)
+            }
             Ok(RelayRemoteResourceFrameReply {
                 status: RelayRemoteResourceFrameStatus::Unavailable,
             }) => {
+                tracing::debug!(
+                    jid = %target,
+                    message_id = stanza_message_id(stanza),
+                    outcome = ?FullJidDeliveryOutcome::Unavailable,
+                    "clustered remote-resource delivery outcome"
+                );
                 self.cleanup_remote_owner_resource_if_registration(
                     target,
                     registration.registration_id,
@@ -2491,6 +2571,7 @@ impl OrderedRelayDeliveryBridge {
             Err(error) => {
                 tracing::warn!(
                     jid = %target,
+                    message_id = stanza_message_id(stanza),
                     %error,
                     "clustered remote-resource acked delivery relay ask failed"
                 );

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -267,32 +267,45 @@ fn route_target_stanza_is_iq(target: &RemoteResourceRouteTarget) -> bool {
     }
 }
 
-fn log_remote_resource_route_outcome(
-    target: &RemoteResourceRouteTarget,
-    outcome: FullJidDeliveryOutcome,
-) {
+/// The few small fields the delivery-outcome log needs, extracted
+/// before the route target (and its full stanza) is moved into the
+/// routing future — logging must never force a stanza deep-clone.
+struct RouteOutcomeLog {
+    kind: &'static str,
+    entity: String,
+    message_id: String,
+}
+
+fn route_outcome_log(target: &RemoteResourceRouteTarget) -> RouteOutcomeLog {
     match target {
-        RemoteResourceRouteTarget::FullJid { target, stanza } => tracing::debug!(
-            jid = %target,
-            message_id = stanza_message_id(&stanza.0),
-            ?outcome,
-            "ordered-relay full-JID delivery outcome"
-        ),
-        RemoteResourceRouteTarget::BareJid { target, stanza } => tracing::debug!(
-            jid = %target,
-            message_id = stanza_message_id(&stanza.0),
-            ?outcome,
-            "ordered-relay bare-JID delivery outcome"
-        ),
+        RemoteResourceRouteTarget::FullJid { target, stanza } => RouteOutcomeLog {
+            kind: "full-JID",
+            entity: target.to_string(),
+            message_id: stanza_message_id(&stanza.0).to_owned(),
+        },
+        RemoteResourceRouteTarget::BareJid { target, stanza } => RouteOutcomeLog {
+            kind: "bare-JID",
+            entity: target.to_string(),
+            message_id: stanza_message_id(&stanza.0).to_owned(),
+        },
         RemoteResourceRouteTarget::MucProxy {
             room_jid, stanza, ..
-        } => tracing::debug!(
-            room = %room_jid,
-            message_id = stanza_message_id(&stanza.0),
-            ?outcome,
-            "ordered-relay MUC proxy delivery outcome"
-        ),
+        } => RouteOutcomeLog {
+            kind: "MUC proxy",
+            entity: room_jid.to_string(),
+            message_id: stanza_message_id(&stanza.0).to_owned(),
+        },
     }
+}
+
+fn log_remote_resource_route_outcome(context: &RouteOutcomeLog, outcome: FullJidDeliveryOutcome) {
+    tracing::debug!(
+        kind = context.kind,
+        entity = %context.entity,
+        message_id = %context.message_id,
+        ?outcome,
+        "ordered-relay delivery outcome"
+    );
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -1956,27 +1969,27 @@ impl OrderedRelayDeliveryBridge {
         origin_stanza: &Stanza,
         origin: &OrderedRelayRouteOrigin,
     ) -> Option<FullJidDeliveryOutcome> {
+        let outcome_log = route_outcome_log(&target);
         if let Some(handoff) = origin.handoff.clone() {
             if handoff.mark_deferred() {
                 let bridge = Arc::clone(&self);
                 let origin_stanza = origin_stanza.clone();
-                let outcome_target = target.clone();
                 tokio::spawn(async move {
                     let outcome = bridge
                         .route_remote_resource_origin_once(remote_origin, target)
                         .await
                         .unwrap_or(FullJidDeliveryOutcome::Dropped);
-                    log_remote_resource_route_outcome(&outcome_target, outcome);
+                    log_remote_resource_route_outcome(&outcome_log, outcome);
                     handoff.complete(replies_for_origin_handoff(&origin_stanza, outcome));
                 });
                 return Some(FullJidDeliveryOutcome::Delivered);
             }
         }
         let outcome = self
-            .route_remote_resource_origin_once(remote_origin, target.clone())
+            .route_remote_resource_origin_once(remote_origin, target)
             .await;
         if let Some(outcome) = outcome {
-            log_remote_resource_route_outcome(&target, outcome);
+            log_remote_resource_route_outcome(&outcome_log, outcome);
         }
         outcome
     }

--- a/server/crates/waddle-server/src/notification_outbox/drain.rs
+++ b/server/crates/waddle-server/src/notification_outbox/drain.rs
@@ -57,6 +57,14 @@ impl NotificationOutboxStore {
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
+                        tracing::info!(
+                            recipient = %candidate.recipient_bare_jid(),
+                            conversation = %candidate.conversation_jid(),
+                            notification_class = candidate.class().as_db_value(),
+                            push_stage = "suppressed",
+                            suppression_reason = SuppressedReason::Xep0191Blocked.as_db_value(),
+                            "push pipeline transition"
+                        );
                         waddle_xmpp::telemetry::reliability::increment_push_suppressed(
                             SuppressedReason::Xep0191Blocked.telemetry_reason(),
                         );
@@ -142,20 +150,21 @@ impl NotificationOutboxStore {
             };
             let rich = match outcome {
                 T1PushDispatchOutcome::Suppressed { reason } => {
-                    tracing::info!(
-                        recipient = %candidate.recipient_bare_jid(),
-                        conversation = %candidate.conversation_jid(),
-                        sender = %candidate.sender_jid(),
-                        class = ?candidate.class(),
-                        %reason,
-                        "T1 push gate suppressed XEP-0357 notification candidate"
-                    );
                     let now_ms = crate::time::now_ms();
                     let mut tx = self.db.begin().await?;
                     record_candidate_suppressed_reason_tx(&mut tx, &candidate, reason).await?;
                     let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
                     tx.commit().await?;
                     if claimed > 0 {
+                        tracing::info!(
+                            recipient = %candidate.recipient_bare_jid(),
+                            conversation = %candidate.conversation_jid(),
+                            sender = %candidate.sender_jid(),
+                            notification_class = candidate.class().as_db_value(),
+                            push_stage = "suppressed",
+                            suppression_reason = reason.as_db_value(),
+                            "T1 push gate suppressed XEP-0357 notification candidate"
+                        );
                         waddle_xmpp::telemetry::reliability::increment_push_suppressed(
                             reason.telemetry_reason(),
                         );
@@ -197,6 +206,29 @@ impl NotificationOutboxStore {
                 .get(&recipient_key)
                 .expect("target cache populated")
                 .clone();
+            if targets.is_empty() {
+                let reason = SuppressedReason::Xep0357NoRegistration;
+                let now_ms = crate::time::now_ms();
+                let mut tx = self.db.begin().await?;
+                record_candidate_suppressed_reason_tx(&mut tx, &candidate, reason).await?;
+                let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
+                tx.commit().await?;
+                if claimed > 0 {
+                    tracing::info!(
+                        recipient = %candidate.recipient_bare_jid(),
+                        conversation = %candidate.conversation_jid(),
+                        notification_class = candidate.class().as_db_value(),
+                        push_stage = "suppressed",
+                        suppression_reason = reason.as_db_value(),
+                        "push pipeline transition"
+                    );
+                    waddle_xmpp::telemetry::reliability::increment_push_suppressed(
+                        reason.telemetry_reason(),
+                    );
+                    processed += 1;
+                }
+                continue;
+            }
             let context = build_waddle_context(&candidate);
             let now_ms = crate::time::now_ms();
             let mut tx = self.db.begin().await?;
@@ -252,6 +284,14 @@ impl NotificationOutboxStore {
             let claimed = mark_candidate_outboxed_tx(&mut tx, candidate, now_ms).await?;
             tx.commit().await?;
             if claimed > 0 {
+                tracing::info!(
+                    recipient = %candidate.recipient_bare_jid(),
+                    conversation = %candidate.conversation_jid(),
+                    notification_class = candidate.class().as_db_value(),
+                    push_stage = "suppressed",
+                    suppression_reason = reason.as_db_value(),
+                    "push pipeline transition"
+                );
                 waddle_xmpp::telemetry::reliability::increment_push_suppressed(
                     reason.telemetry_reason(),
                 );

--- a/server/crates/waddle-server/src/notification_outbox/enqueue.rs
+++ b/server/crates/waddle-server/src/notification_outbox/enqueue.rs
@@ -74,9 +74,23 @@ impl NotificationOutboxStore {
             // `ON CONFLICT (cols) DO NOTHING` for each path
             // (Greptile review on PR #758).
             waddle_xmpp::telemetry::reliability::increment_push_candidate_coalesced();
+            tracing::info!(
+                recipient = %candidate.recipient_bare_jid(),
+                conversation = %candidate.conversation_jid(),
+                notification_class = candidate.class().as_db_value(),
+                push_stage = "coalesced",
+                "push pipeline transition"
+            );
             return Ok(NotificationCandidateInsertOutcome::Duplicate);
         }
         waddle_xmpp::telemetry::reliability::increment_push_candidate_created();
+        tracing::info!(
+            recipient = %candidate.recipient_bare_jid(),
+            conversation = %candidate.conversation_jid(),
+            notification_class = candidate.class().as_db_value(),
+            push_stage = "candidate_created",
+            "push pipeline transition"
+        );
         Ok(NotificationCandidateInsertOutcome::Inserted)
     }
 

--- a/server/crates/waddle-server/src/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/src/notification_outbox/publish.rs
@@ -230,16 +230,45 @@ impl NotificationOutboxStore {
             match &outcome {
                 NotificationOutboxPublishOutcome::Published { .. } => {
                     waddle_xmpp::telemetry::reliability::increment_push_outbox_published();
+                    tracing::info!(
+                        recipient = %job.recipient_bare_jid(),
+                        conversation = %job.conversation_jid(),
+                        notification_class = job.class().as_db_value(),
+                        push_stage = "published",
+                        "push pipeline transition"
+                    );
                 }
                 NotificationOutboxPublishOutcome::RetryScheduled { .. } => {
                     waddle_xmpp::telemetry::reliability::increment_push_outbox_retry_scheduled(
                         waddle_xmpp::telemetry::attributes::PushRetryReason::Unknown,
                     );
+                    tracing::warn!(
+                        recipient = %job.recipient_bare_jid(),
+                        conversation = %job.conversation_jid(),
+                        notification_class = job.class().as_db_value(),
+                        push_stage = "retry_scheduled",
+                        "push pipeline transition"
+                    );
                 }
                 NotificationOutboxPublishOutcome::Failed { .. } => {
                     waddle_xmpp::telemetry::reliability::increment_push_outbox_dead_lettered();
+                    tracing::warn!(
+                        recipient = %job.recipient_bare_jid(),
+                        conversation = %job.conversation_jid(),
+                        notification_class = job.class().as_db_value(),
+                        push_stage = "dead_lettered",
+                        "push pipeline transition"
+                    );
                 }
                 NotificationOutboxPublishOutcome::Suppressed { .. } => {
+                    tracing::info!(
+                        recipient = %job.recipient_bare_jid(),
+                        conversation = %job.conversation_jid(),
+                        notification_class = job.class().as_db_value(),
+                        push_stage = "suppressed",
+                        suppression_reason = SuppressedReason::UnreadZeroAtPublish.as_db_value(),
+                        "push pipeline transition"
+                    );
                     waddle_xmpp::telemetry::reliability::increment_push_suppressed(
                         SuppressedReason::UnreadZeroAtPublish.telemetry_reason(),
                     );

--- a/server/crates/waddle-server/src/notification_outbox/types.rs
+++ b/server/crates/waddle-server/src/notification_outbox/types.rs
@@ -72,7 +72,7 @@ pub enum NotificationClass {
 }
 
 impl NotificationClass {
-    pub(super) fn as_db_value(self) -> &'static str {
+    pub(crate) fn as_db_value(self) -> &'static str {
         match self {
             Self::DirectMessage => "dm",
             Self::DirectMessageMention => "dm_mention",
@@ -152,9 +152,8 @@ pub(crate) enum SuppressedReason {
     /// path is structurally a no-row outcome, but the audit shape
     /// exists so race-window state changes can record it.
     Xep0357Self,
-    /// Recipient has no XEP-0357 push registration. Reserved variant;
-    /// emitted by the publish-layer disable transitions
-    /// (XEP-0357 §6) in later slices.
+    /// Recipient has no usable active first-party XEP-0357 push
+    /// registration when the T1 drain resolves delivery targets.
     Xep0357NoRegistration,
     /// Recipient's XEP-0357 push registration was disabled in
     /// response to a stanza-error from the push service

--- a/server/crates/waddle-server/src/push_service/worker.rs
+++ b/server/crates/waddle-server/src/push_service/worker.rs
@@ -775,14 +775,16 @@ impl DatabasePushServiceStore {
         };
         let item_id_arc: Arc<str> = Arc::from(item_id);
         let recipient = recipient.clone();
-        let log_context = parsed.cloned();
+        // `Arc` so the per-device fan-out clones a refcount, not the
+        // parsed payload, for the web-arm log context.
+        let log_context = Arc::new(parsed.cloned());
 
         stream::iter(sealed_devices.iter().cloned())
             .map(move |device| {
                 let item_id = Arc::clone(&item_id_arc);
                 let web_provider = web_provider.clone();
                 let recipient = recipient.clone();
-                let log_context = log_context.clone();
+                let log_context = Arc::clone(&log_context);
                 async move {
                     match (&web_provider, device.platform) {
                         (Some((signer, sender, sub, parsed, secrets)), PushDevicePlatform::Web) => {

--- a/server/crates/waddle-server/src/push_service/worker.rs
+++ b/server/crates/waddle-server/src/push_service/worker.rs
@@ -8,6 +8,7 @@ use jid::BareJid;
 use waddle_xmpp::push::types::VapidSub;
 use waddle_xmpp::push::vapid::VapidSigner;
 use waddle_xmpp::push::WebPushSender;
+use waddle_xmpp::telemetry::attributes::MetricAttribute;
 use waddle_xmpp::XmppError;
 
 use super::devices::{
@@ -148,30 +149,74 @@ fn web_push_outcome_diagnostic(outcome: &waddle_xmpp::push::types::WebPushOutcom
 /// `push_delivery_attempts.status` wire format. Free function (not a
 /// method) so the per-device future is `Send + 'static`-compatible
 /// inside the `buffer_unordered` fan-out in `dispatch_devices`.
+struct WebPushDispatchProvider<'a> {
+    signer: &'a Arc<dyn VapidSigner>,
+    sender: &'a Arc<dyn WebPushSender>,
+    sub: &'a VapidSub,
+    secrets: &'a PushSecretCipher,
+}
+
 async fn dispatch_web_device_owned(
     device: &dispatch::SealedActiveDevice,
+    recipient: &BareJid,
     parsed: &dispatch::ParsedPushPayload,
     item_id: &str,
-    signer: &Arc<dyn VapidSigner>,
-    sender: &Arc<dyn WebPushSender>,
-    sub: &VapidSub,
-    secrets: &PushSecretCipher,
+    provider: WebPushDispatchProvider<'_>,
 ) -> DispatchedAttempt {
-    let target = match dispatch::WebPushTarget::try_from_sealed(device, secrets) {
+    let target = match dispatch::WebPushTarget::try_from_sealed(device, provider.secrets) {
         Ok(target) => target,
         Err(reason) => {
+            let status = dispatch::skip_reason_to_attempt_status(reason);
+            tracing::warn!(
+                recipient = %recipient,
+                conversation = %parsed.conversation,
+                notification_class = parsed.class.as_db_value(),
+                provider = "web_push",
+                push_stage = "provider_dispatch_skipped",
+                provider_outcome = status,
+                "push provider transition"
+            );
             return DispatchedAttempt {
                 device_id: device.device_id.clone(),
                 platform: device.platform,
-                status: dispatch::skip_reason_to_attempt_status(reason),
+                status,
                 last_error: None,
                 retry_after: None,
             };
         }
     };
-    match dispatch::dispatch_one_web_push(&target, parsed, item_id, signer, sub, sender).await {
+    match dispatch::dispatch_one_web_push(
+        &target,
+        parsed,
+        item_id,
+        provider.signer,
+        provider.sub,
+        provider.sender,
+    )
+    .await
+    {
         Ok(outcome) => {
             let status = dispatch::outcome_to_attempt_status(&outcome);
+            match waddle_xmpp::telemetry::push_pipeline::record_web_push_outcome(&outcome) {
+                Some(stage) => tracing::info!(
+                    recipient = %recipient,
+                    conversation = %parsed.conversation,
+                    notification_class = parsed.class.as_db_value(),
+                    provider = "web_push",
+                    push_stage = stage.value(),
+                    provider_outcome = status,
+                    "push provider transition"
+                ),
+                None => tracing::warn!(
+                    recipient = %recipient,
+                    conversation = %parsed.conversation,
+                    notification_class = parsed.class.as_db_value(),
+                    provider = "web_push",
+                    push_stage = "provider_no_response",
+                    provider_outcome = status,
+                    "push provider transition"
+                ),
+            }
             let last_error = if matches!(
                 outcome,
                 waddle_xmpp::push::types::WebPushOutcome::Delivered { .. }
@@ -201,7 +246,7 @@ async fn dispatch_web_device_owned(
                 outcome,
                 waddle_xmpp::push::types::WebPushOutcome::ClockSkew { .. }
             ) {
-                signer.invalidate_cache();
+                provider.signer.invalidate_cache();
             }
             // XEP-0357 §6 forward cleanup runs in
             // `finalize_publish_job` — when the persisted status hits
@@ -231,13 +276,24 @@ async fn dispatch_web_device_owned(
         // retry loop. Recorded as `web-internal-error` so an operator
         // can grep for it and fix the underlying bug; the device stays
         // active (not a per-device problem).
-        Err(error) => DispatchedAttempt {
-            device_id: device.device_id.clone(),
-            platform: device.platform,
-            status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
-            last_error: Some(truncate_last_error(&error.to_string())),
-            retry_after: None,
-        },
+        Err(error) => {
+            tracing::error!(
+                recipient = %recipient,
+                conversation = %parsed.conversation,
+                notification_class = parsed.class.as_db_value(),
+                provider = "web_push",
+                push_stage = "provider_dispatch_failed",
+                provider_outcome = ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+                "push provider transition"
+            );
+            DispatchedAttempt {
+                device_id: device.device_id.clone(),
+                platform: device.platform,
+                status: ATTEMPT_STATUS_WEB_INTERNAL_ERROR,
+                last_error: Some(truncate_last_error(&error.to_string())),
+                retry_after: None,
+            }
+        }
     }
 }
 
@@ -429,31 +485,38 @@ impl DatabasePushServiceStore {
         // unconditionally would reject test fixtures whose
         // `<notification>` payload omits the `urn:waddle:push:context:0`
         // child the chat publisher attaches in production.
-        let parsed = if self.web_push_provider_ready() {
-            match dispatch::parse_publish_payload(&payload_xml) {
-                Ok(parsed) => Some(parsed),
-                Err(error) => {
-                    // Bad payload is permanent: mark the job failed in a
-                    // tiny dedicated tx and return zero attempts.
-                    self.mark_publish_job_failed_after_phase1(
-                        job.job_id(),
-                        job.owner_bare_jid(),
-                        job.node(),
-                        &format!("XEP-0357 payload parse failed: {error}"),
-                        now_ms,
-                    )
-                    .await?;
-                    return Ok(Some(PushFanoutResult {
-                        item_id: job.item_id().to_string(),
-                        attempted_devices: 0,
-                    }));
-                }
+        let web_push_provider_ready = self.web_push_provider_ready();
+        let parsed = match dispatch::parse_publish_payload(&payload_xml) {
+            Ok(parsed) => Some(parsed),
+            Err(error) if web_push_provider_ready => {
+                // Bad payload is permanent: mark the job failed in a
+                // tiny dedicated tx and return zero attempts.
+                self.mark_publish_job_failed_after_phase1(
+                    job.job_id(),
+                    job.owner_bare_jid(),
+                    job.node(),
+                    &format!("XEP-0357 payload parse failed: {error}"),
+                    now_ms,
+                )
+                .await?;
+                return Ok(Some(PushFanoutResult {
+                    item_id: job.item_id().to_string(),
+                    attempted_devices: 0,
+                }));
             }
-        } else {
-            None
+            // Provider-less tests historically use minimal XEP-0357
+            // fixtures without Waddle context. Keep accepting them;
+            // valid production payloads still parse above and supply
+            // safe structured fields for the degraded-provider log.
+            Err(_) => None,
         };
         let attempts = self
-            .dispatch_devices(&sealed_devices, parsed.as_ref(), job.item_id())
+            .dispatch_devices(
+                &sealed_devices,
+                job.owner_bare_jid(),
+                parsed.as_ref(),
+                job.item_id(),
+            )
             .await;
 
         // ---- Phase 3: tx2 — record attempts and finalize the job.
@@ -685,6 +748,7 @@ impl DatabasePushServiceStore {
     async fn dispatch_devices(
         &self,
         sealed_devices: &[dispatch::SealedActiveDevice],
+        recipient: &BareJid,
         parsed: Option<&dispatch::ParsedPushPayload>,
         item_id: &str,
     ) -> Vec<DispatchedAttempt> {
@@ -710,16 +774,29 @@ impl DatabasePushServiceStore {
             _ => None,
         };
         let item_id_arc: Arc<str> = Arc::from(item_id);
+        let recipient = recipient.clone();
+        let log_context = parsed.cloned();
 
         stream::iter(sealed_devices.iter().cloned())
             .map(move |device| {
                 let item_id = Arc::clone(&item_id_arc);
                 let web_provider = web_provider.clone();
+                let recipient = recipient.clone();
+                let log_context = log_context.clone();
                 async move {
                     match (&web_provider, device.platform) {
                         (Some((signer, sender, sub, parsed, secrets)), PushDevicePlatform::Web) => {
                             dispatch_web_device_owned(
-                                &device, parsed, &item_id, signer, sender, sub, secrets,
+                                &device,
+                                &recipient,
+                                parsed,
+                                &item_id,
+                                WebPushDispatchProvider {
+                                    signer,
+                                    sender,
+                                    sub,
+                                    secrets,
+                                },
                             )
                             .await
                         }
@@ -729,13 +806,26 @@ impl DatabasePushServiceStore {
                         // operator fixes the boot config); APNS/FCM
                         // devices retain the legacy `fake-sent` marker
                         // (their senders ship in #529 / #530).
-                        (None, PushDevicePlatform::Web) => DispatchedAttempt {
-                            device_id: device.device_id.clone(),
-                            platform: device.platform,
-                            status: ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
-                            last_error: Some("Web Push provider not configured".to_string()),
-                            retry_after: None,
-                        },
+                        (None, PushDevicePlatform::Web) => {
+                            if let Some(parsed) = log_context.as_ref() {
+                                tracing::warn!(
+                                    recipient = %recipient,
+                                    conversation = %parsed.conversation,
+                                    notification_class = parsed.class.as_db_value(),
+                                    provider = "web_push",
+                                    push_stage = "provider_not_configured",
+                                    provider_outcome = ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+                                    "push provider transition"
+                                );
+                            }
+                            DispatchedAttempt {
+                                device_id: device.device_id.clone(),
+                                platform: device.platform,
+                                status: ATTEMPT_STATUS_WEB_NOT_CONFIGURED,
+                                last_error: Some("Web Push provider not configured".to_string()),
+                                retry_after: None,
+                            }
+                        }
                         (_, PushDevicePlatform::Apns | PushDevicePlatform::Fcm) => {
                             // APNS/FCM are stubbed until #529/#530 land
                             // their real senders. Keep the historical

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -392,14 +392,17 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         .merge(well_known_router)
         // Merge upload routes for XEP-0363 HTTP File Upload
         .merge(upload_router)
+        .layer(CompressionLayer::new())
+        .layer(configure_cors())
+        // These two observability layers stay outside CORS so preflight
+        // responses are measured and receive the same span attributes as
+        // requests that reach a route handler.
         .layer(middleware::from_fn(attach_http_route_template))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_request_span)
                 .on_response(observe_http_response),
-        )
-        .layer(CompressionLayer::new())
-        .layer(configure_cors());
+        );
     Ok(router)
 }
 

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -18,19 +18,16 @@ use crate::server::session_janitors::{
     spawn_user_actor_reaper,
 };
 use crate::server::topology::bootstrap_fresh_xmpp_topology;
-use crate::server::trace::make_request_span;
+use crate::server::trace::{attach_http_route_template, make_request_span, observe_http_response};
 use crate::server::{AppState, XmppConfig};
 use anyhow::Result;
-use axum::{routing::get, Router};
+use axum::{middleware, routing::get, Router};
 use rustls_acme::tower::TowerHttp01ChallengeService;
 use sqlx::sqlite::SqliteConnectOptions;
 use std::str::FromStr;
 use std::sync::Arc;
-use tower_http::{
-    compression::CompressionLayer,
-    trace::{DefaultOnResponse, TraceLayer},
-};
-use tracing::{info, warn, Level};
+use tower_http::{compression::CompressionLayer, trace::TraceLayer};
+use tracing::{info, warn};
 use waddle_xmpp::mam::{MamStorage, SqlxMamStorage};
 use waddle_xmpp::registry::ConnectionRegistry;
 
@@ -395,10 +392,11 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         .merge(well_known_router)
         // Merge upload routes for XEP-0363 HTTP File Upload
         .merge(upload_router)
+        .layer(middleware::from_fn(attach_http_route_template))
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_request_span)
-                .on_response(DefaultOnResponse::new().level(Level::INFO)),
+                .on_response(observe_http_response),
         )
         .layer(CompressionLayer::new())
         .layer(configure_cors());

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -253,6 +253,7 @@ pub(super) fn auth_error_to_response(err: AuthError) -> (StatusCode, Json<ErrorR
         | AuthError::TokenExchangeFailed(_)
         | AuthError::UserInfoFailed(_)
         | AuthError::HttpError(_)
+        | AuthError::ProviderUnreachable(_)
         | AuthError::JwtError(_) => StatusCode::BAD_GATEWAY,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
@@ -267,6 +268,7 @@ pub(super) fn auth_error_to_response(err: AuthError) -> (StatusCode, Json<ErrorR
         AuthError::TokenExchangeFailed(_) => "token_exchange_failed",
         AuthError::UserInfoFailed(_) => "userinfo_failed",
         AuthError::JwtError(_) => "jwt_error",
+        AuthError::ProviderUnreachable(_) => "provider_unreachable",
         _ => "auth_error",
     };
 

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -19,11 +19,14 @@ use crate::db::actor::{DbExecute, DbQueryOne};
 use crate::db::{row_value, ValueExt};
 use crate::permissions::PermissionActor;
 use crate::server::bootstrap_membership::{reconcile_user_membership, BootstrapMembershipConfig};
+use crate::server::routes::auth_telemetry::{
+    record_auth_failure, record_auth_success, AuthFailure,
+};
 use crate::server::AppState;
 use axum::{
     extract::{Query, State},
     http::{header, StatusCode},
-    response::{IntoResponse, Json, Redirect},
+    response::{IntoResponse, Json, Redirect, Response},
     routing::{get, post},
     Router,
 };
@@ -37,6 +40,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{error, instrument, warn};
 use uuid::Uuid;
+use waddle_xmpp::telemetry::attributes::AuthStage;
 
 mod callback;
 mod handshake;
@@ -269,6 +273,40 @@ pub(super) fn auth_error_to_response(err: AuthError) -> (StatusCode, Json<ErrorR
     (status, Json(ErrorResponse::new(code, &err.to_string())))
 }
 
+pub(super) fn auth_error_response(provider: &str, stage: AuthStage, err: AuthError) -> Response {
+    record_auth_failure(provider, None, AuthFailure::from_error(stage, &err));
+    match err {
+        AuthError::HttpError(detail) => {
+            let (code, message) = match stage {
+                AuthStage::OidcAuthorization => (
+                    "authorization_failed",
+                    format!("Authorization failed: {detail}"),
+                ),
+                AuthStage::OidcCallback => {
+                    ("jwt_error", format!("JWT validation failed: {detail}"))
+                }
+                AuthStage::TokenExchange => (
+                    "token_exchange_failed",
+                    format!("Token exchange failed: {detail}"),
+                ),
+                AuthStage::Userinfo => (
+                    "userinfo_failed",
+                    format!("User info fetch failed: {detail}"),
+                ),
+                AuthStage::State | AuthStage::DeviceFlow | AuthStage::Scram => {
+                    ("auth_error", format!("HTTP request failed: {detail}"))
+                }
+            };
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new(code, &message)),
+            )
+                .into_response()
+        }
+        other => auth_error_to_response(other).into_response(),
+    }
+}
+
 async fn load_avatar_url(
     actor: &kameo::actor::ActorRef<crate::db::actor::DbActor>,
     user_jid: &str,
@@ -343,7 +381,7 @@ pub async fn list_providers_handler(State(state): State<Arc<AuthState>>) -> impl
     (StatusCode::OK, Json(state.providers.list()))
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, query))]
 pub async fn start_handler(
     State(state): State<Arc<AuthState>>,
     Query(query): Query<StartQuery>,
@@ -351,6 +389,7 @@ pub async fn start_handler(
     let provider = match state.providers.get(&query.provider) {
         Some(p) => p,
         None => {
+            record_auth_failure("unknown", None, AuthFailure::AuthorizationInvalidClient);
             return auth_error_to_response(AuthError::InvalidProvider(query.provider))
                 .into_response();
         }
@@ -361,7 +400,9 @@ pub async fn start_handler(
             let session_transport =
                 match BrowserSessionTransport::from_query(&query.session_transport) {
                     Ok(value) => value,
-                    Err(err) => return auth_error_to_response(err).into_response(),
+                    Err(err) => {
+                        return auth_error_response(&provider.id, AuthStage::OidcAuthorization, err)
+                    }
                 };
             PendingFlow::Browser {
                 next: query.next,
@@ -370,6 +411,7 @@ pub async fn start_handler(
         }
         "device" => {
             let Some(device_code) = query.device_code else {
+                record_auth_failure(&provider.id, None, AuthFailure::DeviceMalformed);
                 return auth_error_to_response(AuthError::InvalidRequest(
                     "device flow requires device_code".to_string(),
                 ))
@@ -379,10 +421,11 @@ pub async fn start_handler(
         }
         "xmpp" => {
             let Some(client_redirect_uri) = query.redirect_uri else {
-                return auth_error_to_response(AuthError::InvalidRequest(
-                    "xmpp flow requires redirect_uri".to_string(),
-                ))
-                .into_response();
+                return auth_error_response(
+                    &provider.id,
+                    AuthStage::OidcAuthorization,
+                    AuthError::InvalidRequest("xmpp flow requires redirect_uri".to_string()),
+                );
             };
             PendingFlow::Xmpp {
                 client_redirect_uri,
@@ -391,16 +434,20 @@ pub async fn start_handler(
             }
         }
         _ => {
-            return auth_error_to_response(AuthError::InvalidRequest(
-                "flow must be browser|device|xmpp".to_string(),
-            ))
-            .into_response();
+            return auth_error_response(
+                &provider.id,
+                AuthStage::OidcAuthorization,
+                AuthError::InvalidRequest("flow must be browser|device|xmpp".to_string()),
+            );
         }
     };
 
     match state.start_authorization(provider, flow).await {
-        Ok(url) => Redirect::temporary(&url).into_response(),
-        Err(err) => auth_error_to_response(err).into_response(),
+        Ok(url) => {
+            record_auth_success(AuthStage::OidcAuthorization);
+            Redirect::temporary(&url).into_response()
+        }
+        Err(err) => auth_error_response(&provider.id, AuthStage::OidcAuthorization, err),
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -42,6 +42,7 @@ pub(super) async fn callback_handler(
         record_auth_failure(&pending.provider_id, None, AuthFailure::StateMismatch);
         return auth_error_to_response(AuthError::InvalidState).into_response();
     }
+    record_auth_success(AuthStage::State);
 
     let provider = match state.providers.get(&pending.provider_id) {
         Some(p) => p,
@@ -207,8 +208,6 @@ pub(super) async fn callback_handler(
             }
         }
     };
-
-    record_auth_success(AuthStage::State);
 
     let linked = match state
         .identity_service

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[instrument(skip(state))]
+#[instrument(skip(state, query))]
 pub(super) async fn callback_handler(
     State(state): State<Arc<AuthState>>,
     Query(query): Query<CallbackQuery>,
@@ -9,32 +9,48 @@ pub(super) async fn callback_handler(
         let msg = query
             .error_description
             .unwrap_or_else(|| "provider returned an error".to_string());
+        record_auth_failure("unknown", None, AuthFailure::AuthorizationRejected);
         return auth_error_to_response(AuthError::AuthorizationFailed(format!("{}: {}", err, msg)))
             .into_response();
     }
 
-    let (Some(code), Some(state_key)) = (query.code, query.state) else {
+    let Some(state_key) = query.state else {
+        record_auth_failure("unknown", None, AuthFailure::StateMismatch);
+        return auth_error_to_response(AuthError::InvalidState).into_response();
+    };
+    let Some(code) = query.code else {
+        record_auth_failure("unknown", None, AuthFailure::CallbackInvalidCode);
         return auth_error_to_response(AuthError::InvalidRequest("missing code/state".to_string()))
             .into_response();
     };
 
     let pending = match state.auth_handshake.take_pending(&state_key).await {
         Ok(Some(pending)) => pending,
-        Ok(None) => return auth_error_to_response(AuthError::InvalidState).into_response(),
-        Err(err) => return auth_error_to_response(err).into_response(),
+        Ok(None) => {
+            record_auth_failure("unknown", None, AuthFailure::StateMismatch);
+            return auth_error_to_response(AuthError::InvalidState).into_response();
+        }
+        Err(err) => return auth_error_response("unknown", AuthStage::State, err),
     };
 
     if pending.is_expired() {
+        record_auth_failure(&pending.provider_id, None, AuthFailure::StateExpired);
         return auth_error_to_response(AuthError::InvalidState).into_response();
     }
 
     if pending.state != state_key {
+        record_auth_failure(&pending.provider_id, None, AuthFailure::StateMismatch);
         return auth_error_to_response(AuthError::InvalidState).into_response();
     }
 
     let provider = match state.providers.get(&pending.provider_id) {
         Some(p) => p,
         None => {
+            record_auth_failure(
+                &pending.provider_id,
+                None,
+                AuthFailure::CallbackInvalidClient,
+            );
             return auth_error_to_response(AuthError::InvalidProvider(pending.provider_id))
                 .into_response();
         }
@@ -53,12 +69,23 @@ pub(super) async fn callback_handler(
             });
             let issuer = match issuer {
                 Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Err(err) => return auth_error_response(&provider.id, AuthStage::OidcCallback, err),
             };
 
             let discovery = match oidc::discover(&state.http_client, issuer).await {
                 Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Err(err) => {
+                    record_auth_failure(
+                        &provider.id,
+                        None,
+                        AuthFailure::from_error(AuthStage::OidcCallback, &err),
+                    );
+                    let response_error = match err {
+                        AuthError::HttpError(detail) => AuthError::AuthorizationFailed(detail),
+                        other => other,
+                    };
+                    return auth_error_to_response(response_error).into_response();
+                }
             };
 
             let token = match oidc::exchange_authorization_code(
@@ -72,8 +99,13 @@ pub(super) async fn callback_handler(
             )
             .await
             {
-                Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Ok(v) => {
+                    record_auth_success(AuthStage::TokenExchange);
+                    v
+                }
+                Err(err) => {
+                    return auth_error_response(&provider.id, AuthStage::TokenExchange, err)
+                }
             };
 
             match oidc::claims_from_token_response(
@@ -85,28 +117,56 @@ pub(super) async fn callback_handler(
             )
             .await
             {
-                Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Ok(outcome) => {
+                    match outcome.userinfo {
+                        oidc::UserinfoFetchOutcome::NotRequested => {}
+                        oidc::UserinfoFetchOutcome::Succeeded => {
+                            record_auth_success(AuthStage::Userinfo);
+                        }
+                        oidc::UserinfoFetchOutcome::Failed(error) => {
+                            record_auth_failure(
+                                &provider.id,
+                                None,
+                                AuthFailure::from_error(AuthStage::Userinfo, &error),
+                            );
+                        }
+                    }
+                    outcome.claims
+                }
+                Err(err) => {
+                    let stage = match &err {
+                        AuthError::InvalidNonce => AuthStage::State,
+                        AuthError::UserInfoFailed(_) => AuthStage::Userinfo,
+                        _ => AuthStage::OidcCallback,
+                    };
+                    return auth_error_response(&provider.id, stage, err);
+                }
             }
         }
         AuthProviderKind::OAuth2 => {
             let token_endpoint = match provider.token_endpoint.as_deref() {
                 Some(v) => v,
                 None => {
-                    return auth_error_to_response(AuthError::InvalidRequest(
-                        "oauth2 provider missing token_endpoint".to_string(),
-                    ))
-                    .into_response();
+                    return auth_error_response(
+                        &provider.id,
+                        AuthStage::TokenExchange,
+                        AuthError::InvalidRequest(
+                            "oauth2 provider missing token_endpoint".to_string(),
+                        ),
+                    );
                 }
             };
 
             let userinfo_endpoint = match provider.userinfo_endpoint.as_deref() {
                 Some(v) => v,
                 None => {
-                    return auth_error_to_response(AuthError::InvalidRequest(
-                        "oauth2 provider missing userinfo_endpoint".to_string(),
-                    ))
-                    .into_response();
+                    return auth_error_response(
+                        &provider.id,
+                        AuthStage::Userinfo,
+                        AuthError::InvalidRequest(
+                            "oauth2 provider missing userinfo_endpoint".to_string(),
+                        ),
+                    );
                 }
             };
 
@@ -121,8 +181,13 @@ pub(super) async fn callback_handler(
             )
             .await
             {
-                Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Ok(v) => {
+                    record_auth_success(AuthStage::TokenExchange);
+                    v
+                }
+                Err(err) => {
+                    return auth_error_response(&provider.id, AuthStage::TokenExchange, err)
+                }
             };
 
             match oidc::claims_from_oauth2_fallback(
@@ -134,11 +199,16 @@ pub(super) async fn callback_handler(
             )
             .await
             {
-                Ok(v) => v,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Ok(v) => {
+                    record_auth_success(AuthStage::Userinfo);
+                    v
+                }
+                Err(err) => return auth_error_response(&provider.id, AuthStage::Userinfo, err),
             }
         }
     };
+
+    record_auth_success(AuthStage::State);
 
     let linked = match state
         .identity_service
@@ -146,7 +216,7 @@ pub(super) async fn callback_handler(
         .await
     {
         Ok(v) => v,
-        Err(err) => return auth_error_to_response(err).into_response(),
+        Err(err) => return auth_error_response(&provider.id, AuthStage::OidcCallback, err),
     };
 
     // Fire-and-forget the OIDC → PEP profile bridge so login latency
@@ -220,10 +290,11 @@ pub(super) async fn callback_handler(
     )
     .await
     {
-        return auth_error_to_response(AuthError::DatabaseError(format!(
-            "Failed to provision account membership: {err}"
-        )))
-        .into_response();
+        return auth_error_response(
+            &provider.id,
+            AuthStage::OidcCallback,
+            AuthError::DatabaseError(format!("Failed to provision account membership: {err}")),
+        );
     }
 
     let session = Session::new(
@@ -233,7 +304,7 @@ pub(super) async fn callback_handler(
     );
 
     if let Err(err) = state.session_manager.create_session(&session).await {
-        return auth_error_to_response(err).into_response();
+        return auth_error_response(&provider.id, AuthStage::OidcCallback, err);
     }
 
     match pending.flow {
@@ -252,11 +323,14 @@ pub(super) async fn callback_handler(
                         {
                             Ok(parsed) => parsed,
                             Err(err) => {
-                                return auth_error_to_response(AuthError::InvalidRequest(format!(
-                                    "invalid browser redirect target: {}",
-                                    err
-                                )))
-                                .into_response();
+                                return auth_error_response(
+                                    &provider.id,
+                                    AuthStage::OidcCallback,
+                                    AuthError::InvalidRequest(format!(
+                                        "invalid browser redirect target: {}",
+                                        err
+                                    )),
+                                );
                             }
                         },
                     };
@@ -285,6 +359,7 @@ pub(super) async fn callback_handler(
                     .parse()
                     .expect("valid cookie"),
             );
+            record_auth_success(AuthStage::OidcCallback);
             response
         }
         PendingFlow::Device { device_code } => {
@@ -319,24 +394,41 @@ pub(super) async fn callback_handler(
                         entry.session_id = Some(session.id.clone());
                         match state.auth_handshake.update_device(&entry).await {
                             Ok(approved) => approved,
-                            Err(err) => return rollback_session(err).await,
+                            Err(err) => {
+                                record_auth_failure(
+                                    &provider.id,
+                                    None,
+                                    AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+                                );
+                                return rollback_session(err).await;
+                            }
                         }
                     }
                 }
                 Ok(None) => false,
-                Err(err) => return rollback_session(err).await,
+                Err(err) => {
+                    record_auth_failure(
+                        &provider.id,
+                        None,
+                        AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+                    );
+                    return rollback_session(err).await;
+                }
             };
 
             if !approved {
                 if let Err(err) = state.session_manager.delete_session(&session.id).await {
                     warn!(error = %err, "Failed to roll back session for expired device grant");
                 }
+                record_auth_failure(&provider.id, None, AuthFailure::DeviceExpired);
                 return auth_error_to_response(AuthError::InvalidRequest(
                     "device authorization expired; restart the device login".to_string(),
                 ))
                 .into_response();
             }
 
+            record_auth_success(AuthStage::DeviceFlow);
+            record_auth_success(AuthStage::OidcCallback);
             (
                 StatusCode::OK,
                 axum::response::Html("<html><body><h1>Device authorized</h1><p>You can close this window.</p></body></html>".to_string()),
@@ -367,17 +459,18 @@ pub(super) async fn callback_handler(
                 if let Err(rollback_err) = state.session_manager.delete_session(&session.id).await {
                     warn!(error = %rollback_err, "Failed to roll back session for failed xmpp code insert");
                 }
-                return auth_error_to_response(err).into_response();
+                return auth_error_response(&provider.id, AuthStage::OidcCallback, err);
             }
 
             let mut redirect = match url::Url::parse(&client_redirect_uri) {
                 Ok(v) => v,
                 Err(err) => {
                     error!(error = %err, "Invalid XMPP redirect URI");
-                    return auth_error_to_response(AuthError::InvalidRequest(
-                        "invalid xmpp redirect_uri".to_string(),
-                    ))
-                    .into_response();
+                    return auth_error_response(
+                        &provider.id,
+                        AuthStage::OidcCallback,
+                        AuthError::InvalidRequest("invalid xmpp redirect_uri".to_string()),
+                    );
                 }
             };
 
@@ -389,6 +482,7 @@ pub(super) async fn callback_handler(
                 }
             }
 
+            record_auth_success(AuthStage::OidcCallback);
             Redirect::temporary(redirect.as_str()).into_response()
         }
     }

--- a/server/crates/waddle-server/src/server/routes/auth/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/tests.rs
@@ -7,6 +7,7 @@ use axum::body::Body;
 use axum::http::{header, Request, StatusCode};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
+use waddle_xmpp::telemetry::test_support;
 
 async fn create_test_auth_state(
     server_config: &ServerConfig,
@@ -202,4 +203,54 @@ async fn secure_cookie_header_tracks_base_url_scheme() {
     assert!(!insecure_state
         .session_cookie_header(Some("token"), 60)
         .contains("Secure"));
+}
+
+#[tokio::test]
+async fn callback_records_state_success_before_subsequent_provider_failure() {
+    let guard = test_support::acquire().await;
+    let server_config = ServerConfig::test_homeserver();
+    let (auth_state, _) = create_test_auth_state(&server_config).await;
+    auth_state
+        .auth_handshake
+        .insert_pending(&PendingAuthorization {
+            state: "validated-state".to_string(),
+            provider_id: "missing-provider".to_string(),
+            nonce: "nonce".to_string(),
+            code_verifier: "verifier".to_string(),
+            redirect_uri: "http://localhost:3000/api/auth/callback".to_string(),
+            client_id: "client-id".to_string(),
+            client_secret: String::new(),
+            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::NoAuthentication,
+            require_dpop: false,
+            flow: PendingFlow::Browser {
+                next: Some("/".to_string()),
+                session_transport: BrowserSessionTransport::Cookie,
+            },
+            created_at: Utc::now(),
+        })
+        .await
+        .expect("insert pending authorization");
+
+    let response = router(auth_state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/callback?state=validated-state&code=authorization-code")
+                .body(Body::empty())
+                .expect("callback request"),
+        )
+        .await
+        .expect("callback response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        guard.counter_sum("waddle.auth.success", &[("stage", "state")]),
+        Some(1),
+    );
+    assert_eq!(
+        guard.counter_sum(
+            "waddle.auth.failures",
+            &[("stage", "oidc_callback"), ("error_code", "invalid_client")]
+        ),
+        Some(1),
+    );
 }

--- a/server/crates/waddle-server/src/server/routes/auth_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/auth_telemetry.rs
@@ -1,0 +1,477 @@
+use crate::auth::AuthError;
+use jid::BareJid;
+use tracing::warn;
+use waddle_xmpp::telemetry::attributes::{AuthErrorCode, AuthStage, MetricAttribute};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum AuthFailure<'a> {
+    Error {
+        stage: AuthStage,
+        error: &'a AuthError,
+    },
+    AuthorizationRejected,
+    AuthorizationInvalidClient,
+    AuthorizationMalformed,
+    CallbackInvalidCode,
+    CallbackInvalidClient,
+    TokenInvalidCode,
+    TokenInvalidGrant,
+    TokenExpired,
+    TokenMalformed,
+    StateMismatch,
+    StateExpired,
+    DeviceInvalidCode,
+    DeviceInvalidGrant,
+    DeviceInvalidClient,
+    DeviceExpired,
+    DeviceMalformed,
+    DeviceOther,
+    ScramMalformed,
+    ScramInvalidCredentials,
+    ScramUnknownUser,
+    ScramOther,
+}
+
+impl<'a> AuthFailure<'a> {
+    pub(super) fn from_error(stage: AuthStage, error: &'a AuthError) -> Self {
+        Self::Error { stage, error }
+    }
+}
+
+pub(super) fn classify_auth_failure(failure: AuthFailure<'_>) -> (AuthStage, AuthErrorCode) {
+    match failure {
+        AuthFailure::Error { stage, error } => {
+            let error_code = match error {
+                AuthError::InvalidProvider(_) => AuthErrorCode::InvalidClient,
+                AuthError::InvalidRequest(_) => AuthErrorCode::Malformed,
+                AuthError::InvalidState | AuthError::InvalidNonce => AuthErrorCode::InvalidState,
+                AuthError::AuthorizationFailed(_) => AuthErrorCode::Other,
+                AuthError::TokenExchangeFailed(_) => AuthErrorCode::InvalidGrant,
+                AuthError::UserInfoFailed(_) => AuthErrorCode::UserinfoFailed,
+                AuthError::JwtError(_) | AuthError::InvalidPassword(_) => {
+                    AuthErrorCode::InvalidCredentials
+                }
+                AuthError::SessionNotFound(_) => AuthErrorCode::InvalidGrant,
+                AuthError::SessionExpired => AuthErrorCode::Expired,
+                AuthError::DatabaseError(_)
+                | AuthError::UserAlreadyExists(_)
+                | AuthError::CryptoError(_)
+                | AuthError::RegistrationDisabled => AuthErrorCode::Other,
+                AuthError::HttpError(_) => AuthErrorCode::ProviderUnreachable,
+                AuthError::UserNotFound(_) => AuthErrorCode::UnknownUser,
+                AuthError::InvalidUsername(_) => AuthErrorCode::Malformed,
+            };
+            (stage, error_code)
+        }
+        AuthFailure::AuthorizationRejected => (AuthStage::OidcAuthorization, AuthErrorCode::Other),
+        AuthFailure::AuthorizationInvalidClient => {
+            (AuthStage::OidcAuthorization, AuthErrorCode::InvalidClient)
+        }
+        AuthFailure::AuthorizationMalformed => {
+            (AuthStage::OidcAuthorization, AuthErrorCode::Malformed)
+        }
+        AuthFailure::CallbackInvalidCode => (AuthStage::OidcCallback, AuthErrorCode::InvalidCode),
+        AuthFailure::CallbackInvalidClient => {
+            (AuthStage::OidcCallback, AuthErrorCode::InvalidClient)
+        }
+        AuthFailure::TokenInvalidCode => (AuthStage::TokenExchange, AuthErrorCode::InvalidCode),
+        AuthFailure::TokenInvalidGrant => (AuthStage::TokenExchange, AuthErrorCode::InvalidGrant),
+        AuthFailure::TokenExpired => (AuthStage::TokenExchange, AuthErrorCode::Expired),
+        AuthFailure::TokenMalformed => (AuthStage::TokenExchange, AuthErrorCode::Malformed),
+        AuthFailure::StateMismatch => (AuthStage::State, AuthErrorCode::InvalidState),
+        AuthFailure::StateExpired => (AuthStage::State, AuthErrorCode::Expired),
+        AuthFailure::DeviceInvalidCode => (AuthStage::DeviceFlow, AuthErrorCode::InvalidCode),
+        AuthFailure::DeviceInvalidGrant => (AuthStage::DeviceFlow, AuthErrorCode::InvalidGrant),
+        AuthFailure::DeviceInvalidClient => (AuthStage::DeviceFlow, AuthErrorCode::InvalidClient),
+        AuthFailure::DeviceExpired => (AuthStage::DeviceFlow, AuthErrorCode::Expired),
+        AuthFailure::DeviceMalformed => (AuthStage::DeviceFlow, AuthErrorCode::Malformed),
+        AuthFailure::DeviceOther => (AuthStage::DeviceFlow, AuthErrorCode::Other),
+        AuthFailure::ScramMalformed => (AuthStage::Scram, AuthErrorCode::Malformed),
+        AuthFailure::ScramInvalidCredentials => {
+            (AuthStage::Scram, AuthErrorCode::InvalidCredentials)
+        }
+        AuthFailure::ScramUnknownUser => (AuthStage::Scram, AuthErrorCode::UnknownUser),
+        AuthFailure::ScramOther => (AuthStage::Scram, AuthErrorCode::Other),
+    }
+}
+
+/// Record an auth rejection at the shared metric/log choke point.
+///
+/// The failure-ratio alert rule follows in the #1324 alerts tree once
+/// production baselines have been observed.
+pub(super) fn record_auth_failure(
+    provider: &str,
+    bare_identifier: Option<&BareJid>,
+    failure: AuthFailure<'_>,
+) {
+    let (stage, error_code) = classify_auth_failure(failure);
+
+    match bare_identifier {
+        Some(identifier) => warn!(
+            provider,
+            stage = stage.value(),
+            error_code = error_code.value(),
+            bare_identifier = %identifier,
+            "Authentication rejected",
+        ),
+        None => warn!(
+            provider,
+            stage = stage.value(),
+            error_code = error_code.value(),
+            "Authentication rejected",
+        ),
+    }
+
+    waddle_xmpp::counter_add!(
+        "waddle.auth.failures",
+        "1",
+        "Authentication rejections by stage and enumerated error code.",
+        1,
+        stage,
+        error_code,
+    );
+}
+
+pub(super) fn record_auth_success(stage: AuthStage) {
+    waddle_xmpp::counter_add!(
+        "waddle.auth.success",
+        "1",
+        "Successful authentication outcomes by stage.",
+        1,
+        stage,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_auth_failure, record_auth_failure, record_auth_success, AuthFailure};
+    use crate::auth::AuthError;
+    use waddle_xmpp::telemetry::attributes::{AuthErrorCode, AuthStage};
+    use waddle_xmpp::telemetry::test_support;
+
+    #[tokio::test]
+    async fn concrete_auth_errors_map_and_export_exhaustively_without_inspecting_messages() {
+        let guard = test_support::acquire().await;
+        let cases = [
+            (
+                AuthError::InvalidProvider("provider".to_string()),
+                AuthErrorCode::InvalidClient,
+            ),
+            (
+                AuthError::InvalidRequest("request".to_string()),
+                AuthErrorCode::Malformed,
+            ),
+            (AuthError::InvalidState, AuthErrorCode::InvalidState),
+            (AuthError::InvalidNonce, AuthErrorCode::InvalidState),
+            (
+                AuthError::AuthorizationFailed("authorization".to_string()),
+                AuthErrorCode::Other,
+            ),
+            (
+                AuthError::TokenExchangeFailed("exchange".to_string()),
+                AuthErrorCode::InvalidGrant,
+            ),
+            (
+                AuthError::UserInfoFailed("userinfo".to_string()),
+                AuthErrorCode::UserinfoFailed,
+            ),
+            (
+                AuthError::JwtError("jwt".to_string()),
+                AuthErrorCode::InvalidCredentials,
+            ),
+            (
+                AuthError::SessionNotFound("session".to_string()),
+                AuthErrorCode::InvalidGrant,
+            ),
+            (AuthError::SessionExpired, AuthErrorCode::Expired),
+            (
+                AuthError::DatabaseError("database".to_string()),
+                AuthErrorCode::Other,
+            ),
+            (
+                AuthError::HttpError("transport".to_string()),
+                AuthErrorCode::ProviderUnreachable,
+            ),
+            (
+                AuthError::UserAlreadyExists("user".to_string()),
+                AuthErrorCode::Other,
+            ),
+            (
+                AuthError::UserNotFound("user".to_string()),
+                AuthErrorCode::UnknownUser,
+            ),
+            (
+                AuthError::InvalidUsername("username".to_string()),
+                AuthErrorCode::Malformed,
+            ),
+            (
+                AuthError::InvalidPassword("password".to_string()),
+                AuthErrorCode::InvalidCredentials,
+            ),
+            (
+                AuthError::CryptoError("crypto".to_string()),
+                AuthErrorCode::Other,
+            ),
+            (AuthError::RegistrationDisabled, AuthErrorCode::Other),
+        ];
+
+        for (error, expected_code) in cases {
+            assert_eq!(
+                classify_auth_failure(AuthFailure::from_error(AuthStage::OidcCallback, &error,)),
+                (AuthStage::OidcCallback, expected_code),
+            );
+            record_auth_failure(
+                "unknown",
+                None,
+                AuthFailure::from_error(AuthStage::OidcCallback, &error),
+            );
+        }
+
+        let expected_counts = [
+            ("invalid_client", 1),
+            ("malformed", 2),
+            ("invalid_state", 2),
+            ("other", 5),
+            ("invalid_grant", 2),
+            ("userinfo_failed", 1),
+            ("invalid_credentials", 2),
+            ("expired", 1),
+            ("provider_unreachable", 1),
+            ("unknown_user", 1),
+        ];
+        for (error_code, expected_count) in expected_counts {
+            assert_eq!(
+                guard.counter_sum(
+                    "waddle.auth.failures",
+                    &[("stage", "oidc_callback"), ("error_code", error_code),],
+                ),
+                Some(expected_count),
+                "wrong exported count for {error_code}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn auth_counters_export_every_stage_and_error_code_at_the_reader_seam() {
+        let guard = test_support::acquire().await;
+        let provider_unreachable = AuthError::HttpError("transport".to_string());
+        let unknown_user = AuthError::UserNotFound("user".to_string());
+        let userinfo_rejected = AuthError::UserInfoFailed("userinfo".to_string());
+        let failure_cases = [
+            (
+                AuthFailure::AuthorizationRejected,
+                AuthStage::OidcAuthorization,
+                AuthErrorCode::Other,
+                "oidc_authorization",
+                "other",
+            ),
+            (
+                AuthFailure::AuthorizationInvalidClient,
+                AuthStage::OidcAuthorization,
+                AuthErrorCode::InvalidClient,
+                "oidc_authorization",
+                "invalid_client",
+            ),
+            (
+                AuthFailure::AuthorizationMalformed,
+                AuthStage::OidcAuthorization,
+                AuthErrorCode::Malformed,
+                "oidc_authorization",
+                "malformed",
+            ),
+            (
+                AuthFailure::CallbackInvalidCode,
+                AuthStage::OidcCallback,
+                AuthErrorCode::InvalidCode,
+                "oidc_callback",
+                "invalid_code",
+            ),
+            (
+                AuthFailure::CallbackInvalidClient,
+                AuthStage::OidcCallback,
+                AuthErrorCode::InvalidClient,
+                "oidc_callback",
+                "invalid_client",
+            ),
+            (
+                AuthFailure::TokenInvalidCode,
+                AuthStage::TokenExchange,
+                AuthErrorCode::InvalidCode,
+                "token_exchange",
+                "invalid_code",
+            ),
+            (
+                AuthFailure::TokenInvalidGrant,
+                AuthStage::TokenExchange,
+                AuthErrorCode::InvalidGrant,
+                "token_exchange",
+                "invalid_grant",
+            ),
+            (
+                AuthFailure::TokenExpired,
+                AuthStage::TokenExchange,
+                AuthErrorCode::Expired,
+                "token_exchange",
+                "expired",
+            ),
+            (
+                AuthFailure::TokenMalformed,
+                AuthStage::TokenExchange,
+                AuthErrorCode::Malformed,
+                "token_exchange",
+                "malformed",
+            ),
+            (
+                AuthFailure::StateMismatch,
+                AuthStage::State,
+                AuthErrorCode::InvalidState,
+                "state",
+                "invalid_state",
+            ),
+            (
+                AuthFailure::StateExpired,
+                AuthStage::State,
+                AuthErrorCode::Expired,
+                "state",
+                "expired",
+            ),
+            (
+                AuthFailure::DeviceInvalidCode,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::InvalidCode,
+                "device_flow",
+                "invalid_code",
+            ),
+            (
+                AuthFailure::DeviceInvalidGrant,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::InvalidGrant,
+                "device_flow",
+                "invalid_grant",
+            ),
+            (
+                AuthFailure::DeviceInvalidClient,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::InvalidClient,
+                "device_flow",
+                "invalid_client",
+            ),
+            (
+                AuthFailure::DeviceExpired,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::Expired,
+                "device_flow",
+                "expired",
+            ),
+            (
+                AuthFailure::DeviceMalformed,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::Malformed,
+                "device_flow",
+                "malformed",
+            ),
+            (
+                AuthFailure::DeviceOther,
+                AuthStage::DeviceFlow,
+                AuthErrorCode::Other,
+                "device_flow",
+                "other",
+            ),
+            (
+                AuthFailure::ScramMalformed,
+                AuthStage::Scram,
+                AuthErrorCode::Malformed,
+                "scram",
+                "malformed",
+            ),
+            (
+                AuthFailure::ScramInvalidCredentials,
+                AuthStage::Scram,
+                AuthErrorCode::InvalidCredentials,
+                "scram",
+                "invalid_credentials",
+            ),
+            (
+                AuthFailure::ScramUnknownUser,
+                AuthStage::Scram,
+                AuthErrorCode::UnknownUser,
+                "scram",
+                "unknown_user",
+            ),
+            (
+                AuthFailure::ScramOther,
+                AuthStage::Scram,
+                AuthErrorCode::Other,
+                "scram",
+                "other",
+            ),
+            (
+                AuthFailure::from_error(AuthStage::Userinfo, &userinfo_rejected),
+                AuthStage::Userinfo,
+                AuthErrorCode::UserinfoFailed,
+                "userinfo",
+                "userinfo_failed",
+            ),
+            (
+                AuthFailure::from_error(AuthStage::OidcAuthorization, &provider_unreachable),
+                AuthStage::OidcAuthorization,
+                AuthErrorCode::ProviderUnreachable,
+                "oidc_authorization",
+                "provider_unreachable",
+            ),
+            (
+                AuthFailure::from_error(AuthStage::OidcCallback, &unknown_user),
+                AuthStage::OidcCallback,
+                AuthErrorCode::UnknownUser,
+                "oidc_callback",
+                "unknown_user",
+            ),
+        ];
+
+        for &(failure, stage, error_code, _, _) in &failure_cases {
+            assert_eq!(classify_auth_failure(failure), (stage, error_code));
+            record_auth_failure("unknown", None, failure);
+        }
+
+        let stages = [
+            (AuthStage::OidcAuthorization, "oidc_authorization"),
+            (AuthStage::OidcCallback, "oidc_callback"),
+            (AuthStage::TokenExchange, "token_exchange"),
+            (AuthStage::Userinfo, "userinfo"),
+            (AuthStage::State, "state"),
+            (AuthStage::DeviceFlow, "device_flow"),
+            (AuthStage::Scram, "scram"),
+        ];
+        for (stage, _) in stages {
+            record_auth_success(stage);
+        }
+
+        for (stage, stage_value) in stages {
+            assert_eq!(
+                guard.counter_sum("waddle.auth.success", &[("stage", stage_value)],),
+                Some(1),
+                "missing success sample for {stage:?}",
+            );
+        }
+
+        for &(_, _, _, stage, error_code) in &failure_cases {
+            assert_eq!(
+                guard.counter_sum(
+                    "waddle.auth.failures",
+                    &[("stage", stage), ("error_code", error_code)],
+                ),
+                Some(1),
+                "missing failure sample for {stage}/{error_code}",
+            );
+        }
+
+        assert_eq!(
+            guard.metric_unit("waddle.auth.failures"),
+            Some("1".to_string())
+        );
+        assert_eq!(
+            guard.metric_unit("waddle.auth.success"),
+            Some("1".to_string())
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/auth_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/auth_telemetry.rs
@@ -57,7 +57,9 @@ pub(super) fn classify_auth_failure(failure: AuthFailure<'_>) -> (AuthStage, Aut
                 | AuthError::UserAlreadyExists(_)
                 | AuthError::CryptoError(_)
                 | AuthError::RegistrationDisabled => AuthErrorCode::Other,
-                AuthError::HttpError(_) => AuthErrorCode::ProviderUnreachable,
+                AuthError::HttpError(_) | AuthError::ProviderUnreachable(_) => {
+                    AuthErrorCode::ProviderUnreachable
+                }
                 AuthError::UserNotFound(_) => AuthErrorCode::UnknownUser,
                 AuthError::InvalidUsername(_) => AuthErrorCode::Malformed,
             };
@@ -193,6 +195,10 @@ mod tests {
                 AuthErrorCode::ProviderUnreachable,
             ),
             (
+                AuthError::ProviderUnreachable(reqwest::StatusCode::SERVICE_UNAVAILABLE),
+                AuthErrorCode::ProviderUnreachable,
+            ),
+            (
                 AuthError::UserAlreadyExists("user".to_string()),
                 AuthErrorCode::Other,
             ),
@@ -236,7 +242,7 @@ mod tests {
             ("userinfo_failed", 1),
             ("invalid_credentials", 2),
             ("expired", 1),
-            ("provider_unreachable", 1),
+            ("provider_unreachable", 2),
             ("unknown_user", 1),
         ];
         for (error_code, expected_count) in expected_counts {

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -1,6 +1,7 @@
 //! OAuth device flow routes.
 
 use super::auth::{AuthState, DeviceAuthStatus, DeviceAuthorization, ErrorResponse, PendingFlow};
+use super::auth_telemetry::{record_auth_failure, record_auth_success, AuthFailure};
 use crate::auth::localpart_to_jid;
 use axum::{
     extract::{Form, Query, State},
@@ -13,6 +14,7 @@ use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{info, instrument, warn};
+use waddle_xmpp::telemetry::attributes::AuthStage;
 
 pub fn router(auth_state: Arc<AuthState>) -> Router {
     Router::new()
@@ -137,12 +139,13 @@ fn generate_user_code() -> String {
     format!("{}-{}", letters, numbers)
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, request))]
 pub async fn device_start_handler(
     State(state): State<Arc<AuthState>>,
     Json(request): Json<DeviceStartRequest>,
 ) -> impl IntoResponse {
     if state.providers.get(&request.provider).is_none() {
+        record_auth_failure("unknown", None, AuthFailure::DeviceInvalidClient);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -175,6 +178,11 @@ pub async fn device_start_handler(
             }
             Ok(false) => continue,
             Err(err) => {
+                record_auth_failure(
+                    &request.provider,
+                    None,
+                    AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+                );
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -185,7 +193,7 @@ pub async fn device_start_handler(
     }
 
     let Some(auth) = auth else {
-        warn!("Device flow could not allocate a unique user_code after retries");
+        record_auth_failure(&request.provider, None, AuthFailure::DeviceOther);
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::new(
@@ -216,7 +224,7 @@ pub async fn device_start_handler(
         .into_response()
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, request))]
 pub async fn device_poll_handler(
     State(state): State<Arc<AuthState>>,
     Json(request): Json<DevicePollRequest>,
@@ -224,6 +232,7 @@ pub async fn device_poll_handler(
     let auth = match state.auth_handshake.get_device(&request.device_code).await {
         Ok(Some(v)) => v,
         Ok(None) => {
+            record_auth_failure("unknown", None, AuthFailure::DeviceInvalidCode);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -234,6 +243,11 @@ pub async fn device_poll_handler(
                 .into_response();
         }
         Err(err) => {
+            record_auth_failure(
+                "unknown",
+                None,
+                AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -250,6 +264,7 @@ pub async fn device_poll_handler(
         {
             warn!(error = %err, "Failed to remove expired device authorization");
         }
+        record_auth_failure(&auth.provider_id, None, AuthFailure::DeviceExpired);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -274,6 +289,7 @@ pub async fn device_poll_handler(
         }
         DeviceAuthStatus::Approved => {
             let Some(session_id) = auth.session_id.clone() else {
+                record_auth_failure(&auth.provider_id, None, AuthFailure::DeviceInvalidGrant);
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(ErrorResponse::new(
@@ -307,25 +323,35 @@ pub async fn device_poll_handler(
                     )
                         .into_response()
                 }
-                Ok(None) => (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::new(
-                        "invalid_grant",
-                        "Session no longer exists",
-                    )),
-                )
-                    .into_response(),
-                Err(err) => (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new("server_error", &err.to_string())),
-                )
-                    .into_response(),
+                Ok(None) => {
+                    record_auth_failure(&auth.provider_id, None, AuthFailure::DeviceInvalidGrant);
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse::new(
+                            "invalid_grant",
+                            "Session no longer exists",
+                        )),
+                    )
+                        .into_response()
+                }
+                Err(err) => {
+                    record_auth_failure(
+                        &auth.provider_id,
+                        None,
+                        AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+                    );
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new("server_error", &err.to_string())),
+                    )
+                        .into_response()
+                }
             }
         }
     }
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, query))]
 pub async fn device_verify_page_handler(
     State(state): State<Arc<AuthState>>,
     Query(query): Query<VerifyQuery>,
@@ -337,7 +363,7 @@ pub async fn device_verify_page_handler(
     Html(html)
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, request))]
 pub async fn device_verify_submit_handler(
     State(state): State<Arc<AuthState>>,
     Form(request): Form<VerifySubmitRequest>,
@@ -351,6 +377,7 @@ pub async fn device_verify_submit_handler(
     {
         Ok(Some(v)) => v,
         Ok(None) => {
+            record_auth_failure("unknown", None, AuthFailure::DeviceInvalidCode);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new("invalid_user_code", "Invalid user code")),
@@ -358,6 +385,11 @@ pub async fn device_verify_submit_handler(
                 .into_response();
         }
         Err(err) => {
+            record_auth_failure(
+                "unknown",
+                None,
+                AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -367,6 +399,7 @@ pub async fn device_verify_submit_handler(
     };
 
     if auth.is_expired() {
+        record_auth_failure(&auth.provider_id, None, AuthFailure::DeviceExpired);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -381,6 +414,7 @@ pub async fn device_verify_submit_handler(
     match state.auth_handshake.update_device(&auth).await {
         Ok(true) => {}
         Ok(false) => {
+            record_auth_failure(&auth.provider_id, None, AuthFailure::DeviceInvalidGrant);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -391,6 +425,11 @@ pub async fn device_verify_submit_handler(
                 .into_response();
         }
         Err(err) => {
+            record_auth_failure(
+                &auth.provider_id,
+                None,
+                AuthFailure::from_error(AuthStage::DeviceFlow, &err),
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -405,7 +444,7 @@ pub async fn device_verify_submit_handler(
     let provider = match state.providers.get(&provider_id) {
         Some(v) => v,
         None => {
-            warn!(provider_id = %provider_id, "Provider no longer configured during device flow");
+            record_auth_failure(&provider_id, None, AuthFailure::DeviceInvalidClient);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -422,14 +461,22 @@ pub async fn device_verify_submit_handler(
         .await
     {
         Ok(url) => {
+            record_auth_success(AuthStage::OidcAuthorization);
             info!(provider = %provider.id, "Device flow continuing via provider authorization");
             axum::response::Redirect::temporary(&url).into_response()
         }
-        Err(err) => (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::new("authorization_failed", &err.to_string())),
-        )
-            .into_response(),
+        Err(err) => {
+            record_auth_failure(
+                &provider.id,
+                None,
+                AuthFailure::from_error(AuthStage::OidcAuthorization, &err),
+            );
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new("authorization_failed", &err.to_string())),
+            )
+                .into_response()
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -83,7 +83,7 @@ use jid::{BareJid, FullJid, Jid};
 use kameo::actor::ActorRef;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 use waddle_extensions::{
     message_has_framework_envelope, DisplayText, ExtensionEffect, ExtensionEnvelope,
     ExtensionManager, MessageMarkupKind, MessageMarkupSpan, ReplyTarget, RoomJid, StanzaId,

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,6 +1,8 @@
 use super::*;
 use waddle_xmpp::mam::{MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
+#[cfg(feature = "clustering")]
 use waddle_xmpp::muc::RoomClaimFenceContext;
+#[cfg(feature = "clustering")]
 use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 
 /// Archive fencing authority resolved for one room write. `Guarded` owns
@@ -9,10 +11,12 @@ use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 /// fence from a genuinely unclustered `Unfenced` deployment.
 pub(super) enum RoomArchiveFence {
     Unfenced,
+    #[cfg(feature = "clustering")]
     Guarded {
         context: RoomClaimFenceContext,
         _identity_guard: CurrentNodeIdentityGuard,
     },
+    #[cfg(feature = "clustering")]
     OwnershipLost,
 }
 
@@ -67,6 +71,7 @@ pub(super) async fn resolve_room_claim_fence(deps: &Deps<'_>, room: &BareJid) ->
     }
 }
 
+#[cfg(feature = "clustering")]
 async fn guard_clustered_room_claim_fence(
     fence: Option<RoomClaimFenceContext>,
     node_identity: Option<&SharedNodeIdentity>,
@@ -91,6 +96,7 @@ pub(super) async fn archive_groupchat_message(
     fence: &RoomArchiveFence,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
+    #[cfg(feature = "clustering")]
     if matches!(fence, RoomArchiveFence::OwnershipLost) {
         return ArchiveGroupchatOutcome::OwnershipLost;
     }
@@ -227,12 +233,14 @@ pub(super) async fn finish_archive_groupchat_message(
     // running the `SELECT ... FOR SHARE` INSIDE the same transaction as
     // this insert.
     let store_result = match fence {
+        #[cfg(feature = "clustering")]
         RoomArchiveFence::Guarded { context, .. } => {
             mam_storage
                 .store_message_fenced(room, &archived, context)
                 .await
         }
         RoomArchiveFence::Unfenced => mam_storage.store_message(room, &archived).await,
+        #[cfg(feature = "clustering")]
         RoomArchiveFence::OwnershipLost => return ArchiveGroupchatOutcome::OwnershipLost,
     };
     match store_result {

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,6 +1,8 @@
 use super::*;
 use waddle_xmpp::mam::{MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
+#[cfg(feature = "clustering")]
 use waddle_xmpp::muc::RoomClaimFenceContext;
+#[cfg(feature = "clustering")]
 use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 
 /// Archive fencing authority resolved for one room write. `Guarded` owns
@@ -9,10 +11,12 @@ use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 /// fence from a genuinely unclustered `Unfenced` deployment.
 pub(super) enum RoomArchiveFence {
     Unfenced,
+    #[cfg(feature = "clustering")]
     Guarded {
         context: RoomClaimFenceContext,
         _identity_guard: CurrentNodeIdentityGuard,
     },
+    #[cfg(feature = "clustering")]
     OwnershipLost,
 }
 
@@ -67,6 +71,7 @@ pub(super) async fn resolve_room_claim_fence(deps: &Deps<'_>, room: &BareJid) ->
     }
 }
 
+#[cfg(feature = "clustering")]
 async fn guard_clustered_room_claim_fence(
     fence: Option<RoomClaimFenceContext>,
     node_identity: Option<&SharedNodeIdentity>,
@@ -91,8 +96,11 @@ pub(super) async fn archive_groupchat_message(
     fence: &RoomArchiveFence,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
-    if matches!(fence, RoomArchiveFence::OwnershipLost) {
-        return ArchiveGroupchatOutcome::OwnershipLost;
+    #[cfg(feature = "clustering")]
+    {
+        if matches!(fence, RoomArchiveFence::OwnershipLost) {
+            return ArchiveGroupchatOutcome::OwnershipLost;
+        }
     }
     // XEP-0313 §MUC Archives: for non-anonymous rooms the *archived*
     // copy carries a room-authored `<x xmlns='muc#user'><item
@@ -227,12 +235,14 @@ pub(super) async fn finish_archive_groupchat_message(
     // running the `SELECT ... FOR SHARE` INSIDE the same transaction as
     // this insert.
     let store_result = match fence {
+        #[cfg(feature = "clustering")]
         RoomArchiveFence::Guarded { context, .. } => {
             mam_storage
                 .store_message_fenced(room, &archived, context)
                 .await
         }
         RoomArchiveFence::Unfenced => mam_storage.store_message(room, &archived).await,
+        #[cfg(feature = "clustering")]
         RoomArchiveFence::OwnershipLost => return ArchiveGroupchatOutcome::OwnershipLost,
     };
     match store_result {

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -459,10 +459,11 @@ async fn insert_groupchat_notification_candidate(
         crate::notification_outbox::T1PushDispatchOutcome::Deliver { .. } => {}
         crate::notification_outbox::T1PushDispatchOutcome::Suppressed { reason } => {
             info!(
-                recipient = %owner,
-                room = %room,
-                class = ?class,
-                %reason,
+                recipient = %candidate.recipient_bare_jid(),
+                conversation = %candidate.conversation_jid(),
+                notification_class = candidate.class().as_db_value(),
+                push_stage = "suppressed",
+                suppression_reason = reason.as_db_value(),
                 "ProjectGroupchatInbox: T0 push gate suppressed groupchat candidate; no candidate row persisted"
             );
             waddle_xmpp::telemetry::reliability::increment_push_suppressed(

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -440,10 +440,12 @@ async fn enqueue_xep0357_notification_candidate_for_message(
         crate::notification_outbox::T1PushDispatchOutcome::Deliver { .. } => {}
         crate::notification_outbox::T1PushDispatchOutcome::Suppressed { reason } => {
             info!(
-                recipient = %recipient,
+                recipient = %candidate.recipient_bare_jid(),
+                conversation = %candidate.conversation_jid(),
                 sender = %sender,
-                is_mention,
-                %reason,
+                notification_class = candidate.class().as_db_value(),
+                push_stage = "suppressed",
+                suppression_reason = reason.as_db_value(),
                 "T0 push gate suppressed XEP-0357 DM candidate; no candidate row persisted"
             );
             waddle_xmpp::telemetry::reliability::increment_push_suppressed(

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -531,15 +531,28 @@ pub(super) async fn dispatch_to_room(
         dispatch_timestamp,
     };
     let mut working = prototype;
+    let fanout_started = std::time::Instant::now();
+    let fanout_span = info_span!(
+        "xmpp.muc.fanout",
+        room = %room_jid,
+        message_id = incoming.id.as_ref().map_or("", |id| id.0.as_str()),
+        recipients = tracing::field::Empty,
+    );
     // Run only the post-gate pipeline (canonicalize → archive → inbox
     // → reflector). The occupancy gate already ran above as an
     // explicit stand-alone call (Copilot review on PR #279); using
     // the full `default_room_dispatcher()` here would re-run it.
-    let dispatch_outcome = default_room_pipeline_dispatcher().dispatch(&mut working, &ctx);
+    let dispatch_outcome = fanout_span
+        .in_scope(|| default_room_pipeline_dispatcher().dispatch(&mut working, &ctx));
     let observer_message = working.clone();
     let mut dispatch_events = dispatch_outcome.events;
     bind_room_claim_fence(&mut dispatch_events, snapshot.claim_fence.as_ref());
     let dispatch_events = order_subject_persistence_after_archive(dispatch_events);
+    let recipients = dispatch_events
+        .iter()
+        .filter(|event| matches!(event, OutboundEvent::RouteToConnection { .. }))
+        .count();
+    fanout_span.record("recipients", recipients);
 
     // 6. Recursively interpret the chain's emitted events. Pass the
     //    depth through unchanged: `recursion_depth` is the headless
@@ -549,7 +562,16 @@ pub(super) async fn dispatch_to_room(
     //    promotes to a headless recipient pass (depth bumped there).
     //    Bumping here would break that path for every offline
     //    occupant.
-    let nested = Box::pin(interpret_with_depth(dispatch_events, deps, recursion_depth)).await;
+    let nested = Box::pin(
+        interpret_with_depth(dispatch_events, deps, recursion_depth).instrument(fanout_span),
+    )
+    .await;
+    waddle_xmpp::histogram_record!(
+        "xmpp.muc.fanout.latency",
+        "ms",
+        "MUC fanout latency: accepted groupchat broadcast until all per-recipient sends are enqueued.",
+        fanout_started.elapsed().as_secs_f64() * 1000.0,
+    );
     let retry_suppression = nested.retry_suppression;
     outcome.frames.extend(nested.frames);
     if nested.close {

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -542,8 +542,8 @@ pub(super) async fn dispatch_to_room(
     // → reflector). The occupancy gate already ran above as an
     // explicit stand-alone call (Copilot review on PR #279); using
     // the full `default_room_dispatcher()` here would re-run it.
-    let dispatch_outcome = fanout_span
-        .in_scope(|| default_room_pipeline_dispatcher().dispatch(&mut working, &ctx));
+    let dispatch_outcome =
+        fanout_span.in_scope(|| default_room_pipeline_dispatcher().dispatch(&mut working, &ctx));
     let observer_message = working.clone();
     let mut dispatch_events = dispatch_outcome.events;
     bind_room_claim_fence(&mut dispatch_events, snapshot.claim_fence.as_ref());

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -535,7 +535,10 @@ pub(super) async fn dispatch_to_room(
     let fanout_span = info_span!(
         "xmpp.muc.fanout",
         room = %room_jid,
-        message_id = incoming.id.as_ref().map_or("", |id| id.0.as_str()),
+        // `working` (not `incoming`): id-less client messages get a
+        // server-generated UUID stamped on the prototype above, so the
+        // fanout trace never collapses them onto an empty id.
+        message_id = working.id.as_ref().map_or("", |id| id.0.as_str()),
         recipients = tracing::field::Empty,
     );
     // Run only the post-gate pipeline (canonicalize → archive → inbox

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -124,6 +124,7 @@ pub(crate) async fn route_to_connection(
     if recursion_depth >= MAX_RECIPIENT_PASS_DEPTH {
         debug!(
             target_jid = %jid,
+            message_id = stanza_message_id(stanza.as_ref()),
             recursion_depth,
             "RouteToConnection: headless recipient-pass already running; \
              dropping nested route (full or bare) to prevent duplicate \
@@ -350,6 +351,7 @@ async fn route_dm_to_full_jid(
             .unwrap_or_else(|error| {
                 warn!(
                     jid = %full,
+                    message_id = stanza_message_id(stanza.as_ref()),
                     %error,
                     "RouteToConnection: failed to enumerate detached \
                      resources for full-JID DM delivery"
@@ -385,6 +387,7 @@ async fn route_dm_to_full_jid(
                 } else {
                     debug!(
                         jid = %full,
+                        message_id = stanza_message_id(stanza.as_ref()),
                         "RouteToConnection: shared recipient pass produced no \
                          wire copy for detached full-JID DM (blocked or \
                          halted); dropping delivery"
@@ -403,6 +406,7 @@ async fn route_dm_to_full_jid(
                     // headless pass's fail-closed rule.
                     warn!(
                         jid = %full,
+                        message_id = stanza_message_id(stanza.as_ref()),
                         "RouteToConnection: blocklist load failed for detached \
                          full-JID DM; dropping instead of queueing the \
                          unfiltered stanza (XEP-0191 fail-closed)"
@@ -424,6 +428,7 @@ async fn route_dm_to_full_jid(
     // headless pass, or the §8.5.1 nonexistent-account bounce).
     debug!(
         jid = %full,
+        message_id = stanza_message_id(stanza.as_ref()),
         "RouteToConnection: full-JID DM has no matching live or detached \
          resource; falling back to bare-JID delivery per RFC 6121 \
          §8.5.3.2.1"
@@ -486,6 +491,7 @@ async fn route_to_bare_jid(
                 .unwrap_or_else(|error| {
                     warn!(
                         bare_jid = %bare,
+                        message_id = stanza_message_id(stanza.as_ref()),
                         %error,
                         "RouteToConnection: failed to enumerate \
                          detached resources for bare-JID delivery"
@@ -642,6 +648,7 @@ async fn route_to_bare_jid(
                         } else {
                             debug!(
                                 bare_jid = %bare,
+                                message_id = stanza_message_id(stanza.as_ref()),
                                 "RouteToConnection: shared recipient pass \
                                  produced no wire copy (blocked or halted); \
                                  dropping delivery"
@@ -696,6 +703,7 @@ async fn route_to_bare_jid(
             if skip_raw_detached_queueing {
                 debug!(
                     bare_jid = %bare,
+                    message_id = stanza_message_id(stanza.as_ref()),
                     "RouteToConnection: blocklist load failed; skipping raw \
                      detached XEP-0198 queueing (fail-closed) — live \
                      per-resource delivery above keeps its own snapshot"
@@ -746,6 +754,7 @@ async fn route_to_bare_jid(
                             any_landed = true;
                             debug!(
                                 jid = %full,
+                                message_id = stanza_message_id(stanza.as_ref()),
                                 "RouteToConnection: bare-JID stanza queued \
                                  for detached XEP-0198 replay"
                             );
@@ -753,6 +762,7 @@ async fn route_to_bare_jid(
                         Ok(false) => {
                             debug!(
                                 jid = %full,
+                                message_id = stanza_message_id(stanza.as_ref()),
                                 "RouteToConnection: detached session expired \
                                  between enumeration and queue; dropping"
                             );
@@ -760,6 +770,7 @@ async fn route_to_bare_jid(
                         Err(error) => {
                             warn!(
                                 jid = %full,
+                                message_id = stanza_message_id(stanza.as_ref()),
                                 %error,
                                 "RouteToConnection: failed to record bare-JID \
                                  stanza for detached resource"
@@ -787,6 +798,7 @@ async fn route_to_bare_jid(
                 } else {
                     debug!(
                         bare_jid = %bare,
+                        message_id = stanza_message_id(stanza.as_ref()),
                         "RouteToConnection: every selected/detached target \
                          turned out stale (self-healed via DroppedClosed \
                          eviction); running the headless recipient pass so \
@@ -1093,6 +1105,7 @@ async fn queue_processed_for_detached(
             Ok(true) => {
                 debug!(
                     jid = %full,
+                    message_id = stanza_message_id(stanza),
                     "RouteToConnection: processed DM queued for detached \
                      XEP-0198 replay"
                 );
@@ -1100,6 +1113,7 @@ async fn queue_processed_for_detached(
             Ok(false) => {
                 debug!(
                     jid = %full,
+                    message_id = stanza_message_id(stanza),
                     "RouteToConnection: detached session gone between \
                      enumeration and queue (resumed or expired); retrying \
                      as live delivery"
@@ -1109,6 +1123,7 @@ async fn queue_processed_for_detached(
             Err(error) => {
                 warn!(
                     jid = %full,
+                    message_id = stanza_message_id(stanza),
                     %error,
                     "RouteToConnection: failed to record processed DM for \
                      detached resource; retrying as live delivery"
@@ -1134,9 +1149,17 @@ async fn retry_unqueued_detached_as_live(
         let outcome = deliver_direct_to_full_with_registered_remote(deps, &full, processed).await;
         debug!(
             jid = %full,
+            message_id = stanza_message_id(processed),
             ?outcome,
             "RouteToConnection: second-chance live delivery after failed \
              detached queueing"
         );
+    }
+}
+
+fn stanza_message_id(stanza: &Stanza) -> &str {
+    match stanza {
+        Stanza::Message(message) => message.id.as_ref().map_or("", |id| id.0.as_str()),
+        Stanza::Iq(_) | Stanza::Presence(_) => "",
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -493,6 +493,7 @@ async fn deliver_one_via_actor(
     stanza: &Stanza,
     kind: ActorSendKind,
 ) -> FullJidDeliveryOutcome {
+    let message_id = stanza_message_id(stanza);
     // FUTURE CLEANUP (ADR-0017; Greptile review on PR #1177, tracked in #1195):
     // for a bare-JID DM this is the SECOND `GetUser` for the same bare JID —
     // `select_bare_jid_live_targets` already resolved the `UserActor` during
@@ -519,7 +520,7 @@ async fn deliver_one_via_actor(
                 .into();
         }
         Err(error) => {
-            warn!(jid = %target, %error, "actor delivery: GetUser failed; routing to detached");
+            warn!(jid = %target, message_id, %error, "actor delivery: GetUser failed; routing to detached");
             return detached_after_routing_failure(
                 deliver_to_detached(sm_session_registry, target, stanza).await,
             );
@@ -576,7 +577,7 @@ async fn deliver_one_via_actor(
 
     match outcome {
         Ok(waddle_xmpp::registry::BroadcastOutcome::Delivered) => {
-            debug!(jid = %target, "actor delivery: queued for recipient");
+            debug!(jid = %target, message_id, "actor delivery: queued for recipient");
             FullJidDeliveryOutcome::Delivered
         }
         // Still full after every retry — surface the loss instead of the
@@ -588,6 +589,7 @@ async fn deliver_one_via_actor(
             waddle_xmpp::telemetry::reliability::increment_delivery_retry_exhausted_drop();
             warn!(
                 jid = %target,
+                message_id,
                 retries = DROPPED_FULL_RETRY_DELAYS.len(),
                 "actor delivery: recipient channel still full after bounded retries; dropped"
             );
@@ -604,6 +606,7 @@ async fn deliver_one_via_actor(
         Err((ActorSendFailure::NeverEnqueued, error)) => {
             warn!(
                 jid = %target,
+                message_id,
                 %error,
                 "actor delivery: TrySend ask failed before enqueue; routing to detached"
             );
@@ -620,6 +623,7 @@ async fn deliver_one_via_actor(
             waddle_xmpp::telemetry::reliability::increment_delivery_terminal_error_drop();
             warn!(
                 jid = %target,
+                message_id,
                 %error,
                 "actor delivery: TrySend ask failed terminally (possibly enqueued); \
                  dropping to avoid double-delivery"
@@ -718,6 +722,7 @@ pub(super) async fn deliver_peer_to_live_only(
     target: &jid::FullJid,
     stanza: &Stanza,
 ) -> FullJidDeliveryOutcome {
+    let message_id = stanza_message_id(stanza);
     let Some(user_registry) = user_registry else {
         return FullJidDeliveryOutcome::Unavailable;
     };
@@ -734,6 +739,7 @@ pub(super) async fn deliver_peer_to_live_only(
         Err(error) => {
             warn!(
                 jid = %target,
+                message_id,
                 %error,
                 "live-only delivery: GetUser failed; treating as unavailable \
                  so the detached/bare fallback runs"
@@ -751,11 +757,11 @@ pub(super) async fn deliver_peer_to_live_only(
         .await
     {
         Ok(waddle_xmpp::registry::BroadcastOutcome::Delivered) => {
-            debug!(jid = %target, "live-only delivery: queued for recipient");
+            debug!(jid = %target, message_id, "live-only delivery: queued for recipient");
             FullJidDeliveryOutcome::Delivered
         }
         Ok(waddle_xmpp::registry::BroadcastOutcome::DroppedFull) => {
-            debug!(jid = %target, "live-only delivery: recipient channel full; dropped");
+            debug!(jid = %target, message_id, "live-only delivery: recipient channel full; dropped");
             FullJidDeliveryOutcome::Dropped
         }
         Ok(waddle_xmpp::registry::BroadcastOutcome::NotConnected)
@@ -766,6 +772,7 @@ pub(super) async fn deliver_peer_to_live_only(
             ActorSendFailure::NeverEnqueued => {
                 warn!(
                     jid = %target,
+                    message_id,
                     error = %error,
                     "live-only delivery: TrySendPeer failed before enqueue; \
                      treating as unavailable so the detached/bare fallback runs"
@@ -776,6 +783,7 @@ pub(super) async fn deliver_peer_to_live_only(
                 waddle_xmpp::telemetry::reliability::increment_delivery_terminal_error_drop();
                 warn!(
                     jid = %target,
+                    message_id,
                     error = %error,
                     "live-only delivery: TrySendPeer failed terminally (possibly \
                      enqueued); dropping to avoid double-delivery"
@@ -808,8 +816,9 @@ pub(super) async fn deliver_to_detached(
     target: &jid::FullJid,
     stanza: &Stanza,
 ) -> DetachedDeliveryOutcome {
+    let message_id = stanza_message_id(stanza);
     let Some(sm) = sm_session_registry else {
-        debug!(jid = %target, "RouteToConnection: target offline, dropping");
+        debug!(jid = %target, message_id, "RouteToConnection: target offline, dropping");
         return DetachedDeliveryOutcome::Unavailable;
     };
     match sm
@@ -819,6 +828,7 @@ pub(super) async fn deliver_to_detached(
         Ok(true) => {
             debug!(
                 jid = %target,
+                message_id,
                 "RouteToConnection: recipient detached, queued for XEP-0198 replay"
             );
             DetachedDeliveryOutcome::Queued
@@ -826,6 +836,7 @@ pub(super) async fn deliver_to_detached(
         Ok(false) => {
             debug!(
                 jid = %target,
+                message_id,
                 "RouteToConnection: target offline and no detached session, dropping"
             );
             DetachedDeliveryOutcome::Unavailable
@@ -833,11 +844,19 @@ pub(super) async fn deliver_to_detached(
         Err(error) => {
             warn!(
                 jid = %target,
+                message_id,
                 %error,
                 "RouteToConnection: failed to record stanza for detached resource"
             );
             DetachedDeliveryOutcome::Failed
         }
+    }
+}
+
+fn stanza_message_id(stanza: &Stanza) -> &str {
+    match stanza {
+        Stanza::Message(message) => message.id.as_ref().map_or("", |id| id.0.as_str()),
+        Stanza::Iq(_) | Stanza::Presence(_) => "",
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -7,10 +7,33 @@ use super::groupchat_validation::lookup_groupchat_retraction_target;
 use super::room_dispatch::normalize_thread_create_source;
 use super::*;
 use kameo::actor::Spawn;
+use std::io;
 use waddle_xmpp::xep::{set_thread_create, ThreadCreate};
 use waddle_xmpp::Stanza;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
 
 fn test_registry() -> ConnectionRegistry {
     ConnectionRegistry::new()
@@ -3265,6 +3288,171 @@ async fn dispatch_to_room_drops_when_no_web_socket_state_in_deps() {
     assert!(!outcome.close);
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn dispatch_to_room_fanout_span_and_latency_cover_recipient_enqueues() {
+    use waddle_xmpp::muc::room_actor::Join;
+    use waddle_xmpp::muc::room_registry_actor::CreateRoom;
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::{Affiliation, Role};
+
+    let metric_guard = waddle_xmpp::telemetry::test_support::acquire().await;
+    let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+    let room_jid: jid::BareJid = "trace@muc.example.com".parse().expect("room JID");
+    let alice: jid::FullJid = "alice@example.com/web".parse().expect("alice JID");
+    let bob: jid::FullJid = "bob@example.com/phone".parse().expect("bob JID");
+    let room = state
+        .deps
+        .protocol
+        .room_registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-trace".to_string(),
+            channel_id: "c-trace".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create room");
+    for (nick, real_jid) in [("alice", alice.clone()), ("bob", bob.clone())] {
+        room.ask(Join {
+            nick: nick.to_string(),
+            real_jid,
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join room");
+    }
+
+    let (alice_tx, mut alice_rx) = tokio::sync::mpsc::channel(8);
+    let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(
+        &state.deps.protocol.connection_registry,
+        &state.deps.protocol.user_registry,
+        &alice,
+        alice_tx,
+    )
+    .await;
+    register_into_both_tiers(
+        &state.deps.protocol.connection_registry,
+        &state.deps.protocol.user_registry,
+        &bob,
+        bob_tx,
+    )
+    .await;
+
+    let deps = Deps {
+        connection_registry: &state.deps.protocol.connection_registry,
+        user_registry: Some(&state.deps.protocol.user_registry),
+        sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
+        mam_storage: Some(&state.deps.protocol.mam_storage),
+        inbox_storage: Some(&state.deps.protocol.inbox_storage),
+        extension_manager: Some(&state.deps.protocol.extension_manager),
+        room_registry: Some(&state.deps.protocol.room_registry),
+        web_socket_state: Some(state.as_ref()),
+        authenticated_session: None,
+        local_domain: state.deps.auth_state.xmpp_domain.as_str(),
+        blocking_storage: Some(&state.deps.protocol.blocking_storage),
+        message_dispatcher: Some(&state.deps.protocol.dispatcher),
+        pending_delivery_storage: Some(&state.deps.protocol.pending_delivery_storage),
+        ordered_relay_origin: None,
+    };
+    let mut message = Message::new(Some(jid::Jid::from(room_jid.clone())));
+    message.from = Some(jid::Jid::from(alice));
+    message.type_ = XmppMessageType::Groupchat;
+    message.id = Some(xmpp_parsers::message::Id("fanout-production-1".into()));
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "sensitive production fanout body".to_string(),
+    );
+
+    let bytes = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(CaptureWriter(Arc::clone(&bytes)))
+        .finish();
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+    let outcome = interpret(
+        vec![OutboundEvent::DispatchToRoom {
+            room: room_jid,
+            message: Box::new(message),
+        }],
+        &deps,
+    )
+    .await;
+
+    assert!(outcome.frames.is_empty());
+    assert!(
+        alice_rx.try_recv().is_ok(),
+        "sender reflection was enqueued"
+    );
+    assert!(
+        bob_rx.try_recv().is_ok(),
+        "recipient reflection was enqueued"
+    );
+    let output = String::from_utf8(bytes.lock().expect("capture lock").clone())
+        .expect("captured tracing is UTF-8");
+    let fanout_span = output
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|event| {
+            event
+                .get("span")
+                .filter(|span| {
+                    span.get("name").and_then(serde_json::Value::as_str) == Some("xmpp.muc.fanout")
+                        && span.get("recipients").is_some()
+                })
+                .cloned()
+                .or_else(|| {
+                    event
+                        .get("spans")
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|spans| {
+                            spans
+                                .iter()
+                                .find(|span| {
+                                    span.get("name").and_then(serde_json::Value::as_str)
+                                        == Some("xmpp.muc.fanout")
+                                        && span.get("recipients").is_some()
+                                })
+                                .cloned()
+                        })
+                })
+        })
+        .expect("captured event belongs to xmpp.muc.fanout span");
+    assert_eq!(
+        fanout_span
+            .get("message_id")
+            .and_then(serde_json::Value::as_str),
+        Some("fanout-production-1")
+    );
+    assert_eq!(
+        fanout_span.get("room").and_then(serde_json::Value::as_str),
+        Some("trace@muc.example.com")
+    );
+    assert_eq!(
+        fanout_span
+            .get("recipients")
+            .and_then(serde_json::Value::as_u64),
+        Some(2)
+    );
+    assert!(
+        !output.contains("sensitive production fanout body"),
+        "message bodies must never be tracing fields: {output}"
+    );
+    assert_eq!(
+        metric_guard.histogram_count("xmpp.muc.fanout.latency", &[]),
+        Some(1),
+        "one sample is recorded after both enqueue attempts complete"
+    );
+    assert_eq!(
+        metric_guard
+            .metric_unit("xmpp.muc.fanout.latency")
+            .as_deref(),
+        Some("ms")
+    );
+}
+
 #[tokio::test]
 async fn extension_room_message_dispatches_threaded_muc_message() {
     use waddle_extensions::{
@@ -4060,11 +4248,13 @@ impl SubjectMutationStore {
             .store(0, std::sync::atomic::Ordering::SeqCst);
     }
 
+    #[cfg(feature = "clustering")]
     fn set_fanout_owned(&self, owned: bool) {
         self.fanout_owned
             .store(owned, std::sync::atomic::Ordering::SeqCst);
     }
 
+    #[cfg(feature = "clustering")]
     fn block_fanout_checks(&self, count: usize) -> Arc<tokio::sync::Barrier> {
         let barrier = Arc::new(tokio::sync::Barrier::new(count + 1));
         *self

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -4060,11 +4060,13 @@ impl SubjectMutationStore {
             .store(0, std::sync::atomic::Ordering::SeqCst);
     }
 
+    #[cfg(feature = "clustering")]
     fn set_fanout_owned(&self, owned: bool) {
         self.fanout_owned
             .store(owned, std::sync::atomic::Ordering::SeqCst);
     }
 
+    #[cfg(feature = "clustering")]
     fn block_fanout_checks(&self, count: usize) -> Arc<tokio::sync::Barrier> {
         let barrier = Arc::new(tokio::sync::Barrier::new(count + 1));
         *self

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -35,6 +35,7 @@ use waddle_sfu::{
     verify_webhook_signature, CallId, LiveKitWebhookEvent, ParticipantEnvelope, SfuReconciler,
     WebhookVerifyError, RECONCILE_GRACE_SECONDS,
 };
+use waddle_xmpp::telemetry::attributes::WebhookOutcome;
 
 use super::muc_muji_clear::clear_muji_presence_for_departure;
 use super::websocket::{note_participant_left_by_call_id, WebSocketState};
@@ -111,25 +112,31 @@ async fn livekit_webhook_handler(
         Ok(event) => event,
         Err(WebhookVerifyError::MissingAuthorization)
         | Err(WebhookVerifyError::MalformedAuthorization) => {
+            record_webhook_outcome(WebhookOutcome::SignatureFailed);
             return StatusCode::UNAUTHORIZED;
         }
         Err(WebhookVerifyError::Jwt(error)) => {
+            record_webhook_outcome(WebhookOutcome::SignatureFailed);
             warn!(error = ?error, "LiveKit webhook JWT validation failed");
             return StatusCode::UNAUTHORIZED;
         }
         Err(WebhookVerifyError::MissingBodyHash) | Err(WebhookVerifyError::BodyHashMismatch) => {
+            record_webhook_outcome(WebhookOutcome::SignatureFailed);
             return StatusCode::UNAUTHORIZED;
         }
         Err(WebhookVerifyError::BodyJson(error)) => {
+            record_webhook_outcome(WebhookOutcome::SignatureFailed);
             warn!(error = ?error, "LiveKit webhook body JSON parse failed");
             return StatusCode::BAD_REQUEST;
         }
     };
 
     if !seen.observe(event.event_id()) {
+        record_webhook_outcome(WebhookOutcome::Duplicate);
         debug!(event_id = ?event.event_id(), "LiveKit webhook duplicate; dropping");
         return StatusCode::OK;
     }
+    record_webhook_outcome(WebhookOutcome::Received);
 
     match &event {
         LiveKitWebhookEvent::ParticipantLeft(env)
@@ -171,6 +178,16 @@ async fn livekit_webhook_handler(
     }
 
     StatusCode::OK
+}
+
+fn record_webhook_outcome(outcome: WebhookOutcome) {
+    waddle_xmpp::counter_add!(
+        "waddle.call.webhook.events",
+        "1",
+        "LiveKit webhook ingestion events by outcome.",
+        1,
+        outcome,
+    );
 }
 
 /// How often the reconciliation backstop polls LiveKit for the true
@@ -290,8 +307,63 @@ mod tests {
     use crate::server::routes::websocket::tests::{
         create_test_websocket_state_with_calls, create_test_websocket_state_with_sfu, RecordingSfu,
     };
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use base64::Engine;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+    use std::io;
     use waddle_sfu::{Identity, MediaCapabilities};
     use waddle_xmpp::protocol::ConnectionPhase;
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn signed_webhook_headers(secret: &[u8], body: &[u8]) -> HeaderMap {
+        let mut hasher = Sha256::new();
+        hasher.update(body);
+        let claims = json!({
+            "sha256": BASE64_STANDARD.encode(hasher.finalize()),
+            "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+            "iat": chrono::Utc::now().timestamp(),
+        });
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .expect("sign test webhook");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}")
+                .parse()
+                .expect("valid auth header"),
+        );
+        headers
+    }
 
     #[test]
     fn seen_event_ids_deduplicates_repeat_observations() {
@@ -300,6 +372,74 @@ mod tests {
         assert!(!seen.observe(Some("EV_1")));
         assert!(seen.observe(Some("EV_2")));
         assert!(!seen.observe(Some("EV_2")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn duplicate_webhook_emits_debug_log_and_counter() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let _subscriber = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::DEBUG)
+                .with_writer(CaptureWriter(buffer.clone()))
+                .finish(),
+        );
+        let state = create_test_websocket_state_with_calls().await;
+        let secret = state
+            .deps
+            .protocol
+            .sfu
+            .as_ref()
+            .expect("call fixture has SFU")
+            .webhook_secret()
+            .as_bytes()
+            .to_vec();
+        let body = serde_json::to_vec(&json!({
+            "event": "participant_joined",
+            "id": "EV_duplicate_metric",
+            "room": { "name": "general@muc.example.com" },
+            "participant": { "identity": "alice@example.com/web" }
+        }))
+        .expect("serialize webhook body");
+        let headers = signed_webhook_headers(&secret, &body);
+        let seen = Arc::new(SeenEventIds::default());
+
+        let first = livekit_webhook_handler(
+            Extension(state.clone()),
+            State(seen.clone()),
+            headers.clone(),
+            Bytes::from(body.clone()),
+        )
+        .await
+        .into_response();
+        let duplicate =
+            livekit_webhook_handler(Extension(state), State(seen), headers, Bytes::from(body))
+                .await
+                .into_response();
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(duplicate.status(), StatusCode::OK);
+        assert_eq!(
+            metrics.counter_sum("waddle.call.webhook.events", &[("outcome", "received")]),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.counter_sum("waddle.call.webhook.events", &[("outcome", "duplicate")]),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.call.webhook.events"),
+            Some("1".to_string())
+        );
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are UTF-8");
+        assert!(
+            logs.contains("LiveKit webhook duplicate; dropping"),
+            "{logs}"
+        );
+        assert!(logs.contains("\"level\":\"DEBUG\""), "{logs}");
+        assert!(logs.contains("EV_duplicate_metric"), "{logs}");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -125,7 +125,7 @@ async fn livekit_webhook_handler(
             return StatusCode::UNAUTHORIZED;
         }
         Err(WebhookVerifyError::BodyJson(error)) => {
-            record_webhook_outcome(WebhookOutcome::SignatureFailed);
+            record_webhook_outcome(WebhookOutcome::DecodeFailed);
             warn!(error = ?error, "LiveKit webhook body JSON parse failed");
             return StatusCode::BAD_REQUEST;
         }
@@ -440,6 +440,48 @@ mod tests {
         );
         assert!(logs.contains("\"level\":\"DEBUG\""), "{logs}");
         assert!(logs.contains("EV_duplicate_metric"), "{logs}");
+    }
+
+    #[tokio::test]
+    async fn signed_undecodable_webhook_records_decode_failure() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let state = create_test_websocket_state_with_calls().await;
+        let secret = state
+            .deps
+            .protocol
+            .sfu
+            .as_ref()
+            .expect("call fixture has SFU")
+            .webhook_secret()
+            .as_bytes()
+            .to_vec();
+        let body = b"{not-json";
+        let headers = signed_webhook_headers(&secret, body);
+
+        let response = livekit_webhook_handler(
+            Extension(state),
+            State(Arc::new(SeenEventIds::default())),
+            headers,
+            Bytes::from_static(body),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            metrics.counter_sum(
+                "waddle.call.webhook.events",
+                &[("outcome", "decode_failed")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.counter_sum(
+                "waddle.call.webhook.events",
+                &[("outcome", "signature_failed")]
+            ),
+            Some(0)
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -1,6 +1,7 @@
 // Route modules for Waddle Server API
 pub mod auth; // Provider auth broker, session management
 pub mod auth_page; // Web-based auth page for XMPP credentials
+mod auth_telemetry; // Unified auth rejection/success observability (#1328)
 pub mod calendar_feed; // Read-only iCalendar projection of xCal community events
 pub mod device; // OAuth Device Flow for CLI
 pub mod extension_webhooks; // Extension webhook ingress

--- a/server/crates/waddle-server/src/server/routes/websocket/call_signaling_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/call_signaling_telemetry.rs
@@ -1,0 +1,124 @@
+use jid::BareJid;
+use waddle_xmpp::telemetry::attributes::{CallSignalEvent, MetricAttribute, SfuDenialReason};
+
+pub(crate) enum CallSignalTarget<'a> {
+    Peer(&'a BareJid),
+    Room(&'a BareJid),
+}
+
+pub(crate) fn record_call_signal(
+    event: CallSignalEvent,
+    user: &BareJid,
+    target: Option<CallSignalTarget<'_>>,
+) {
+    match target {
+        Some(CallSignalTarget::Peer(peer)) => tracing::info!(
+            event = event.value(),
+            user = %user,
+            peer = %peer,
+            "call signaling event"
+        ),
+        Some(CallSignalTarget::Room(room)) => tracing::info!(
+            event = event.value(),
+            user = %user,
+            room = %room,
+            "call signaling event"
+        ),
+        None => tracing::info!(
+            event = event.value(),
+            user = %user,
+            "call signaling event"
+        ),
+    }
+    waddle_xmpp::counter_add!(
+        "waddle.call.signaling",
+        "1",
+        "JMI and Muji call-signaling events.",
+        1,
+        event,
+    );
+}
+
+pub(crate) fn record_sfu_token_denial(room: &BareJid, user: &BareJid, reason: SfuDenialReason) {
+    tracing::warn!(
+        room = %room,
+        user = %user,
+        reason = reason.value(),
+        "SFU token request denied"
+    );
+    waddle_xmpp::counter_add!(
+        "waddle.call.sfu_token.denied",
+        "1",
+        "SFU token requests denied by reason.",
+        1,
+        reason,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn jmi_signal_emits_info_with_bare_jids_and_counter() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let _subscriber = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::INFO)
+                .with_writer(CaptureWriter(buffer.clone()))
+                .finish(),
+        );
+        let user: BareJid = "alice@example.com".parse().expect("valid user JID");
+        let peer: BareJid = "bob@example.com".parse().expect("valid peer JID");
+
+        record_call_signal(
+            CallSignalEvent::JmiPropose,
+            &user,
+            Some(CallSignalTarget::Peer(&peer)),
+        );
+
+        assert_eq!(
+            metrics.counter_sum("waddle.call.signaling", &[("event", "jmi_propose")]),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.call.signaling"),
+            Some("1".to_string())
+        );
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are UTF-8");
+        assert!(logs.contains("\"level\":\"INFO\""), "{logs}");
+        assert!(logs.contains("jmi_propose"), "{logs}");
+        assert!(logs.contains("alice@example.com"), "{logs}");
+        assert!(logs.contains("bob@example.com"), "{logs}");
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/call_signaling_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/call_signaling_telemetry.rs
@@ -46,13 +46,7 @@ pub(crate) fn record_sfu_token_denial(room: &BareJid, user: &BareJid, reason: Sf
         reason = reason.value(),
         "SFU token request denied"
     );
-    waddle_xmpp::counter_add!(
-        "waddle.call.sfu_token.denied",
-        "1",
-        "SFU token requests denied by reason.",
-        1,
-        reason,
-    );
+    waddle_xmpp::telemetry::call::increment_sfu_token_denied(reason);
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -65,18 +65,25 @@ async fn xmpp_websocket_handler(
     // span on the session into one giant trace (Tempo truncates
     // those). Dispatch spans stay independent roots, correlated via
     // their `xmpp.resource`/`user` attributes instead.
-    if let Some(client_context) = crate::server::trace::client_trace_context_from_query(uri.query())
-    {
-        let established_span = tracing::info_span!(
-            "xmpp.connection.established",
-            client.trace_id = %client_context.trace_id(),
-        );
-        tracing_opentelemetry::OpenTelemetrySpanExt::add_link(&established_span, client_context);
+    if let Some(established_span) = connection_established_span(uri.query()) {
         let _enter = established_span.enter();
     }
 
     ws.protocols(["xmpp"])
         .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
+}
+
+fn connection_established_span(query: Option<&str>) -> Option<tracing::Span> {
+    let client_parent = crate::server::trace::client_trace_parent_from_query(query)?;
+    let established_span = tracing::info_span!(
+        "xmpp.connection.established",
+        client.trace_id = %client_parent.trace_id(),
+    );
+    tracing_opentelemetry::OpenTelemetrySpanExt::add_link(
+        &established_span,
+        client_parent.remote_span_context(),
+    );
+    Some(established_span)
 }
 
 /// Size of the outbound message channel buffer
@@ -1020,7 +1027,57 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
     use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn connection_span_records_client_trace_id_from_query() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CaptureWriter(Arc::clone(&bytes)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = connection_established_span(Some(
+                "traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            ))
+            .expect("valid traceparent creates a connection span");
+            let _entered = span.enter();
+            tracing::info!("connection field probe");
+        });
+
+        let output = String::from_utf8(bytes.lock().expect("capture lock").clone())
+            .expect("captured tracing is UTF-8");
+        assert!(
+            output.contains("\"client.trace_id\":\"0af7651916cd43dd8448eb211c80319c\""),
+            "connection span must expose the linked client trace id: {output}"
+        );
+    }
 
     #[tokio::test]
     async fn abandoned_inbound_slot_does_not_block_handoff_cleanup() {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1027,40 +1027,32 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
+    use tracing_subscriber::prelude::*;
 
-    #[derive(Clone)]
-    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+    #[derive(Clone, Debug)]
+    struct CaptureSpanExporter(Arc<Mutex<Vec<SpanData>>>);
 
-    impl io::Write for CaptureWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().expect("capture lock").extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
+    impl SpanExporter for CaptureSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.0.lock().expect("capture lock").extend(batch);
             Ok(())
         }
     }
 
-    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
-        type Writer = CaptureWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
-
     #[test]
-    fn connection_span_records_client_trace_id_from_query() {
-        let bytes = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::fmt()
-            .json()
-            .with_max_level(tracing::Level::INFO)
-            .with_writer(CaptureWriter(Arc::clone(&bytes)))
-            .finish();
+    fn connection_span_records_client_trace_id_and_remote_link_from_query() {
+        let exported = Arc::new(Mutex::new(Vec::new()));
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(CaptureSpanExporter(Arc::clone(&exported)))
+            .build();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer().with_tracer(provider.tracer("connection-span-test")),
+        );
 
         tracing::subscriber::with_default(subscriber, || {
             let span = connection_established_span(Some(
@@ -1068,15 +1060,29 @@ mod tests {
             ))
             .expect("valid traceparent creates a connection span");
             let _entered = span.enter();
-            tracing::info!("connection field probe");
         });
 
-        let output = String::from_utf8(bytes.lock().expect("capture lock").clone())
-            .expect("captured tracing is UTF-8");
+        let exported = exported.lock().expect("capture lock");
+        let span = exported
+            .iter()
+            .find(|span| span.name == "xmpp.connection.established")
+            .expect("connection span exported");
         assert!(
-            output.contains("\"client.trace_id\":\"0af7651916cd43dd8448eb211c80319c\""),
-            "connection span must expose the linked client trace id: {output}"
+            span.attributes.iter().any(|attribute| {
+                attribute.key.as_str() == "client.trace_id"
+                    && attribute.value.to_string() == "0af7651916cd43dd8448eb211c80319c"
+            }),
+            "connection span must expose the linked client trace id: {:?}",
+            span.attributes,
         );
+        assert_eq!(span.links.len(), 1, "connection span has one client link");
+        let linked = &span.links[0].span_context;
+        assert_eq!(
+            linked.trace_id().to_string(),
+            "0af7651916cd43dd8448eb211c80319c"
+        );
+        assert_eq!(linked.span_id().to_string(), "b7ad6b7169203331");
+        assert!(linked.is_remote());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -4,7 +4,10 @@ use super::{
     isr_resume::handle_isr_resume_authenticate,
     parse_errors::{is_sasl_parse_failure, parse_error_responses},
     resource_binding::handle_resource_binding,
-    sasl::{handle_sasl_oauthbearer, handle_sasl_scram_client_first, handle_sasl_scram_response},
+    sasl::{
+        handle_sasl_oauthbearer, handle_sasl_scram_client_first, handle_sasl_scram_response,
+        record_scram_failure,
+    },
     state::WsConnState,
     stream_management::{handle_sm_stanza, SmCtx},
     transport_xml::{
@@ -12,6 +15,7 @@ use super::{
         websocket_stream_open_xml,
     },
 };
+use crate::server::routes::auth_telemetry::AuthFailure;
 
 /// Handle an XMPP frame per RFC 7395
 pub(super) async fn handle_xmpp_frame(
@@ -92,6 +96,7 @@ async fn handle_xmpp_frame_impl(
         Err(err) => {
             if let Some(responses) = parse_error_responses(frame, &err) {
                 if phase.scram_pending_username().is_some() && is_sasl_parse_failure(frame, &err) {
+                    record_scram_failure(AuthFailure::ScramMalformed, None);
                     let _ = phase.take_scram_pending();
                 }
                 warn!(
@@ -130,6 +135,9 @@ async fn handle_xmpp_frame_impl(
             if !phase.allows_sasl_auth() {
                 let reset_scram_phase = phase.scram_pending_username().is_some();
                 warn!(phase = ?phase, mechanism = %mechanism, "SASL auth received in invalid phase");
+                if mechanism == "SCRAM-SHA-256" {
+                    record_scram_failure(AuthFailure::ScramOther, None);
+                }
                 if reset_scram_phase {
                     let _ = phase.take_scram_pending();
                 }
@@ -202,6 +210,7 @@ async fn handle_xmpp_frame_impl(
         InboundFrame::SaslResponse(data) => {
             if !phase.allows_sasl_response() {
                 warn!(phase = ?phase, "SASL response received in invalid phase");
+                record_scram_failure(AuthFailure::ScramOther, None);
                 return vec![sasl_failure_xml("not-authorized")];
             }
             let scram = phase

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -135,7 +135,7 @@ async fn handle_xmpp_frame_impl(
             if !phase.allows_sasl_auth() {
                 let reset_scram_phase = phase.scram_pending_username().is_some();
                 warn!(phase = ?phase, mechanism = %mechanism, "SASL auth received in invalid phase");
-                if mechanism == "SCRAM-SHA-256" {
+                if reset_scram_phase || mechanism == "SCRAM-SHA-256" {
                     record_scram_failure(AuthFailure::ScramOther, None);
                 }
                 if reset_scram_phase {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use std::future::pending;
+use std::io;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use waddle_xmpp::Stanza;
 use xmpp_parsers::iq::Iq;
@@ -33,6 +35,72 @@ fn iq_result_stanza(id: &str) -> Stanza {
 fn message_stanza() -> Stanza {
     let to: xmpp_parsers::jid::Jid = "bob@example.com".parse().expect("to jid");
     Stanza::Message(Message::new(Some(to)))
+}
+
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn groupchat_dispatch_span_carries_correlation_and_bound_identity_without_body() {
+    let room: xmpp_parsers::jid::Jid = "team@muc.example.com".parse().expect("room jid");
+    let mut message = Message::new(Some(room));
+    message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+    message.id = Some(xmpp_parsers::message::Id("dispatch-correlation-1".into()));
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "sensitive body must not enter telemetry".into(),
+    );
+    let stanza = Stanza::Message(message);
+    let bound: jid::FullJid = "alice@example.com/browser".parse().expect("bound jid");
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_max_level(tracing::Level::INFO)
+        .with_writer(CaptureWriter(Arc::clone(&bytes)))
+        .finish();
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let backstop = StanzaBackstop::capture(&stanza, Some(&bound));
+    run_with_backstop(backstop, async {
+        tracing::info!("dispatch field probe");
+        Vec::new()
+    })
+    .await
+    .expect("dispatch completes");
+
+    let output = String::from_utf8(bytes.lock().expect("capture lock").clone())
+        .expect("captured tracing is UTF-8");
+    for expected in [
+        "\"message_id\":\"dispatch-correlation-1\"",
+        "\"room\":\"team@muc.example.com\"",
+        "\"xmpp.resource\":\"browser\"",
+        "\"user\":\"alice@example.com\"",
+    ] {
+        assert!(output.contains(expected), "missing {expected} in {output}");
+    }
+    assert!(
+        !output.contains("sensitive body must not enter telemetry"),
+        "message bodies must never be tracing fields: {output}"
+    );
 }
 
 fn presence_stanza() -> Stanza {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -27,13 +27,17 @@
 
 use jid::{BareJid, FullJid};
 use waddle_xmpp::muc::room_actor::GetOccupantByJid;
+use waddle_xmpp::telemetry::attributes::{CallSignalEvent, SfuDenialReason};
 use waddle_xmpp::xep::xep0166::NS_JINGLE;
 use waddle_xmpp::xep::xep0272::{find_muji, Muji};
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::jingle::{Action, Jingle};
 use xmpp_parsers::stanza_error::StanzaError;
 
-use super::super::super::cleanup::get_room_actor;
+use super::super::super::call_signaling_telemetry::{
+    record_call_signal, record_sfu_token_denial, CallSignalTarget,
+};
+use super::super::super::cleanup::get_room_actor_result;
 use super::super::super::WebSocketState;
 use super::errors::{bad_request_iq_error, forbidden_iq_error, internal_server_error_iq_error};
 
@@ -100,6 +104,20 @@ pub(super) async fn verify_muji_jingle_request(
             return GateOutcome::Deny(Box::new(bad_request_iq_error("malformed <jingle/> stanza")));
         }
     };
+    let user = full_jid.to_bare();
+    match jingle.action {
+        Action::SessionInitiate => record_call_signal(
+            CallSignalEvent::MujiJoin,
+            &user,
+            Some(CallSignalTarget::Room(&room_jid)),
+        ),
+        Action::SessionTerminate => record_call_signal(
+            CallSignalEvent::MujiLeave,
+            &user,
+            Some(CallSignalTarget::Room(&room_jid)),
+        ),
+        _ => {}
+    }
     if !matches!(jingle.action, Action::SessionInitiate) {
         return GateOutcome::Allow;
     }
@@ -137,10 +155,25 @@ async fn verify_room_membership(
     // through the XEP-0045 path. (The room actor is created on
     // first MUC join; absence means "no one has joined this room
     // in this process's lifetime.")
-    let Some(actor) = get_room_actor(state, room_jid).await else {
-        return GateOutcome::Deny(Box::new(forbidden_iq_error(
-            "not an occupant of the requested room — join the MUC first",
-        )));
+    let actor = match get_room_actor_result(state, room_jid).await {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            record_sfu_token_denial(room_jid, &full_jid.to_bare(), SfuDenialReason::RoomNotFound);
+            return GateOutcome::Deny(Box::new(forbidden_iq_error(
+                "not an occupant of the requested room — join the MUC first",
+            )));
+        }
+        Err(error) => {
+            tracing::debug!(room = %room_jid, error = %error, "Muji gate room lookup failed");
+            record_sfu_token_denial(
+                room_jid,
+                &full_jid.to_bare(),
+                SfuDenialReason::InternalError,
+            );
+            return GateOutcome::Deny(Box::new(internal_server_error_iq_error(
+                "could not verify MUC membership; please retry",
+            )));
+        }
     };
 
     match actor
@@ -150,10 +183,22 @@ async fn verify_room_membership(
         .await
     {
         Ok(Some(_occupant)) => GateOutcome::Allow,
-        Ok(None) => GateOutcome::Deny(Box::new(forbidden_iq_error(
-            "not an occupant of the requested room — join the MUC first",
-        ))),
+        Ok(None) => {
+            record_sfu_token_denial(
+                room_jid,
+                &full_jid.to_bare(),
+                SfuDenialReason::MembershipDenied,
+            );
+            GateOutcome::Deny(Box::new(forbidden_iq_error(
+                "not an occupant of the requested room — join the MUC first",
+            )))
+        }
         Err(_) => {
+            record_sfu_token_denial(
+                room_jid,
+                &full_jid.to_bare(),
+                SfuDenialReason::InternalError,
+            );
             // Actor ask flaked — this is a transient server-side
             // failure, not an authorization decision. RFC 6120
             // §8.3.3 maps "the server could not process the
@@ -172,6 +217,8 @@ async fn verify_room_membership(
 mod tests {
     use super::*;
     use crate::server::routes::websocket::tests::create_test_websocket_state;
+    use std::io;
+    use std::sync::{Arc, Mutex};
     use waddle_xmpp::muc::room_actor::Join;
     use waddle_xmpp::muc::room_registry_actor::CreateInstantRoom;
     use waddle_xmpp::xep::xep0167::MediaKind;
@@ -182,6 +229,31 @@ mod tests {
 
     fn full(s: &str) -> FullJid {
         s.parse().expect("valid full jid")
+    }
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
     }
 
     fn muji_audio() -> Muji {
@@ -283,6 +355,52 @@ mod tests {
             panic!("expected Deny");
         };
         assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn membership_denial_emits_warn_with_bare_jid_and_counter() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let _subscriber = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::WARN)
+                .with_writer(CaptureWriter(buffer.clone()))
+                .finish(),
+        );
+        let state = create_test_websocket_state().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice = full("alice@example.com/web");
+        let mallory = full("mallory@example.com/laptop");
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let outcome = verify_muji_jingle_request(
+            &state,
+            &mallory,
+            &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+        )
+        .await;
+
+        assert!(matches!(outcome, GateOutcome::Deny(_)));
+        assert_eq!(
+            metrics.counter_sum(
+                "waddle.call.sfu_token.denied",
+                &[("reason", "membership_denied")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.call.sfu_token.denied"),
+            Some("1".to_string())
+        );
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are UTF-8");
+        assert!(logs.contains("general@muc.example.com"), "{logs}");
+        assert!(logs.contains("mallory@example.com"), "{logs}");
+        assert!(logs.contains("membership_denied"), "{logs}");
+        assert!(logs.contains("\"level\":\"WARN\""), "{logs}");
+        assert!(logs.contains("SFU token request denied"), "{logs}");
+        assert!(!logs.contains("mallory@example.com/laptop"), "{logs}");
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -170,8 +170,12 @@ async fn verify_room_membership(
                 &full_jid.to_bare(),
                 SfuDenialReason::InternalError,
             );
-            return GateOutcome::Deny(Box::new(internal_server_error_iq_error(
-                "could not verify MUC membership; please retry",
+            // Telemetry records the true cause, but the wire error
+            // stays `forbidden` — the exact shape this path produced
+            // before the telemetry work; changing client-visible
+            // retry semantics is out of scope here.
+            return GateOutcome::Deny(Box::new(forbidden_iq_error(
+                "not an occupant of the requested room — join the MUC first",
             )));
         }
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -3,12 +3,17 @@ use waddle_xmpp::{
     parser::stanza_to_string,
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
-    xep::{NS_DELAY, NS_INBOX, NS_WADDLE_INBOX},
+    telemetry::attributes::CallSignalEvent,
+    xep::xep0353::NS_JINGLE_MESSAGE,
+    xep::{has_hint, Hint, NS_DELAY, NS_INBOX, NS_WADDLE_INBOX},
     Stanza,
 };
 
 use super::super::{
-    interpret_loop::build_interpret_deps, replay::drive_interpret_loop, WebSocketState,
+    call_signaling_telemetry::{record_call_signal, CallSignalTarget},
+    interpret_loop::build_interpret_deps,
+    replay::drive_interpret_loop,
+    WebSocketState,
 };
 use crate::auth::Session;
 use waddle_xmpp::protocol::ConnectionPhase;
@@ -135,6 +140,7 @@ pub async fn handle_message(
             }
         };
     }
+    record_jmi_signal(&incoming, &bound_jid.to_bare());
     if let Some(frames) = handle_muc_direct_message(&incoming, state, &bound_jid).await {
         return frames;
     }
@@ -148,6 +154,35 @@ pub async fn handle_message(
     // only from TransportReady/Tick in the connection loop), and
     // `close` was already ignored on this path — only frames matter.
     drive_interpret_loop(events, sm, &deps).await.frames
+}
+
+fn record_jmi_signal(message: &xmpp_parsers::message::Message, user: &jid::BareJid) {
+    let Some(event) = classify_jmi_signal(message) else {
+        return;
+    };
+    let peer = message.to.as_ref().map(jid::Jid::to_bare);
+    record_call_signal(event, user, peer.as_ref().map(CallSignalTarget::Peer));
+}
+
+fn classify_jmi_signal(message: &xmpp_parsers::message::Message) -> Option<CallSignalEvent> {
+    if message.type_ != xmpp_parsers::message::MessageType::Chat || !has_hint(message, Hint::Store)
+    {
+        return None;
+    }
+
+    let event = message.payloads.iter().find_map(|payload| {
+        if payload.ns() != NS_JINGLE_MESSAGE || payload.attr("id").is_none_or(str::is_empty) {
+            return None;
+        }
+        match payload.name() {
+            "propose" => Some(CallSignalEvent::JmiPropose),
+            "proceed" => Some(CallSignalEvent::JmiProceed),
+            "reject" => Some(CallSignalEvent::JmiReject),
+            "retract" => Some(CallSignalEvent::JmiRetract),
+            _ => None,
+        }
+    });
+    event
 }
 
 fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {
@@ -178,7 +213,7 @@ fn remove_framework_envelopes(message: &mut xmpp_parsers::message::Message) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use xmpp_parsers::message::Message;
+    use xmpp_parsers::message::{Message, MessageType};
     use xmpp_parsers::minidom::Element;
 
     #[test]
@@ -201,5 +236,50 @@ mod tests {
             .payloads
             .iter()
             .any(|payload| payload.ns().starts_with("urn:waddle:")));
+    }
+
+    #[test]
+    fn classifies_conformant_jmi_chat_signal() {
+        let mut message = Message::new(Some(
+            "bob@example.com/phone"
+                .parse::<jid::Jid>()
+                .expect("valid JID"),
+        ));
+        message.payloads.push(
+            Element::builder("proceed", NS_JINGLE_MESSAGE)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "call-1")
+                .build(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_hint_element(Hint::Store));
+
+        assert_eq!(
+            classify_jmi_signal(&message),
+            Some(CallSignalEvent::JmiProceed)
+        );
+    }
+
+    #[test]
+    fn ignores_non_chat_or_malformed_jmi_signal() {
+        let mut message = Message::new(Some(
+            "bob@example.com/phone"
+                .parse::<jid::Jid>()
+                .expect("valid JID"),
+        ));
+        message.type_ = MessageType::Groupchat;
+        message.payloads.push(
+            Element::builder("proceed", NS_JINGLE_MESSAGE)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "call-1")
+                .build(),
+        );
+        message
+            .payloads
+            .push(waddle_xmpp::xep::build_hint_element(Hint::Store));
+        assert_eq!(classify_jmi_signal(&message), None);
+
+        message.type_ = MessageType::Chat;
+        message.payloads[0] = Element::builder("proceed", NS_JINGLE_MESSAGE).build();
+        assert_eq!(classify_jmi_signal(&message), None);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -66,7 +66,12 @@ pub async fn handle_muc_join_with_ordered_relay(
     state: &WebSocketState,
     request: MucJoinRequest<'_>,
 ) -> Vec<String> {
-    info!(room = %request.room_jid, nick = %request.nick, sender = %request.sender_jid, "MUC join request");
+    info!(
+        room = %request.room_jid,
+        nick = %request.nick,
+        user = %request.sender_jid.to_bare(),
+        "MUC join request"
+    );
 
     handle_muc_join_unlocked(
         state,
@@ -614,6 +619,11 @@ mod tests {
 /// attribute (the counter keys on the stanza error condition alone).
 #[derive(Debug, Clone, Copy)]
 enum ManagedAdmissionResolverOutcome {
+    /// Managed-channel lookup failed before the affiliation resolver
+    /// could run.
+    ManagedChannelLookupError,
+    /// Admission failed before the affiliation resolver was consulted.
+    NotConsulted,
     /// The join carried no authenticated session, so the resolver was
     /// never consulted.
     SessionMissing,
@@ -627,67 +637,79 @@ enum ManagedAdmissionResolverOutcome {
     NoAffiliation,
     /// The resolver failed to produce an affiliation (backend error).
     ResolverError,
+    /// The resolver produced an affiliation before a later admission
+    /// step failed.
+    Resolved(Affiliation),
 }
 
 impl ManagedAdmissionResolverOutcome {
     fn as_str(self) -> &'static str {
         match self {
+            Self::ManagedChannelLookupError => "managed-channel-lookup-error",
+            Self::NotConsulted => "not-consulted",
             Self::SessionMissing => "session-missing",
             Self::SessionJidMalformed => "session-jid-malformed",
             Self::Banned => "banned",
             Self::NoAffiliation => "no-affiliation",
             Self::ResolverError => "resolver-error",
+            Self::Resolved(Affiliation::Outcast) => "outcast",
+            Self::Resolved(Affiliation::None) => "none",
+            Self::Resolved(Affiliation::Member) => "member",
+            Self::Resolved(Affiliation::Admin) => "admin",
+            Self::Resolved(Affiliation::Owner) => "owner",
         }
     }
 }
 
-/// The typed descriptor of a single managed-channel admission denial:
-/// the XEP-0045 §7.2 stanza error it maps to plus the diagnostic
-/// context (`members_only`, resolver outcome) recorded on the log.
-struct ManagedAdmissionDenial {
+/// The typed descriptor of a single join-admission denial: the
+/// XEP-0045 §7.2 stanza error it maps to plus the resolver outcome
+/// recorded when the room is a managed channel.
+struct JoinAdmissionDenial {
     /// The RFC 6120 §8.3.3 stanza error condition; the counter keys on
     /// this alone.
     condition: waddle_xmpp::telemetry::attributes::StanzaErrorCondition,
     /// The `<error type=.../>` class carried on the presence error.
     error_type: ErrorType,
-    /// Whether admission treated the channel as members-only.
-    members_only: bool,
     /// What the affiliation/membership resolver reported.
     resolver_outcome: ManagedAdmissionResolverOutcome,
     /// Human-facing `<text/>` on the presence error.
     message: &'static str,
 }
 
-/// Central choke point for managed-channel admission denials (#1315).
+/// Central choke point for join-admission denials covered by #1315.
 ///
 /// Every managed-channel join rejection routes through here so the
 /// denial is never invisible again: it emits one info-level structured
-/// log (bare room JID, bare user JID, condition, `members_only`, and
-/// the resolver outcome) and increments the
+/// log (bare room JID, bare user JID, condition, and resolver outcome)
+/// and increments the
 /// `waddle.muc.admission.denied` counter keyed by the stanza error
 /// condition, then returns the XEP-0045 §7.2 presence-error frame
-/// unchanged. JIDs live on the log only — never as a metric attribute.
-fn deny_managed_channel_admission(
+/// unchanged. Unmanaged joins reuse the typed error builder without
+/// emitting this managed-channel telemetry. JIDs live on the log only
+/// — never as a metric attribute.
+fn deny_join_admission(
     room_jid: &BareJid,
     sender_jid: &FullJid,
     nick: &str,
-    denial: ManagedAdmissionDenial,
+    managed_channel: bool,
+    denial: JoinAdmissionDenial,
 ) -> Vec<String> {
-    info!(
-        room = %room_jid,
-        user = %sender_jid.to_bare(),
-        condition = denial.condition.as_str(),
-        members_only = denial.members_only,
-        resolver_outcome = denial.resolver_outcome.as_str(),
-        "managed-channel admission denied"
-    );
-    waddle_xmpp::counter_add!(
-        "waddle.muc.admission.denied",
-        "{denial}",
-        "Managed-channel admission denials by stanza error condition.",
-        1,
-        denial.condition,
-    );
+    if managed_channel {
+        info!(
+            room = %room_jid,
+            user = %sender_jid.to_bare(),
+            condition = denial.condition.as_str(),
+            resolver_outcome = denial.resolver_outcome.as_str(),
+            "managed-channel admission denied"
+        );
+        waddle_xmpp::counter_add!(
+            "waddle.muc.admission.denied",
+            "1",
+            "Managed-channel admission denials by stanza error condition.",
+            1,
+            denial.condition,
+        );
+    }
     vec![build_muc_presence_error_xml(
         room_jid,
         nick,
@@ -737,17 +759,20 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
             Ok(channel) => channel,
             Err(error) => {
                 warn!(room = %room_jid, error = %error, "Failed to resolve managed MUC channel");
-                return vec![build_muc_presence_error_xml(
+                return deny_join_admission(
                     room_jid,
-                    &nick,
                     sender_jid,
-                    StanzaError::new(
-                        ErrorType::Wait,
-                        DefinedCondition::InternalServerError,
-                        "en",
-                        "Failed to resolve managed channel for room.",
-                    ),
-                )];
+                    &nick,
+                    true,
+                    JoinAdmissionDenial {
+                        condition:
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                        error_type: ErrorType::Wait,
+                        resolver_outcome:
+                            ManagedAdmissionResolverOutcome::ManagedChannelLookupError,
+                        message: "Failed to resolve managed channel for room.",
+                    },
+                );
             }
         };
         let (existing_room_actor, room_preparation_pending) =
@@ -758,17 +783,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 ) => (None, true),
                 Err(error) => {
                     warn!(room = %room_jid, %error, "Failed to look up MUC room before join");
-                    return vec![build_muc_presence_error_xml(
+                    return deny_join_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Wait,
-                            DefinedCondition::InternalServerError,
-                            "en",
-                            "Failed to look up room before join.",
-                        ),
-                    )];
+                        &nick,
+                        managed_channel.is_some(),
+                        JoinAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                            error_type: ErrorType::Wait,
+                            resolver_outcome: ManagedAdmissionResolverOutcome::NotConsulted,
+                            message: "Failed to look up room before join.",
+                        },
+                    );
                 }
             };
         let existing_room_snapshot = if let Some(actor) = existing_room_actor.as_ref() {
@@ -784,17 +811,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         continue;
                     }
                     warn!(room = %room_jid, error = ?error, "Failed to snapshot MUC room before join");
-                    return vec![build_muc_presence_error_xml(
+                    return deny_join_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Wait,
-                            DefinedCondition::InternalServerError,
-                            "en",
-                            "Failed to snapshot room before join.",
-                        ),
-                    )];
+                        &nick,
+                        managed_channel.is_some(),
+                        JoinAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                            error_type: ErrorType::Wait,
+                            resolver_outcome: ManagedAdmissionResolverOutcome::NotConsulted,
+                            message: "Failed to snapshot room before join.",
+                        },
+                    );
                 }
             }
         } else {
@@ -806,15 +835,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
             .unwrap_or(0);
         let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
             let Some(session) = authenticated_session else {
-                return deny_managed_channel_admission(
+                return deny_join_admission(
                     room_jid,
                     sender_jid,
                     &nick,
-                    ManagedAdmissionDenial {
+                    true,
+                    JoinAdmissionDenial {
                         condition:
                             waddle_xmpp::telemetry::attributes::StanzaErrorCondition::NotAuthorized,
                         error_type: ErrorType::Auth,
-                        members_only: channel.members_only,
                         resolver_outcome: ManagedAdmissionResolverOutcome::SessionMissing,
                         message: "Authentication required to join managed channel.",
                     },
@@ -825,15 +854,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 .map(|snapshot| snapshot.room.config.members_only)
                 .unwrap_or(channel.members_only);
             let Ok(session_bare) = session.user_jid.parse::<BareJid>() else {
-                return deny_managed_channel_admission(
+                return deny_join_admission(
                     room_jid,
                     sender_jid,
                     &nick,
-                    ManagedAdmissionDenial {
+                    true,
+                    JoinAdmissionDenial {
                         condition:
                             waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
                         error_type: ErrorType::Wait,
-                        members_only: admission_members_only,
                         resolver_outcome: ManagedAdmissionResolverOutcome::SessionJidMalformed,
                         message: "Failed to resolve managed-channel affiliation.",
                     },
@@ -873,15 +902,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         Affiliation::Outcast,
                         admission_revision,
                     );
-                    return deny_managed_channel_admission(
+                    return deny_join_admission(
                         room_jid,
                         sender_jid,
                         &nick,
-                        ManagedAdmissionDenial {
+                        true,
+                        JoinAdmissionDenial {
                             condition:
                                 waddle_xmpp::telemetry::attributes::StanzaErrorCondition::Forbidden,
                             error_type: ErrorType::Auth,
-                            members_only: admission_members_only,
                             resolver_outcome: ManagedAdmissionResolverOutcome::Banned,
                             message: "Banned from managed channel.",
                         },
@@ -908,15 +937,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                             Affiliation::None,
                             admission_revision,
                         );
-                        return deny_managed_channel_admission(
+                        return deny_join_admission(
                             room_jid,
                             sender_jid,
                             &nick,
-                            ManagedAdmissionDenial {
+                            true,
+                            JoinAdmissionDenial {
                                 condition:
                                     waddle_xmpp::telemetry::attributes::StanzaErrorCondition::RegistrationRequired,
                                 error_type: ErrorType::Auth,
-                                members_only: admission_members_only,
                                 resolver_outcome: ManagedAdmissionResolverOutcome::NoAffiliation,
                                 message: "Membership required to join managed channel.",
                             },
@@ -925,15 +954,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                     Some(Affiliation::None)
                 }
                 Err(()) => {
-                    return deny_managed_channel_admission(
+                    return deny_join_admission(
                         room_jid,
                         sender_jid,
                         &nick,
-                        ManagedAdmissionDenial {
+                        true,
+                        JoinAdmissionDenial {
                             condition:
                                 waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
                             error_type: ErrorType::Wait,
-                            members_only: admission_members_only,
                             resolver_outcome: ManagedAdmissionResolverOutcome::ResolverError,
                             message: "Failed to resolve managed-channel affiliation.",
                         },
@@ -943,6 +972,9 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
         } else {
             None
         };
+        let resolver_outcome = managed_affiliation
+            .map(ManagedAdmissionResolverOutcome::Resolved)
+            .unwrap_or(ManagedAdmissionResolverOutcome::NotConsulted);
 
         let (room_actor, created_instant_room) = match existing_room_actor {
             Some(actor) => (actor, false),
@@ -1116,17 +1148,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                             %error,
                             "Failed to get or create room actor for MUC join"
                         );
-                        return vec![build_muc_presence_error_xml(
+                        return deny_join_admission(
                             room_jid,
-                            &nick,
                             sender_jid,
-                            StanzaError::new(
-                                ErrorType::Wait,
-                                DefinedCondition::InternalServerError,
-                                "en",
-                                "Failed to get or create the room.",
-                            ),
-                        )];
+                            &nick,
+                            managed_channel.is_some(),
+                            JoinAdmissionDenial {
+                                condition:
+                                    waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                                error_type: ErrorType::Wait,
+                                resolver_outcome,
+                                message: "Failed to get or create the room.",
+                            },
+                        );
                     }
                 };
                 // #1134: the created-bit is registry-authoritative —
@@ -1190,17 +1224,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         continue;
                     }
                     warn!(room = %room_jid, nick = %nick, error = ?error, "MUC join failed twice against a destroyed room actor");
-                    return vec![build_muc_presence_error_xml(
+                    return deny_join_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Wait,
-                            DefinedCondition::InternalServerError,
-                            "en",
-                            "Room was evicted while joining; please retry.",
-                        ),
-                    )];
+                        &nick,
+                        managed_channel.is_some(),
+                        JoinAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                            error_type: ErrorType::Wait,
+                            resolver_outcome,
+                            message: "Room was evicted while joining; please retry.",
+                        },
+                    );
                 }
                 let nick_collision = matches!(
                     &error,
@@ -1255,17 +1291,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         stale_admission_retries += 1;
                         continue;
                     }
-                    return vec![build_muc_presence_error_xml(
+                    return deny_join_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(
-                            ErrorType::Wait,
-                            DefinedCondition::InternalServerError,
-                            "en",
-                            "Room admission changed while joining; please retry.",
-                        ),
-                    )];
+                        &nick,
+                        managed_channel.is_some(),
+                        JoinAdmissionDenial {
+                            condition:
+                                waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                            error_type: ErrorType::Wait,
+                            resolver_outcome,
+                            message: "Room admission changed while joining; please retry.",
+                        },
+                    );
                 }
                 if let kameo::error::SendError::HandlerError(
                     waddle_xmpp::muc::room_actor::RoomActorError::JoinForbidden { reason },
@@ -1273,24 +1311,28 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 {
                     // XEP-0045 §7.2.8: bans map to <forbidden/> even in
                     // members-only rooms (#1265 item 1).
-                    let (error_type, condition, message) = match reason {
+                    let (condition, message) = match reason {
                         waddle_xmpp::muc::room_actor::JoinDenialReason::MembersOnly => (
-                            ErrorType::Auth,
-                            DefinedCondition::RegistrationRequired,
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::RegistrationRequired,
                             "Membership required to join this room.",
                         ),
                         waddle_xmpp::muc::room_actor::JoinDenialReason::Banned => (
-                            ErrorType::Auth,
-                            DefinedCondition::Forbidden,
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::Forbidden,
                             "You are banned from this room.",
                         ),
                     };
-                    return vec![build_muc_presence_error_xml(
+                    return deny_join_admission(
                         room_jid,
-                        &nick,
                         sender_jid,
-                        StanzaError::new(error_type, condition, "en", message),
-                    )];
+                        &nick,
+                        managed_channel.is_some(),
+                        JoinAdmissionDenial {
+                            condition,
+                            error_type: ErrorType::Auth,
+                            resolver_outcome,
+                            message,
+                        },
+                    );
                 }
                 // ADR-0017 Phase 3 Slice 7 FIX 4/FIX 6 (council-adjudicated):
                 // this incarnation's durable restore has not (yet) resolved
@@ -1372,17 +1414,19 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 // retry path) — kept as a typed fail-safe so a future
                 // variant can never stall the client with an empty reply.
                 warn!(room = %room_jid, nick = %nick, error = ?error, "Failed to join MUC room");
-                return vec![build_muc_presence_error_xml(
+                return deny_join_admission(
                     room_jid,
-                    &nick,
                     sender_jid,
-                    StanzaError::new(
-                        ErrorType::Wait,
-                        DefinedCondition::InternalServerError,
-                        "en",
-                        "Failed to join the room; please retry.",
-                    ),
-                )];
+                    &nick,
+                    managed_channel.is_some(),
+                    JoinAdmissionDenial {
+                        condition:
+                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                        error_type: ErrorType::Wait,
+                        resolver_outcome,
+                        message: "Failed to join the room; please retry.",
+                    },
+                );
             }
         };
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -691,10 +691,10 @@ fn deny_join_admission(
     room_jid: &BareJid,
     sender_jid: &FullJid,
     nick: &str,
-    managed_channel: bool,
+    managed_channel_confirmed: bool,
     denial: JoinAdmissionDenial,
 ) -> Vec<String> {
-    if managed_channel {
+    if managed_channel_confirmed {
         info!(
             room = %room_jid,
             user = %sender_jid.to_bare(),
@@ -759,14 +759,23 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
             Ok(channel) => channel,
             Err(error) => {
                 warn!(room = %room_jid, error = %error, "Failed to resolve managed MUC channel");
+                let condition =
+                    waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError;
+                info!(
+                    room = %room_jid,
+                    user = %sender_jid.to_bare(),
+                    condition = condition.as_str(),
+                    resolver_outcome =
+                        ManagedAdmissionResolverOutcome::ManagedChannelLookupError.as_str(),
+                    "managed-channel admission denied"
+                );
                 return deny_join_admission(
                     room_jid,
                     sender_jid,
                     &nick,
-                    true,
+                    false,
                     JoinAdmissionDenial {
-                        condition:
-                            waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError,
+                        condition,
                         error_type: ErrorType::Wait,
                         resolver_outcome:
                             ManagedAdmissionResolverOutcome::ManagedChannelLookupError,

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -68,6 +68,7 @@ use waddle_xmpp::auth::ScramServer;
 use waddle_xmpp::pubsub::PubSubStorage;
 
 mod batch_write;
+mod call_signaling_telemetry;
 mod cleanup;
 mod connection;
 mod frame;

--- a/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/sasl.rs
@@ -1,4 +1,8 @@
 use super::transport_xml::{element_to_xml, sasl_failure_xml, sasl_success_xml};
+use crate::server::routes::auth_telemetry::{
+    record_auth_failure, record_auth_success, AuthFailure,
+};
+use waddle_xmpp::telemetry::attributes::AuthStage;
 
 /// Count the failed attempt on `xmpp.auth.attempts` (#1320) and build
 /// the SASL failure frame. Every failure return in this module routes
@@ -6,6 +10,20 @@ use super::transport_xml::{element_to_xml, sasl_failure_xml, sasl_success_xml};
 /// malformed first message) are not invisible to the counter.
 fn sasl_failure_counted(mechanism: &'static str) -> String {
     waddle_xmpp::metrics::record_auth_attempt(mechanism, false);
+    sasl_failure_xml("not-authorized")
+}
+
+fn scram_bare_identifier(username: &str, domain: &str) -> Option<BareJid> {
+    format!("{username}@{domain}").parse().ok()
+}
+
+pub(super) fn record_scram_failure(failure: AuthFailure<'_>, bare_identifier: Option<&BareJid>) {
+    record_auth_failure("native", bare_identifier, failure);
+    waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", false);
+}
+
+fn scram_failure_counted(failure: AuthFailure<'_>, bare_identifier: Option<&BareJid>) -> String {
+    record_scram_failure(failure, bare_identifier);
     sasl_failure_xml("not-authorized")
 }
 use super::*;
@@ -103,17 +121,15 @@ pub(super) async fn handle_sasl_scram_client_first(
 
     let decoded = match BASE64_STANDARD.decode(b64_data.trim()) {
         Ok(data) => data,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: failed to decode base64 client-first");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            return vec![scram_failure_counted(AuthFailure::ScramMalformed, None)];
         }
     };
 
     let client_first = match String::from_utf8(decoded) {
         Ok(s) => s,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: invalid UTF-8 in client-first");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            return vec![scram_failure_counted(AuthFailure::ScramMalformed, None)];
         }
     };
 
@@ -123,9 +139,8 @@ pub(super) async fn handle_sasl_scram_client_first(
         let mut tmp = ScramServer::new();
         match tmp.process_client_first(&client_first) {
             Ok(result) => result.username,
-            Err(e) => {
-                warn!(error = %e, "SCRAM: failed to parse client-first");
-                return vec![sasl_failure_counted("SCRAM-SHA-256")];
+            Err(_) => {
+                return vec![scram_failure_counted(AuthFailure::ScramMalformed, None)];
             }
         }
     };
@@ -140,12 +155,18 @@ pub(super) async fn handle_sasl_scram_client_first(
     {
         Ok(Some(creds)) => creds,
         Ok(None) => {
-            warn!(username = %username, "SCRAM: user not found");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+            let bare_identifier = scram_bare_identifier(&username, domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramUnknownUser,
+                bare_identifier.as_ref(),
+            )];
         }
-        Err(e) => {
-            warn!(error = %e, username = %username, "SCRAM: credential lookup failed");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            let bare_identifier = scram_bare_identifier(&username, domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramOther,
+                bare_identifier.as_ref(),
+            )];
         }
     };
 
@@ -154,9 +175,12 @@ pub(super) async fn handle_sasl_scram_client_first(
     let mut scram_server = ScramServer::with_salt_b64(creds.salt_b64, creds.iterations);
     let server_first = match scram_server.process_client_first(&client_first) {
         Ok(result) => result,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: failed to process client-first with stored params");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            let bare_identifier = scram_bare_identifier(&username, domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramOther,
+                bare_identifier.as_ref(),
+            )];
         }
     };
 
@@ -190,32 +214,34 @@ pub(super) fn handle_sasl_scram_response(
 ) -> Vec<String> {
     let decoded = match BASE64_STANDARD.decode(b64_data.trim()) {
         Ok(data) => data,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: failed to decode base64 client-final");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            let bare_identifier = scram_bare_identifier(scram.username(), domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramMalformed,
+                bare_identifier.as_ref(),
+            )];
         }
     };
 
     let client_final = match String::from_utf8(decoded) {
         Ok(s) => s,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: invalid UTF-8 in client-final");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            let bare_identifier = scram_bare_identifier(scram.username(), domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramMalformed,
+                bare_identifier.as_ref(),
+            )];
         }
     };
 
     let server_final = match scram.process_client_final(&client_final) {
-        Ok(result) => {
-            waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", true);
-            result
-        }
-        Err(e) => {
-            warn!(
-                error = %e,
-                username = %scram.username(),
-                "SCRAM-SHA-256 authentication failed"
-            );
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Ok(result) => result,
+        Err(_) => {
+            let bare_identifier = scram_bare_identifier(scram.username(), domain);
+            return vec![scram_failure_counted(
+                AuthFailure::ScramInvalidCredentials,
+                bare_identifier.as_ref(),
+            )];
         }
     };
 
@@ -223,17 +249,15 @@ pub(super) fn handle_sasl_scram_response(
     let bare_jid_str = format!("{}@{}", scram.username(), domain);
     let full_jid = match format!("{}/pending", bare_jid_str).parse::<FullJid>() {
         Ok(jid) => jid,
-        Err(e) => {
-            warn!(error = %e, jid = %bare_jid_str, "SCRAM: JID construction failed");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            return vec![scram_failure_counted(AuthFailure::ScramOther, None)];
         }
     };
 
     let bare_jid: BareJid = match bare_jid_str.parse() {
         Ok(jid) => jid,
-        Err(e) => {
-            warn!(error = %e, "SCRAM: bare JID parse failed");
-            return vec![sasl_failure_counted("SCRAM-SHA-256")];
+        Err(_) => {
+            return vec![scram_failure_counted(AuthFailure::ScramOther, None)];
         }
     };
 
@@ -241,6 +265,8 @@ pub(super) fn handle_sasl_scram_response(
         jid = %bare_jid_str,
         "SASL SCRAM-SHA-256 authentication successful",
     );
+    waddle_xmpp::metrics::record_auth_attempt("SCRAM-SHA-256", true);
+    record_auth_success(AuthStage::Scram);
 
     let session = Session::new(&bare_jid.to_string(), scram.username(), scram.username());
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
@@ -448,6 +448,54 @@ async fn websocket_failed_reauth_during_scram_resets_phase_and_allows_retry() {
 }
 
 #[tokio::test]
+async fn different_auth_mechanism_aborting_scram_records_scram_failure_metrics() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let state = create_test_websocket_state().await;
+    let domain = state.deps.auth_state.xmpp_domain.clone();
+    register_test_native_user(state.as_ref(), "alice", "correct horse battery staple").await;
+    let client_first = BASE64_STANDARD.encode("n,,n=alice,r=fyko+d2lbbFgONRv9qkxdawL");
+    let scram_auth = element_to_xml(
+        Element::builder("auth", waddle_xmpp::ns::SASL)
+            .attr(
+                minidom::rxml::xml_ncname!("mechanism").to_owned(),
+                "SCRAM-SHA-256",
+            )
+            .append(client_first)
+            .build(),
+    );
+    let different_auth = element_to_xml(
+        Element::builder("auth", waddle_xmpp::ns::SASL)
+            .attr(minidom::rxml::xml_ncname!("mechanism").to_owned(), "PLAIN")
+            .append(BASE64_STANDARD.encode("\0alice\0irrelevant"))
+            .build(),
+    );
+    let mut conn = WsConnState::new();
+
+    let first = handle_xmpp_frame(&scram_auth, &domain, state.as_ref(), &mut conn).await;
+    assert_eq!(first.len(), 1);
+    assert_eq!(conn.phase.scram_pending_username(), Some("alice"));
+
+    let second = handle_xmpp_frame(&different_auth, &domain, state.as_ref(), &mut conn).await;
+
+    assert_eq!(second, vec![sasl_failure_xml("not-authorized")]);
+    assert!(matches!(conn.phase, ConnectionPhase::Unauthenticated));
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.auth.failures",
+            &[("stage", "scram"), ("error_code", "other")]
+        ),
+        Some(1),
+    );
+    assert_eq!(
+        metrics.counter_sum(
+            "xmpp.auth.attempts",
+            &[("mechanism", "SCRAM-SHA-256"), ("result", "failure")]
+        ),
+        Some(1),
+    );
+}
+
+#[tokio::test]
 async fn websocket_resource_bind_returns_client_iq() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1,5 +1,45 @@
 use super::*;
 use crate::permissions::CheckPermission;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer lock")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn captured_logs(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+        .expect("captured logs are valid UTF-8")
+}
+
+fn captured_admission_denial_log(buffer: &Arc<Mutex<Vec<u8>>>) -> String {
+    let logs = captured_logs(buffer);
+    logs.lines()
+        .find(|line| line.contains("managed-channel admission denied"))
+        .unwrap_or_else(|| panic!("managed-channel admission denial log not found in:\n{logs}"))
+        .to_string()
+}
 
 fn expected_local_room_fence(
     room_jid: &BareJid,
@@ -1097,6 +1137,178 @@ async fn managed_registration_required_denial_increments_admission_counter() {
     assert!(
         get_room_actor(state.as_ref(), &room_jid).await.is_none(),
         "denied members-only join must not create the room actor"
+    );
+}
+
+/// #1315: an unauthenticated managed-channel join is rejected with
+/// `<not-authorized/>`; the denial must be counted and logged at INFO
+/// without exposing the joining resource in the denial event's user field.
+#[tokio::test(flavor = "current_thread")]
+async fn managed_not_authorized_denial_emits_admission_telemetry() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CaptureWriter(buffer.clone()))
+            .finish(),
+    );
+    let state = create_test_websocket_state().await;
+    let room_jid: BareJid = "private-space@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "private-space".to_string(),
+            name: "Private Space".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: true,
+            public_room: false,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("not-authorized"),
+        "unauthenticated managed-channel join must be not-authorized: {denied:?}"
+    );
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.muc.admission.denied",
+            &[("condition", "not-authorized")]
+        ),
+        Some(1),
+        "the not-authorized admission denial must increment the counter exactly once"
+    );
+    assert_eq!(
+        metrics.metric_unit("waddle.muc.admission.denied"),
+        Some("1".to_string()),
+        "the admission denial counter must use the dimensionless unit"
+    );
+
+    let denial_log = captured_admission_denial_log(&buffer);
+    assert!(denial_log.contains("\"level\":\"INFO\""), "{denial_log}");
+    assert!(
+        denial_log.contains("\"room\":\"private-space@muc.example.com\""),
+        "{denial_log}"
+    );
+    assert!(
+        denial_log.contains("\"user\":\"alice@example.com\""),
+        "{denial_log}"
+    );
+    let all_logs = captured_logs(&buffer);
+    assert!(!all_logs.contains("alice@example.com/web"), "{all_logs}");
+    assert!(
+        denial_log.contains("\"condition\":\"not-authorized\""),
+        "{denial_log}"
+    );
+    assert!(
+        denial_log.contains("\"resolver_outcome\":\"session-missing\""),
+        "{denial_log}"
+    );
+}
+
+/// #1315: malformed authenticated-session identity is an internal
+/// managed-channel admission failure. It must emit the same condition-only
+/// counter and bare-JID INFO fields as policy denials.
+#[tokio::test(flavor = "current_thread")]
+async fn managed_internal_server_error_denial_emits_admission_telemetry() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CaptureWriter(buffer.clone()))
+            .finish(),
+    );
+    let state = create_test_websocket_state().await;
+    let malformed_session = crate::auth::Session::new("not a jid", "alice", "alice");
+    let room_jid: BareJid = "resolver-failure@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "resolver-failure".to_string(),
+            name: "Resolver Failure".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: true,
+            public_room: false,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(malformed_session),
+    )
+    .await;
+
+    assert_eq!(denied.len(), 1);
+    assert!(
+        denied[0].contains("internal-server-error"),
+        "malformed managed-channel identity must fail closed: {denied:?}"
+    );
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.muc.admission.denied",
+            &[("condition", "internal-server-error")]
+        ),
+        Some(1),
+        "the internal-server-error admission denial must increment the counter exactly once"
+    );
+
+    let denial_log = captured_admission_denial_log(&buffer);
+    assert!(denial_log.contains("\"level\":\"INFO\""), "{denial_log}");
+    assert!(
+        denial_log.contains("\"room\":\"resolver-failure@muc.example.com\""),
+        "{denial_log}"
+    );
+    assert!(
+        denial_log.contains("\"user\":\"alice@example.com\""),
+        "{denial_log}"
+    );
+    let all_logs = captured_logs(&buffer);
+    assert!(!all_logs.contains("alice@example.com/web"), "{all_logs}");
+    assert!(
+        denial_log.contains("\"condition\":\"internal-server-error\""),
+        "{denial_log}"
+    );
+    assert!(
+        denial_log.contains("\"resolver_outcome\":\"session-jid-malformed\""),
+        "{denial_log}"
     );
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1312,6 +1312,52 @@ async fn managed_internal_server_error_denial_emits_admission_telemetry() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn managed_channel_lookup_failure_is_logged_but_not_counted_as_a_denial() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(CaptureWriter(buffer.clone()))
+            .finish(),
+    );
+    let state = create_test_websocket_state().await;
+    let room_jid: BareJid = "lookup-failure@muc.example.com".parse().expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    state.deps.app_state.db_pool.global_actor().kill();
+    tokio::task::yield_now().await;
+
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &None,
+    )
+    .await;
+
+    assert_eq!(denied.len(), 1);
+    assert!(denied[0].contains("internal-server-error"), "{denied:?}");
+    assert_eq!(
+        metrics
+            .counter_sum("waddle.muc.admission.denied", &[])
+            .unwrap_or(0),
+        0,
+        "an unresolved managed status must not count as a managed-channel denial"
+    );
+
+    let denial_log = captured_admission_denial_log(&buffer);
+    assert!(
+        denial_log.contains("\"resolver_outcome\":\"managed-channel-lookup-error\""),
+        "{denial_log}"
+    );
+}
+
 /// #1315: a channel-banned (outcast) joiner is rejected with
 /// `<forbidden/>` per XEP-0045 §7.2.8, even in an open room. The
 /// denial must be counted under the `forbidden` condition through the

--- a/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
+++ b/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
@@ -1,6 +1,7 @@
 //! XMPP OAuth routes (XEP-0493) backed by the auth broker.
 
 use super::auth::{AuthState, ErrorResponse, PendingFlow};
+use super::auth_telemetry::{record_auth_failure, record_auth_success, AuthFailure};
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -12,7 +13,8 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument};
+use waddle_xmpp::telemetry::attributes::AuthStage;
 
 pub fn router(auth_state: Arc<AuthState>) -> Router {
     Router::new()
@@ -72,12 +74,13 @@ fn default_response_type() -> String {
     "code".to_string()
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, params))]
 pub async fn xmpp_authorize_handler(
     State(state): State<Arc<AuthState>>,
     Query(params): Query<XmppAuthorizeQuery>,
 ) -> impl IntoResponse {
     if params.response_type != "code" {
+        record_auth_failure("unknown", None, AuthFailure::AuthorizationMalformed);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -90,6 +93,7 @@ pub async fn xmpp_authorize_handler(
 
     if let Some(method) = params.code_challenge_method.as_deref() {
         if method != "S256" {
+            record_auth_failure("unknown", None, AuthFailure::AuthorizationMalformed);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -108,6 +112,7 @@ pub async fn xmpp_authorize_handler(
             if let Some(default) = list.first() {
                 default.id.clone()
             } else {
+                record_auth_failure("unknown", None, AuthFailure::AuthorizationInvalidClient);
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(ErrorResponse::new(
@@ -123,6 +128,7 @@ pub async fn xmpp_authorize_handler(
     let provider = match state.providers.get(&provider_id) {
         Some(v) => v,
         None => {
+            record_auth_failure("unknown", None, AuthFailure::AuthorizationInvalidClient);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new("invalid_provider", "Unknown provider")),
@@ -142,12 +148,22 @@ pub async fn xmpp_authorize_handler(
         )
         .await
     {
-        Ok(url) => Redirect::temporary(&url).into_response(),
-        Err(err) => (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse::new("authorization_failed", &err.to_string())),
-        )
-            .into_response(),
+        Ok(url) => {
+            record_auth_success(AuthStage::OidcAuthorization);
+            Redirect::temporary(&url).into_response()
+        }
+        Err(err) => {
+            record_auth_failure(
+                &provider.id,
+                None,
+                AuthFailure::from_error(AuthStage::OidcAuthorization, &err),
+            );
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new("authorization_failed", &err.to_string())),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -173,12 +189,13 @@ fn pkce_s256(verifier: &str) -> String {
     URL_SAFE_NO_PAD.encode(digest)
 }
 
-#[instrument(skip(state))]
+#[instrument(skip(state, request))]
 pub async fn xmpp_token_handler(
     State(state): State<Arc<AuthState>>,
     Form(request): Form<XmppTokenRequest>,
 ) -> impl IntoResponse {
     if request.grant_type != "authorization_code" {
+        record_auth_failure("waddle", None, AuthFailure::TokenMalformed);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -192,6 +209,7 @@ pub async fn xmpp_token_handler(
     let code = match state.auth_handshake.take_xmpp_code(&request.code).await {
         Ok(Some(code)) => code,
         Ok(None) => {
+            record_auth_failure("waddle", None, AuthFailure::TokenInvalidCode);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -202,6 +220,11 @@ pub async fn xmpp_token_handler(
                 .into_response();
         }
         Err(err) => {
+            record_auth_failure(
+                "waddle",
+                None,
+                AuthFailure::from_error(AuthStage::TokenExchange, &err),
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -211,6 +234,7 @@ pub async fn xmpp_token_handler(
     };
 
     if code.is_expired() {
+        record_auth_failure("waddle", None, AuthFailure::TokenExpired);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -222,6 +246,7 @@ pub async fn xmpp_token_handler(
     }
 
     if code.redirect_uri != request.redirect_uri {
+        record_auth_failure("waddle", None, AuthFailure::TokenInvalidGrant);
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new("invalid_grant", "redirect_uri mismatch")),
@@ -231,6 +256,7 @@ pub async fn xmpp_token_handler(
 
     if let Some(challenge) = code.code_challenge.as_deref() {
         let Some(verifier) = request.code_verifier.as_deref() else {
+            record_auth_failure("waddle", None, AuthFailure::TokenMalformed);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -242,7 +268,7 @@ pub async fn xmpp_token_handler(
         };
 
         if pkce_s256(verifier) != challenge {
-            warn!("XMPP token exchange failed PKCE verification");
+            record_auth_failure("waddle", None, AuthFailure::TokenInvalidGrant);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -257,6 +283,7 @@ pub async fn xmpp_token_handler(
     let session = match state.session_manager.get_session(&code.session_id).await {
         Ok(Some(s)) => s,
         Ok(None) => {
+            record_auth_failure("waddle", None, AuthFailure::TokenInvalidGrant);
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new("invalid_grant", "Session not found")),
@@ -264,6 +291,11 @@ pub async fn xmpp_token_handler(
                 .into_response();
         }
         Err(err) => {
+            record_auth_failure(
+                "waddle",
+                None,
+                AuthFailure::from_error(AuthStage::TokenExchange, &err),
+            );
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("server_error", &err.to_string())),
@@ -277,6 +309,7 @@ pub async fn xmpp_token_handler(
         username = %session.username,
         "Issued XMPP OAuth bearer token"
     );
+    record_auth_success(AuthStage::TokenExchange);
 
     (
         StatusCode::OK,

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -582,6 +582,7 @@ async fn http_request_metrics_use_route_template_and_status_class() {
     let raw_path = "/api/files/nonexistent/private-filename.txt";
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri(raw_path)
@@ -613,6 +614,29 @@ async fn http_request_metrics_use_route_template_and_status_class() {
     assert_eq!(
         metrics.metric_unit("http.server.request.duration"),
         Some("s".to_string()),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/health")
+                .header(header::ORIGIN, "https://waddle.chat")
+                .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        metrics.histogram_count(
+            "http.server.request.duration",
+            &[("route", "/health"), ("status_class", "2xx")],
+        ),
+        Some(1),
+        "CORS preflights must be observed like every other matched request",
     );
 }
 

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -576,6 +576,47 @@ async fn test_health_endpoint() {
 }
 
 #[tokio::test]
+async fn http_request_metrics_use_route_template_and_status_class() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let app = test_app().await;
+    let raw_path = "/api/files/nonexistent/private-filename.txt";
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(raw_path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        metrics.histogram_count(
+            "http.server.request.duration",
+            &[
+                ("route", "/api/files/{slot_id}/{filename}"),
+                ("status_class", "4xx"),
+            ],
+        ),
+        Some(1),
+    );
+    assert_eq!(
+        metrics.histogram_count(
+            "http.server.request.duration",
+            &[("route", raw_path), ("status_class", "4xx")],
+        ),
+        Some(0),
+        "raw request paths must never become metric labels",
+    );
+    assert_eq!(
+        metrics.metric_unit("http.server.request.duration"),
+        Some("s".to_string()),
+    );
+}
+
+#[tokio::test]
 async fn test_healthz_alias_endpoint() {
     let app = test_app().await;
 

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -129,9 +129,11 @@ fn matched_route_template(request: &Request<Body>) -> Option<&'static str> {
 /// on the connection-scoped span (links, not parenting — the
 /// connection outlives the browser's connect span).
 ///
-/// Strictly parsed W3C version-00 trace parent supplied by the browser.
-/// Keeping this typed until the OpenTelemetry boundary prevents raw query
-/// strings from flowing through connection state or tracing call sites.
+/// Strictly parsed W3C trace parent supplied by the browser. Version `00`
+/// must have exactly four fields; future versions retain the version-00 field
+/// lengths and may append opaque extension fields. Keeping this typed until
+/// the OpenTelemetry boundary prevents raw query strings from flowing through
+/// connection state or tracing call sites.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ClientTraceParent {
     trace_id: TraceId,
@@ -155,7 +157,7 @@ impl ClientTraceParent {
     }
 }
 
-/// Returns `None` for absent, malformed, non-version-00, uppercase, short, or
+/// Returns `None` for absent, malformed, version `ff`, uppercase, short, or
 /// all-zero ids. Invalid client input is deliberately ignored rather than
 /// affecting the WebSocket upgrade response.
 pub(crate) fn client_trace_parent_from_query(query: Option<&str>) -> Option<ClientTraceParent> {
@@ -167,8 +169,10 @@ pub(crate) fn client_trace_parent_from_query(query: Option<&str>) -> Option<Clie
     let trace_id_field = parts.next()?;
     let parent_id_field = parts.next()?;
     let flags_field = parts.next()?;
-    if parts.next().is_some()
-        || version != "00"
+    let has_extension = parts.next().is_some();
+    if !is_lower_hex(version, 2)
+        || version == "ff"
+        || (version == "00" && has_extension)
         || !is_lower_hex(trace_id_field, 32)
         || !is_lower_hex(parent_id_field, 16)
         || !is_lower_hex(flags_field, 2)
@@ -379,8 +383,6 @@ mod tests {
             Some("traceparent=00-0AF7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-B7ad6b7169203331-01"),
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0A"),
-            // Version 00 must have exactly four fields.
-            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra"),
             // Flags must be exactly two hex digits.
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0"),
         ] {
@@ -392,12 +394,37 @@ mod tests {
     }
 
     #[test]
-    fn wrong_traceparent_version_is_rejected() {
-        for version in ["01", "fe", "ff"] {
-            let query = format!(
-                "traceparent={version}-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-            );
-            assert!(client_trace_parent_from_query(Some(&query)).is_none());
+    fn higher_traceparent_version_is_accepted() {
+        assert!(client_trace_parent_from_query(Some(
+            "traceparent=01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        ))
+        .is_some());
+    }
+
+    #[test]
+    fn traceparent_version_ff_is_rejected() {
+        assert!(client_trace_parent_from_query(Some(
+            "traceparent=ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn version_zero_traceparent_with_extras_is_rejected() {
+        assert!(client_trace_parent_from_query(Some(
+            "traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn higher_version_traceparent_with_extras_is_accepted() {
+        for query in [
+            "traceparent=02-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-vendor-field",
+            "traceparent=02-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-",
+            "traceparent=02-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01--opaque",
+        ] {
+            assert!(client_trace_parent_from_query(Some(query)).is_some());
         }
     }
 

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -1,7 +1,5 @@
 use axum::http::Uri;
-use opentelemetry::trace::{
-    SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
-};
+use opentelemetry::trace::{SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState};
 use opentelemetry_http::HeaderExtractor;
 use tracing::{info_span, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -1,5 +1,7 @@
 use axum::http::Uri;
-use opentelemetry::trace::TraceContextExt;
+use opentelemetry::trace::{
+    SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+};
 use opentelemetry_http::HeaderExtractor;
 use tracing::{info_span, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -39,50 +41,70 @@ pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>)
 /// on the connection-scoped span (links, not parenting — the
 /// connection outlives the browser's connect span).
 ///
-/// Returns `None` for absent, malformed, or all-zero ids — a garbage
-/// value from a client must never poison the server span.
-pub(crate) fn client_trace_context_from_query(
-    query: Option<&str>,
-) -> Option<opentelemetry::trace::SpanContext> {
-    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
+/// Strictly parsed W3C version-00 trace parent supplied by the browser.
+/// Keeping this typed until the OpenTelemetry boundary prevents raw query
+/// strings from flowing through connection state or tracing call sites.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ClientTraceParent {
+    trace_id: TraceId,
+    parent_id: SpanId,
+    flags: TraceFlags,
+}
 
+impl ClientTraceParent {
+    pub(crate) fn trace_id(self) -> TraceId {
+        self.trace_id
+    }
+
+    pub(crate) fn remote_span_context(self) -> SpanContext {
+        SpanContext::new(
+            self.trace_id,
+            self.parent_id,
+            self.flags,
+            true,
+            TraceState::default(),
+        )
+    }
+}
+
+/// Returns `None` for absent, malformed, non-version-00, uppercase, short, or
+/// all-zero ids. Invalid client input is deliberately ignored rather than
+/// affecting the WebSocket upgrade response.
+pub(crate) fn client_trace_parent_from_query(query: Option<&str>) -> Option<ClientTraceParent> {
     let traceparent = query?
         .split('&')
         .find_map(|pair| pair.strip_prefix("traceparent="))?;
     let mut parts = traceparent.split('-');
     let version = parts.next()?;
-    let trace_id = TraceId::from_hex(parts.next()?).ok()?;
-    let span_id = SpanId::from_hex(parts.next()?).ok()?;
+    let trace_id_field = parts.next()?;
+    let parent_id_field = parts.next()?;
     let flags_field = parts.next()?;
-    if flags_field.len() != 2 {
-        return None;
-    }
-    let flags = u8::from_str_radix(flags_field, 16).ok()?;
-    // W3C trace-context: the version is exactly two lowercase hex
-    // digits and 0xff is forbidden; version 00 has exactly four
-    // fields (higher versions may append more, which we accept after
-    // a parseable 00-shaped prefix).
-    if version.len() != 2
-        || !version
-            .bytes()
-            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-        || version == "ff"
+    if parts.next().is_some()
+        || version != "00"
+        || !is_lower_hex(trace_id_field, 32)
+        || !is_lower_hex(parent_id_field, 16)
+        || !is_lower_hex(flags_field, 2)
     {
         return None;
     }
-    if version == "00" && parts.next().is_some() {
+    let trace_id = TraceId::from_hex(trace_id_field).ok()?;
+    let parent_id = SpanId::from_hex(parent_id_field).ok()?;
+    let flags = u8::from_str_radix(flags_field, 16).ok()?;
+    if trace_id == TraceId::INVALID || parent_id == SpanId::INVALID {
         return None;
     }
-    if trace_id == TraceId::INVALID || span_id == SpanId::INVALID {
-        return None;
-    }
-    Some(SpanContext::new(
+    Some(ClientTraceParent {
         trace_id,
-        span_id,
-        TraceFlags::new(flags),
-        true,
-        TraceState::default(),
-    ))
+        parent_id,
+        flags: TraceFlags::new(flags),
+    })
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn redacted_request_uri(uri: &Uri) -> String {
@@ -116,11 +138,12 @@ mod tests {
     }
 
     #[test]
-    fn traceparent_query_parses_to_remote_span_context() {
-        let context = client_trace_context_from_query(Some(
+    fn traceparent_query_parses_to_typed_remote_parent() {
+        let parent = client_trace_parent_from_query(Some(
             "protocol=xmpp&traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
         ))
         .expect("valid traceparent must parse");
+        let context = parent.remote_span_context();
         assert_eq!(
             context.trace_id().to_string(),
             "0af7651916cd43dd8448eb211c80319c"
@@ -131,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn garbage_or_zero_traceparent_is_rejected() {
+    fn malformed_or_zero_traceparent_is_rejected() {
         for query in [
             None,
             Some(""),
@@ -139,19 +162,42 @@ mod tests {
             Some("traceparent=nonsense"),
             Some("traceparent=00-00000000000000000000000000000000-b7ad6b7169203331-01"),
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01"),
-            Some("traceparent=ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
-            // Non-hex / uppercase version bytes are rejected outright.
+            // Non-hex / uppercase bytes are rejected outright.
             Some("traceparent=zz-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
             Some("traceparent=0F-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            Some("traceparent=00-0AF7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-B7ad6b7169203331-01"),
+            Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0A"),
             // Version 00 must have exactly four fields.
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra"),
             // Flags must be exactly two hex digits.
             Some("traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-0"),
         ] {
             assert!(
-                client_trace_context_from_query(query).is_none(),
+                client_trace_parent_from_query(query).is_none(),
                 "must reject {query:?}"
             );
+        }
+    }
+
+    #[test]
+    fn wrong_traceparent_version_is_rejected() {
+        for version in ["01", "fe", "ff"] {
+            let query = format!(
+                "traceparent={version}-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+            );
+            assert!(client_trace_parent_from_query(Some(&query)).is_none());
+        }
+    }
+
+    #[test]
+    fn short_traceparent_fields_are_rejected() {
+        for query in [
+            "traceparent=00-af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "traceparent=00-0af7651916cd43dd8448eb211c80319c-7ad6b7169203331-01",
+            "traceparent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-1",
+        ] {
+            assert!(client_trace_parent_from_query(Some(query)).is_none());
         }
     }
 

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -1,8 +1,53 @@
-use axum::http::Uri;
+use std::time::Duration;
+
+use axum::{
+    body::Body,
+    extract::MatchedPath,
+    http::{Request, Response, Uri},
+    middleware::Next,
+    response::Response as AxumResponse,
+};
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry_http::HeaderExtractor;
-use tracing::{info_span, Span};
+use tower_http::trace::{DefaultOnResponse, OnResponse};
+use tracing::{field, info_span, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+use waddle_xmpp::telemetry::attributes::{HttpRouteTemplate, HttpStatusClass};
+
+const HTTP_ROUTE_TEMPLATES: &[&str] = &[
+    "/health",
+    "/healthz",
+    "/ready",
+    "/readyz",
+    "/metrics",
+    "/api/v1/health",
+    "/.well-known/acme-challenge/{challenge_token}",
+    "/api/auth/providers",
+    "/api/auth/start",
+    "/api/auth/callback",
+    "/api/auth/session",
+    "/api/auth/logout",
+    "/api/auth/device/start",
+    "/api/auth/device/poll",
+    "/api/auth/device/verify",
+    "/.well-known/oauth-authorization-server",
+    "/api/auth/xmpp/authorize",
+    "/api/auth/xmpp/token",
+    "/auth",
+    "/auth/start",
+    "/auth/callback",
+    "/webhooks/providers/{provider_id}/{plugin_id}",
+    "/api/v1/livekit/webhook",
+    "/api/calendar/community-feed-url",
+    "/api/calendar/community/{token}/events.ics",
+    "/api/test/profile-publish",
+    "/debug/state-inventory",
+    "/ws",
+    "/.well-known/host-meta",
+    "/.well-known/host-meta.json",
+    "/api/upload/{slot_id}",
+    "/api/files/{slot_id}/{filename}",
+];
 
 /// Build the per-request `tracing` span and attach the inbound W3C
 /// trace context (if any) as its OpenTelemetry parent.
@@ -15,13 +60,18 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 /// caller carrying no headers — the latter keeps starting a fresh
 /// root span instead of being silently re-parented to whatever the
 /// extractor returns for the empty case.
-pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>) -> Span {
+pub(crate) fn make_request_span(request: &Request<Body>) -> Span {
     let span = info_span!(
         "http_request",
         method = %request.method(),
         uri = %redacted_request_uri(request.uri()),
         version = ?request.version(),
+        http.route = field::Empty,
+        http.status_code = field::Empty,
     );
+    if let Some(route) = matched_route_template(request) {
+        span.record("http.route", route);
+    }
     let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.extract(&HeaderExtractor(request.headers()))
     });
@@ -29,6 +79,46 @@ pub(crate) fn make_request_span(request: &axum::http::Request<axum::body::Body>)
         let _ = span.set_parent(parent_cx);
     }
     span
+}
+
+/// Carry the bounded route label from the matched request into the response,
+/// where tower-http supplies the final status and elapsed request time.
+pub(crate) async fn attach_http_route_template(request: Request<Body>, next: Next) -> AxumResponse {
+    let route = matched_route_template(&request).map(HttpRouteTemplate::new);
+    let mut response = next.run(request).await;
+    if let Some(route) = route {
+        response.extensions_mut().insert(route);
+    }
+    response
+}
+
+/// Add response-only span fields and record the request-duration sample.
+pub(crate) fn observe_http_response<B>(response: &Response<B>, latency: Duration, span: &Span) {
+    let status = response.status().as_u16();
+    span.record("http.status_code", i64::from(status));
+
+    if let Some(route) = response.extensions().get::<HttpRouteTemplate>() {
+        waddle_xmpp::histogram_record!(
+            "http.server.request.duration",
+            "s",
+            "HTTP server request duration.",
+            latency.as_secs_f64(),
+            *route,
+            HttpStatusClass::from_status(status),
+        );
+    }
+
+    DefaultOnResponse::new()
+        .level(Level::INFO)
+        .on_response(response, latency, span);
+}
+
+fn matched_route_template(request: &Request<Body>) -> Option<&'static str> {
+    let matched = request.extensions().get::<MatchedPath>()?.as_str();
+    HTTP_ROUTE_TEMPLATES
+        .iter()
+        .copied()
+        .find(|template| *template == matched)
 }
 
 /// Parse a W3C `traceparent` value carried as a WebSocket-upgrade

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -191,7 +191,130 @@ fn redacted_request_uri(uri: &Uri) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::BTreeMap,
+        fmt,
+        sync::{Arc, Mutex},
+    };
+
+    use axum::{routing::get, Router};
+    use tower::ServiceExt;
+    use tower_http::trace::TraceLayer;
+    use tracing::{
+        field::{Field, Visit},
+        span::{Attributes, Id, Record},
+        Subscriber,
+    };
+    use tracing_subscriber::{layer::Context, prelude::*, registry::LookupSpan, Layer};
+
     use super::*;
+
+    #[derive(Clone, Default)]
+    struct HttpSpanCapture {
+        fields: Arc<Mutex<BTreeMap<String, String>>>,
+    }
+
+    impl HttpSpanCapture {
+        fn record(&self, values: impl FnOnce(&mut HttpSpanVisitor<'_>)) {
+            let mut fields = self.fields.lock().expect("HTTP span capture lock");
+            values(&mut HttpSpanVisitor {
+                fields: &mut fields,
+            });
+        }
+    }
+
+    struct HttpSpanVisitor<'a> {
+        fields: &'a mut BTreeMap<String, String>,
+    }
+
+    impl Visit for HttpSpanVisitor<'_> {
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for HttpSpanCapture
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attributes: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+            if attributes.metadata().name() == "http_request" {
+                self.record(|visitor| attributes.record(visitor));
+            }
+        }
+
+        fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+            let is_http_request = ctx
+                .span(id)
+                .is_some_and(|span| span.metadata().name() == "http_request");
+            if is_http_request {
+                self.record(|visitor| values.record(visitor));
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_span_records_route_status_and_redacted_uri() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let capture = HttpSpanCapture::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+        let app = Router::new()
+            .route(
+                "/api/calendar/community/{token}/events.ics",
+                get(|| async { axum::http::StatusCode::UNAUTHORIZED }),
+            )
+            .layer(axum::middleware::from_fn(attach_http_route_template))
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(make_request_span)
+                    .on_response(observe_http_response),
+            );
+        let sensitive_token = "sensitive-calendar-token";
+        let raw_uri = format!("/api/calendar/community/{sensitive_token}/events.ics");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(&raw_uri)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+        let fields = capture.fields.lock().expect("HTTP span capture lock");
+        assert_eq!(
+            fields.get("http.route").map(String::as_str),
+            Some("/api/calendar/community/{token}/events.ics"),
+        );
+        assert_eq!(
+            fields.get("http.status_code").map(String::as_str),
+            Some("401"),
+        );
+        assert_eq!(
+            fields.get("uri").map(String::as_str),
+            Some("/api/calendar/community/:token/events.ics"),
+        );
+        assert!(
+            fields
+                .values()
+                .all(|value| !value.contains(sensitive_token)),
+            "request span must not expose the raw calendar token: {fields:?}",
+        );
+    }
 
     #[test]
     fn calendar_feed_token_is_redacted_from_request_uri() {

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -132,16 +132,14 @@ pub async fn promote_session_unacked(
     for entry in &session.unacked_stanzas {
         let stanza = parse_stanza(&entry.stanza_xml);
         let message_id = match &stanza {
-            Some(Stanza::Message(message)) => {
-                message.id.as_ref().map_or("", |id| id.0.as_str())
-            }
-            Some(Stanza::Iq(_)) | Some(Stanza::Presence(_)) | None => "",
+            Some(Stanza::Message(message)) => message.id.clone(),
+            Some(Stanza::Iq(_)) | Some(Stanza::Presence(_)) | None => None,
         };
         if tombstoned_sequences.contains(&entry.sequence) {
             debug!(
                 stream_id = %session.stream_id,
                 sequence = entry.sequence,
-                message_id,
+                message_id = message_id.as_ref().map_or("", |id| id.0.as_str()),
                 "Q6 promotion: stanza matches a recent tombstone; scrubbed"
             );
             summary.record(entry.sequence, &PromotedOutcome::Scrubbed);
@@ -168,7 +166,7 @@ pub async fn promote_session_unacked(
         debug!(
             stream_id = %session.stream_id,
             sequence = entry.sequence,
-            message_id,
+            message_id = message_id.as_ref().map_or("", |id| id.0.as_str()),
             ?outcome,
             "Q6 promotion: per-stanza outcome"
         );

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -130,16 +130,24 @@ pub async fn promote_session_unacked(
     };
 
     for entry in &session.unacked_stanzas {
+        let stanza = parse_stanza(&entry.stanza_xml);
+        let message_id = match &stanza {
+            Some(Stanza::Message(message)) => {
+                message.id.as_ref().map_or("", |id| id.0.as_str())
+            }
+            Some(Stanza::Iq(_)) | Some(Stanza::Presence(_)) | None => "",
+        };
         if tombstoned_sequences.contains(&entry.sequence) {
             debug!(
                 stream_id = %session.stream_id,
                 sequence = entry.sequence,
+                message_id,
                 "Q6 promotion: stanza matches a recent tombstone; scrubbed"
             );
             summary.record(entry.sequence, &PromotedOutcome::Scrubbed);
             continue;
         }
-        let outcome = match parse_stanza(&entry.stanza_xml) {
+        let outcome = match stanza {
             Some(Stanza::Message(message)) => {
                 let ctx = PromotionContext {
                     online: &online,
@@ -160,6 +168,7 @@ pub async fn promote_session_unacked(
         debug!(
             stream_id = %session.stream_id,
             sequence = entry.sequence,
+            message_id,
             ?outcome,
             "Q6 promotion: per-stanza outcome"
         );

--- a/server/crates/waddle-server/src/sm_promotion/pending.rs
+++ b/server/crates/waddle-server/src/sm_promotion/pending.rs
@@ -94,6 +94,7 @@ pub(super) async fn insert_pending(
             // node's own promote/confirm pass, never dead-lettered here.
             warn!(
                 recipient = %recipient,
+                message_id = original_message.id.as_ref().map_or("", |id| id.0.as_str()),
                 %entity,
                 "Q6 promotion: pending_delivery insert_fenced observed a lost claim \
                  (NotOwner); caller must NOT confirm_drained so the durable SM row \
@@ -104,6 +105,7 @@ pub(super) async fn insert_pending(
         Err(error) => {
             warn!(
                 recipient = %recipient,
+                message_id = original_message.id.as_ref().map_or("", |id| id.0.as_str()),
                 error = %error,
                 "Q6 promotion: pending_delivery insert failed; \
                  caller must NOT confirm_drained so durable SM row survives \
@@ -162,6 +164,7 @@ async fn send_quota_bounce(
         warn!(
             recipient = %recipient,
             sender = %sender_jid,
+            message_id = original_message.id.as_ref().map_or("", |id| id.0.as_str()),
             "Q6 promotion: <service-unavailable/> bounce was not deliverable \
              (remote sender or no bound resource) — XEP-0160 §3 step 3 \
              conformance gap until s2s lands"

--- a/server/crates/waddle-server/tests/notification_outbox/worker.rs
+++ b/server/crates/waddle-server/tests/notification_outbox/worker.rs
@@ -125,6 +125,64 @@ async fn candidate_insert_is_idempotent_and_worker_coalesces_distinct_messages()
     assert_eq!(jobs[0].class(), NotificationClass::DirectMessage);
 }
 
+#[tokio::test]
+async fn candidate_without_first_party_registration_is_suppressed_and_observable() {
+    let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+    waddle_xmpp::prometheus::reset_metrics_for_test();
+    let store = store().await;
+    let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let projection = settings_projection().await;
+    let room_policy = StubRoomPolicy::new();
+    let candidate = candidate("archive-no-registration");
+    store
+        .insert_candidate(&candidate)
+        .await
+        .expect("candidate insert");
+
+    assert_eq!(
+        store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                drain_deps_with_noop_activity(&room_policy, &NoopDndReader, noop_activity_reader()),
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidate without registration"),
+        1,
+    );
+    assert!(store
+        .pending_outbox_jobs()
+        .await
+        .expect("pending jobs")
+        .is_empty());
+
+    let mut rows = store
+        .query(
+            "SELECT outboxed_at_ms, suppressed_reason FROM notification_candidates WHERE stanza_id = ?",
+            waddle_server::db_params!["archive-no-registration"],
+        )
+        .await
+        .expect("candidate audit query");
+    let row = rows
+        .next()
+        .await
+        .expect("candidate audit row")
+        .expect("candidate audit row");
+    assert!(row.get::<Option<i64>>(0).expect("outboxed_at_ms").is_some());
+    assert_eq!(
+        row.get::<Option<String>>(1)
+            .expect("suppressed_reason")
+            .as_deref(),
+        Some("xep0357_no_registration"),
+    );
+    assert!(waddle_xmpp::prometheus::render_metrics()
+        .contains("waddle_push_suppressed_total{reason=\"xep0357_no_registration\"} 1"));
+}
+
 /// T1 race-window regression: a candidate inserted while the
 /// recipient's XEP-0492 setting said "deliver" must still be
 /// suppressed at drain time if the setting flipped to `<never/>`

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -4,7 +4,7 @@ use jid::BareJid;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Postgres, QueryBuilder, Sqlite};
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, Span};
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
 use waddle_xmpp_core::xep0359::OriginId;
 
@@ -23,22 +23,38 @@ use super::{MamDatabaseBackend, SqlxMamStorage};
 
 #[async_trait]
 impl MamStorage for SqlxMamStorage {
-    #[instrument(skip(self, message), fields(archive = %archive_jid))]
+    #[instrument(
+        skip(self, message),
+        fields(
+            archive = %archive_jid,
+            message_id = message.stanza_id.as_ref().map(|id| id.id.as_str()).unwrap_or_default(),
+            room = tracing::field::Empty,
+        )
+    )]
     async fn store_message(
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
     ) -> Result<StoreOutcome, MamStorageError> {
+        record_archive_room(archive_jid, message);
         super::write::store_message(&self.backend, archive_jid, message).await
     }
 
-    #[instrument(skip(self, message, fence), fields(archive = %archive_jid))]
+    #[instrument(
+        skip(self, message, fence),
+        fields(
+            archive = %archive_jid,
+            message_id = message.stanza_id.as_ref().map(|id| id.id.as_str()).unwrap_or_default(),
+            room = tracing::field::Empty,
+        )
+    )]
     async fn store_message_fenced(
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
         fence: &RoomClaimFenceContext,
     ) -> Result<StoreOutcome, MamStorageError> {
+        record_archive_room(archive_jid, message);
         if !self.fencing_enabled {
             return self.store_message(archive_jid, message).await;
         }
@@ -507,5 +523,11 @@ impl MamStorage for SqlxMamStorage {
         tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
     ) -> Result<TerminalTombstoneOutcome, MamStorageError> {
         super::write::replace_with_terminal_tombstone(&self.backend, archive_id, tombstone).await
+    }
+}
+
+fn record_archive_room(archive_jid: &BareJid, message: &ArchivedMessage) {
+    if message.message_type == xmpp_parsers::message::MessageType::Groupchat {
+        Span::current().record("room", tracing::field::display(archive_jid));
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
@@ -73,7 +73,7 @@ impl MucRoom {
         tracing::Span::current().record("recipients", outbound.len());
         crate::metrics::record_muc_message();
         crate::histogram_record!(
-            "xmpp.muc.fanout.latency",
+            "waddle.muc.fanout.duration",
             "ms",
             "MUC fanout latency: groupchat broadcast accepted until the \
              per-recipient outbound set is built.",
@@ -270,23 +270,6 @@ mod tests {
         assert!(
             !output.contains("sensitive fanout body"),
             "message bodies must never be tracing fields: {output}"
-        );
-    }
-
-    #[tokio::test]
-    async fn fanout_latency_histogram_uses_canonical_name_and_unit() {
-        let guard = crate::telemetry::test_support::acquire().await;
-        room_with_two_occupants()
-            .broadcast_message("alice", &correlated_message())
-            .expect("broadcast succeeds");
-
-        assert_eq!(
-            guard.histogram_count("xmpp.muc.fanout.latency", &[]),
-            Some(1)
-        );
-        assert_eq!(
-            guard.metric_unit("xmpp.muc.fanout.latency").as_deref(),
-            Some("ms")
         );
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
@@ -73,7 +73,7 @@ impl MucRoom {
         tracing::Span::current().record("recipients", outbound.len());
         crate::metrics::record_muc_message();
         crate::histogram_record!(
-            "waddle.muc.fanout.duration",
+            "xmpp.muc.fanout.latency",
             "ms",
             "MUC fanout latency: groupchat broadcast accepted until the \
              per-recipient outbound set is built.",
@@ -176,5 +176,117 @@ impl MucRoom {
             setter_nick,
             set_at,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Affiliation, Role};
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("capture lock").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn room_with_two_occupants() -> MucRoom {
+        let mut room = MucRoom::new(
+            "team@muc.example.com".parse().expect("room jid"),
+            "waddle-1".into(),
+            "channel-1".into(),
+            Default::default(),
+        );
+        for (real_jid, nick) in [
+            ("alice@example.com/browser", "alice"),
+            ("bob@example.com/phone", "bob"),
+        ] {
+            room.add_occupant(Occupant {
+                real_jid: real_jid.parse().expect("occupant jid"),
+                nick: nick.into(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+                is_remote: false,
+                home_server: None,
+            });
+        }
+        room
+    }
+
+    fn correlated_message() -> Message {
+        let mut message = Message::new(None::<Jid>);
+        message.id = Some(xmpp_parsers::message::Id("fanout-correlation-1".into()));
+        message.type_ = MessageType::Groupchat;
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "sensitive fanout body".into(),
+        );
+        message
+    }
+
+    #[test]
+    fn fanout_span_carries_room_message_id_and_recipient_count_without_body() {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(CaptureWriter(Arc::clone(&bytes)))
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            room_with_two_occupants()
+                .broadcast_message("alice", &correlated_message())
+                .expect("broadcast succeeds");
+        });
+
+        let output = String::from_utf8(bytes.lock().expect("capture lock").clone())
+            .expect("captured tracing is UTF-8");
+        for expected in [
+            "\"room\":\"team@muc.example.com\"",
+            "\"message_id\":\"fanout-correlation-1\"",
+            "\"recipients\":2",
+        ] {
+            assert!(output.contains(expected), "missing {expected} in {output}");
+        }
+        assert!(
+            !output.contains("sensitive fanout body"),
+            "message bodies must never be tracing fields: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fanout_latency_histogram_uses_canonical_name_and_unit() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        room_with_two_occupants()
+            .broadcast_message("alice", &correlated_message())
+            .expect("broadcast succeeds");
+
+        assert_eq!(
+            guard.histogram_count("xmpp.muc.fanout.latency", &[]),
+            Some(1)
+        );
+        assert_eq!(
+            guard.metric_unit("xmpp.muc.fanout.latency").as_deref(),
+            Some("ms")
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_broadcast.rs
@@ -19,7 +19,7 @@ impl MucRoom {
     /// - All occupants receive the message (including the sender as echo)
     /// - Visitors in moderated rooms cannot send messages
     #[instrument(
-        name = "xmpp.muc.fanout",
+        name = "xmpp.muc.broadcast_build",
         skip(self, message),
         fields(
             room = %self.room_jid,
@@ -73,10 +73,11 @@ impl MucRoom {
         tracing::Span::current().record("recipients", outbound.len());
         crate::metrics::record_muc_message();
         crate::histogram_record!(
-            "waddle.muc.fanout.duration",
+            "xmpp.muc.broadcast_build.duration",
             "ms",
-            "MUC fanout latency: groupchat broadcast accepted until the \
-             per-recipient outbound set is built.",
+            "MUC broadcast-build duration: groupchat broadcast accepted until \
+             the per-recipient outbound set is built. The full delivery \
+             fan-out interval is `xmpp.muc.fanout.latency`.",
             fanout_started.elapsed().as_secs_f64() * 1000.0,
         );
 

--- a/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
@@ -16,6 +16,7 @@ use waddle_sfu::{Identity, SfuService};
 
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::traits::IqHandler;
+use crate::telemetry::attributes::RequestOutcome;
 use crate::xep::xep0215::{
     build_services_result_element, build_stun_service_element, build_turn_service, ServiceType,
     NS_EXT_DISCO,
@@ -98,13 +99,21 @@ impl IqHandler for ExtDiscoHandler {
             // spoof any identity into the TURN username).
             let identity = Identity::from_jid(ctx.full_jid.clone());
             match self.sfu.issue_turn_credentials(&identity) {
-                Ok(cred) => services.push(build_turn_service(
-                    self.sfu.turn_host(),
-                    self.turn_tls_port,
-                    &cred,
-                )),
+                Ok(cred) => {
+                    record_turn_credential_outcome(RequestOutcome::Success);
+                    services.push(build_turn_service(
+                        self.sfu.turn_host(),
+                        self.turn_tls_port,
+                        &cred,
+                    ));
+                }
                 Err(e) => {
-                    tracing::error!(error = %e, "TURN credential mint failed");
+                    record_turn_credential_outcome(RequestOutcome::Failure);
+                    tracing::error!(
+                        user = %ctx.full_jid.to_bare(),
+                        error = %e,
+                        "TURN credential mint failed"
+                    );
                     return error_reply(
                         iq,
                         DefinedCondition::InternalServerError,
@@ -137,6 +146,16 @@ impl IqHandler for ExtDiscoHandler {
             reply,
         ))))]
     }
+}
+
+fn record_turn_credential_outcome(outcome: RequestOutcome) {
+    crate::counter_add!(
+        "waddle.call.turn_credentials",
+        "1",
+        "TURN credential issuance attempts by outcome.",
+        1,
+        outcome,
+    );
 }
 
 /// Wire-form `type` value for the (typed) filter on the inbound
@@ -263,6 +282,25 @@ mod tests {
         assert_eq!(stun.attr("type"), Some("stun"));
         assert_eq!(stun.attr("transport"), Some("udp"));
         assert_eq!(stun.attr("port"), Some("3478"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn turn_credential_issuance_emits_success_counter() {
+        let metrics = crate::telemetry::test_support::acquire().await;
+        let jid = test_jid();
+        let handler = ExtDiscoHandler::new(fixture_sfu(), 443, 3478);
+
+        let events = handler.handle(&services_get_iq(), &ctx(&jid));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            metrics.counter_sum("waddle.call.turn_credentials", &[("outcome", "success")]),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.call.turn_credentials"),
+            Some("1".to_string())
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -27,6 +27,7 @@ use waddle_sfu::{CallId, Identity, MediaCapabilities, SfuError, SfuService};
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::handlers::session_initiate_rate_limit::SessionInitiateRateLimit;
 use crate::protocol::traits::IqHandler;
+use crate::telemetry::attributes::{MetricAttribute, SfuDenialReason};
 use crate::xep::xep0166::NS_JINGLE;
 use crate::xep::xep0272::{find_muji, Muji};
 use crate::xep::xep_waddle_livekit_transport::{
@@ -452,6 +453,9 @@ impl JingleHandler {
             // authenticated session. Non-initiate actions should not
             // carry it, so we ignore it there per the XEP.
             if let Err(e) = resolve_muji_initiator(&jingle, ctx) {
+                if let Some(room_jid) = muji.room.as_ref() {
+                    record_sfu_token_authorization_denial(room_jid, &ctx.full_jid.to_bare());
+                }
                 return e.into_reply(iq);
             }
         }
@@ -847,7 +851,7 @@ enum RewriteError {
     UnsupportedTransport,
     InvalidWaddleTransport(TransportParseError),
     ClientSuppliedIssuedTransport,
-    SfuFailed(SfuError),
+    SfuFailed,
 }
 
 impl RewriteError {
@@ -881,8 +885,7 @@ impl RewriteError {
                 DefinedCondition::BadRequest,
                 "Waddle LiveKit transport credentials must be server-issued",
             ),
-            Self::SfuFailed(inner) => {
-                tracing::error!(error = %inner, "SFU operation failed during Jingle handling");
+            Self::SfuFailed => {
                 error_reply(iq, DefinedCondition::InternalServerError, "internal error")
             }
         }
@@ -973,13 +976,20 @@ fn rewrite_contents_transport(
     if contents.is_empty() {
         return Ok(());
     }
-    let token = sfu
-        .issue_join_token(
-            call_id,
-            peer_identity,
-            MediaCapabilities::full_participant(),
-        )
-        .map_err(RewriteError::SfuFailed)?;
+    let token = match sfu.issue_join_token(
+        call_id,
+        peer_identity,
+        MediaCapabilities::full_participant(),
+    ) {
+        Ok(token) => {
+            record_sfu_token_minted(call_id, peer_identity);
+            token
+        }
+        Err(error) => {
+            record_sfu_token_mint_failure(call_id, peer_identity, &error);
+            return Err(RewriteError::SfuFailed);
+        }
+    };
     let issued = WaddleLiveKitTransport::Issued(IssuedTransport {
         url: token.url,
         room: token.room,
@@ -991,6 +1001,57 @@ fn rewrite_contents_transport(
         content.transport = Some(Transport::Unknown(issued_elem.clone()));
     }
     Ok(())
+}
+
+fn record_sfu_token_minted(call_id: &CallId, identity: &Identity) {
+    let user = identity.as_jid().to_bare();
+    tracing::info!(
+        room = %call_id.as_str(),
+        user = %user,
+        "LiveKit SFU token minted"
+    );
+    crate::counter_add!(
+        "waddle.call.sfu_token.minted",
+        "1",
+        "LiveKit SFU tokens minted.",
+        1,
+    );
+}
+
+fn record_sfu_token_mint_failure(call_id: &CallId, identity: &Identity, error: &SfuError) {
+    let user = identity.as_jid().to_bare();
+    let reason = SfuDenialReason::InternalError;
+    tracing::warn!(
+        room = %call_id.as_str(),
+        user = %user,
+        reason = reason.value(),
+        error = %error,
+        "LiveKit SFU token mint failed"
+    );
+    crate::counter_add!(
+        "waddle.call.sfu_token.denied",
+        "1",
+        "SFU token requests denied by reason.",
+        1,
+        reason,
+    );
+}
+
+fn record_sfu_token_authorization_denial(room: &BareJid, user: &BareJid) {
+    let reason = SfuDenialReason::NotAuthorized;
+    tracing::warn!(
+        room = %room,
+        user = %user,
+        reason = reason.value(),
+        "SFU token request denied"
+    );
+    crate::counter_add!(
+        "waddle.call.sfu_token.denied",
+        "1",
+        "SFU token requests denied by reason.",
+        1,
+        reason,
+    );
 }
 
 fn revoke_other_dm_participants(
@@ -1083,6 +1144,7 @@ mod tests {
     use crate::xep::xep0167::opus_audio_description;
     use chrono::Duration;
     use jid::FullJid;
+    use std::io;
     use waddle_sfu::{
         ApiKey, ApiSecret, LiveKitSfu, SfuConfig, TurnHost, TurnSharedSecret, WebsocketUrl,
     };
@@ -1121,6 +1183,31 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
     fn session_initiate_iq(initiator: &str, responder: &str, sid: &str) -> Iq {
         let mut content = Content::new(Creator::Initiator, ContentId("audio".into()));
         content.description = Some(xmpp_parsers::jingle::Description::Rtp(
@@ -1156,6 +1243,27 @@ mod tests {
             to: Some(to.parse().unwrap()),
             id: "a1".into(),
             payload: jingle.into(),
+        }
+    }
+
+    fn muji_session_initiate_iq(room: &str) -> Iq {
+        let mut content = Content::new(Creator::Initiator, ContentId("audio".into()));
+        content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+            opus_audio_description(),
+        ));
+        content.transport = Some(Transport::Unknown(
+            WaddleLiveKitTransport::Request.to_element(),
+        ));
+        let mut jingle = Jingle::new(Action::SessionInitiate, SessionId("muji-observe".into()));
+        jingle.initiator = Some("alice@waddle.test/desktop".parse().unwrap());
+        jingle.contents.push(content);
+        let mut payload: Element = jingle.into();
+        payload.append_child(Muji::for_room(room.parse().expect("valid room JID")).to_element());
+        Iq::Set {
+            from: Some("alice@waddle.test/desktop".parse().unwrap()),
+            to: Some("calls.waddle.test".parse().unwrap()),
+            id: "muji-observe".into(),
+            payload,
         }
     }
 
@@ -1225,6 +1333,88 @@ mod tests {
             }
             WaddleLiveKitTransport::Request => panic!("server must populate the transport"),
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn muji_token_mint_emits_info_with_bare_jid_and_counter() {
+        let metrics = crate::telemetry::test_support::acquire().await;
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let _subscriber = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::INFO)
+                .with_writer(CaptureWriter(buffer.clone()))
+                .finish(),
+        );
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+
+        let events = handler.handle(
+            &muji_session_initiate_iq("general@muc.waddle.test"),
+            &ctx(&jid),
+        );
+
+        assert!(
+            !events.is_empty(),
+            "successful Muji token mint must produce the focus response"
+        );
+        assert_eq!(
+            metrics.counter_sum("waddle.call.sfu_token.minted", &[]),
+            Some(1)
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.call.sfu_token.minted"),
+            Some("1".to_string())
+        );
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are UTF-8");
+        assert!(logs.contains("general@muc.waddle.test"), "{logs}");
+        assert!(logs.contains("alice@waddle.test"), "{logs}");
+        assert!(logs.contains("\"level\":\"INFO\""), "{logs}");
+        assert!(logs.contains("LiveKit SFU token minted"), "{logs}");
+        assert!(!logs.contains("alice@waddle.test/desktop"), "{logs}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn muji_spoofed_initiator_emits_not_authorized_denial() {
+        let metrics = crate::telemetry::test_support::acquire().await;
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let _subscriber = tracing::subscriber::set_default(
+            tracing_subscriber::fmt()
+                .json()
+                .with_max_level(tracing::Level::WARN)
+                .with_writer(CaptureWriter(buffer.clone()))
+                .finish(),
+        );
+        let mut iq = muji_session_initiate_iq("general@muc.waddle.test");
+        let Iq::Set { payload, .. } = &mut iq else {
+            panic!("expected IQ set");
+        };
+        payload.set_attr(
+            minidom::rxml::Namespace::NONE,
+            minidom::rxml::xml_ncname!("initiator").to_owned(),
+            "mallory@waddle.test/laptop",
+        );
+        let jid = test_ctx_jid();
+        let handler = JingleHandler::new(fixture_sfu());
+
+        let events = handler.handle(&iq, &ctx(&jid));
+
+        assert_error_condition(&events, DefinedCondition::Forbidden);
+        assert_eq!(
+            metrics.counter_sum(
+                "waddle.call.sfu_token.denied",
+                &[("reason", "not_authorized")]
+            ),
+            Some(1)
+        );
+        let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+            .expect("captured logs are UTF-8");
+        assert!(logs.contains("\"level\":\"WARN\""), "{logs}");
+        assert!(logs.contains("general@muc.waddle.test"), "{logs}");
+        assert!(logs.contains("alice@waddle.test"), "{logs}");
+        assert!(!logs.contains("alice@waddle.test/desktop"), "{logs}");
+        assert!(!logs.contains("mallory@waddle.test/laptop"), "{logs}");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -1010,12 +1010,7 @@ fn record_sfu_token_minted(call_id: &CallId, identity: &Identity) {
         user = %user,
         "LiveKit SFU token minted"
     );
-    crate::counter_add!(
-        "waddle.call.sfu_token.minted",
-        "1",
-        "LiveKit SFU tokens minted.",
-        1,
-    );
+    crate::telemetry::call::increment_sfu_token_minted();
 }
 
 fn record_sfu_token_mint_failure(call_id: &CallId, identity: &Identity, error: &SfuError) {
@@ -1028,13 +1023,7 @@ fn record_sfu_token_mint_failure(call_id: &CallId, identity: &Identity, error: &
         error = %error,
         "LiveKit SFU token mint failed"
     );
-    crate::counter_add!(
-        "waddle.call.sfu_token.denied",
-        "1",
-        "SFU token requests denied by reason.",
-        1,
-        reason,
-    );
+    crate::telemetry::call::increment_sfu_token_denied(reason);
 }
 
 fn record_sfu_token_authorization_denial(room: &BareJid, user: &BareJid) {
@@ -1045,13 +1034,7 @@ fn record_sfu_token_authorization_denial(room: &BareJid, user: &BareJid) {
         reason = reason.value(),
         "SFU token request denied"
     );
-    crate::counter_add!(
-        "waddle.call.sfu_token.denied",
-        "1",
-        "SFU token requests denied by reason.",
-        1,
-        reason,
-    );
+    crate::telemetry::call::increment_sfu_token_denied(reason);
 }
 
 fn revoke_other_dm_participants(

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -15,7 +15,10 @@ impl ConnectionRegistry {
     /// stale connections and removed from the registry; if a concurrent
     /// `register` installed a fresh sender on the same JID between our lookup and
     /// a failed send, the stanza is retried on the replacement rather than lost.
-    #[instrument(skip(self, stanza), fields(to = %jid))]
+    #[instrument(
+        skip(self, stanza),
+        fields(to = %jid, message_id = stanza_message_id(&stanza))
+    )]
     pub async fn send_to(&self, jid: &FullJid, stanza: Stanza) -> SendResult {
         let sender = match self.connections.get(jid) {
             Some(entry) => entry.value().sender.clone(),
@@ -315,5 +318,12 @@ impl ConnectionRegistry {
             self.presence_states.remove(jid);
             debug!(jid = %jid, "Evicted stale owned closed connection entry");
         }
+    }
+}
+
+fn stanza_message_id(stanza: &Stanza) -> &str {
+    match stanza {
+        Stanza::Message(message) => message.id.as_ref().map_or("", |id| id.0.as_str()),
+        Stanza::Iq(_) | Stanza::Presence(_) => "",
     }
 }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -17,7 +17,12 @@ impl ConnectionRegistry {
     /// a failed send, the stanza is retried on the replacement rather than lost.
     #[instrument(
         skip(self, stanza),
-        fields(to = %jid, message_id = stanza_message_id(&stanza))
+        fields(
+            to = %jid,
+            message_id = %crate::telemetry::messages::fanout_span_message_id(
+                stanza_message_id(&stanza)
+            )
+        )
     )]
     pub async fn send_to(&self, jid: &FullJid, stanza: Stanza) -> SendResult {
         let sender = match self.connections.get(jid) {

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -293,3 +293,336 @@ impl MetricAttribute for StanzaErrorCondition {
         self.as_str()
     }
 }
+
+/// `route` — an HTTP route **template** from the router table
+/// (`/api/auth/token`, `/api/channels/{id}`), never a raw request
+/// path. The value space is bounded by the set of `&'static str`
+/// templates in the router definition; constructing one from anything
+/// but a router-table literal is a review error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HttpRouteTemplate(&'static str);
+
+impl HttpRouteTemplate {
+    /// Wrap a router-table route template. `template` MUST be the
+    /// matched route pattern registered with the router, not a
+    /// request path.
+    #[must_use]
+    pub const fn new(template: &'static str) -> Self {
+        Self(template)
+    }
+}
+
+impl sealed::Sealed for HttpRouteTemplate {}
+impl MetricAttribute for HttpRouteTemplate {
+    fn key(&self) -> &'static str {
+        "route"
+    }
+    fn value(&self) -> &'static str {
+        self.0
+    }
+}
+
+/// `status_class` — HTTP response status bucketed to its class, so
+/// the status dimension is exactly five values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpStatusClass {
+    Informational,
+    Success,
+    Redirection,
+    ClientError,
+    ServerError,
+}
+
+impl HttpStatusClass {
+    /// Bucket a numeric status code. Out-of-range codes collapse into
+    /// the nearest class boundary (sub-100 → 1xx, 600+ → 5xx) so the
+    /// label set stays closed.
+    #[must_use]
+    pub const fn from_status(status: u16) -> Self {
+        match status {
+            0..=199 => Self::Informational,
+            200..=299 => Self::Success,
+            300..=399 => Self::Redirection,
+            400..=499 => Self::ClientError,
+            _ => Self::ServerError,
+        }
+    }
+}
+
+impl sealed::Sealed for HttpStatusClass {}
+impl MetricAttribute for HttpStatusClass {
+    fn key(&self) -> &'static str {
+        "status_class"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Informational => "1xx",
+            Self::Success => "2xx",
+            Self::Redirection => "3xx",
+            Self::ClientError => "4xx",
+            Self::ServerError => "5xx",
+        }
+    }
+}
+
+/// `stage` — which step of the authentication surface a sample
+/// belongs to (#1328). One variant per rejection choke point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthStage {
+    /// OIDC authorization start / redirect handling.
+    OidcAuthorization,
+    /// OIDC IdP callback (code + state redemption).
+    OidcCallback,
+    /// OAuth token exchange (`/api/auth/token`, XMPP code exchange).
+    TokenExchange,
+    /// OIDC userinfo fetch.
+    Userinfo,
+    /// State / CSRF validation.
+    State,
+    /// OAuth device flow (verify / poll / approve).
+    DeviceFlow,
+    /// Native XEP/SASL SCRAM authentication.
+    Scram,
+}
+
+impl sealed::Sealed for AuthStage {}
+impl MetricAttribute for AuthStage {
+    fn key(&self) -> &'static str {
+        "stage"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::OidcAuthorization => "oidc_authorization",
+            Self::OidcCallback => "oidc_callback",
+            Self::TokenExchange => "token_exchange",
+            Self::Userinfo => "userinfo",
+            Self::State => "state",
+            Self::DeviceFlow => "device_flow",
+            Self::Scram => "scram",
+        }
+    }
+}
+
+/// `error_code` — the enumerated authentication failure classes
+/// (#1328). A closed metric-facing set: auth code maps its concrete
+/// errors into these buckets before emitting, so an IdP's free-form
+/// error string can never become a label value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthErrorCode {
+    /// Unknown, reused, or expired `state` (CSRF mismatch included).
+    InvalidState,
+    /// Authorization code missing, unknown, or already redeemed.
+    InvalidCode,
+    /// Token exchange rejected the grant.
+    InvalidGrant,
+    /// Client credentials rejected.
+    InvalidClient,
+    /// Token or handshake artifact expired.
+    Expired,
+    /// Userinfo fetch failed or returned an unusable document.
+    UserinfoFailed,
+    /// The upstream IdP was unreachable or returned a transport error.
+    ProviderUnreachable,
+    /// SCRAM credential verification failed.
+    InvalidCredentials,
+    /// The account is unknown.
+    UnknownUser,
+    /// Structurally malformed request (missing/invalid parameters).
+    Malformed,
+    /// Any rejection not covered by a specific bucket.
+    Other,
+}
+
+impl sealed::Sealed for AuthErrorCode {}
+impl MetricAttribute for AuthErrorCode {
+    fn key(&self) -> &'static str {
+        "error_code"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::InvalidState => "invalid_state",
+            Self::InvalidCode => "invalid_code",
+            Self::InvalidGrant => "invalid_grant",
+            Self::InvalidClient => "invalid_client",
+            Self::Expired => "expired",
+            Self::UserinfoFailed => "userinfo_failed",
+            Self::ProviderUnreachable => "provider_unreachable",
+            Self::InvalidCredentials => "invalid_credentials",
+            Self::UnknownUser => "unknown_user",
+            Self::Malformed => "malformed",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// `event` — call-signaling event kinds (#1319): XEP-0353 Jingle
+/// Message Initiation verbs plus Muji room join/leave.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallSignalEvent {
+    JmiPropose,
+    JmiProceed,
+    JmiReject,
+    JmiRetract,
+    MujiJoin,
+    MujiLeave,
+}
+
+impl sealed::Sealed for CallSignalEvent {}
+impl MetricAttribute for CallSignalEvent {
+    fn key(&self) -> &'static str {
+        "event"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::JmiPropose => "jmi_propose",
+            Self::JmiProceed => "jmi_proceed",
+            Self::JmiReject => "jmi_reject",
+            Self::JmiRetract => "jmi_retract",
+            Self::MujiJoin => "muji_join",
+            Self::MujiLeave => "muji_leave",
+        }
+    }
+}
+
+/// `reason` — why the Muji/SFU token gate refused to mint a LiveKit
+/// JWT (#1319). Closed metric-facing set; the gate maps its concrete
+/// denial into these buckets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SfuDenialReason {
+    /// The requester is not a member/occupant of the room.
+    MembershipDenied,
+    /// The room does not exist.
+    RoomNotFound,
+    /// The requester failed authentication/authorization upstream of
+    /// membership (bad session, missing identity).
+    NotAuthorized,
+    /// The gate itself failed (lookup error, dependency failure).
+    InternalError,
+}
+
+impl sealed::Sealed for SfuDenialReason {}
+impl MetricAttribute for SfuDenialReason {
+    fn key(&self) -> &'static str {
+        "reason"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::MembershipDenied => "membership_denied",
+            Self::RoomNotFound => "room_not_found",
+            Self::NotAuthorized => "not_authorized",
+            Self::InternalError => "internal_error",
+        }
+    }
+}
+
+/// `outcome` — LiveKit webhook ingestion outcome (#1319).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebhookOutcome {
+    /// A fresh, signature-valid event.
+    Received,
+    /// A replay of an already-processed event id.
+    Duplicate,
+    /// Signature verification failed.
+    SignatureFailed,
+}
+
+impl sealed::Sealed for WebhookOutcome {}
+impl MetricAttribute for WebhookOutcome {
+    fn key(&self) -> &'static str {
+        "outcome"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Received => "received",
+            Self::Duplicate => "duplicate",
+            Self::SignatureFailed => "signature_failed",
+        }
+    }
+}
+
+/// `outcome` — generic success/failure for bounded request-shaped
+/// operations (token mint, TURN credential issuance, provider send).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestOutcome {
+    Success,
+    Failure,
+}
+
+impl sealed::Sealed for RequestOutcome {}
+impl MetricAttribute for RequestOutcome {
+    fn key(&self) -> &'static str {
+        "outcome"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+/// `stage` — where in the push-notification pipeline a sample was
+/// taken (#531). One variant per observable pipeline transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushStage {
+    /// A notification candidate was created from committed state.
+    CandidateCreated,
+    /// The candidate was suppressed (see `PushSuppressReason`).
+    Suppressed,
+    /// The candidate was coalesced into an existing notification.
+    Coalesced,
+    /// The XEP-0357 publish reached the push service.
+    Published,
+    /// The downstream provider accepted the notification.
+    ProviderSent,
+    /// The downstream provider rejected the notification.
+    ProviderRejected,
+    /// The downstream provider reported an expired token.
+    ProviderTokenExpired,
+    /// The outbox scheduled a retry.
+    RetryScheduled,
+    /// The outbox dead-lettered the job.
+    DeadLettered,
+}
+
+impl sealed::Sealed for PushStage {}
+impl MetricAttribute for PushStage {
+    fn key(&self) -> &'static str {
+        "stage"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::CandidateCreated => "candidate_created",
+            Self::Suppressed => "suppressed",
+            Self::Coalesced => "coalesced",
+            Self::Published => "published",
+            Self::ProviderSent => "provider_sent",
+            Self::ProviderRejected => "provider_rejected",
+            Self::ProviderTokenExpired => "provider_token_expired",
+            Self::RetryScheduled => "retry_scheduled",
+            Self::DeadLettered => "dead_lettered",
+        }
+    }
+}
+
+/// `provider` — which push provider a sample refers to (#531).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushProvider {
+    WebPush,
+    Apns,
+    Fcm,
+}
+
+impl sealed::Sealed for PushProvider {}
+impl MetricAttribute for PushProvider {
+    fn key(&self) -> &'static str {
+        "provider"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::WebPush => "web_push",
+            Self::Apns => "apns",
+            Self::Fcm => "fcm",
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -524,6 +524,8 @@ pub enum WebhookOutcome {
     Duplicate,
     /// Signature verification failed.
     SignatureFailed,
+    /// The signature was valid, but the body did not decode as an event.
+    DecodeFailed,
 }
 
 impl sealed::Sealed for WebhookOutcome {}
@@ -536,6 +538,7 @@ impl MetricAttribute for WebhookOutcome {
             Self::Received => "received",
             Self::Duplicate => "duplicate",
             Self::SignatureFailed => "signature_failed",
+            Self::DecodeFailed => "decode_failed",
         }
     }
 }

--- a/server/crates/waddle-xmpp/src/telemetry/call.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/call.rs
@@ -1,0 +1,26 @@
+//! Typed counters for the `waddle.call.sfu_token.*` family, shared by
+//! the protocol-layer Jingle handler and the server-side Muji gate so
+//! one family is never emitted from divergent macro sites.
+
+use super::attributes::SfuDenialReason;
+
+/// Count a minted LiveKit SFU token.
+pub fn increment_sfu_token_minted() {
+    crate::counter_add!(
+        "waddle.call.sfu_token.minted",
+        "1",
+        "LiveKit SFU tokens minted.",
+        1,
+    );
+}
+
+/// Count an SFU token denial by reason.
+pub fn increment_sfu_token_denied(reason: SfuDenialReason) {
+    crate::counter_add!(
+        "waddle.call.sfu_token.denied",
+        "1",
+        "SFU token requests denied by reason.",
+        1,
+        reason,
+    );
+}

--- a/server/crates/waddle-xmpp/src/telemetry/messages.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/messages.rs
@@ -17,6 +17,23 @@ use super::attributes::MessageKind;
 use crate::Stanza;
 use xmpp_parsers::message::MessageType;
 
+const FANOUT_MESSAGE_ID_MAX_BYTES: usize = 64;
+
+/// Bound a client-controlled message id before attaching it to a
+/// per-recipient fan-out span. The returned slice is at most 64 bytes and
+/// always ends on a UTF-8 boundary.
+pub fn fanout_span_message_id(message_id: &str) -> &str {
+    if message_id.len() <= FANOUT_MESSAGE_ID_MAX_BYTES {
+        return message_id;
+    }
+
+    let mut end = FANOUT_MESSAGE_ID_MAX_BYTES;
+    while !message_id.is_char_boundary(end) {
+        end -= 1;
+    }
+    &message_id[..end]
+}
+
 /// Classify a stanza about to be queued for local delivery. `None`
 /// for non-messages and body-less message stanzas.
 pub fn delivered_message_kind(stanza: &Stanza) -> Option<MessageKind> {
@@ -102,6 +119,23 @@ mod tests {
             xmpp_parsers::presence::Type::None,
         ));
         assert_eq!(delivered_message_kind(&presence), None);
+    }
+
+    #[test]
+    fn fanout_span_message_id_caps_bytes_without_splitting_utf8() {
+        let ascii = "a".repeat(FANOUT_MESSAGE_ID_MAX_BYTES + 1);
+        assert_eq!(
+            fanout_span_message_id(&ascii),
+            "a".repeat(FANOUT_MESSAGE_ID_MAX_BYTES)
+        );
+
+        let multibyte = format!("{}é", "a".repeat(FANOUT_MESSAGE_ID_MAX_BYTES - 1));
+        assert_eq!(
+            fanout_span_message_id(&multibyte),
+            "a".repeat(FANOUT_MESSAGE_ID_MAX_BYTES - 1)
+        );
+        assert!(fanout_span_message_id(&multibyte)
+            .is_char_boundary(fanout_span_message_id(&multibyte).len()));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -49,6 +49,7 @@
 
 pub mod attributes;
 pub mod messages;
+pub mod push_pipeline;
 pub mod reliability;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -48,6 +48,7 @@
 //! `test`/`test-utils`).
 
 pub mod attributes;
+pub mod call;
 pub mod messages;
 pub mod push_pipeline;
 pub mod reliability;

--- a/server/crates/waddle-xmpp/src/telemetry/push_pipeline.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/push_pipeline.rs
@@ -18,6 +18,11 @@ pub fn increment_candidate_created() {
     increment_pipeline(PushStage::CandidateCreated);
 }
 
+/// Record a candidate suppressed by notification policy.
+pub fn increment_suppressed() {
+    increment_pipeline(PushStage::Suppressed);
+}
+
 /// Record a duplicate candidate coalesced at durable insertion.
 pub fn increment_coalesced() {
     increment_pipeline(PushStage::Coalesced);
@@ -26,6 +31,16 @@ pub fn increment_coalesced() {
 /// Record an XEP-0357 outbox job accepted by the Push Service.
 pub fn increment_published() {
     increment_pipeline(PushStage::Published);
+}
+
+/// Record an outbox job scheduled for another delivery attempt.
+pub fn increment_retry_scheduled() {
+    increment_pipeline(PushStage::RetryScheduled);
+}
+
+/// Record an outbox job terminally dead-lettered.
+pub fn increment_dead_lettered() {
+    increment_pipeline(PushStage::DeadLettered);
 }
 
 fn increment_provider(stage: PushStage, provider: PushProvider) {
@@ -62,33 +77,29 @@ pub fn increment_provider_token_expired(provider: PushProvider) {
 /// retryable.
 pub fn record_web_push_outcome(outcome: &WebPushOutcome) -> Option<PushStage> {
     let stage = match outcome {
-        WebPushOutcome::Delivered { .. } => PushStage::ProviderSent,
-        WebPushOutcome::SubscriptionGone { .. } => PushStage::ProviderTokenExpired,
+        WebPushOutcome::Delivered { .. } => {
+            increment_provider_sent(PushProvider::WebPush);
+            PushStage::ProviderSent
+        }
+        WebPushOutcome::SubscriptionGone { .. } => {
+            increment_provider_token_expired(PushProvider::WebPush);
+            PushStage::ProviderTokenExpired
+        }
         WebPushOutcome::ClockSkew { .. }
         | WebPushOutcome::RateLimited { .. }
         | WebPushOutcome::PayloadTooLarge { .. }
         | WebPushOutcome::BadRequest { status: 1.. }
         | WebPushOutcome::Transient {
             kind: TransientFailure::ServerError { .. },
-        } => PushStage::ProviderRejected,
+        } => {
+            increment_provider_rejected(PushProvider::WebPush);
+            PushStage::ProviderRejected
+        }
         WebPushOutcome::BadRequest { status: 0 }
         | WebPushOutcome::Transient {
             kind: TransientFailure::Network | TransientFailure::Timeout,
         } => return None,
     };
-    match stage {
-        PushStage::ProviderSent => increment_provider_sent(PushProvider::WebPush),
-        PushStage::ProviderRejected => increment_provider_rejected(PushProvider::WebPush),
-        PushStage::ProviderTokenExpired => {
-            increment_provider_token_expired(PushProvider::WebPush);
-        }
-        PushStage::CandidateCreated
-        | PushStage::Suppressed
-        | PushStage::Coalesced
-        | PushStage::Published
-        | PushStage::RetryScheduled
-        | PushStage::DeadLettered => unreachable!("provider classifier returned pipeline stage"),
-    }
     Some(stage)
 }
 

--- a/server/crates/waddle-xmpp/src/telemetry/push_pipeline.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/push_pipeline.rs
@@ -1,0 +1,188 @@
+//! Typed OpenTelemetry counters for push-pipeline transitions.
+
+use super::attributes::{PushProvider, PushStage};
+use crate::push::types::{TransientFailure, WebPushOutcome};
+
+fn increment_pipeline(stage: PushStage) {
+    crate::counter_add!(
+        "waddle.push.pipeline",
+        "{notification}",
+        "Push notification pipeline transitions.",
+        1,
+        stage,
+    );
+}
+
+/// Record a candidate that entered the durable notification pipeline.
+pub fn increment_candidate_created() {
+    increment_pipeline(PushStage::CandidateCreated);
+}
+
+/// Record a duplicate candidate coalesced at durable insertion.
+pub fn increment_coalesced() {
+    increment_pipeline(PushStage::Coalesced);
+}
+
+/// Record an XEP-0357 outbox job accepted by the Push Service.
+pub fn increment_published() {
+    increment_pipeline(PushStage::Published);
+}
+
+fn increment_provider(stage: PushStage, provider: PushProvider) {
+    crate::counter_add!(
+        "waddle.push.provider",
+        "{notification}",
+        "Push notification outcomes at the downstream provider boundary.",
+        1,
+        stage,
+        provider,
+    );
+}
+
+/// Record a notification accepted by a downstream provider.
+pub fn increment_provider_sent(provider: PushProvider) {
+    increment_provider(PushStage::ProviderSent, provider);
+}
+
+/// Record a notification rejected by a downstream provider.
+pub fn increment_provider_rejected(provider: PushProvider) {
+    increment_provider(PushStage::ProviderRejected, provider);
+}
+
+/// Record a downstream provider's expired-token response.
+pub fn increment_provider_token_expired(provider: PushProvider) {
+    increment_provider(PushStage::ProviderTokenExpired, provider);
+}
+
+/// Classify and record a typed result returned by the live Web Push provider.
+///
+/// Network and timeout failures do not increment the provider family because
+/// no provider response was received. Provider-side 5xx responses do: the
+/// provider actively rejected that attempt, even though the job remains
+/// retryable.
+pub fn record_web_push_outcome(outcome: &WebPushOutcome) -> Option<PushStage> {
+    let stage = match outcome {
+        WebPushOutcome::Delivered { .. } => PushStage::ProviderSent,
+        WebPushOutcome::SubscriptionGone { .. } => PushStage::ProviderTokenExpired,
+        WebPushOutcome::ClockSkew { .. }
+        | WebPushOutcome::RateLimited { .. }
+        | WebPushOutcome::PayloadTooLarge { .. }
+        | WebPushOutcome::BadRequest { status: 1.. }
+        | WebPushOutcome::Transient {
+            kind: TransientFailure::ServerError { .. },
+        } => PushStage::ProviderRejected,
+        WebPushOutcome::BadRequest { status: 0 }
+        | WebPushOutcome::Transient {
+            kind: TransientFailure::Network | TransientFailure::Timeout,
+        } => return None,
+    };
+    match stage {
+        PushStage::ProviderSent => increment_provider_sent(PushProvider::WebPush),
+        PushStage::ProviderRejected => increment_provider_rejected(PushProvider::WebPush),
+        PushStage::ProviderTokenExpired => {
+            increment_provider_token_expired(PushProvider::WebPush);
+        }
+        PushStage::CandidateCreated
+        | PushStage::Suppressed
+        | PushStage::Coalesced
+        | PushStage::Published
+        | PushStage::RetryScheduled
+        | PushStage::DeadLettered => unreachable!("provider classifier returned pipeline stage"),
+    }
+    Some(stage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn candidate_created_exports_through_the_metric_reader() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        increment_candidate_created();
+        assert_eq!(
+            guard.counter_sum("waddle.push.pipeline", &[("stage", "candidate_created")]),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn coalesced_exports_through_the_metric_reader() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        increment_coalesced();
+        assert_eq!(
+            guard.counter_sum("waddle.push.pipeline", &[("stage", "coalesced")]),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn published_exports_with_the_notification_unit() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        increment_published();
+        assert_eq!(
+            guard.counter_sum("waddle.push.pipeline", &[("stage", "published")]),
+            Some(1)
+        );
+        assert_eq!(
+            guard.metric_unit("waddle.push.pipeline"),
+            Some("{notification}".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn delivered_provider_outcome_exports_sent() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        record_web_push_outcome(&WebPushOutcome::Delivered { status: 201 });
+        assert_eq!(
+            guard.counter_sum(
+                "waddle.push.provider",
+                &[("stage", "provider_sent"), ("provider", "web_push")]
+            ),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_provider_outcome_exports_rejected() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        record_web_push_outcome(&WebPushOutcome::BadRequest { status: 400 });
+        assert_eq!(
+            guard.counter_sum(
+                "waddle.push.provider",
+                &[("stage", "provider_rejected"), ("provider", "web_push")]
+            ),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn local_preflight_failure_does_not_export_provider_rejection() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        assert_eq!(
+            record_web_push_outcome(&WebPushOutcome::BadRequest { status: 0 }),
+            None
+        );
+        assert_eq!(guard.counter_sum("waddle.push.provider", &[]), None);
+    }
+
+    #[tokio::test]
+    async fn gone_provider_outcome_exports_token_expired_with_notification_unit() {
+        let guard = crate::telemetry::test_support::acquire().await;
+        record_web_push_outcome(&WebPushOutcome::SubscriptionGone { status: 410 });
+        assert_eq!(
+            guard.counter_sum(
+                "waddle.push.provider",
+                &[
+                    ("stage", "provider_token_expired"),
+                    ("provider", "web_push")
+                ]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            guard.metric_unit("waddle.push.provider"),
+            Some("{notification}".to_string())
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -98,27 +98,44 @@ dual_increment!(
     "Unacked stanzas evicted from a detached XEP-0198 session replay window."
 );
 
-dual_increment!(
-    increment_push_candidate_created,
-    crate::prometheus::increment_push_candidate_created,
-    "xmpp.push.candidate_created",
-    "{notification}",
-    "XEP-0357 notification candidates inserted into the durable pipeline."
-);
-dual_increment!(
-    increment_push_candidate_coalesced,
-    crate::prometheus::increment_push_candidate_coalesced,
-    "xmpp.push.candidate_coalesced",
-    "{notification}",
-    "Duplicate XEP-0357 notification candidates coalesced at insertion."
-);
-dual_increment!(
-    increment_push_outbox_published,
-    crate::prometheus::increment_push_outbox_published,
-    "xmpp.push.outbox_published",
-    "{notification}",
-    "XEP-0357 notification outbox jobs accepted by the Push Service."
-);
+/// Record a durable push candidate in the legacy, reliability, and typed
+/// pipeline families.
+pub fn increment_push_candidate_created() {
+    crate::prometheus::increment_push_candidate_created();
+    crate::counter_add!(
+        "xmpp.push.candidate_created",
+        "{notification}",
+        "XEP-0357 notification candidates inserted into the durable pipeline.",
+        1,
+    );
+    super::push_pipeline::increment_candidate_created();
+}
+
+/// Record duplicate candidate coalescing in the legacy, reliability, and
+/// typed pipeline families.
+pub fn increment_push_candidate_coalesced() {
+    crate::prometheus::increment_push_candidate_coalesced();
+    crate::counter_add!(
+        "xmpp.push.candidate_coalesced",
+        "{notification}",
+        "Duplicate XEP-0357 notification candidates coalesced at insertion.",
+        1,
+    );
+    super::push_pipeline::increment_coalesced();
+}
+
+/// Record Push Service acceptance in the legacy, reliability, and typed
+/// pipeline families.
+pub fn increment_push_outbox_published() {
+    crate::prometheus::increment_push_outbox_published();
+    crate::counter_add!(
+        "xmpp.push.outbox_published",
+        "{notification}",
+        "XEP-0357 notification outbox jobs accepted by the Push Service.",
+        1,
+    );
+    super::push_pipeline::increment_published();
+}
 /// Dual-emit for outbox retry scheduling. Hand-written (not
 /// `dual_increment!`) because the OTel successor must carry the same
 /// `reason` label shape the legacy text family renders

--- a/server/crates/waddle-xmpp/src/telemetry/reliability.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/reliability.rs
@@ -151,14 +151,21 @@ pub fn increment_push_outbox_retry_scheduled(reason: PushRetryReason) {
         1,
         reason,
     );
+    super::push_pipeline::increment_retry_scheduled();
 }
-dual_increment!(
-    increment_push_outbox_dead_lettered,
-    crate::prometheus::increment_push_outbox_dead_lettered,
-    "xmpp.push.outbox_dead_lettered",
-    "{notification}",
-    "XEP-0357 notification outbox jobs terminally dead-lettered."
-);
+
+/// Record terminal outbox dead-lettering in the legacy, reliability, and
+/// typed pipeline families.
+pub fn increment_push_outbox_dead_lettered() {
+    crate::prometheus::increment_push_outbox_dead_lettered();
+    crate::counter_add!(
+        "xmpp.push.outbox_dead_lettered",
+        "{notification}",
+        "XEP-0357 notification outbox jobs terminally dead-lettered.",
+        1,
+    );
+    super::push_pipeline::increment_dead_lettered();
+}
 
 /// Record one typed push suppression in both telemetry systems.
 pub fn increment_push_suppressed(reason: PushSuppressReason) {
@@ -170,6 +177,7 @@ pub fn increment_push_suppressed(reason: PushSuppressReason) {
         1,
         reason,
     );
+    super::push_pipeline::increment_suppressed();
 }
 
 // No dual helper for the legacy unknown-reason catch-all: the sealed
@@ -335,6 +343,10 @@ mod tests {
         increment_push_suppressed(PushSuppressReason::Xep0492Never);
         assert_eq!(
             guard.counter_sum("xmpp.push.suppressed", &[("reason", "xep0492_never")]),
+            Some(1)
+        );
+        assert_eq!(
+            guard.counter_sum("waddle.push.pipeline", &[("stage", "suppressed")]),
             Some(1)
         );
         assert!(crate::prometheus::render_metrics()
@@ -666,5 +678,12 @@ mod tests {
             Some(1)
         );
         assert!(rendered.contains("waddle_push_suppressed_total{reason=\"waddle_dnd\"} 1\n"));
+        for stage in ["suppressed", "retry_scheduled", "dead_lettered"] {
+            assert_eq!(
+                guard.counter_sum("waddle.push.pipeline", &[("stage", stage)]),
+                Some(1),
+                "typed pipeline sample missing or wrong for {stage}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes the remaining observability gaps in one telemetry-only PR: #1321, #1326 (in-repo portions), #1329, #1328, #1319, #1318, #1315, and the observability slice of #531. No XMPP wire-behavior changes anywhere.

## What landed

### Foundation
- Extended the sealed metric-attribute allowlist (`telemetry/attributes.rs`) with the bounded dimensions used below: HTTP route template + status class, auth stage + error code, call-signaling event + SFU denial reason, webhook outcome, generic request outcome, push pipeline stage + provider. All closed sets; max 2 dimensions per instrument; all metrics via `counter_add!`/`histogram_record!`; the Prometheus text renderer stays frozen.

### #1329 — HTTP telemetry
`http.server.request.duration` histogram (UCUM `s`, route-template × status-class) recorded once per response; the request span now carries `http.route` + `http.status_code` (raw URI stays redacted); routes labeled from the router's static template table, never raw paths. Router-harness test asserts samples incl. the CORS-preflight path.

### #1328 — auth failure telemetry
`waddle.auth.failures` (stage × error_code) + `waddle.auth.success` (stage) via a central exhaustive error-classification (`auth_telemetry.rs`) wired at every rejection choke point: OIDC authorization/callback, token exchange, userinfo, state/CSRF/nonce, device flow, and SCRAM (which keeps `xmpp.auth.attempts` alongside). Warn logs carry stage + enumerated code only — no tokens, no secrets. Reader-seam tests cover every stage and the mapping exhaustively. Failure-ratio alert rule deferred to the #1324 alerts tree (documented at the helper).

### #1319 — call-signaling observability
The formerly silent Muji/SFU token gate now emits info+counter on mint and warn+counter on denial (`waddle.call.sfu_token.minted` / `.denied{reason}` — membership, room-not-found, not-authorized, internal); TURN/extdisco issuance (`waddle.call.turn_credentials{outcome}`); LiveKit webhook received/duplicate/signature-failed (`waddle.call.webhook.events{outcome}`); JMI propose/proceed/reject/retract + Muji join/leave structured logs and `waddle.call.signaling{event}`. Red→green test evidence on mint, deny, and webhook-dup paths.

### #1315 — managed-channel admission denials (server + client)
Every join rejection (registration-required, forbidden/banned, not-authorized, internal-server-error) routes through one `deny_join_admission` choke point: info log (room, bare user, condition, resolver outcome) + `waddle.muc.admission.denied{condition}`. The chat `muc-join` beacon context now carries the denied room's localpart (sanitizer untouched).

### #1321 — message-id correlation + latency histograms
`message_id` (and `room` for groupchat) now flow as fields on the dispatch span, MAM archive persist, MUC fanout (`xmpp.muc.fanout` with recipient count), per-recipient delivery outcomes (actor, detached, registry, second-chance, clustered relay), and pending-delivery promotion logs — a Tempo/Loki search by message id returns the whole path. New `xmpp.muc.fanout.latency` (ms) spans broadcast→all-enqueued; dispatch latency was already live. Field-plumbing tests at both seams.

### #1326 — cross-stack correlation (in-repo portions)
Dispatch span carries `xmpp.resource` + bare `user`; Faro session attributes carry the client's XMPP resource; the client appends a W3C `traceparent` query parameter to the WS upgrade URL (sanitizer passes only a validated triplet through, still scrubbing everything else); the server parses it strictly (typed parser, silent skip on malformed) into an OTel span link + `client.trace_id` on connection-scoped spans. Prod-beacon verification remains a post-deploy step tracked on the issue.

### #1318 — chat call telemetry
`chat.call.lifecycle` — exactly one per call attempt with outcome (proposed/accepted/declined/timeout/failed), end reason (hangup/peer-left/error/reconnect-exhausted, incl. retracted, non-active teardown, failed-preflight paths), duration bucket, `call_kind: dm|muc`; `call_kind` added to `chat.call.media_path` and `chat.call.audio_processing`; end-of-call quality summary (RTT/loss bands, quality level, reconnect count); device/permission failures as recoverable Faro errors; `reportCallError` sites route through Faro.

### #531 — push pipeline observability slice
`waddle.push.pipeline{stage}` for candidate-created/coalesced/published and `waddle.push.provider{stage×provider}` for provider sent/rejected/token-expired at the dispatch boundary (WebPush live; APNS/FCM slots ready), reusing the existing #1418 dual-emit families for suppression/retry/dead-letter (no double-counting). Structured logs carry bare JIDs + bounded class/provider/reason — no bodies, tokens, or endpoints. The E2E XEP conformance matrices stay in #531 (still blocked by #518–#530).

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings`: clean (default + `--features clustering`); no new allows; Cargo.toml/lock untouched.
- Full server suite (`cargo nextest run --workspace --no-fail-fast`): **7267 tests, 7266 passed** — the single failure is the pre-existing #1416 flake (reproduced 2/3 in isolation on this branch's base; unrelated to this diff).
- Doctests: pass. `cargo fmt`: no drift.
- Chat: `bun test` **3464 pass / 0 fail**; `bun run lint` (knip): clean.
- Metric-reader-seam tests cover every new counter/histogram; tracing-capture tests cover the new span/log fields.
- Adversarial review: three independent personas (repo-rules/XMPP-conformance, correctness/hot-paths, privacy/security) + an independent gpt-5.6 review; findings fixed until none actionable remained.

## Method
Foundation seeded first, then 7 parallel workstreams implemented by gpt-5.6 (Codex CLI, high reasoning) in isolated worktrees, merged, integrated, and reviewed. XEP review: telemetry-only; the `traceparent` WS query param and Faro beacons fall under the repo's operational-telemetry exception; call/push counters wrap existing XEP-0353/0272/0215/0357 paths without altering stanzas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Issue closure

Closes #1329. Closes #1328. Closes #1319. Closes #1315.

Left open deliberately: #1321 and #1318 (each has one acceptance criterion that can only be verified against prod after deploy — Tempo/Loki message-id search; beacons observed in Faro), #1326 (prod-beacon verification pending), and #531 (this PR delivers only the observability slice; the E2E conformance matrices remain blocked by #518–#530).
