### PR TITLE
fix(server): device-verify redirect must be 303 so browsers GET the IdP authorize URL

### DIFF
--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -533,4 +533,4 @@ pub async fn logout_handler(
 }
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/server/crates/waddle-server/src/server/routes/auth/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/tests.rs
@@ -9,7 +9,7 @@ use http_body_util::BodyExt;
 use tower::ServiceExt;
 use waddle_xmpp::telemetry::test_support;
 
-async fn create_test_auth_state(
+pub(crate) async fn create_test_auth_state(
     server_config: &ServerConfig,
 ) -> (Arc<AuthState>, kameo::actor::ActorRef<DbActor>) {
     let public_websocket_url =

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -463,7 +463,10 @@ pub async fn device_verify_submit_handler(
         Ok(url) => {
             record_auth_success(AuthStage::OidcAuthorization);
             info!(provider = %provider.id, "Device flow continuing via provider authorization");
-            axum::response::Redirect::temporary(&url).into_response()
+            // 303 See Other: this handler answers a POSTed form, so the
+            // redirect must switch the browser to GET — a 307 would replay
+            // the POST against the IdP's GET-only authorize endpoint.
+            axum::response::Redirect::to(&url).into_response()
         }
         Err(err) => {
             record_auth_failure(
@@ -483,6 +486,94 @@ pub async fn device_verify_submit_handler(
 #[cfg(test)]
 mod tests {
     use super::render_device_verify_html;
+    use super::router;
+    use crate::auth::{AuthProviderConfig, AuthProviderKind, AuthProviderTokenEndpointAuthMethod};
+    use crate::config::ServerConfig;
+    use crate::server::routes::auth::tests::create_test_auth_state;
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn test_oauth2_provider() -> AuthProviderConfig {
+        AuthProviderConfig {
+            id: "test-idp".to_string(),
+            display_name: "Test IdP".to_string(),
+            kind: AuthProviderKind::OAuth2,
+            dynamic_client_registration: false,
+            client_id: "test-client".to_string(),
+            client_secret: String::new(),
+            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::NoAuthentication,
+            require_dpop: false,
+            scopes: vec!["profile".to_string()],
+            issuer: Some("https://idp.example.com".to_string()),
+            authorization_endpoint: Some("https://idp.example.com/authorize".to_string()),
+            token_endpoint: Some("https://idp.example.com/token".to_string()),
+            userinfo_endpoint: Some("https://idp.example.com/userinfo".to_string()),
+            jwks_uri: None,
+            subject_claim: "sub".to_string(),
+            username_claim: None,
+            email_claim: None,
+        }
+    }
+
+    /// The verify form is a POST; the redirect to the IdP's GET-only
+    /// authorize endpoint must be 303 See Other so the browser switches
+    /// to GET instead of replaying the POST (which 307 would).
+    #[tokio::test]
+    async fn verify_submit_redirects_to_idp_with_303_see_other() {
+        let mut server_config = ServerConfig::test_homeserver();
+        server_config.auth.providers = vec![test_oauth2_provider()];
+        let (auth_state, _actor) = create_test_auth_state(&server_config).await;
+        let app = router(auth_state);
+
+        let start_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/device/start")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"provider":"test-idp"}"#))
+                    .expect("start request"),
+            )
+            .await
+            .expect("start response");
+        assert_eq!(start_response.status(), StatusCode::OK);
+        let start_body = start_response
+            .into_body()
+            .collect()
+            .await
+            .expect("start body")
+            .to_bytes();
+        let start_json: serde_json::Value =
+            serde_json::from_slice(&start_body).expect("start json");
+        let user_code = start_json["user_code"].as_str().expect("user_code");
+
+        let verify_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/device/verify")
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .body(Body::from(format!("user_code={user_code}")))
+                    .expect("verify request"),
+            )
+            .await
+            .expect("verify response");
+
+        assert_eq!(verify_response.status(), StatusCode::SEE_OTHER);
+        let location = verify_response
+            .headers()
+            .get(header::LOCATION)
+            .expect("location header")
+            .to_str()
+            .expect("location utf-8");
+        assert!(
+            location.starts_with("https://idp.example.com/authorize?"),
+            "redirect must target the IdP authorize endpoint, got {location}"
+        );
+    }
 
     #[test]
     fn device_verify_html_uses_valid_unescaped_attributes() {

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -522,6 +522,10 @@ mod tests {
     /// to GET instead of replaying the POST (which 307 would).
     #[tokio::test]
     async fn verify_submit_redirects_to_idp_with_303_see_other() {
+        // The happy path emits waddle.auth.success; hold the global
+        // telemetry guard so guarded export assertions elsewhere don't
+        // race this emission.
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
         let mut server_config = ServerConfig::test_homeserver();
         server_config.auth.providers = vec![test_oauth2_provider()];
         let (auth_state, _actor) = create_test_auth_state(&server_config).await;


### PR DESCRIPTION
## Problem

Android app login against the deployed server dead-ends on a 404. The app runs the OAuth device flow: `POST /api/auth/device/start`, then opens the verify page in a Custom Tab. Tapping **Continue** lands the browser on a 404 page on `colony.waddle.social` and the app polls forever.

## Root cause (confirmed against the live deployment)

- The verify page submits a **POST form** to `/api/auth/device/verify`.
- `device_verify_submit_handler` answered with `Redirect::temporary` — **HTTP 307** — pointing at the IdP's authorize endpoint.
- Per RFC 9110 §15.4.8, a 307 makes the browser **replay the POST** against the redirect target. Colony's better-auth `/api/auth/oauth2/authorize` endpoint is registered **GET-only** → 404.
- Live repro: `POST https://colony.waddle.social/api/auth/oauth2/authorize` → 404, while a GET of the same URL works (302 → `/sign-in`). Every other hop of the flow was probed live and is healthy (device start, verify page, dynamic client registration, Colony discovery/sign-in, GitHub authorize).

## Change

- `server/crates/waddle-server/src/server/routes/device.rs`: the verify-submit success arm now redirects with `Redirect::to` (**303 See Other**, RFC 9110 §15.4.4 — the status defined for POST-form → GET-navigation handoff). The four other `Redirect::temporary` sites are on GET handlers where 307 preserves GET and stay unchanged.
- New device-flow route test `verify_submit_redirects_to_idp_with_303_see_other`: walks `device/start` → `device/verify` against a configured OAuth2 provider (no network — explicit `authorization_endpoint`, no DCR) and asserts **303 + Location on the IdP authorize endpoint**. Mutation-checked: reverting to `Redirect::temporary` fails the test with 307≠303.
- Test reuses the existing auth route harness by widening `auth::tests`/`create_test_auth_state` to `pub(crate)` (both `#[cfg(test)]`-gated; mirrors the `websocket::tests::create_test_websocket_state` pattern), and holds the global telemetry guard because the happy path emits `waddle.auth.success`.

## Review

Two adversarial review passes (HTTP/OAuth spec lawyer, Rust test-quality maintainer):
- Confirmed 303 is spec-correct and no client consumes the status programmatically (Android/Apple only open the verify URL in a browser engine; no repo code POSTs to `/api/auth/device/verify`).
- Audited all redirect call sites against their route methods — this was the only POST-handler 307.
- No open-redirect or caching concern (Location comes from server-configured provider config; 303 is not heuristically cacheable).
- One real finding (missing telemetry guard in the new test) — fixed in a follow-up commit.

`cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the device/auth route test suites are clean.

## Verification

- Route test asserts the 303 contract.
- After deploy to `xmpp.waddle.social`: live probe of `device/start` → `device/verify` must return 303 with `Location` on `colony.waddle.social/api/auth/oauth2/authorize`; then Android login end-to-end (verify page → Continue → Colony sign-in → GitHub → consent → "Device authorized" → app completes poll).
