### PR TITLE
fix(cloud): dashboards pipeline — folder resolution, datasource pinning, Faro query schema

### DIFF
--- a/infrastructure/waddle.cloud/dashboards/01-overview.json
+++ b/infrastructure/waddle.cloud/dashboards/01-overview.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -11,7 +14,10 @@
         "type": "dashboard"
       },
       {
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": false,
         "iconColor": "rgba(255, 145, 0, 1)",
@@ -19,7 +25,9 @@
         "target": {
           "limit": 100,
           "matchAny": false,
-          "tags": ["deploy"],
+          "tags": [
+            "deploy"
+          ],
           "type": "tags"
         }
       }
@@ -32,7 +40,10 @@
     {
       "type": "timeseries",
       "title": "Connected users by pod",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum by (instance) (waddle_connected_users)",
@@ -40,14 +51,26 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Message rate by kind",
       "description": "Ships dark until #1320 wires the kind label on the delivered-message metric.",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum by (kind) (rate(waddle_messages_delivered_total[5m]))",
@@ -55,13 +78,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "ops" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Room count",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(xmpp_muc_rooms_active)",
@@ -69,13 +104,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Server error-log rate",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} | detected_level=\"error\" [5m]))",
@@ -83,13 +130,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "WebSocket resets",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"WebSocket error\" [5m]))",
@@ -97,28 +156,55 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "overview"],
+  "tags": [
+    "waddle",
+    "overview"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_PROMETHEUS",
         "type": "datasource",
-        "query": "prometheus"
+        "query": "prometheus",
+        "regex": "/-prom$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-prom",
+          "value": "grafanacloud-prom"
+        }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
-        "query": "loki"
+        "query": "loki",
+        "regex": "/-logs$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-logs",
+          "value": "grafanacloud-logs"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle overview",
   "uid": "waddle-overview",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/01-overview.json
+++ b/infrastructure/waddle.cloud/dashboards/01-overview.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -14,10 +11,7 @@
         "type": "dashboard"
       },
       {
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": false,
         "iconColor": "rgba(255, 145, 0, 1)",
@@ -25,9 +19,7 @@
         "target": {
           "limit": 100,
           "matchAny": false,
-          "tags": [
-            "deploy"
-          ],
+          "tags": ["deploy"],
           "type": "tags"
         }
       }
@@ -40,10 +32,7 @@
     {
       "type": "timeseries",
       "title": "Connected users by pod",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum by (instance) (waddle_connected_users)",
@@ -51,26 +40,14 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Message rate by kind",
       "description": "Ships dark until #1320 wires the kind label on the delivered-message metric.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum by (kind) (rate(waddle_messages_delivered_total[5m]))",
@@ -78,25 +55,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ops"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "ops" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Room count",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(xmpp_muc_rooms_active)",
@@ -104,25 +69,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Server error-log rate",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} | detected_level=\"error\" [5m]))",
@@ -130,25 +83,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "WebSocket resets",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"WebSocket error\" [5m]))",
@@ -156,25 +97,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "overview"
-  ],
+  "tags": ["waddle", "overview"],
   "templating": {
     "list": [
       {
@@ -182,29 +111,18 @@
         "type": "datasource",
         "query": "prometheus",
         "regex": "/-prom$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-prom",
-          "value": "grafanacloud-prom"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-prom", "value": "grafanacloud-prom" }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
         "query": "loki",
         "regex": "/-logs$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-logs",
-          "value": "grafanacloud-logs"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-logs", "value": "grafanacloud-logs" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle overview",
   "uid": "waddle-overview",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
+++ b/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,10 +19,7 @@
     {
       "type": "timeseries",
       "title": "Stream-management evictions and pauses",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_sm_unacked_evicted_total[5m]))",
@@ -48,25 +42,13 @@
           "refId": "D"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Pending-delivery flush and claims",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_pending_flush_batches_total[5m]))",
@@ -94,25 +76,13 @@
           "refId": "E"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Push delivery funnel",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_push_candidate_created_total[5m]))",
@@ -140,25 +110,13 @@
           "refId": "E"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Broadcast outcomes",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_broadcast_delivered_total[5m]))",
@@ -181,25 +139,13 @@
           "refId": "D"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "SM resume success vs missing cached session",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed\" != \"without cached detached Session\" [5m]))",
@@ -212,25 +158,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "delivery"
-  ],
+  "tags": ["waddle", "delivery"],
   "templating": {
     "list": [
       {
@@ -238,29 +172,18 @@
         "type": "datasource",
         "query": "prometheus",
         "regex": "/-prom$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-prom",
-          "value": "grafanacloud-prom"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-prom", "value": "grafanacloud-prom" }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
         "query": "loki",
         "regex": "/-logs$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-logs",
-          "value": "grafanacloud-logs"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-logs", "value": "grafanacloud-logs" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle delivery reliability",
   "uid": "waddle-delivery-reliability",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
+++ b/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -19,7 +22,10 @@
     {
       "type": "timeseries",
       "title": "Stream-management evictions and pauses",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_sm_unacked_evicted_total[5m]))",
@@ -42,13 +48,25 @@
           "refId": "D"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Pending-delivery flush and claims",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_pending_flush_batches_total[5m]))",
@@ -76,13 +94,25 @@
           "refId": "E"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Push delivery funnel",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_push_candidate_created_total[5m]))",
@@ -110,13 +140,25 @@
           "refId": "E"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Broadcast outcomes",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_broadcast_delivered_total[5m]))",
@@ -139,13 +181,25 @@
           "refId": "D"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "SM resume success vs missing cached session",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed\" != \"without cached detached Session\" [5m]))",
@@ -158,28 +212,55 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "delivery"],
+  "tags": [
+    "waddle",
+    "delivery"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_PROMETHEUS",
         "type": "datasource",
-        "query": "prometheus"
+        "query": "prometheus",
+        "regex": "/-prom$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-prom",
+          "value": "grafanacloud-prom"
+        }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
-        "query": "loki"
+        "query": "loki",
+        "regex": "/-logs$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-logs",
+          "value": "grafanacloud-logs"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle delivery reliability",
   "uid": "waddle-delivery-reliability",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
+++ b/infrastructure/waddle.cloud/dashboards/02-delivery-reliability.json
@@ -22,22 +22,22 @@
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
-          "expr": "sum(increase(waddle_sm_unacked_evicted_total[5m]))",
+          "expr": "sum(increase(waddle_sm_unacked_evicted_total[5m])) or vector(0)",
           "legendFormat": "unacked evicted",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(waddle_sm_detached_unacked_evicted_total[5m]))",
+          "expr": "sum(increase(waddle_sm_detached_unacked_evicted_total[5m])) or vector(0)",
           "legendFormat": "detached unacked evicted",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(waddle_sm_send_window_pauses_total[5m]))",
+          "expr": "sum(increase(waddle_sm_send_window_pauses_total[5m])) or vector(0)",
           "legendFormat": "send-window pauses",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(waddle_sm_send_window_pause_timeouts_total[5m]))",
+          "expr": "sum(increase(waddle_sm_send_window_pause_timeouts_total[5m])) or vector(0)",
           "legendFormat": "pause timeouts",
           "refId": "D"
         }
@@ -51,27 +51,27 @@
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
-          "expr": "sum(increase(waddle_pending_flush_batches_total[5m]))",
+          "expr": "sum(increase(waddle_pending_flush_batches_total[5m])) or vector(0)",
           "legendFormat": "flush batches",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(waddle_pending_flush_rows_pushed_total[5m]))",
+          "expr": "sum(increase(waddle_pending_flush_rows_pushed_total[5m])) or vector(0)",
           "legendFormat": "rows pushed",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(waddle_pending_delivery_orphan_claims_released_total[5m]))",
+          "expr": "sum(increase(waddle_pending_delivery_orphan_claims_released_total[5m])) or vector(0)",
           "legendFormat": "orphan claims released",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(waddle_pending_delivery_quota_exceeded_total[5m]))",
+          "expr": "sum(increase(waddle_pending_delivery_quota_exceeded_total[5m])) or vector(0)",
           "legendFormat": "quota exceeded",
           "refId": "D"
         },
         {
-          "expr": "sum(increase(waddle_pending_delivery_aged_out_total[5m]))",
+          "expr": "sum(increase(waddle_pending_delivery_aged_out_total[5m])) or vector(0)",
           "legendFormat": "aged out",
           "refId": "E"
         }
@@ -85,17 +85,17 @@
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
-          "expr": "sum(increase(waddle_push_candidate_created_total[5m]))",
+          "expr": "sum(increase(waddle_push_candidate_created_total[5m])) or vector(0)",
           "legendFormat": "created",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(waddle_push_candidate_coalesced_total[5m]))",
+          "expr": "sum(increase(waddle_push_candidate_coalesced_total[5m])) or vector(0)",
           "legendFormat": "coalesced",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(waddle_push_outbox_published_total[5m]))",
+          "expr": "sum(increase(waddle_push_outbox_published_total[5m])) or vector(0)",
           "legendFormat": "published",
           "refId": "C"
         },
@@ -105,7 +105,7 @@
           "refId": "D"
         },
         {
-          "expr": "sum(increase(waddle_push_outbox_dead_lettered_total[5m]))",
+          "expr": "sum(increase(waddle_push_outbox_dead_lettered_total[5m])) or vector(0)",
           "legendFormat": "dead-lettered",
           "refId": "E"
         }
@@ -119,22 +119,22 @@
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
-          "expr": "sum(increase(waddle_broadcast_delivered_total[5m]))",
+          "expr": "sum(increase(waddle_broadcast_delivered_total[5m])) or vector(0)",
           "legendFormat": "delivered",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(waddle_broadcast_not_connected_total[5m]))",
+          "expr": "sum(increase(waddle_broadcast_not_connected_total[5m])) or vector(0)",
           "legendFormat": "not connected",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(waddle_broadcast_dropped_full_total[5m]))",
+          "expr": "sum(increase(waddle_broadcast_dropped_full_total[5m])) or vector(0)",
           "legendFormat": "dropped: full",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(waddle_broadcast_dropped_closed_total[5m]))",
+          "expr": "sum(increase(waddle_broadcast_dropped_closed_total[5m])) or vector(0)",
           "legendFormat": "dropped: closed",
           "refId": "D"
         }
@@ -148,12 +148,12 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed\" != \"without cached detached Session\" [5m]))",
+          "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed\" != \"without cached detached Session\" [5m])) or vector(0)",
           "legendFormat": "resumed",
           "refId": "A"
         },
         {
-          "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed without cached detached Session\" [5m]))",
+          "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"SM resumed without cached detached Session\" [5m])) or vector(0)",
           "legendFormat": "missing cached session",
           "refId": "B"
         }

--- a/infrastructure/waddle.cloud/dashboards/03-clustering.json
+++ b/infrastructure/waddle.cloud/dashboards/03-clustering.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,10 +19,7 @@
     {
       "type": "timeseries",
       "title": "Node heartbeat age",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "max by (service_instance_id) (waddle_clustering_node_heartbeat_age_ms_milliseconds)",
@@ -33,25 +27,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ms"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Connected peers per pod",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "max by (service_instance_id) (waddle_clustering_connected_peers_peer)",
@@ -59,26 +41,14 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Claims released or abandoned on drain",
       "description": "Ships dark until #1295 completes drain-claim instrumentation rollout.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_clustering_claims_released_on_drain_claim_total[5m]))",
@@ -91,25 +61,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Ordered-relay acknowledgements",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "sum(increase(waddle_clustering_ordered_relay_acks_reply_total[5m]))",
@@ -122,25 +80,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "ClaimHeldByAnotherNode rate",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"ClaimHeldByAnotherNode\" [5m]))",
@@ -148,25 +94,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
     },
     {
       "type": "timeseries",
       "title": "Cross-node resume events",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"cross-node resume\" [5m]))",
@@ -179,25 +113,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "clustering"
-  ],
+  "tags": ["waddle", "clustering"],
   "templating": {
     "list": [
       {
@@ -205,29 +127,18 @@
         "type": "datasource",
         "query": "prometheus",
         "regex": "/-prom$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-prom",
-          "value": "grafanacloud-prom"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-prom", "value": "grafanacloud-prom" }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
         "query": "loki",
         "regex": "/-logs$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-logs",
-          "value": "grafanacloud-logs"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-logs", "value": "grafanacloud-logs" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle clustering",
   "uid": "waddle-clustering",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/03-clustering.json
+++ b/infrastructure/waddle.cloud/dashboards/03-clustering.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -19,7 +22,10 @@
     {
       "type": "timeseries",
       "title": "Node heartbeat age",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "max by (service_instance_id) (waddle_clustering_node_heartbeat_age_ms_milliseconds)",
@@ -27,13 +33,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Connected peers per pod",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "max by (service_instance_id) (waddle_clustering_connected_peers_peer)",
@@ -41,14 +59,26 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Claims released or abandoned on drain",
       "description": "Ships dark until #1295 completes drain-claim instrumentation rollout.",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_clustering_claims_released_on_drain_claim_total[5m]))",
@@ -61,13 +91,25 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Ordered-relay acknowledgements",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "sum(increase(waddle_clustering_ordered_relay_acks_reply_total[5m]))",
@@ -80,13 +122,25 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "ClaimHeldByAnotherNode rate",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"ClaimHeldByAnotherNode\" [5m]))",
@@ -94,13 +148,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
     },
     {
       "type": "timeseries",
       "title": "Cross-node resume events",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum(count_over_time({service_name=\"waddle-server\"} |= \"cross-node resume\" [5m]))",
@@ -113,28 +179,55 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "clustering"],
+  "tags": [
+    "waddle",
+    "clustering"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_PROMETHEUS",
         "type": "datasource",
-        "query": "prometheus"
+        "query": "prometheus",
+        "regex": "/-prom$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-prom",
+          "value": "grafanacloud-prom"
+        }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
-        "query": "loki"
+        "query": "loki",
+        "regex": "/-logs$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-logs",
+          "value": "grafanacloud-logs"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle clustering",
   "uid": "waddle-clustering",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/04-client-experience.json
+++ b/infrastructure/waddle.cloud/dashboards/04-client-experience.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -19,7 +22,10 @@
     {
       "type": "timeseries",
       "title": "Exceptions by value template",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum by (value_template) (count_over_time({service_name=\"waddle-chat\", kind=\"exception\"}[5m]))",
@@ -27,13 +33,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Reconnect duration p50 / p95",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "quantile_over_time(0.50, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.reconnect.duration_ms\" | json | unwrap values_duration_ms [5m])",
@@ -46,13 +64,25 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "ms" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Catch-up duration and outcomes",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.catchup\" | json | unwrap values_duration_ms [5m])",
@@ -66,20 +96,38 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "short" },
+        "defaults": {
+          "unit": "short"
+        },
         "overrides": [
           {
-            "matcher": { "id": "byFrameRefID", "options": "A" },
-            "properties": [{ "id": "unit", "value": "ms" }]
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Outbound queue depth",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.queue.depth\" | json | unwrap values_persisted [5m])",
@@ -92,13 +140,25 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Session lifecycle: fresh vs resumed",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum by (attributes_type) (count_over_time({service_name=\"waddle-chat\", kind=\"event\"} |= \"chat.xmpp.session.lifecycle\" | json [5m]))",
@@ -106,13 +166,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
     },
     {
       "type": "timeseries",
       "title": "Room-join failures by condition",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "sum by (value_template) (count_over_time({service_name=\"waddle-chat\", kind=\"exception\"} |= \"room-join-\" [5m]))",
@@ -120,13 +192,25 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
     },
     {
       "type": "timeseries",
       "title": "Web vitals",
-      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
       "targets": [
         {
           "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"web-vitals\" | json | unwrap values_lcp [5m])",
@@ -145,30 +229,57 @@
         }
       ],
       "fieldConfig": {
-        "defaults": { "unit": "ms" },
+        "defaults": {
+          "unit": "ms"
+        },
         "overrides": [
           {
-            "matcher": { "id": "byFrameRefID", "options": "C" },
-            "properties": [{ "id": "unit", "value": "none" }]
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "client"],
+  "tags": [
+    "waddle",
+    "client"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_LOKI",
         "type": "datasource",
-        "query": "loki"
+        "query": "loki",
+        "regex": "/-logs$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-logs",
+          "value": "grafanacloud-logs"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle client experience",
   "uid": "waddle-client-experience",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/04-client-experience.json
+++ b/infrastructure/waddle.cloud/dashboards/04-client-experience.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -22,10 +19,7 @@
     {
       "type": "timeseries",
       "title": "Exceptions by value template",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum by (value_template) (count_over_time({service_name=\"waddle-chat\", kind=\"exception\"}[5m]))",
@@ -33,25 +27,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Reconnect duration p50 / p95",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "quantile_over_time(0.50, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.reconnect.duration_ms\" | json | unwrap values_duration_ms [5m])",
@@ -64,25 +46,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ms"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Catch-up duration and outcomes",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.catchup\" | json | unwrap values_duration_ms [5m])",
@@ -96,38 +66,20 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        },
+        "defaults": { "unit": "short" },
         "overrides": [
           {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "A"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ms"
-              }
-            ]
+            "matcher": { "id": "byFrameRefID", "options": "A" },
+            "properties": [{ "id": "unit", "value": "ms" }]
           }
         ]
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      }
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Outbound queue depth",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.queue.depth\" | json | unwrap values_persisted [5m])",
@@ -140,25 +92,13 @@
           "refId": "B"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Session lifecycle: fresh vs resumed",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum by (attributes_type) (count_over_time({service_name=\"waddle-chat\", kind=\"event\"} |= \"chat.xmpp.session.lifecycle\" | json [5m]))",
@@ -166,25 +106,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
     },
     {
       "type": "timeseries",
       "title": "Room-join failures by condition",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "sum by (value_template) (count_over_time({service_name=\"waddle-chat\", kind=\"exception\"} |= \"room-join-\" [5m]))",
@@ -192,25 +120,13 @@
           "refId": "A"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      }
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
     },
     {
       "type": "timeseries",
       "title": "Web vitals",
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
+      "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
           "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"web-vitals\" | json | unwrap values_lcp [5m])",
@@ -229,38 +145,20 @@
         }
       ],
       "fieldConfig": {
-        "defaults": {
-          "unit": "ms"
-        },
+        "defaults": { "unit": "ms" },
         "overrides": [
           {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "C"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "none"
-              }
-            ]
+            "matcher": { "id": "byFrameRefID", "options": "C" },
+            "properties": [{ "id": "unit", "value": "none" }]
           }
         ]
       },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      }
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "client"
-  ],
+  "tags": ["waddle", "client"],
   "templating": {
     "list": [
       {
@@ -268,18 +166,11 @@
         "type": "datasource",
         "query": "loki",
         "regex": "/-logs$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-logs",
-          "value": "grafanacloud-logs"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-logs", "value": "grafanacloud-logs" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle client experience",
   "uid": "waddle-client-experience",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/04-client-experience.json
+++ b/infrastructure/waddle.cloud/dashboards/04-client-experience.json
@@ -36,12 +36,12 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "quantile_over_time(0.50, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.reconnect.duration_ms\" | json | unwrap values_duration_ms [5m])",
+          "expr": "quantile_over_time(0.50, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.reconnect.duration_ms\" | logfmt | unwrap value_duration_ms | __error__=\"\" [5m])",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
-          "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.reconnect.duration_ms\" | json | unwrap values_duration_ms [5m])",
+          "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.reconnect.duration_ms\" | logfmt | unwrap value_duration_ms | __error__=\"\" [5m])",
           "legendFormat": "p95",
           "refId": "B"
         }
@@ -55,12 +55,12 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.catchup\" | json | unwrap values_duration_ms [5m])",
+          "expr": "quantile_over_time(0.95, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.catchup\" | logfmt | unwrap value_duration_ms | __error__=\"\" [5m])",
           "legendFormat": "duration p95",
           "refId": "A"
         },
         {
-          "expr": "sum by (context_outcome) (count_over_time({service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.catchup\" | json [5m]))",
+          "expr": "sum by (context_outcome) (count_over_time({service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.catchup\" | logfmt [5m]))",
           "legendFormat": "outcome: {{context_outcome}}",
           "refId": "B"
         }
@@ -82,12 +82,12 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.queue.depth\" | json | unwrap values_persisted [5m])",
+          "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.queue.depth\" | logfmt | unwrap value_persisted | __error__=\"\" [5m])",
           "legendFormat": "persisted",
           "refId": "A"
         },
         {
-          "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurements\"} |= \"chat.xmpp.queue.depth\" | json | unwrap values_inflight [5m])",
+          "expr": "max_over_time({service_name=\"waddle-chat\", kind=\"measurement\"} |= \"chat.xmpp.queue.depth\" | logfmt | unwrap value_inflight | __error__=\"\" [5m])",
           "legendFormat": "in flight",
           "refId": "B"
         }
@@ -101,8 +101,8 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "sum by (attributes_type) (count_over_time({service_name=\"waddle-chat\", kind=\"event\"} |= \"chat.xmpp.session.lifecycle\" | json [5m]))",
-          "legendFormat": "{{attributes_type}}",
+          "expr": "sum by (event_data_type) (count_over_time({service_name=\"waddle-chat\", kind=\"event\"} |= \"chat.xmpp.session.lifecycle\" | logfmt [5m]))",
+          "legendFormat": "{{event_data_type}}",
           "refId": "A"
         }
       ],
@@ -129,17 +129,17 @@
       "datasource": { "type": "loki", "uid": "${DS_LOKI}" },
       "targets": [
         {
-          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"web-vitals\" | json | unwrap values_lcp [5m])",
+          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"web-vitals\" | logfmt | unwrap value_lcp | __error__=\"\" [5m])",
           "legendFormat": "LCP p75",
           "refId": "A"
         },
         {
-          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"web-vitals\" | json | unwrap values_inp [5m])",
+          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"web-vitals\" | logfmt | unwrap value_inp | __error__=\"\" [5m])",
           "legendFormat": "INP p75",
           "refId": "B"
         },
         {
-          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurements\"} |= \"web-vitals\" | json | unwrap values_cls [5m])",
+          "expr": "quantile_over_time(0.75, {service_name=\"waddle-chat\", kind=\"measurement\"} |= \"web-vitals\" | logfmt | unwrap value_cls | __error__=\"\" [5m])",
           "legendFormat": "CLS p75",
           "refId": "C"
         }

--- a/infrastructure/waddle.cloud/dashboards/05-calls.json
+++ b/infrastructure/waddle.cloud/dashboards/05-calls.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,11 +18,7 @@
   "panels": [],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "calls",
-    "skeleton"
-  ],
+  "tags": ["waddle", "calls", "skeleton"],
   "templating": {
     "list": [
       {
@@ -33,29 +26,18 @@
         "type": "datasource",
         "query": "prometheus",
         "regex": "/-prom$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-prom",
-          "value": "grafanacloud-prom"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-prom", "value": "grafanacloud-prom" }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
         "query": "loki",
         "regex": "/-logs$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-logs",
-          "value": "grafanacloud-logs"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-logs", "value": "grafanacloud-logs" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle calls",
   "uid": "waddle-calls",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/05-calls.json
+++ b/infrastructure/waddle.cloud/dashboards/05-calls.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -18,22 +21,41 @@
   "panels": [],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "calls", "skeleton"],
+  "tags": [
+    "waddle",
+    "calls",
+    "skeleton"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_PROMETHEUS",
         "type": "datasource",
-        "query": "prometheus"
+        "query": "prometheus",
+        "regex": "/-prom$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-prom",
+          "value": "grafanacloud-prom"
+        }
       },
       {
         "name": "DS_LOKI",
         "type": "datasource",
-        "query": "loki"
+        "query": "loki",
+        "regex": "/-logs$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-logs",
+          "value": "grafanacloud-logs"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle calls",
   "uid": "waddle-calls",
   "version": 1

--- a/infrastructure/waddle.cloud/dashboards/06-state-inventory.json
+++ b/infrastructure/waddle.cloud/dashboards/06-state-inventory.json
@@ -1,7 +1,5 @@
 {
-  "annotations": {
-    "list": []
-  },
+  "annotations": { "list": [] },
   "description": "Waddle server long-lived in-memory maps, sampled every 15 s by `state_inventory_metrics::spawn_state_inventory_publisher` and exported through the standard OTel meter provider into Grafana Cloud Mimir via the in-cluster grafana-alloy collector. Each panel charts a logical group of maps against `process_resident_memory_bytes` so an RSS climb correlates directly to whichever .len() is growing. Hand-buildable on purpose so it survives Grafana upgrades and is reviewable in PRs.",
   "editable": true,
   "graphTooltip": 1,
@@ -9,188 +7,78 @@
     {
       "type": "timeseries",
       "title": "Process RSS",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
           "expr": "waddle_process_resident_memory_bytes_By",
           "legendFormat": "{{service_instance_id}}"
         }
       ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      }
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 }
     },
     {
       "type": "timeseries",
       "title": "Auth state maps (.len())",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        {
-          "expr": "waddle_state_auth_pending_auth_entry",
-          "legendFormat": "pending_auth"
-        },
-        {
-          "expr": "waddle_state_auth_device_auth_entry",
-          "legendFormat": "device_auth"
-        },
-        {
-          "expr": "waddle_state_auth_xmpp_auth_codes_entry",
-          "legendFormat": "xmpp_auth_codes"
-        },
-        {
-          "expr": "waddle_state_auth_dynamic_oidc_clients_entry",
-          "legendFormat": "dynamic_oidc_clients"
-        },
-        {
-          "expr": "waddle_state_auth_dynamic_oidc_client_locks_entry",
-          "legendFormat": "dynamic_oidc_client_locks"
-        }
+        { "expr": "waddle_state_auth_pending_auth_entry", "legendFormat": "pending_auth" },
+        { "expr": "waddle_state_auth_device_auth_entry", "legendFormat": "device_auth" },
+        { "expr": "waddle_state_auth_xmpp_auth_codes_entry", "legendFormat": "xmpp_auth_codes" },
+        { "expr": "waddle_state_auth_dynamic_oidc_clients_entry", "legendFormat": "dynamic_oidc_clients" },
+        { "expr": "waddle_state_auth_dynamic_oidc_client_locks_entry", "legendFormat": "dynamic_oidc_client_locks" }
       ],
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      }
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Profile + dispatch in-flight",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        {
-          "expr": "waddle_state_profile_avatar_source_locks_entry",
-          "legendFormat": "avatar_source_locks"
-        },
-        {
-          "expr": "waddle_state_profile_publish_tracker_in_flight_entry",
-          "legendFormat": "profile_publish"
-        },
-        {
-          "expr": "waddle_state_profile_provider_dispatch_in_flight_entry",
-          "legendFormat": "provider_dispatch"
-        }
+        { "expr": "waddle_state_profile_avatar_source_locks_entry", "legendFormat": "avatar_source_locks" },
+        { "expr": "waddle_state_profile_publish_tracker_in_flight_entry", "legendFormat": "profile_publish" },
+        { "expr": "waddle_state_profile_provider_dispatch_in_flight_entry", "legendFormat": "provider_dispatch" }
       ],
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      }
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
     {
       "type": "timeseries",
       "title": "Sessions + caps",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        {
-          "expr": "waddle_state_sessions_sm_live_sessions_entry",
-          "legendFormat": "sm_live"
-        },
-        {
-          "expr": "waddle_state_sessions_resumable_sessions_entry",
-          "legendFormat": "resumable"
-        },
-        {
-          "expr": "waddle_state_caps_caps_cache_entry",
-          "legendFormat": "caps_cache"
-        },
-        {
-          "expr": "waddle_state_caps_pending_resolutions_entry",
-          "legendFormat": "caps_pending"
-        }
+        { "expr": "waddle_state_sessions_sm_live_sessions_entry", "legendFormat": "sm_live" },
+        { "expr": "waddle_state_sessions_resumable_sessions_entry", "legendFormat": "resumable" },
+        { "expr": "waddle_state_caps_caps_cache_entry", "legendFormat": "caps_cache" },
+        { "expr": "waddle_state_caps_pending_resolutions_entry", "legendFormat": "caps_pending" }
       ],
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      }
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
     },
     {
       "type": "timeseries",
       "title": "Connections + presence",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        {
-          "expr": "waddle_state_connections_full_jid_connections_entry",
-          "legendFormat": "connections"
-        },
-        {
-          "expr": "waddle_state_connections_pending_subscription_stanzas_entry",
-          "legendFormat": "pending_subs"
-        },
-        {
-          "expr": "waddle_state_connections_presence_states_entry",
-          "legendFormat": "presence_states"
-        },
-        {
-          "expr": "waddle_state_connections_last_activity_entry",
-          "legendFormat": "last_activity"
-        }
+        { "expr": "waddle_state_connections_full_jid_connections_entry", "legendFormat": "connections" },
+        { "expr": "waddle_state_connections_pending_subscription_stanzas_entry", "legendFormat": "pending_subs" },
+        { "expr": "waddle_state_connections_presence_states_entry", "legendFormat": "presence_states" },
+        { "expr": "waddle_state_connections_last_activity_entry", "legendFormat": "last_activity" }
       ],
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      }
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
     },
     {
       "type": "timeseries",
       "title": "MUC rooms (total vs dormant — reclaimable headroom)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        {
-          "expr": "waddle_state_rooms_total_entry",
-          "legendFormat": "total"
-        },
-        {
-          "expr": "waddle_state_rooms_dormant_entry",
-          "legendFormat": "dormant (will be evicted)"
-        }
+        { "expr": "waddle_state_rooms_total_entry", "legendFormat": "total" },
+        { "expr": "waddle_state_rooms_dormant_entry", "legendFormat": "dormant (will be evicted)" }
       ],
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      }
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "waddle",
-    "memory",
-    "leak-hunt"
-  ],
+  "tags": ["waddle", "memory", "leak-hunt"],
   "templating": {
     "list": [
       {
@@ -198,18 +86,11 @@
         "type": "datasource",
         "query": "prometheus",
         "regex": "/-prom$/",
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-waddlesocial-prom",
-          "value": "grafanacloud-prom"
-        }
+        "current": { "selected": true, "text": "grafanacloud-waddlesocial-prom", "value": "grafanacloud-prom" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle server — long-lived state inventory",
   "uid": "waddle-state-inventory",
   "version": 2

--- a/infrastructure/waddle.cloud/dashboards/06-state-inventory.json
+++ b/infrastructure/waddle.cloud/dashboards/06-state-inventory.json
@@ -1,5 +1,7 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "description": "Waddle server long-lived in-memory maps, sampled every 15 s by `state_inventory_metrics::spawn_state_inventory_publisher` and exported through the standard OTel meter provider into Grafana Cloud Mimir via the in-cluster grafana-alloy collector. Each panel charts a logical group of maps against `process_resident_memory_bytes` so an RSS climb correlates directly to whichever .len() is growing. Hand-buildable on purpose so it survives Grafana upgrades and is reviewable in PRs.",
   "editable": true,
   "graphTooltip": 1,
@@ -7,88 +9,207 @@
     {
       "type": "timeseries",
       "title": "Process RSS",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
         {
           "expr": "waddle_process_resident_memory_bytes_By",
           "legendFormat": "{{service_instance_id}}"
         }
       ],
-      "fieldConfig": { "defaults": { "unit": "bytes" } },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
     },
     {
       "type": "timeseries",
       "title": "Auth state maps (.len())",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "waddle_state_auth_pending_auth_entry", "legendFormat": "pending_auth" },
-        { "expr": "waddle_state_auth_device_auth_entry", "legendFormat": "device_auth" },
-        { "expr": "waddle_state_auth_xmpp_auth_codes_entry", "legendFormat": "xmpp_auth_codes" },
-        { "expr": "waddle_state_auth_dynamic_oidc_clients_entry", "legendFormat": "dynamic_oidc_clients" },
-        { "expr": "waddle_state_auth_dynamic_oidc_client_locks_entry", "legendFormat": "dynamic_oidc_client_locks" }
+        {
+          "expr": "waddle_state_auth_pending_auth_entry",
+          "legendFormat": "pending_auth"
+        },
+        {
+          "expr": "waddle_state_auth_device_auth_entry",
+          "legendFormat": "device_auth"
+        },
+        {
+          "expr": "waddle_state_auth_xmpp_auth_codes_entry",
+          "legendFormat": "xmpp_auth_codes"
+        },
+        {
+          "expr": "waddle_state_auth_dynamic_oidc_clients_entry",
+          "legendFormat": "dynamic_oidc_clients"
+        },
+        {
+          "expr": "waddle_state_auth_dynamic_oidc_client_locks_entry",
+          "legendFormat": "dynamic_oidc_client_locks"
+        }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Profile + dispatch in-flight",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "waddle_state_profile_avatar_source_locks_entry", "legendFormat": "avatar_source_locks" },
-        { "expr": "waddle_state_profile_publish_tracker_in_flight_entry", "legendFormat": "profile_publish" },
-        { "expr": "waddle_state_profile_provider_dispatch_in_flight_entry", "legendFormat": "provider_dispatch" }
+        {
+          "expr": "waddle_state_profile_avatar_source_locks_entry",
+          "legendFormat": "avatar_source_locks"
+        },
+        {
+          "expr": "waddle_state_profile_publish_tracker_in_flight_entry",
+          "legendFormat": "profile_publish"
+        },
+        {
+          "expr": "waddle_state_profile_provider_dispatch_in_flight_entry",
+          "legendFormat": "provider_dispatch"
+        }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
     },
     {
       "type": "timeseries",
       "title": "Sessions + caps",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "waddle_state_sessions_sm_live_sessions_entry", "legendFormat": "sm_live" },
-        { "expr": "waddle_state_sessions_resumable_sessions_entry", "legendFormat": "resumable" },
-        { "expr": "waddle_state_caps_caps_cache_entry", "legendFormat": "caps_cache" },
-        { "expr": "waddle_state_caps_pending_resolutions_entry", "legendFormat": "caps_pending" }
+        {
+          "expr": "waddle_state_sessions_sm_live_sessions_entry",
+          "legendFormat": "sm_live"
+        },
+        {
+          "expr": "waddle_state_sessions_resumable_sessions_entry",
+          "legendFormat": "resumable"
+        },
+        {
+          "expr": "waddle_state_caps_caps_cache_entry",
+          "legendFormat": "caps_cache"
+        },
+        {
+          "expr": "waddle_state_caps_pending_resolutions_entry",
+          "legendFormat": "caps_pending"
+        }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
     },
     {
       "type": "timeseries",
       "title": "Connections + presence",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "waddle_state_connections_full_jid_connections_entry", "legendFormat": "connections" },
-        { "expr": "waddle_state_connections_pending_subscription_stanzas_entry", "legendFormat": "pending_subs" },
-        { "expr": "waddle_state_connections_presence_states_entry", "legendFormat": "presence_states" },
-        { "expr": "waddle_state_connections_last_activity_entry", "legendFormat": "last_activity" }
+        {
+          "expr": "waddle_state_connections_full_jid_connections_entry",
+          "legendFormat": "connections"
+        },
+        {
+          "expr": "waddle_state_connections_pending_subscription_stanzas_entry",
+          "legendFormat": "pending_subs"
+        },
+        {
+          "expr": "waddle_state_connections_presence_states_entry",
+          "legendFormat": "presence_states"
+        },
+        {
+          "expr": "waddle_state_connections_last_activity_entry",
+          "legendFormat": "last_activity"
+        }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
     },
     {
       "type": "timeseries",
       "title": "MUC rooms (total vs dormant — reclaimable headroom)",
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "targets": [
-        { "expr": "waddle_state_rooms_total_entry", "legendFormat": "total" },
-        { "expr": "waddle_state_rooms_dormant_entry", "legendFormat": "dormant (will be evicted)" }
+        {
+          "expr": "waddle_state_rooms_total_entry",
+          "legendFormat": "total"
+        },
+        {
+          "expr": "waddle_state_rooms_dormant_entry",
+          "legendFormat": "dormant (will be evicted)"
+        }
       ],
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["waddle", "memory", "leak-hunt"],
+  "tags": [
+    "waddle",
+    "memory",
+    "leak-hunt"
+  ],
   "templating": {
     "list": [
       {
         "name": "DS_PROMETHEUS",
         "type": "datasource",
-        "query": "prometheus"
+        "query": "prometheus",
+        "regex": "/-prom$/",
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-waddlesocial-prom",
+          "value": "grafanacloud-prom"
+        }
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "title": "Waddle server — long-lived state inventory",
   "uid": "waddle-state-inventory",
   "version": 2

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -267,24 +267,15 @@ schema.#Project & {
 					folder_response="$(mktemp)"
 					trap 'rm -f "${folder_response}"' EXIT
 
-					folder_status="$(curl -sS -o "${folder_response}" -w '%{http_code}' \
-					  -X POST "${grafana_url}/api/folders" \
-					  -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
-					  -H 'Content-Type: application/json' \
-					  --data '{"uid":"waddle","title":"Waddle"}')"
-					case "${folder_status}" in
-					  200|201|409) ;;
-					  *)
-					    echo "Grafana folder creation failed with HTTP ${folder_status}:" >&2
-					    cat "${folder_response}" >&2
-					    exit 1
-					    ;;
-					esac
-
-					# Resolve the folder by its stable uid, matching the create
-					# above; the title-based lookup is only a fallback for a
-					# pre-existing folder that was created under another uid
-					# (create then 409s on the duplicate title).
+					# Resolve the folder BEFORE ever creating it, in three steps:
+					# 1) by its stable uid; 2) by unique title in the folder
+					# listing; 3) create it. Ensure-by-create cannot lead here:
+					# a create colliding on uid answers 412 version-mismatch
+					# (409 only covers title collisions), and Grafana Cloud has
+					# been observed serving folders that list fine but 404 on
+					# the by-uid endpoint (the post-merge #1327 sync failed on
+					# exactly that), which only the listing fallback survives.
+					folder_uid=""
 					folder_lookup_status="$(curl -sS -o "${folder_response}" -w '%{http_code}' \
 					  "${grafana_url}/api/folders/uid/waddle" \
 					  -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}")"
@@ -293,7 +284,24 @@ schema.#Project & {
 					else
 					  folder_uid="$(curl --fail-with-body -sS "${grafana_url}/api/folders" \
 					    -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
-					    | jq -er '[.[] | select(.title == "Waddle")] | if length == 1 then .[0].uid else error("expected exactly one Waddle folder") end')"
+					    | jq -r '[.[] | select(.title == "Waddle")] | if length == 1 then .[0].uid else "" end')"
+					fi
+					if [ -z "${folder_uid}" ]; then
+					  folder_status="$(curl -sS -o "${folder_response}" -w '%{http_code}' \
+					    -X POST "${grafana_url}/api/folders" \
+					    -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
+					    -H 'Content-Type: application/json' \
+					    --data '{"uid":"waddle","title":"Waddle"}')"
+					  case "${folder_status}" in
+					    200|201)
+					      folder_uid="$(jq -er '.uid' "${folder_response}")"
+					      ;;
+					    *)
+					      echo "Grafana folder creation failed with HTTP ${folder_status}:" >&2
+					      cat "${folder_response}" >&2
+					      exit 1
+					      ;;
+					  esac
 					fi
 
 					for dashboard_file in dashboards/*.json; do

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -282,9 +282,27 @@ schema.#Project & {
 					if [ "${folder_lookup_status}" = "200" ]; then
 					  folder_uid="$(jq -er '.uid' "${folder_response}")"
 					else
-					  folder_uid="$(curl --fail-with-body -sS "${grafana_url}/api/folders" \
+					  # Fall back to the listing: first by the stable uid (covers a
+					  # renamed title and the observed list-ok/uid-endpoint-404
+					  # state), then by unique title. Several folders titled
+					  # Waddle is an ambiguity a human must resolve — creating
+					  # yet another folder would strand the existing ones.
+					  curl --fail-with-body -sS "${grafana_url}/api/folders" \
 					    -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
-					    | jq -r '[.[] | select(.title == "Waddle")] | if length == 1 then .[0].uid else "" end')"
+					    > "${folder_response}"
+					  folder_uid="$(jq -r \
+					    '[.[] | select(.uid == "waddle")] | if length == 1 then .[0].uid else "" end' \
+					    "${folder_response}")"
+					  if [ -z "${folder_uid}" ]; then
+					    title_matches="$(jq -r '[.[] | select(.title == "Waddle")] | length' "${folder_response}")"
+					    if [ "${title_matches}" -gt 1 ]; then
+					      echo "Refusing to sync: ${title_matches} folders titled \"Waddle\" and none with uid \"waddle\"; resolve the duplicates manually." >&2
+					      exit 1
+					    fi
+					    if [ "${title_matches}" = "1" ]; then
+					      folder_uid="$(jq -er '[.[] | select(.title == "Waddle")] | .[0].uid' "${folder_response}")"
+					    fi
+					  fi
 					fi
 					if [ -z "${folder_uid}" ]; then
 					  folder_status="$(curl -sS -o "${folder_response}" -w '%{http_code}' \

--- a/infrastructure/waddle.cloud/scripts/validate-dashboards.sh
+++ b/infrastructure/waddle.cloud/scripts/validate-dashboards.sh
@@ -44,6 +44,18 @@ for dashboard_file in "${dashboard_files[@]}"; do
     failed=1
   fi
 
+  # Datasource variables must pin a current value and constrain matches
+  # with a regex: an unpinned datasource variable makes Grafana pick the
+  # first type-matching datasource alphabetically, which on Grafana
+  # Cloud is a decoy tenant (grafanacloud-usage for prometheus,
+  # alert-state-history for loki) and renders every panel "No data".
+  if ! jq -e '[.templating.list[]? | select(.type == "datasource")
+      | ((.regex // "" | length) > 0) and ((.current.value // "" | length) > 0)]
+      | all' "${dashboard_file}" >/dev/null; then
+    echo "ERROR: ${dashboard_file}: every datasource template variable must set a regex filter and a current.value default." >&2
+    failed=1
+  fi
+
   if ! jq -e '.panels | type == "array"' "${dashboard_file}" >/dev/null; then
     echo "ERROR: ${dashboard_file}: .panels must be an array." >&2
     failed=1


### PR DESCRIPTION
Two production defects in the #1327 dashboards pipeline, both found and verified against the live stack.

## 1. `dashboardsSync` folder resolution failed on main

The first main-push after #1327 merged failed in `dashboardsSync` (run [29776396541](https://github.com/waddle-social/waddle/actions/runs/29776396541), exit 5), leaving the Waddle folder empty. `deployAnnotation` and `rulesSync` succeeded.

Root cause: the task ensured the folder by POSTing a create and tolerating `200/201/409`, then looked it up by uid. Two Grafana behaviors break that on this stack:

- A create colliding on an **existing uid** answers `412 version-mismatch`, not `409` (409 only covers title collisions).
- The stack's folder record **lists fine in `GET /api/folders` but 404s on `GET /api/folders/uid/waddle`**, so the uid lookup failed and the unique-title jq fallback `error()`d out (jq runtime errors exit 5 — matching the CI log).

Fix: resolve the folder before ever creating it — stable-uid GET, then unique-title match in the folder listing, then create as the last resort (tolerating only `200/201`, failing loudly with the response body otherwise).

## 2. Every synced board rendered "No data"

The `DS_PROMETHEUS`/`DS_LOKI` datasource variables shipped with no `current` value and no `regex`, so Grafana initialized them to the first type-matching datasource **alphabetically** — `grafanacloud-usage` (the billing tenant) and `grafanacloud-waddlesocial-alert-state-history` — neither of which holds waddle data. Confirmed in-browser: the dashboard URL carried `var-DS_PROMETHEUS=grafanacloud-usage&var-DS_LOKI=grafanacloud-alert-state-history` with every panel empty, while the same queries returned live series against the real tenants.

Fix: pin `current.value` to the stack's provisioned datasource uids (`grafanacloud-prom` / `grafanacloud-logs`) and constrain matches with `/-prom$/` and `/-logs$/` regexes so a decoy tenant can never be picked. `validate-dashboards.sh` now rejects any datasource variable missing either, so this bug class fails PR lint (verified red on the unpinned boards, green after).

## Verification

- Ran the fixed `dashboardsSync` body against production with the CI credentials: folder resolves via the listing fallback, **all six dashboards synced into the Waddle folder**.
- Reloaded `waddle-overview` in the browser: variables resolve to `grafanacloud-prom`/`grafanacloud-logs` and every panel binds live series (pods, dm/muc rates, rooms, error/reset rates).
- `jq -S` confirms the formatting-restore commit leaves boards semantically identical; net board diff is just the regex/current additions.
- Task inputs unchanged → zero workflow drift under pinned cuenv 0.54.0; `dashboardsLint` passes.

## 3. Client-experience board: 5 of 7 panels queried a Faro schema that doesn't exist

The panels assumed `kind="measurements"` (the real label value is singular `measurement`), `| json` parsing (Faro collector lines are logfmt), and `values_*`/`attributes_*` field names (the wire carries `value_<name>`, `event_data_<name>`, `context_<name>`). Only the two exception panels worked — `value_template` rides on Loki structured metadata.

Fix: rewrite the five panels against the observed line format (logfmt, singular kind, `value_*` unwraps guarded with `__error__=""`, `event_data_type` for the lifecycle split). Every emitted measurement type was confirmed present in Loki over 24h, and the board was verified rendering all seven panels with live data in the browser.

## 4. Delivery-reliability board: absent tail-event counters rendered "No data"

The board's `waddle_*` families are create-at-increment instruments (evictions, pauses, dead-letters, quota). No events since the current pods started → no `xmpp_*` source series → the alias recording rules correctly record nothing → `increase()` shows "No data" instead of the healthy zero (verified: zero samples over 24h in Mimir for every family except the live broadcast/push-suppressed ones). Fix: wrap the 17 ungrouped `sum(increase(...))` targets and both Loki resume targets in `or vector(0)`; verified live that every legend series now draws an explicit zero line.

## Known follow-up (not in this PR)

Board panels have `id: null`, which breaks panel-level rendering/deeplinks (`/render`, `get_panel_image`). Harmless for interactive use; worth assigning stable panel ids in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
