### PR TITLE
fix(android): bound managed-device test resources

### DIFF
--- a/.github/workflows/waddle-android-devicetests.yml
+++ b/.github/workflows/waddle-android-devicetests.yml
@@ -21,6 +21,7 @@ on:
     - apps/android/detekt.yml
     - apps/android/detekt.yml/**
     - apps/android/env.cue
+    - apps/android/env.cue/**
     - apps/android/gradle.properties
     - apps/android/gradle.properties/**
     - apps/android/gradle/**

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -212,7 +212,7 @@ schema.#Project & {
 		// cached configuration.
 		gmdCheck: schema.#Task & {
 			command: "bash"
-			args: ["-c", "ls -l /dev/kvm && ./gradlew --no-daemon --no-configuration-cache :app:atdApi34DebugAndroidTest"]
+			args: ["-c", "ls -l /dev/kvm && ./gradlew --no-daemon --no-configuration-cache --no-parallel --max-workers=2 '-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC' :app:atdApi34DebugAndroidTest"]
 			dependsOn: [setupSdk, buildRustJni]
 			inputs: _gradleInputs
 		}

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -214,7 +214,8 @@ schema.#Project & {
 			command: "bash"
 			args: ["-c", "ls -l /dev/kvm && ./gradlew --no-daemon --no-configuration-cache --no-parallel --max-workers=2 '-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC' :app:atdApi34DebugAndroidTest"]
 			dependsOn: [setupSdk, buildRustJni]
-			inputs: _gradleInputs
+			// Include this definition so GMD-only changes are selected by affectedness.
+			inputs: list.Concat([_gradleInputs, ["env.cue"]])
 		}
 
 		// Install-in-place artifact: every merge to main rebuilds the


### PR DESCRIPTION
## Summary

Continues the narrow Android managed-device CI repair for [#1425](https://github.com/waddle-social/waddle/issues/1425).

`gmdCheck` retains the KVM probe, `--no-daemon`, `--no-configuration-cache`, and `:app:atdApi34DebugAndroidTest` selector, while adding:

- `--no-parallel`;
- `--max-workers=2`; and
- a managed-device-only 4 GiB JVM value: `-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC`.

## Affectedness repair

The earlier green device workflow was a false success: it recorded one changed file and then reported `No affected tasks`, so it did not run the KVM probe, dependencies, Gradle, emulator, tests, or artifacts.

`gmdCheck` now declares its own `env.cue` as an input. With the CI-pinned cuenv 0.54.0, CI generation deterministically adds the matching recursive `apps/android/env.cue/**` path trigger beside the existing exact path; this generated change is included without manual workflow editing.

## Causality boundary

Exit 137 establishes SIGKILL only; it does not prove cgroup or OOM causality. The 4 GiB heap, no-parallel setting, and worker cap are a focused resource-reduction experiment. A `devices.xml` message remains a possible separate failure if it becomes fatal.

## Validation

- CUE export confirms the complete `gmdCheck` command and `env.cue` input.
- Exact cuenv 0.54.0 `sync ci --all` and `sync ci --check --all` pass with the generated workflow canonical.
- The dry task graph remains `setupSdk -> buildRustJni -> gmdCheck`.
- A shell argv probe confirms the JVM value is one Gradle argument.
- The automatic device run selected `gmdCheck`, probed KVM, ran Gradle, and completed all 24 managed-device tests with 0 failures/skips and a successful build. The `devices.xml` message was nonfatal in that run.
- The pull-request drift task initially ended with a signal-style `-1` despite a clean exact check and no drift diagnostic. One targeted rerun executed `checkCiDrift` for the two changed files and passed. No source change was made for that transient executor failure.

This PR was merged through normal protections; it did not authorize deployment or other production operations.