### PR TITLE
fix(android): remove conflict markers shipped in the rooms parity squash

### DIFF
--- a/apps/android/FEATURE_PARITY.md
+++ b/apps/android/FEATURE_PARITY.md
@@ -132,13 +132,8 @@ In flight in the current improvement sweep:
 
 Biggest remaining gaps after that, in priority order:
 
-<<<<<<< HEAD
-1. **Voice/video calls** — the FFI signaling layer is complete; Android needs a call UI and media stack. Largest single capability gap.
-=======
 1. **Muji group calls (XEP-0272)** — DM calls shipped; the group-call presence flow, mixer session-initiate, and in-call roster remain.
-2. **Room lifecycle + moderation UI** — room create/config, affiliation management (kick/ban), hats display, ad-hoc commands.
->>>>>>> origin/main
-3. **Rich content rendering** — markup spans (0394), markdown, link previews, sticker/GIF pickers; most of the data already arrives typed over FFI.
-4. **Profile editing** — vCard (0292) and avatar publish (0084); currently display-only.
-5. **Group DMs and bookmarks** (0402) — multi-party DMs and server-synced room list.
-6. **Community surfaces** — feed (0472), stories (0501), events, extensions; lowest urgency, largest scope.
+2. **Rich content rendering** — markup spans (0394), markdown, link previews, sticker/GIF pickers; most of the data already arrives typed over FFI.
+3. **Profile editing** — vCard (0292) and avatar publish (0084); currently display-only.
+4. **Group DMs and bookmarks** (0402) — multi-party DMs and server-synced room list.
+5. **Community surfaces** — feed (0472), stories (0501), events, extensions; lowest urgency, largest scope.

--- a/apps/android/app/src/main/kotlin/social/waddle/android/feature/conversation/ConversationScreen.kt
+++ b/apps/android/app/src/main/kotlin/social/waddle/android/feature/conversation/ConversationScreen.kt
@@ -18,11 +18,8 @@ import androidx.compose.material.icons.outlined.Call
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.Search
-<<<<<<< HEAD
-import androidx.compose.material3.AlertDialog
-=======
 import androidx.compose.material.icons.outlined.Videocam
->>>>>>> origin/main
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -81,13 +78,10 @@ fun ConversationScreen(
     searchTarget: MessageSearchTarget? = null,
     /** Own bare JID for the self-mention row highlight (XEP-0372). */
     selfBareJid: String? = null,
-<<<<<<< HEAD
     /** Extra host-specific top-bar actions (room members/settings). */
     extraTopBarActions: @Composable () -> Unit = {},
-=======
     /** DM-only call entry points; `null` (channels, threads) hides them. */
     onStartCall: ((video: Boolean) -> Unit)? = null,
->>>>>>> origin/main
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val typing by viewModel.typing.collectAsStateWithLifecycle()
@@ -149,9 +143,7 @@ fun ConversationScreen(
                     }
                 },
                 actions = {
-<<<<<<< HEAD
                     extraTopBarActions()
-=======
                     if (onStartCall != null) {
                         IconButton(
                             onClick = { onStartCall(false) },
@@ -172,7 +164,6 @@ fun ConversationScreen(
                             )
                         }
                     }
->>>>>>> origin/main
                     if (onOpenThread != null && state.threads.isNotEmpty()) {
                         IconButton(onClick = { threadsOverviewOpen = true }) {
                             Icon(


### PR DESCRIPTION
The #1382 squash landed with unresolved merge markers in `ConversationScreen.kt` (breaking compilation) and `FEATURE_PARITY.md` — the merge-queue entry was created while the PR head was still green, and the marker-bearing follow-up commit slipped into the queued merge.

This applies the intended union resolution:

- `ConversationScreen.kt`: the top bar carries **both** the DM call buttons (#1380) and the host-specific room actions (#1382); both parameters restored (`onStartCall`, `extraTopBarActions`) plus the `Videocam`/`AlertDialog` imports.
- `FEATURE_PARITY.md`: remaining-gaps list keeps **Muji group calls** as the top gap and drops the room-lifecycle entry #1382 shipped.

Verified locally: `detekt` and `:app:compileDebugKotlin` green on this branch; the identical content passed the full suite (detekt, unit tests, lint, androidTest compile) on the pre-squash rooms branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)