### PR TITLE
feat(server): community pubsub client groundwork

### DIFF
--- a/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
@@ -1,25 +1,27 @@
 //! XEP-0472 Pubsub Social Feed — wasm bridge surface.
 //!
 //! The server bootstraps a community feed node at
-//! `urn:xmpp:pubsub-social-feed:1` on the spaces service. These
-//! wasm methods let the chat read the feed (`feed_items`) and
-//! publish new posts (`feed_publish`) via standard XEP-0060
-//! pubsub IQs, with the typed XEP-0472 `<entry/>` payload
-//! constructed / parsed in Rust via `waddle_xmpp_core::xep0472`.
+//! `urn:xmpp:pubsub-social-feed:1` on the community service
+//! (`community.<domain>`). These wasm methods let the chat read the
+//! feed (`feed_items`) and publish new posts (`feed_publish`) via the
+//! shared XEP-0060 pubsub helpers in `waddle_xmpp_client::pubsub`,
+//! with the typed XEP-0472 `<entry/>` payload constructed / parsed in
+//! Rust via `waddle_xmpp_core::xep0472`.
 
 use chrono::{DateTime, Utc};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use waddle_xmpp_client::pubsub::{
+    build_pubsub_items_iq, build_pubsub_publish_iq, parse_pubsub_items_result,
+};
 use waddle_xmpp_core::xep0472::{
     build_feed_entry_element, parse_feed_entry, FeedEntry, NS_ATOM, PUBSUB_NODE_FEED,
 };
 use wasm_bindgen::prelude::*;
 
-use super::{js_error, send_iq_command, to_js_value, WaddleClient};
-use crate::NS_CLIENT;
+use super::{js_error, send_iq_command, service_bare_jid, to_js_value, WaddleClient};
 
-const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 /// Waddle-namespaced typed child on bridged feed entries (PEP →
 /// feed). Carries `kind="mood"|"activity"|"tune"|"avatar"|"vcard"`
 /// so the chat can render a kind-icon next to bridged posts.
@@ -77,72 +79,34 @@ pub(crate) struct JsFeedEntryInput {
     pub link: Option<String>,
 }
 
-fn build_feed_items_iq(spaces_jid: &str, max_items: Option<u32>) -> Element {
+fn build_feed_items_iq(community_service: &jid::BareJid, max_items: Option<u32>) -> Element {
     let id = format!("feed-items-{}", Uuid::new_v4());
-    let mut items_builder = Element::builder("items", NS_PUBSUB).attr(
-        minidom::rxml::xml_ncname!("node").to_owned(),
-        PUBSUB_NODE_FEED,
-    );
-    let max_items_value;
-    if let Some(max) = max_items {
-        max_items_value = max.to_string();
-        items_builder = items_builder.attr(
-            minidom::rxml::xml_ncname!("max_items").to_owned(),
-            max_items_value.as_str(),
-        );
-    }
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(items_builder.build())
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), spaces_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_items_iq(&id, Some(community_service), PUBSUB_NODE_FEED, max_items)
 }
 
-fn build_feed_publish_iq(spaces_jid: &str, item_id: &str, entry: &FeedEntry) -> Element {
+fn build_feed_publish_iq(
+    community_service: &jid::BareJid,
+    item_id: &str,
+    entry: &FeedEntry,
+) -> Element {
     let id = format!("feed-publish-{}", Uuid::new_v4());
-    let item = Element::builder("item", NS_PUBSUB)
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
-        .append(build_feed_entry_element(entry))
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PUBSUB_NODE_FEED,
-        )
-        .append(item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), spaces_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        Some(community_service),
+        PUBSUB_NODE_FEED,
+        Some(item_id),
+        build_feed_entry_element(entry),
+        None,
+    )
 }
 
 fn parse_feed_items_result(iq: &Element) -> Vec<JsFeedEntry> {
-    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
-        return Vec::new();
-    };
-    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
-        return Vec::new();
-    };
-    items
-        .children()
-        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+    parse_pubsub_items_result(iq)
+        .into_iter()
         .filter_map(|item| {
-            let item_id = item.attr("id")?;
-            let entry_el = item
-                .children()
-                .find(|child| child.name() == "entry" && child.ns() == NS_ATOM)?;
+            let entry_el = item.payload("entry", NS_ATOM)?;
             let source = extract_source_kind(entry_el);
-            parse_feed_entry(item_id, entry_el).map(|entry| {
+            parse_feed_entry(&item.id, entry_el).map(|entry| {
                 let mut js = JsFeedEntry::from(entry);
                 js.source = source;
                 js
@@ -154,13 +118,14 @@ fn parse_feed_items_result(iq: &Element) -> Vec<JsFeedEntry> {
 #[wasm_bindgen]
 impl WaddleClient {
     /// Fetch the latest items from the community Social Feed node on
-    /// `spaces_jid` (typically `spaces.<domain>`). Returns an array of
-    /// JsFeedEntry objects ordered as the server delivered them
-    /// (newest first by `last_published`).
+    /// `spaces_jid` — the community service (`community.<domain>`).
+    /// Returns an array of JsFeedEntry objects ordered as the server
+    /// delivered them (newest first by `last_published`).
     pub fn feed_items(&self, spaces_jid: String, max_items: Option<u32>) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
-            let iq = build_feed_items_iq(&spaces_jid, max_items);
+            let service = service_bare_jid(&spaces_jid)?;
+            let iq = build_feed_items_iq(&service, max_items);
             let result = send_iq_command(inner, iq).await?;
             let entries = parse_feed_items_result(&result);
             to_js_value(&entries)
@@ -174,6 +139,7 @@ impl WaddleClient {
     pub fn feed_publish(&self, spaces_jid: String, entry: JsValue) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
+            let service = service_bare_jid(&spaces_jid)?;
             let input: JsFeedEntryInput = serde_wasm_bindgen::from_value(entry)
                 .map_err(|err| js_error(format!("invalid feed entry input: {err}")))?;
             let item_id = format!("post-{}", Uuid::new_v4());
@@ -188,7 +154,7 @@ impl WaddleClient {
                 feed_entry = feed_entry.with_link(link);
             }
             feed_entry = feed_entry.with_published(Utc::now());
-            let iq = build_feed_publish_iq(&spaces_jid, &item_id, &feed_entry);
+            let iq = build_feed_publish_iq(&service, &item_id, &feed_entry);
             send_iq_command(inner, iq).await?;
             // Return the entry we just published so the chat can append
             // it to local state without round-tripping through items.

--- a/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
@@ -174,3 +174,56 @@ impl WaddleClient {
         })
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+
+    fn service() -> jid::BareJid {
+        "community.waddle.test".parse().expect("valid service jid")
+    }
+
+    #[test]
+    fn feed_items_iq_pins_the_xep0060_wire_shape() {
+        let iq = build_feed_items_iq(&service(), Some(50));
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq.attr("id").expect("iq id").starts_with("feed-items-"));
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PUBSUB_NODE_FEED));
+        assert_eq!(items.attr("max_items"), Some("50"));
+
+        let unbounded = build_feed_items_iq(&service(), None);
+        let items = unbounded
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("max_items"), None);
+    }
+
+    #[test]
+    fn feed_publish_iq_pins_the_atom_entry_publish_shape() {
+        let entry = FeedEntry::new("post-1", "hello waddlers");
+        let iq = build_feed_publish_iq(&service(), "post-1", &entry);
+        assert_eq!(iq.attr("type"), Some("set"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq.attr("id").expect("iq id").starts_with("feed-publish-"));
+        let publish = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+            .expect("publish element");
+        assert_eq!(publish.attr("node"), Some(PUBSUB_NODE_FEED));
+        let item = publish.get_child("item", NS_PUBSUB).expect("item element");
+        assert_eq!(item.attr("id"), Some("post-1"));
+        assert!(item.get_child("entry", NS_ATOM).is_some());
+        // No publish-options precondition on feed posts.
+        assert!(iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("publish-options", NS_PUBSUB))
+            .is_none());
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
@@ -151,3 +151,47 @@ impl WaddleClient {
         })
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+
+    fn service() -> jid::BareJid {
+        "community.waddle.test".parse().expect("valid service jid")
+    }
+
+    #[test]
+    fn stories_items_iq_pins_the_xep0060_wire_shape() {
+        let iq = build_stories_items_iq(&service(), Some(100));
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq.attr("id").expect("iq id").starts_with("stories-items-"));
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PUBSUB_NODE_STORIES));
+        assert_eq!(items.attr("max_items"), Some("100"));
+    }
+
+    #[test]
+    fn story_publish_iq_pins_the_atom_entry_publish_shape() {
+        let story = Story::new("story-1");
+        let iq = build_story_publish_iq(&service(), "story-1", &story);
+        assert_eq!(iq.attr("type"), Some("set"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq
+            .attr("id")
+            .expect("iq id")
+            .starts_with("stories-publish-"));
+        let publish = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+            .expect("publish element");
+        assert_eq!(publish.attr("node"), Some(PUBSUB_NODE_STORIES));
+        let item = publish.get_child("item", NS_PUBSUB).expect("item element");
+        assert_eq!(item.attr("id"), Some("story-1"));
+        assert!(item.get_child("entry", NS_ATOM).is_some());
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
@@ -10,15 +10,15 @@ use chrono::{DateTime, Duration, Utc};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use waddle_xmpp_client::pubsub::{
+    build_pubsub_items_iq, build_pubsub_publish_iq, parse_pubsub_items_result,
+};
 use waddle_xmpp_core::xep0501::{
     build_story_element, parse_story, Story, DEFAULT_EXPIRY_HOURS, NS_ATOM, PUBSUB_NODE_STORIES,
 };
 use wasm_bindgen::prelude::*;
 
-use super::{js_error, send_iq_command, to_js_value, WaddleClient};
-use crate::NS_CLIENT;
-
-const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+use super::{js_error, send_iq_command, service_bare_jid, to_js_value, WaddleClient};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct JsStory {
@@ -54,71 +54,33 @@ pub(crate) struct JsStoryInput {
     pub expiry_hours: Option<i64>,
 }
 
-fn build_stories_items_iq(community_jid: &str, max_items: Option<u32>) -> Element {
+fn build_stories_items_iq(community_service: &jid::BareJid, max_items: Option<u32>) -> Element {
     let id = format!("stories-items-{}", Uuid::new_v4());
-    let mut items_builder = Element::builder("items", NS_PUBSUB).attr(
-        minidom::rxml::xml_ncname!("node").to_owned(),
-        PUBSUB_NODE_STORIES,
-    );
-    let max_items_value;
-    if let Some(max) = max_items {
-        max_items_value = max.to_string();
-        items_builder = items_builder.attr(
-            minidom::rxml::xml_ncname!("max_items").to_owned(),
-            max_items_value.as_str(),
-        );
-    }
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(items_builder.build())
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_items_iq(&id, Some(community_service), PUBSUB_NODE_STORIES, max_items)
 }
 
-fn build_story_publish_iq(community_jid: &str, item_id: &str, story: &Story) -> Element {
+fn build_story_publish_iq(
+    community_service: &jid::BareJid,
+    item_id: &str,
+    story: &Story,
+) -> Element {
     let id = format!("stories-publish-{}", Uuid::new_v4());
-    let item = Element::builder("item", NS_PUBSUB)
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
-        .append(build_story_element(story))
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PUBSUB_NODE_STORIES,
-        )
-        .append(item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        Some(community_service),
+        PUBSUB_NODE_STORIES,
+        Some(item_id),
+        build_story_element(story),
+        None,
+    )
 }
 
 fn parse_stories_items_result(iq: &Element) -> Vec<JsStory> {
-    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
-        return Vec::new();
-    };
-    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
-        return Vec::new();
-    };
-    items
-        .children()
-        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+    parse_pubsub_items_result(iq)
+        .into_iter()
         .filter_map(|item| {
-            let item_id = item.attr("id")?;
-            let story_el = item
-                .children()
-                .find(|child| child.name() == "entry" && child.ns() == NS_ATOM)?;
-            parse_story(item_id, story_el).map(JsStory::from)
+            let story_el = item.payload("entry", NS_ATOM)?;
+            parse_story(&item.id, story_el).map(JsStory::from)
         })
         .collect()
 }
@@ -132,7 +94,8 @@ impl WaddleClient {
     pub fn stories_items(&self, community_jid: String, max_items: Option<u32>) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
-            let iq = build_stories_items_iq(&community_jid, max_items);
+            let service = service_bare_jid(&community_jid)?;
+            let iq = build_stories_items_iq(&service, max_items);
             let result = send_iq_command(inner, iq).await?;
             let stories = parse_stories_items_result(&result);
             to_js_value(&stories)
@@ -145,6 +108,7 @@ impl WaddleClient {
     pub fn stories_publish(&self, community_jid: String, input: JsValue) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
+            let service = service_bare_jid(&community_jid)?;
             let input: JsStoryInput = serde_wasm_bindgen::from_value(input)
                 .map_err(|err| js_error(format!("invalid story input: {err}")))?;
             let media_url = input
@@ -170,7 +134,7 @@ impl WaddleClient {
             }
             let hours = input.expiry_hours.unwrap_or(DEFAULT_EXPIRY_HOURS).max(1);
             story = story.with_expiry(Duration::hours(hours));
-            let iq = build_story_publish_iq(&community_jid, &item_id, &story);
+            let iq = build_story_publish_iq(&service, &item_id, &story);
             send_iq_command(inner, iq).await?;
             let posted: DateTime<Utc> = story.posted.unwrap_or_else(Utc::now);
             let expires: DateTime<Utc> = story.expires.expect("with_expiry always sets expires");

--- a/server/crates/waddle-xmpp-client-wasm/src/client_story_reads.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_story_reads.rs
@@ -10,6 +10,10 @@ use chrono::{DateTime, Utc};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use waddle_xmpp_client::pubsub::{
+    build_pubsub_items_iq, build_pubsub_publish_iq, parse_pubsub_items_result, PubsubAccessModel,
+    PubsubPublishOptions, PubsubSendLastPublishedItem,
+};
 use waddle_xmpp_core::waddle_story_reads::{
     StoryId, StoryReads, NS_WADDLE_STORY_READS, PEP_ITEM_WADDLE_STORY_READS,
     PEP_NODE_WADDLE_STORY_READS,
@@ -17,11 +21,6 @@ use waddle_xmpp_core::waddle_story_reads::{
 use wasm_bindgen::prelude::*;
 
 use super::{js_error, send_iq_command, to_js_value, WaddleClient};
-use crate::NS_CLIENT;
-
-const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
-const NS_PUBSUB_PUBLISH_OPTIONS: &str = "http://jabber.org/protocol/pubsub#publish-options";
-const NS_XDATA: &str = "jabber:x:data";
 
 /// JS-facing entry (id, RFC 3339 timestamp). `StoryId` is unwrapped at
 /// this boundary — the wasm/JS layer carries it as a plain string.
@@ -51,104 +50,47 @@ impl From<&StoryReads> for JsStoryReads {
     }
 }
 
-/// Build the `<publish-options>` precondition form. ALL FOUR fields are
+/// The `<publish-options>` precondition values. ALL FOUR fields are
 /// mandatory — omitting any of them lets a server auto-create the node
 /// with different defaults and silently leak read-state notifications.
-pub(crate) fn build_publish_options_form() -> Element {
-    let form = Element::builder("x", NS_XDATA)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
-        .append(hidden_field("FORM_TYPE", NS_PUBSUB_PUBLISH_OPTIONS))
-        .append(text_single_field("pubsub#persist_items", "true"))
-        .append(text_single_field("pubsub#access_model", "whitelist"))
-        .append(text_single_field(
-            "pubsub#send_last_published_item",
-            "never",
-        ))
-        .append(text_single_field("pubsub#max_items", "1"))
-        .build();
-    Element::builder("publish-options", NS_PUBSUB)
-        .append(form)
-        .build()
-}
-
-fn hidden_field(var: &str, value: &str) -> Element {
-    Element::builder("field", NS_XDATA)
-        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
-        .append(Element::builder("value", NS_XDATA).append(value).build())
-        .build()
-}
-
-fn text_single_field(var: &str, value: &str) -> Element {
-    Element::builder("field", NS_XDATA)
-        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
-        .append(Element::builder("value", NS_XDATA).append(value).build())
-        .build()
+fn story_reads_publish_options() -> PubsubPublishOptions {
+    PubsubPublishOptions {
+        persist_items: Some(true),
+        access_model: Some(PubsubAccessModel::Whitelist),
+        send_last_published_item: Some(PubsubSendLastPublishedItem::Never),
+        max_items: Some(1),
+    }
 }
 
 pub(crate) fn build_story_reads_publish_iq(reads: &StoryReads) -> Element {
     let id = format!("story-reads-publish-{}", Uuid::new_v4());
-    let item = Element::builder("item", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("id").to_owned(),
-            PEP_ITEM_WADDLE_STORY_READS,
-        )
-        .append(reads.build_element())
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PEP_NODE_WADDLE_STORY_READS,
-        )
-        .append(item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .append(build_publish_options_form())
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        None,
+        PEP_NODE_WADDLE_STORY_READS,
+        Some(PEP_ITEM_WADDLE_STORY_READS),
+        reads.build_element(),
+        Some(&story_reads_publish_options()),
+    )
 }
 
 pub(crate) fn build_story_reads_fetch_iq() -> Element {
     let id = format!("story-reads-fetch-{}", Uuid::new_v4());
-    let items = Element::builder("items", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PEP_NODE_WADDLE_STORY_READS,
-        )
-        .attr(minidom::rxml::xml_ncname!("max_items").to_owned(), "1")
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB).append(items).build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .append(pubsub)
-        .build()
+    build_pubsub_items_iq(&id, None, PEP_NODE_WADDLE_STORY_READS, Some(1))
 }
 
 /// Parse the items result returned by `build_story_reads_fetch_iq()`.
 ///
 /// Returns an empty `StoryReads` if the node has no items or the result
-/// shape doesn't match expectations — read state is non-critical, so
-/// silently degrading to "nothing read" is better than surfacing an
-/// error the user can't act on.
+/// shape doesn't match expectations (including items without an ItemID
+/// — the read-state item is always published under the fixed `current`
+/// id) — read state is non-critical, so silently degrading to "nothing
+/// read" is better than surfacing an error the user can't act on.
 pub(crate) fn parse_story_reads_fetch_result(iq: &Element) -> StoryReads {
-    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
-        return StoryReads::default();
-    };
-    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
-        return StoryReads::default();
-    };
-    items
-        .children()
-        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+    parse_pubsub_items_result(iq)
+        .into_iter()
         .find_map(|item| {
-            item.children()
-                .find(|c| c.name() == "reads" && c.ns() == NS_WADDLE_STORY_READS)
+            item.payload("reads", NS_WADDLE_STORY_READS)
                 .and_then(|reads_el| StoryReads::parse(reads_el).ok())
         })
         .unwrap_or_default()
@@ -231,6 +173,10 @@ impl WaddleClient {
 mod tests {
     use super::*;
 
+    const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+    const NS_PUBSUB_PUBLISH_OPTIONS: &str = "http://jabber.org/protocol/pubsub#publish-options";
+    const NS_XDATA: &str = "jabber:x:data";
+
     #[test]
     fn publish_iq_carries_required_publish_options() {
         let reads = StoryReads::default();
@@ -294,6 +240,27 @@ mod tests {
         let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
             .parse()
             .expect("valid");
+        let reads = parse_story_reads_fetch_result(&iq);
+        assert!(reads.is_empty());
+    }
+
+    #[test]
+    fn parse_fetch_ignores_items_without_ids() {
+        // The read-state item is always published under the fixed
+        // `current` id; an id-less item is not ours and degrades to
+        // "nothing read" rather than being trusted.
+        let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+            <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+              <items node='urn:waddle:story:reads:0'>\
+                <item>\
+                  <reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='story-a' at='2026-05-19T10:11:12Z'/>\
+                  </reads>\
+                </item>\
+              </items>\
+            </pubsub>\
+          </iq>";
+        let iq: Element = xml.parse().expect("valid");
         let reads = parse_story_reads_fetch_result(&iq);
         assert!(reads.is_empty());
     }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
@@ -10,6 +10,10 @@ use chrono::{DateTime, NaiveDate, Utc};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use waddle_xmpp_client::pubsub::{
+    build_pubsub_items_iq, build_pubsub_publish_iq, build_pubsub_retract_iq,
+    parse_pubsub_items_result,
+};
 use waddle_xmpp_core::xcal::{
     build_vcalendar_with_event, build_vcalendar_with_item, parse_vcalendar_item, Attendee,
     CalendarDateValue, CalendarItem, Freq, PartStat, Rrule, RruleEnd, VEvent, Weekday, NS_XCAL,
@@ -17,10 +21,7 @@ use waddle_xmpp_core::xcal::{
 };
 use wasm_bindgen::prelude::*;
 
-use super::{js_error, send_iq_command, to_js_value, WaddleClient};
-use crate::NS_CLIENT;
-
-const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+use super::{js_error, send_iq_command, service_bare_jid, to_js_value, WaddleClient};
 
 // ── JS-facing shapes ────────────────────────────────────────────────
 
@@ -363,29 +364,9 @@ impl JsVEvent {
 
 // ── IQ builders / parsers ───────────────────────────────────────────
 
-fn build_events_items_iq(community_jid: &str, max_items: Option<u32>) -> Element {
+fn build_events_items_iq(community_service: &jid::BareJid, max_items: Option<u32>) -> Element {
     let id = format!("xcal-items-{}", Uuid::new_v4());
-    let mut items_builder = Element::builder("items", NS_PUBSUB).attr(
-        minidom::rxml::xml_ncname!("node").to_owned(),
-        PUBSUB_NODE_EVENTS,
-    );
-    let max_items_value;
-    if let Some(max) = max_items {
-        max_items_value = max.to_string();
-        items_builder = items_builder.attr(
-            minidom::rxml::xml_ncname!("max_items").to_owned(),
-            max_items_value.as_str(),
-        );
-    }
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(items_builder.build())
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_items_iq(&id, Some(community_service), PUBSUB_NODE_EVENTS, max_items)
 }
 
 /// Build an RSVP item payload for a master event: a VEVENT carrying
@@ -393,7 +374,7 @@ fn build_events_items_iq(community_jid: &str, max_items: Option<u32>) -> Element
 /// PartStat. Item id uses the canonical `<master-uid>-rsvp-<localpart>`
 /// shape so the chat can fold sibling RSVP items back into the master.
 fn build_rsvp_publish_iq(
-    community_jid: &str,
+    community_service: &jid::BareJid,
     master_uid: &str,
     self_localpart: &str,
     self_jid: &str,
@@ -415,56 +396,33 @@ fn build_rsvp_publish_iq(
         recurrence_id: None,
         exdates: Vec::new(),
     };
-    let item = Element::builder("item", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("id").to_owned(),
-            item_id.as_str(),
-        )
-        .append(build_vcalendar_with_event(&rsvp_event))
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PUBSUB_NODE_EVENTS,
-        )
-        .append(item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        Some(community_service),
+        PUBSUB_NODE_EVENTS,
+        Some(item_id.as_str()),
+        build_vcalendar_with_event(&rsvp_event),
+        None,
+    )
 }
 
 /// Build a publish IQ for a CalendarItem (master + overrides) at
 /// the given item id. Used by `xcal_publish_item` to atomically
 /// write a master event plus its per-instance overrides + EXDATEs.
-fn build_item_publish_iq(community_jid: &str, item_id: &str, item: &CalendarItem) -> Element {
+fn build_item_publish_iq(
+    community_service: &jid::BareJid,
+    item_id: &str,
+    item: &CalendarItem,
+) -> Element {
     let id = format!("xcal-publish-{}", Uuid::new_v4());
-    let pubsub_item = Element::builder("item", NS_PUBSUB)
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
-        .append(build_vcalendar_with_item(item))
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PUBSUB_NODE_EVENTS,
-        )
-        .append(pubsub_item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        Some(community_service),
+        PUBSUB_NODE_EVENTS,
+        Some(item_id),
+        build_vcalendar_with_item(item),
+        None,
+    )
 }
 
 fn vevent_from_input(uid: &str, input: JsVEventInput) -> Result<VEvent, JsValue> {
@@ -591,49 +549,27 @@ fn validate_calendar_item_data(item: &CalendarItem) -> Result<(), &'static str> 
     Ok(())
 }
 
-fn build_event_publish_iq(community_jid: &str, item_id: &str, event: &VEvent) -> Element {
+fn build_event_publish_iq(
+    community_service: &jid::BareJid,
+    item_id: &str,
+    event: &VEvent,
+) -> Element {
     let id = format!("xcal-publish-{}", Uuid::new_v4());
-    let item = Element::builder("item", NS_PUBSUB)
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
-        .append(build_vcalendar_with_event(event))
-        .build();
-    let publish = Element::builder("publish", NS_PUBSUB)
-        .attr(
-            minidom::rxml::xml_ncname!("node").to_owned(),
-            PUBSUB_NODE_EVENTS,
-        )
-        .append(item)
-        .build();
-    let pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(publish)
-        .build();
-    Element::builder("iq", NS_CLIENT)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-        .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-        .append(pubsub)
-        .build()
+    build_pubsub_publish_iq(
+        &id,
+        Some(community_service),
+        PUBSUB_NODE_EVENTS,
+        Some(item_id),
+        build_vcalendar_with_event(event),
+        None,
+    )
 }
 
 fn parse_events_items_result(iq: &Element) -> Vec<JsVEvent> {
-    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
-        return Vec::new();
-    };
-    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
-        return Vec::new();
-    };
     let mut flattened = Vec::new();
-    for item in items
-        .children()
-        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
-    {
-        let Some(item_id) = item.attr("id") else {
-            continue;
-        };
-        let Some(vcal) = item
-            .children()
-            .find(|child| child.name() == "vcalendar" && child.ns() == NS_XCAL)
-        else {
+    for item in parse_pubsub_items_result(iq) {
+        let item_id = item.id.as_str();
+        let Some(vcal) = item.payload("vcalendar", NS_XCAL) else {
             continue;
         };
         let Some(parsed) = parse_vcalendar_item(item_id, vcal) else {
@@ -672,7 +608,8 @@ impl WaddleClient {
     pub fn xcal_items(&self, community_jid: String, max_items: Option<u32>) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
-            let iq = build_events_items_iq(&community_jid, max_items);
+            let service = service_bare_jid(&community_jid)?;
+            let iq = build_events_items_iq(&service, max_items);
             let result = send_iq_command(inner, iq).await?;
             let events = parse_events_items_result(&result);
             to_js_value(&events)
@@ -685,11 +622,12 @@ impl WaddleClient {
     pub fn xcal_publish(&self, community_jid: String, input: JsValue) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
+            let service = service_bare_jid(&community_jid)?;
             let input: JsVEventInput = serde_wasm_bindgen::from_value(input)
                 .map_err(|err| js_error(format!("invalid event input: {err}")))?;
             let item_id = format!("evt-{}", Uuid::new_v4());
             let event = vevent_from_input(&item_id, input)?;
-            let iq = build_event_publish_iq(&community_jid, &item_id, &event);
+            let iq = build_event_publish_iq(&service, &item_id, &event);
             send_iq_command(inner, iq).await?;
             let js_event = JsVEvent::from_vevent(&item_id, event);
             to_js_value(&js_event)
@@ -711,6 +649,7 @@ impl WaddleClient {
     ) -> js_sys::Promise {
         let inner = self.inner.clone();
         wasm_bindgen_futures::future_to_promise(async move {
+            let service = service_bare_jid(&community_jid)?;
             let input: JsCalendarItemInput = serde_wasm_bindgen::from_value(input)
                 .map_err(|err| js_error(format!("invalid calendar item input: {err}")))?;
             if item_id.is_empty() {
@@ -725,7 +664,7 @@ impl WaddleClient {
                 item = item.add_override(override_from_input(&item_id, ov)?);
             }
             validate_calendar_item(&item)?;
-            let iq = build_item_publish_iq(&community_jid, &item_id, &item);
+            let iq = build_item_publish_iq(&service, &item_id, &item);
             send_iq_command(inner, iq).await?;
             let js_master = JsVEvent::from_vevent(&item_id, item.master);
             to_js_value(&js_master)
@@ -741,30 +680,10 @@ impl WaddleClient {
             if item_id.is_empty() {
                 return Err(js_error("item_id must not be empty"));
             }
+            let service = service_bare_jid(&community_jid)?;
             let id = format!("xcal-retract-{}", Uuid::new_v4());
-            let item = Element::builder("item", NS_PUBSUB)
-                .attr(
-                    minidom::rxml::xml_ncname!("id").to_owned(),
-                    item_id.as_str(),
-                )
-                .build();
-            let retract = Element::builder("retract", NS_PUBSUB)
-                .attr(
-                    minidom::rxml::xml_ncname!("node").to_owned(),
-                    PUBSUB_NODE_EVENTS,
-                )
-                .attr(minidom::rxml::xml_ncname!("notify").to_owned(), "true")
-                .append(item)
-                .build();
-            let pubsub = Element::builder("pubsub", NS_PUBSUB)
-                .append(retract)
-                .build();
-            let iq = Element::builder("iq", NS_CLIENT)
-                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
-                .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
-                .attr(minidom::rxml::xml_ncname!("to").to_owned(), community_jid)
-                .append(pubsub)
-                .build();
+            let iq =
+                build_pubsub_retract_iq(&id, Some(&service), PUBSUB_NODE_EVENTS, item_id.as_str());
             send_iq_command(inner, iq).await?;
             Ok(JsValue::TRUE)
         })
@@ -795,13 +714,9 @@ impl WaddleClient {
             if !self_jid.contains('@') {
                 return Err(js_error("self_jid must be a bare JID"));
             }
-            let iq = build_rsvp_publish_iq(
-                &community_jid,
-                &master_uid,
-                &self_localpart,
-                &self_jid,
-                partstat,
-            );
+            let service = service_bare_jid(&community_jid)?;
+            let iq =
+                build_rsvp_publish_iq(&service, &master_uid, &self_localpart, &self_jid, partstat);
             send_iq_command(inner, iq).await?;
             to_js_value(&JsAttendee {
                 uri: format!("xmpp:{self_jid}"),

--- a/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
@@ -90,8 +90,65 @@ impl From<&Attendee> for JsAttendee {
 mod tests {
     use super::*;
 
+    const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+
     fn day(year: i32, month: u32, day: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(year, month, day).expect("valid test date")
+    }
+
+    fn service() -> jid::BareJid {
+        "community.waddle.test".parse().expect("valid service jid")
+    }
+
+    #[test]
+    fn events_items_iq_pins_the_xep0060_wire_shape() {
+        let iq = build_events_items_iq(&service(), Some(200));
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq.attr("id").expect("iq id").starts_with("xcal-items-"));
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PUBSUB_NODE_EVENTS));
+        assert_eq!(items.attr("max_items"), Some("200"));
+    }
+
+    #[test]
+    fn event_publish_iq_pins_the_vcalendar_publish_shape() {
+        let event = VEvent::new("evt-1", "Standup");
+        let iq = build_event_publish_iq(&service(), "evt-1", &event);
+        assert_eq!(iq.attr("type"), Some("set"));
+        assert_eq!(iq.attr("to"), Some("community.waddle.test"));
+        assert!(iq.attr("id").expect("iq id").starts_with("xcal-publish-"));
+        let publish = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+            .expect("publish element");
+        assert_eq!(publish.attr("node"), Some(PUBSUB_NODE_EVENTS));
+        let item = publish.get_child("item", NS_PUBSUB).expect("item element");
+        assert_eq!(item.attr("id"), Some("evt-1"));
+        assert!(item.get_child("vcalendar", NS_XCAL).is_some());
+    }
+
+    #[test]
+    fn rsvp_publish_iq_pins_the_sibling_item_id_and_attendee_shape() {
+        let iq = build_rsvp_publish_iq(
+            &service(),
+            "evt-1",
+            "romeo",
+            "romeo@waddle.test",
+            PartStat::Accepted,
+        );
+        assert_eq!(iq.attr("type"), Some("set"));
+        assert!(iq.attr("id").expect("iq id").starts_with("xcal-rsvp-"));
+        let item = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+            .and_then(|publish| publish.get_child("item", NS_PUBSUB))
+            .expect("item element");
+        assert_eq!(item.attr("id"), Some("evt-1-rsvp-romeo"));
+        assert!(item.get_child("vcalendar", NS_XCAL).is_some());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -146,6 +146,13 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
                 }
             }
         }
+        // Emitted by the runtime alongside the Messaging event that
+        // carried the notification. The web client already receives
+        // retracts and attachment summaries through the
+        // `message.pubsub_events` → `on_pubsub_event` path above;
+        // re-dispatching these standalone variants would double-fire
+        // the JS callback, so they are intentionally consumed here.
+        ClientEvent::PubsubItemsRetracted(_) | ClientEvent::PubsubAttachmentSummary(_) => {}
         _ => {}
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/helpers.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/helpers.rs
@@ -65,6 +65,14 @@ pub(crate) fn bare_jid(jid: &str) -> String {
     jid.split('/').next().unwrap_or(jid).to_string()
 }
 
+/// Parse a JS-supplied pubsub service address (e.g. the
+/// `community.<domain>` component) into the typed bare JID the
+/// `waddle_xmpp_client::pubsub` builders require.
+pub(crate) fn service_bare_jid(jid: &str) -> Result<jid::BareJid, JsValue> {
+    jid.parse()
+        .map_err(|err| js_error(format!("invalid pubsub service JID: {err}")))
+}
+
 pub(crate) fn jid_domain(jid: &str) -> String {
     let bare = bare_jid(jid);
     bare.split('@')

--- a/server/crates/waddle-xmpp-client/src/event.rs
+++ b/server/crates/waddle-xmpp-client/src/event.rs
@@ -7,6 +7,7 @@ use crate::inbox::InboxStreamEntry;
 use crate::mam::ArchivedMessage;
 use crate::messaging::{InboundCallEvent, MessagingEvent};
 use crate::pep::PepItem;
+use crate::pubsub_event::{PubsubAttachmentSummaryUpdate, PubsubRetractedItems};
 use crate::request::StanzaId;
 use crate::request::{PendingRequest, RequestCorrelation};
 use crate::state::{SessionBinding, SessionSnapshot};
@@ -38,6 +39,20 @@ pub enum ClientEvent {
     InboxStreamEntry(InboxStreamEntry),
     /// Typed PEP user-state event (mood, activity, tune).
     PepEvent(PepItem),
+    /// XEP-0060 §7.2.2.1 item retraction pushed from a pubsub/PEP
+    /// node. Emitted alongside the [`ClientEvent::Messaging`] event
+    /// that carried the notification. No consumer maps it yet: the
+    /// wasm dispatcher deliberately swallows it (web consumes the
+    /// message-attached `pubsub_events` instead) and the upcoming
+    /// community-surface FFI verbs will route it to Kotlin/Swift
+    /// listeners so they can drop retracted items without digging
+    /// through the message envelope.
+    PubsubItemsRetracted(PubsubRetractedItems),
+    /// XEP-0470 attachment-summary update pushed from a summary node.
+    /// Emitted alongside the [`ClientEvent::Messaging`] event that
+    /// carried the notification; same consumer story as
+    /// [`ClientEvent::PubsubItemsRetracted`].
+    PubsubAttachmentSummary(PubsubAttachmentSummaryUpdate),
     /// Transport-level delivery status for outbound message stanzas.
     MessageDelivery(MessageDeliveryEvent),
     /// XEP-0198 resume snapshot changed. Broadcast by the native driver

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -23,6 +23,7 @@ pub mod messaging;
 pub mod notification_settings;
 pub mod pep;
 pub mod pin;
+pub mod pubsub;
 pub mod pubsub_event;
 pub mod push;
 pub mod request;
@@ -97,8 +98,15 @@ pub use pep::{
     parse_pep_mood, parse_pep_tune, PepItem, UserActivity, UserMood, UserTune, NS_ACTIVITY,
     NS_MOOD, NS_TUNE,
 };
+pub use pubsub::{
+    build_pubsub_items_iq, build_pubsub_publish_iq, build_pubsub_retract_iq,
+    build_pubsub_subscribe_iq, community_service_jid, parse_pubsub_items_result,
+    parse_pubsub_publish_result_item_id, PubsubAccessModel, PubsubPublishOptions, PubsubResultItem,
+    PubsubSendLastPublishedItem, NS_PUBSUB_PUBLISH_OPTIONS,
+};
 pub use pubsub_event::{
-    AttachmentSummaryEvent, PubsubEvent, PubsubEventItem, PubsubEventPayload, ReactionSummaryEvent,
+    AttachmentSummaryEvent, PubsubAttachmentSummaryUpdate, PubsubEvent, PubsubEventItem,
+    PubsubEventPayload, PubsubRetractedItems, ReactionSummaryEvent,
 };
 pub use request::{
     ClientRequest, PendingRequest, RequestCorrelation, RequestId, RequestKind, RequestTracker,

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -100,9 +100,10 @@ pub use pep::{
 };
 pub use pubsub::{
     build_pubsub_items_iq, build_pubsub_publish_iq, build_pubsub_retract_iq,
-    build_pubsub_subscribe_iq, community_service_jid, parse_pubsub_items_result,
-    parse_pubsub_publish_result_item_id, PubsubAccessModel, PubsubPublishOptions, PubsubResultItem,
-    PubsubSendLastPublishedItem, NS_PUBSUB_PUBLISH_OPTIONS,
+    build_pubsub_subscribe_iq, build_pubsub_unsubscribe_iq, community_service_jid,
+    parse_pubsub_items_result, parse_pubsub_publish_result_item_id, parse_pubsub_subscribe_result,
+    PubsubAccessModel, PubsubPublishOptions, PubsubResultItem, PubsubSendLastPublishedItem,
+    PubsubSubscription, PubsubSubscriptionState, NS_PUBSUB_PUBLISH_OPTIONS,
 };
 pub use pubsub_event::{
     AttachmentSummaryEvent, PubsubAttachmentSummaryUpdate, PubsubEvent, PubsubEventItem,

--- a/server/crates/waddle-xmpp-client/src/pubsub.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub.rs
@@ -12,7 +12,9 @@
 //! `<reads/>`) on top of these envelopes; this module owns only the
 //! XEP-0060 pubsub wrapper shapes.
 
-use jid::BareJid;
+use std::str::FromStr;
+
+use jid::{BareJid, Jid};
 use minidom::Element;
 
 use crate::bootstrap::NS_CLIENT;
@@ -33,8 +35,8 @@ const NS_DATA_FORMS: &str = "jabber:x:data";
 /// stories, and xCal events nodes. Mirrors
 /// [`crate::extension_commands::fallback_extension_service_jid`] for
 /// the extensions component.
-pub fn community_service_jid(domain: &str) -> String {
-    format!("community.{domain}")
+pub fn community_service_jid(domain: &str) -> Result<BareJid, jid::Error> {
+    BareJid::from_str(&format!("community.{domain}"))
 }
 
 /// XEP-0060 §4.5 node access models accepted in `pubsub#access_model`
@@ -241,6 +243,84 @@ pub fn build_pubsub_subscribe_iq(
         .append(subscribe)
         .build();
     wrap_pubsub_iq(iq_id, "set", Some(service), pubsub)
+}
+
+/// XEP-0060 §6.2 unsubscribe SET: remove `subscriber`'s subscription
+/// to `node` on `service`, scoped to `subid` when the service handed
+/// one out at subscribe time (§6.2.3.1 requires it when a JID holds
+/// multiple subscriptions to the node).
+pub fn build_pubsub_unsubscribe_iq(
+    iq_id: &str,
+    service: &BareJid,
+    node: &str,
+    subscriber: &BareJid,
+    subid: Option<&str>,
+) -> Element {
+    let mut unsubscribe = Element::builder("unsubscribe", NS_PUBSUB)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            subscriber.to_string(),
+        );
+    if let Some(subid) = subid {
+        unsubscribe = unsubscribe.attr(minidom::rxml::xml_ncname!("subid").to_owned(), subid);
+    }
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(unsubscribe.build())
+        .build();
+    wrap_pubsub_iq(iq_id, "set", Some(service), pubsub)
+}
+
+/// XEP-0060 §6.1.6 subscription states reported on a subscribe result
+/// (or §8.8.4 notification).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PubsubSubscriptionState {
+    Subscribed,
+    Pending,
+    Unconfigured,
+    None,
+}
+
+impl PubsubSubscriptionState {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "subscribed" => Some(Self::Subscribed),
+            "pending" => Some(Self::Pending),
+            "unconfigured" => Some(Self::Unconfigured),
+            "none" => Some(Self::None),
+            _ => Option::None,
+        }
+    }
+}
+
+/// Parsed XEP-0060 §6.1.6 `<subscription/>` from a subscribe result.
+/// `subid` MUST be threaded back into unsubscribe requests when
+/// present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubSubscription {
+    pub node: String,
+    pub jid: Option<Jid>,
+    pub subid: Option<String>,
+    pub state: PubsubSubscriptionState,
+}
+
+/// Parse a XEP-0060 §6.1.6 subscribe result. Returns `None` when the
+/// IQ carries no `<subscription/>` or its `subscription` state is
+/// missing/unknown — the caller surfaces both as a typed protocol
+/// error.
+pub fn parse_pubsub_subscribe_result(iq: &Element) -> Option<PubsubSubscription> {
+    let subscription = iq
+        .get_child("pubsub", NS_PUBSUB)?
+        .get_child("subscription", NS_PUBSUB)?;
+    let state = PubsubSubscriptionState::parse(subscription.attr("subscription")?)?;
+    Some(PubsubSubscription {
+        node: subscription.attr("node")?.to_string(),
+        jid: subscription
+            .attr("jid")
+            .and_then(|jid| Jid::from_str(jid).ok()),
+        subid: subscription.attr("subid").map(str::to_string),
+        state,
+    })
 }
 
 /// XEP-0060 §7.2 retract SET removing `item_id` from `node`, always

--- a/server/crates/waddle-xmpp-client/src/pubsub.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub.rs
@@ -1,0 +1,321 @@
+//! XEP-0060 Publish-Subscribe — typed service-node client helpers.
+//!
+//! Shared IQ builders and result parsers for the XEP-0060 operations
+//! every Waddle community surface performs against a pubsub service
+//! (the `community.<domain>` component) or the account's own PEP
+//! service: items fetch (§6.5), publish with optional XEP-0223
+//! `<publish-options/>` preconditions (§7.1 / §7.1.5), subscribe
+//! (§6.1), and notify-retract (§7.2).
+//!
+//! The XEP-0472 feed, XEP-0501 stories, story-reads, and xCal events
+//! modules layer their typed payloads (`<entry/>`, `<vcalendar/>`,
+//! `<reads/>`) on top of these envelopes; this module owns only the
+//! XEP-0060 pubsub wrapper shapes.
+
+use jid::BareJid;
+use minidom::Element;
+
+use crate::bootstrap::NS_CLIENT;
+use crate::pep::NS_PUBSUB;
+
+#[cfg(test)]
+mod tests;
+
+/// XEP-0060 `<publish-options/>` FORM_TYPE (also the XEP-0060 disco
+/// feature var for publish-options support; pinned equal to
+/// [`crate::mds::NS_PUBSUB_PUBLISH_OPTIONS_FEATURE`] by tests).
+pub const NS_PUBSUB_PUBLISH_OPTIONS: &str = "http://jabber.org/protocol/pubsub#publish-options";
+
+const NS_DATA_FORMS: &str = "jabber:x:data";
+
+/// Conventional JID of the Waddle community pubsub component
+/// (`community.<domain>`) hosting the XEP-0472 social feed, XEP-0501
+/// stories, and xCal events nodes. Mirrors
+/// [`crate::extension_commands::fallback_extension_service_jid`] for
+/// the extensions component.
+pub fn community_service_jid(domain: &str) -> String {
+    format!("community.{domain}")
+}
+
+/// XEP-0060 §4.5 node access models accepted in `pubsub#access_model`
+/// publish-options preconditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PubsubAccessModel {
+    Open,
+    Presence,
+    Roster,
+    Authorize,
+    Whitelist,
+}
+
+impl PubsubAccessModel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Presence => "presence",
+            Self::Roster => "roster",
+            Self::Authorize => "authorize",
+            Self::Whitelist => "whitelist",
+        }
+    }
+}
+
+/// XEP-0060 `pubsub#send_last_published_item` node-configuration
+/// values accepted in publish-options preconditions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PubsubSendLastPublishedItem {
+    Never,
+    OnSub,
+    OnSubAndPresence,
+}
+
+impl PubsubSendLastPublishedItem {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::OnSub => "on_sub",
+            Self::OnSubAndPresence => "on_sub_and_presence",
+        }
+    }
+}
+
+/// Typed XEP-0223/XEP-0060 §7.1.5 `<publish-options/>` precondition
+/// form. Only the node-configuration fields Waddle publishes are
+/// modelled; each `Some` field becomes one `jabber:x:data` submit
+/// field alongside the mandatory hidden FORM_TYPE.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PubsubPublishOptions {
+    pub persist_items: Option<bool>,
+    pub access_model: Option<PubsubAccessModel>,
+    pub send_last_published_item: Option<PubsubSendLastPublishedItem>,
+    pub max_items: Option<u32>,
+}
+
+impl PubsubPublishOptions {
+    /// Build the `<publish-options xmlns='…pubsub'/>` element carrying
+    /// the submit form.
+    pub fn to_element(&self) -> Element {
+        let mut form = Element::builder("x", NS_DATA_FORMS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
+            .append(hidden_field("FORM_TYPE", NS_PUBSUB_PUBLISH_OPTIONS));
+        if let Some(persist_items) = self.persist_items {
+            form = form.append(text_single_field(
+                "pubsub#persist_items",
+                if persist_items { "true" } else { "false" },
+            ));
+        }
+        if let Some(access_model) = self.access_model {
+            form = form.append(text_single_field(
+                "pubsub#access_model",
+                access_model.as_str(),
+            ));
+        }
+        if let Some(send_last) = self.send_last_published_item {
+            form = form.append(text_single_field(
+                "pubsub#send_last_published_item",
+                send_last.as_str(),
+            ));
+        }
+        if let Some(max_items) = self.max_items {
+            form = form.append(text_single_field(
+                "pubsub#max_items",
+                max_items.to_string().as_str(),
+            ));
+        }
+        Element::builder("publish-options", NS_PUBSUB)
+            .append(form.build())
+            .build()
+    }
+}
+
+fn hidden_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+        .append(
+            Element::builder("value", NS_DATA_FORMS)
+                .append(value)
+                .build(),
+        )
+        .build()
+}
+
+fn text_single_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), var)
+        .append(
+            Element::builder("value", NS_DATA_FORMS)
+                .append(value)
+                .build(),
+        )
+        .build()
+}
+
+fn wrap_pubsub_iq(
+    iq_id: &str,
+    iq_type: &str,
+    service: Option<&BareJid>,
+    pubsub: Element,
+) -> Element {
+    let mut builder = Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), iq_type)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), iq_id);
+    if let Some(service) = service {
+        builder = builder.attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            service.to_string(),
+        );
+    }
+    builder.append(pubsub).build()
+}
+
+/// XEP-0060 §6.5.2 items GET for `node`, optionally bounded by §6.5.7
+/// `max_items`. `service: None` routes to the account's own PEP
+/// service (XEP-0163); `Some(service)` addresses a pubsub component
+/// such as `community.<domain>`.
+pub fn build_pubsub_items_iq(
+    iq_id: &str,
+    service: Option<&BareJid>,
+    node: &str,
+    max_items: Option<u32>,
+) -> Element {
+    let mut items = Element::builder("items", NS_PUBSUB)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node);
+    let max_items_value;
+    if let Some(max) = max_items {
+        max_items_value = max.to_string();
+        items = items.attr(
+            minidom::rxml::xml_ncname!("max_items").to_owned(),
+            max_items_value.as_str(),
+        );
+    }
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(items.build())
+        .build();
+    wrap_pubsub_iq(iq_id, "get", service, pubsub)
+}
+
+/// XEP-0060 §7.1 publish SET for one `<item/>` on `node`.
+/// `item_id: None` lets the service generate the ItemID (§7.1.1);
+/// `publish_options` appends a XEP-0223/§7.1.5 precondition form after
+/// the `<publish/>` element.
+pub fn build_pubsub_publish_iq(
+    iq_id: &str,
+    service: Option<&BareJid>,
+    node: &str,
+    item_id: Option<&str>,
+    payload: Element,
+    publish_options: Option<&PubsubPublishOptions>,
+) -> Element {
+    let mut item = Element::builder("item", NS_PUBSUB);
+    if let Some(item_id) = item_id {
+        item = item.attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id);
+    }
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .append(item.append(payload).build())
+        .build();
+    let mut pubsub = Element::builder("pubsub", NS_PUBSUB).append(publish);
+    if let Some(options) = publish_options {
+        pubsub = pubsub.append(options.to_element());
+    }
+    wrap_pubsub_iq(iq_id, "set", service, pubsub.build())
+}
+
+/// XEP-0060 §6.1 subscribe SET: subscribe `subscriber` (the account's
+/// bare JID per §6.1.1) to `node` on `service`.
+pub fn build_pubsub_subscribe_iq(
+    iq_id: &str,
+    service: &BareJid,
+    node: &str,
+    subscriber: &BareJid,
+) -> Element {
+    let subscribe = Element::builder("subscribe", NS_PUBSUB)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            subscriber.to_string(),
+        )
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(subscribe)
+        .build();
+    wrap_pubsub_iq(iq_id, "set", Some(service), pubsub)
+}
+
+/// XEP-0060 §7.2 retract SET removing `item_id` from `node`, always
+/// with `notify='true'` so subscribers receive the §7.2.2.1 retract
+/// notification (the community surfaces rely on it for live removal).
+pub fn build_pubsub_retract_iq(
+    iq_id: &str,
+    service: Option<&BareJid>,
+    node: &str,
+    item_id: &str,
+) -> Element {
+    let retract = Element::builder("retract", NS_PUBSUB)
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node)
+        .attr(minidom::rxml::xml_ncname!("notify").to_owned(), "true")
+        .append(
+            Element::builder("item", NS_PUBSUB)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), item_id)
+                .build(),
+        )
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(retract)
+        .build();
+    wrap_pubsub_iq(iq_id, "set", service, pubsub)
+}
+
+/// One `<item/>` from a XEP-0060 §6.5 items result: its ItemID plus
+/// every payload child, preserved as typed elements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubResultItem {
+    pub id: String,
+    pub payloads: Vec<Element>,
+}
+
+impl PubsubResultItem {
+    /// First payload child matching `name`/`ns` — the idiom every
+    /// surface uses to pick its typed payload (`<entry/>`,
+    /// `<vcalendar/>`, `<reads/>`) out of the item.
+    pub fn payload(&self, name: &str, ns: &str) -> Option<&Element> {
+        self.payloads.iter().find(|payload| payload.is(name, ns))
+    }
+}
+
+/// Parse a XEP-0060 §6.5 items result IQ into typed items. Tolerant by
+/// design: a missing `<pubsub/>`/`<items/>` wrapper yields an empty
+/// list, and items without an ItemID are skipped (every Waddle node
+/// persists items under explicit ids).
+pub fn parse_pubsub_items_result(iq: &Element) -> Vec<PubsubResultItem> {
+    let Some(items) = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+    else {
+        return Vec::new();
+    };
+    items
+        .children()
+        .filter(|child| child.is("item", NS_PUBSUB))
+        .filter_map(|item| {
+            let id = item.attr("id")?.to_owned();
+            Some(PubsubResultItem {
+                id,
+                payloads: item.children().cloned().collect(),
+            })
+        })
+        .collect()
+}
+
+/// Parse the ItemID out of a XEP-0060 §7.1.2 publish success result
+/// (`<pubsub><publish node='…'><item id='…'/></publish></pubsub>`).
+/// Returns `None` when the service omitted the echo (legal when the
+/// publisher supplied the ItemID itself).
+pub fn parse_pubsub_publish_result_item_id(iq: &Element) -> Option<String> {
+    iq.get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+        .and_then(|publish| publish.get_child("item", NS_PUBSUB))
+        .and_then(|item| item.attr("id"))
+        .map(ToOwned::to_owned)
+}

--- a/server/crates/waddle-xmpp-client/src/pubsub/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub/tests.rs
@@ -1,0 +1,358 @@
+//! Dedicated test suite for the XEP-0060 Publish-Subscribe client
+//! helpers: items/publish/subscribe/retract IQ wire shapes, XEP-0223
+//! publish-options preconditions, items/publish result parsing, and
+//! error tolerance for malformed results.
+
+use jid::BareJid;
+use minidom::Element;
+
+use super::*;
+
+const SERVICE: &str = "community.waddle.test";
+const NODE: &str = "urn:xmpp:pubsub-social-feed:1";
+
+fn service() -> BareJid {
+    SERVICE.parse().expect("valid service jid")
+}
+
+fn payload() -> Element {
+    Element::builder("entry", "http://www.w3.org/2005/Atom")
+        .append("hello")
+        .build()
+}
+
+fn form_field_value(form: &Element, var: &str) -> Option<String> {
+    form.children()
+        .filter(|child| child.is("field", "jabber:x:data"))
+        .find(|child| child.attr("var") == Some(var))
+        .and_then(|field| field.get_child("value", "jabber:x:data"))
+        .map(Element::text)
+}
+
+// ── Namespace / service constants ────────────────────────────────────
+
+#[test]
+fn publish_options_form_type_pins_the_disco_feature_var() {
+    assert_eq!(
+        NS_PUBSUB_PUBLISH_OPTIONS,
+        crate::mds::NS_PUBSUB_PUBLISH_OPTIONS_FEATURE
+    );
+}
+
+#[test]
+fn community_service_jid_is_the_community_subdomain() {
+    assert_eq!(
+        community_service_jid("waddle.test"),
+        "community.waddle.test"
+    );
+    assert!(community_service_jid("waddle.test")
+        .parse::<BareJid>()
+        .is_ok());
+}
+
+// ── Items fetch (§6.5) ───────────────────────────────────────────────
+
+#[test]
+fn items_iq_targets_service_node_without_max_items() {
+    let iq = build_pubsub_items_iq("iq-1", Some(&service()), NODE, None);
+    assert_eq!(iq.attr("type"), Some("get"));
+    assert_eq!(iq.attr("id"), Some("iq-1"));
+    assert_eq!(iq.attr("to"), Some(SERVICE));
+    let items = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+        .expect("items element");
+    assert_eq!(items.attr("node"), Some(NODE));
+    assert_eq!(items.attr("max_items"), None);
+}
+
+#[test]
+fn items_iq_carries_max_items_when_bounded() {
+    let iq = build_pubsub_items_iq("iq-2", Some(&service()), NODE, Some(50));
+    let items = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("items", NS_PUBSUB))
+        .expect("items element");
+    assert_eq!(items.attr("max_items"), Some("50"));
+}
+
+#[test]
+fn items_iq_without_service_routes_to_own_pep() {
+    let iq = build_pubsub_items_iq("iq-3", None, NODE, Some(1));
+    assert_eq!(iq.attr("to"), None);
+}
+
+// ── Publish (§7.1) ───────────────────────────────────────────────────
+
+#[test]
+fn publish_iq_wraps_payload_under_item_on_node() {
+    let iq = build_pubsub_publish_iq(
+        "iq-4",
+        Some(&service()),
+        NODE,
+        Some("post-1"),
+        payload(),
+        None,
+    );
+    assert_eq!(iq.attr("type"), Some("set"));
+    assert_eq!(iq.attr("to"), Some(SERVICE));
+    let publish = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+        .expect("publish element");
+    assert_eq!(publish.attr("node"), Some(NODE));
+    let item = publish.get_child("item", NS_PUBSUB).expect("item element");
+    assert_eq!(item.attr("id"), Some("post-1"));
+    let entry = item
+        .get_child("entry", "http://www.w3.org/2005/Atom")
+        .expect("payload survives");
+    assert_eq!(entry.text(), "hello");
+}
+
+#[test]
+fn publish_iq_omits_item_id_for_service_generated_ids() {
+    let iq = build_pubsub_publish_iq("iq-5", Some(&service()), NODE, None, payload(), None);
+    let item = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+        .and_then(|publish| publish.get_child("item", NS_PUBSUB))
+        .expect("item element");
+    assert_eq!(item.attr("id"), None);
+}
+
+#[test]
+fn publish_iq_has_no_publish_options_unless_requested() {
+    let iq = build_pubsub_publish_iq(
+        "iq-6",
+        Some(&service()),
+        NODE,
+        Some("post-1"),
+        payload(),
+        None,
+    );
+    let pubsub = iq.get_child("pubsub", NS_PUBSUB).expect("pubsub element");
+    assert!(pubsub.get_child("publish-options", NS_PUBSUB).is_none());
+}
+
+// ── Publish options (§7.1.5 / XEP-0223) ──────────────────────────────
+
+#[test]
+fn publish_options_form_carries_every_configured_precondition() {
+    let options = PubsubPublishOptions {
+        persist_items: Some(true),
+        access_model: Some(PubsubAccessModel::Whitelist),
+        send_last_published_item: Some(PubsubSendLastPublishedItem::Never),
+        max_items: Some(1),
+    };
+    let iq = build_pubsub_publish_iq(
+        "iq-7",
+        None,
+        NODE,
+        Some("current"),
+        payload(),
+        Some(&options),
+    );
+    let pubsub = iq.get_child("pubsub", NS_PUBSUB).expect("pubsub element");
+    let form = pubsub
+        .get_child("publish-options", NS_PUBSUB)
+        .and_then(|options| options.get_child("x", "jabber:x:data"))
+        .expect("submit form");
+    assert_eq!(form.attr("type"), Some("submit"));
+    assert_eq!(
+        form_field_value(form, "FORM_TYPE").as_deref(),
+        Some(NS_PUBSUB_PUBLISH_OPTIONS)
+    );
+    assert_eq!(
+        form_field_value(form, "pubsub#persist_items").as_deref(),
+        Some("true")
+    );
+    assert_eq!(
+        form_field_value(form, "pubsub#access_model").as_deref(),
+        Some("whitelist")
+    );
+    assert_eq!(
+        form_field_value(form, "pubsub#send_last_published_item").as_deref(),
+        Some("never")
+    );
+    assert_eq!(
+        form_field_value(form, "pubsub#max_items").as_deref(),
+        Some("1")
+    );
+}
+
+#[test]
+fn publish_options_form_type_field_is_hidden() {
+    let form_owner = PubsubPublishOptions::default().to_element();
+    let form = form_owner
+        .get_child("x", "jabber:x:data")
+        .expect("submit form");
+    let form_type = form
+        .children()
+        .find(|child| child.attr("var") == Some("FORM_TYPE"))
+        .expect("FORM_TYPE field");
+    assert_eq!(form_type.attr("type"), Some("hidden"));
+}
+
+#[test]
+fn publish_options_omit_unset_fields() {
+    let options = PubsubPublishOptions {
+        max_items: Some(1),
+        ..PubsubPublishOptions::default()
+    };
+    let element = options.to_element();
+    let form = element.get_child("x", "jabber:x:data").expect("form");
+    assert!(form_field_value(form, "pubsub#persist_items").is_none());
+    assert!(form_field_value(form, "pubsub#access_model").is_none());
+    assert!(form_field_value(form, "pubsub#send_last_published_item").is_none());
+    assert_eq!(
+        form_field_value(form, "pubsub#max_items").as_deref(),
+        Some("1")
+    );
+}
+
+// ── Subscribe (§6.1) ─────────────────────────────────────────────────
+
+#[test]
+fn subscribe_iq_carries_node_and_subscriber_bare_jid() {
+    let subscriber: BareJid = "romeo@waddle.test".parse().expect("valid jid");
+    let iq = build_pubsub_subscribe_iq("iq-8", &service(), NODE, &subscriber);
+    assert_eq!(iq.attr("type"), Some("set"));
+    assert_eq!(iq.attr("to"), Some(SERVICE));
+    let subscribe = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("subscribe", NS_PUBSUB))
+        .expect("subscribe element");
+    assert_eq!(subscribe.attr("node"), Some(NODE));
+    assert_eq!(subscribe.attr("jid"), Some("romeo@waddle.test"));
+}
+
+// ── Retract (§7.2) ───────────────────────────────────────────────────
+
+#[test]
+fn retract_iq_always_requests_subscriber_notification() {
+    let iq = build_pubsub_retract_iq("iq-9", Some(&service()), NODE, "post-1");
+    assert_eq!(iq.attr("type"), Some("set"));
+    assert_eq!(iq.attr("to"), Some(SERVICE));
+    let retract = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("retract", NS_PUBSUB))
+        .expect("retract element");
+    assert_eq!(retract.attr("node"), Some(NODE));
+    assert_eq!(retract.attr("notify"), Some("true"));
+    let item = retract.get_child("item", NS_PUBSUB).expect("item element");
+    assert_eq!(item.attr("id"), Some("post-1"));
+}
+
+// ── Items result parsing (§6.5.2) ────────────────────────────────────
+
+#[test]
+fn parse_items_result_returns_ids_with_typed_payloads() {
+    let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+        <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+          <items node='urn:xmpp:pubsub-social-feed:1'>\
+            <item id='post-1'>\
+              <entry xmlns='http://www.w3.org/2005/Atom'>first</entry>\
+            </item>\
+            <item id='post-2'>\
+              <entry xmlns='http://www.w3.org/2005/Atom'>second</entry>\
+            </item>\
+          </items>\
+        </pubsub>\
+      </iq>";
+    let iq: Element = xml.parse().expect("valid xml");
+    let items = parse_pubsub_items_result(&iq);
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].id, "post-1");
+    assert_eq!(items[1].id, "post-2");
+    let entry = items[0]
+        .payload("entry", "http://www.w3.org/2005/Atom")
+        .expect("entry payload");
+    assert_eq!(entry.text(), "first");
+}
+
+#[test]
+fn parse_items_result_finds_payload_among_multiple_children() {
+    let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+        <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+          <items node='n'>\
+            <item id='post-1'>\
+              <decoration xmlns='urn:example:decoration'/>\
+              <entry xmlns='http://www.w3.org/2005/Atom'>real</entry>\
+            </item>\
+          </items>\
+        </pubsub>\
+      </iq>";
+    let iq: Element = xml.parse().expect("valid xml");
+    let items = parse_pubsub_items_result(&iq);
+    let entry = items[0]
+        .payload("entry", "http://www.w3.org/2005/Atom")
+        .expect("entry payload");
+    assert_eq!(entry.text(), "real");
+    assert!(items[0].payload("missing", "urn:example:none").is_none());
+}
+
+#[test]
+fn parse_items_result_skips_items_without_ids() {
+    let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+        <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+          <items node='n'>\
+            <item><entry xmlns='http://www.w3.org/2005/Atom'/></item>\
+            <item id='kept'/>\
+          </items>\
+        </pubsub>\
+      </iq>";
+    let iq: Element = xml.parse().expect("valid xml");
+    let items = parse_pubsub_items_result(&iq);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].id, "kept");
+    assert!(items[0].payloads.is_empty());
+}
+
+#[test]
+fn parse_items_result_tolerates_missing_wrappers() {
+    let bare: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
+        .parse()
+        .expect("valid xml");
+    assert!(parse_pubsub_items_result(&bare).is_empty());
+
+    let empty: Element = "<iq xmlns='jabber:client' type='result' id='x'>\
+        <pubsub xmlns='http://jabber.org/protocol/pubsub'/></iq>"
+        .parse()
+        .expect("valid xml");
+    assert!(parse_pubsub_items_result(&empty).is_empty());
+}
+
+#[test]
+fn parse_items_result_tolerates_error_iqs() {
+    let error: Element = "<iq xmlns='jabber:client' type='error' id='x'>\
+        <error type='cancel'>\
+          <item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
+        </error></iq>"
+        .parse()
+        .expect("valid xml");
+    assert!(parse_pubsub_items_result(&error).is_empty());
+}
+
+// ── Publish result parsing (§7.1.2) ──────────────────────────────────
+
+#[test]
+fn parse_publish_result_returns_echoed_item_id() {
+    let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+        <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+          <publish node='n'><item id='generated-1'/></publish>\
+        </pubsub>\
+      </iq>";
+    let iq: Element = xml.parse().expect("valid xml");
+    assert_eq!(
+        parse_pubsub_publish_result_item_id(&iq).as_deref(),
+        Some("generated-1")
+    );
+}
+
+#[test]
+fn parse_publish_result_tolerates_bare_success() {
+    let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
+        .parse()
+        .expect("valid xml");
+    assert_eq!(parse_pubsub_publish_result_item_id(&iq), None);
+}

--- a/server/crates/waddle-xmpp-client/src/pubsub/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub/tests.rs
@@ -42,12 +42,12 @@ fn publish_options_form_type_pins_the_disco_feature_var() {
 #[test]
 fn community_service_jid_is_the_community_subdomain() {
     assert_eq!(
-        community_service_jid("waddle.test"),
+        community_service_jid("waddle.test").expect("valid jid"),
         "community.waddle.test"
+            .parse::<BareJid>()
+            .expect("bare jid"),
     );
-    assert!(community_service_jid("waddle.test")
-        .parse::<BareJid>()
-        .is_ok());
+    assert!(community_service_jid("not a domain").is_err());
 }
 
 // ── Items fetch (§6.5) ───────────────────────────────────────────────
@@ -224,6 +224,72 @@ fn subscribe_iq_carries_node_and_subscriber_bare_jid() {
         .expect("subscribe element");
     assert_eq!(subscribe.attr("node"), Some(NODE));
     assert_eq!(subscribe.attr("jid"), Some("romeo@waddle.test"));
+}
+
+#[test]
+fn unsubscribe_iq_carries_node_subscriber_and_optional_subid() {
+    let subscriber: BareJid = "romeo@waddle.test".parse().expect("valid jid");
+    let iq = build_pubsub_unsubscribe_iq("iq-8b", &service(), NODE, &subscriber, Some("sub-1"));
+    assert_eq!(iq.attr("type"), Some("set"));
+    assert_eq!(iq.attr("to"), Some(SERVICE));
+    let unsubscribe = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("unsubscribe", NS_PUBSUB))
+        .expect("unsubscribe element");
+    assert_eq!(unsubscribe.attr("node"), Some(NODE));
+    assert_eq!(unsubscribe.attr("jid"), Some("romeo@waddle.test"));
+    assert_eq!(unsubscribe.attr("subid"), Some("sub-1"));
+
+    let without_subid = build_pubsub_unsubscribe_iq("iq-8c", &service(), NODE, &subscriber, None);
+    let unsubscribe = without_subid
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("unsubscribe", NS_PUBSUB))
+        .expect("unsubscribe element");
+    assert_eq!(unsubscribe.attr("subid"), None);
+}
+
+#[test]
+fn subscribe_result_parses_subscription_state_and_subid() {
+    let iq: Element = format!(
+        "<iq xmlns='jabber:client' type='result' from='{SERVICE}' id='iq-8'>\
+         <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+         <subscription node='{NODE}' jid='romeo@waddle.test' \
+         subid='sub-1' subscription='subscribed'/>\
+         </pubsub></iq>"
+    )
+    .parse()
+    .expect("test IQ parses");
+    let subscription = parse_pubsub_subscribe_result(&iq).expect("parses");
+    assert_eq!(subscription.node, NODE);
+    assert_eq!(
+        subscription
+            .jid
+            .as_ref()
+            .map(ToString::to_string)
+            .as_deref(),
+        Some("romeo@waddle.test"),
+    );
+    assert_eq!(subscription.subid.as_deref(), Some("sub-1"));
+    assert_eq!(subscription.state, PubsubSubscriptionState::Subscribed);
+}
+
+#[test]
+fn subscribe_result_without_subscription_or_state_is_none() {
+    let missing: Element = "<iq xmlns='jabber:client' type='result' id='iq-8'>\
+         <pubsub xmlns='http://jabber.org/protocol/pubsub'/></iq>"
+        .parse()
+        .expect("test IQ parses");
+    assert!(parse_pubsub_subscribe_result(&missing).is_none());
+
+    let unknown_state: Element = format!(
+        "<iq xmlns='jabber:client' type='result' id='iq-8'>\
+         <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+         <subscription node='{NODE}' subscription='bogus'/>\
+         </pubsub></iq>"
+    )
+    .parse()
+    .expect("test IQ parses");
+    assert!(parse_pubsub_subscribe_result(&unknown_state).is_none());
 }
 
 // ── Retract (§7.2) ───────────────────────────────────────────────────

--- a/server/crates/waddle-xmpp-client/src/pubsub_event.rs
+++ b/server/crates/waddle-xmpp-client/src/pubsub_event.rs
@@ -38,6 +38,74 @@ pub struct ReactionSummaryEvent {
     pub reactors: Vec<BareJid>,
 }
 
+/// XEP-0060 §7.2.2.1 item-retract notification, flattened for
+/// [`crate::event::ClientEvent::PubsubItemsRetracted`]: which items
+/// disappeared from which node on which service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubRetractedItems {
+    /// Notifying service (`from` of the event message); `None` when
+    /// the stanza carried no `from` (the account's own PEP service).
+    pub service: Option<Jid>,
+    pub node: String,
+    pub item_ids: Vec<String>,
+}
+
+/// One XEP-0470 attachment-summary update, flattened for
+/// [`crate::event::ClientEvent::PubsubAttachmentSummary`]: the summary
+/// counts for one attached-to item on a summary node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubsubAttachmentSummaryUpdate {
+    /// Notifying service (`from` of the event message); `None` when
+    /// the stanza carried no `from`.
+    pub service: Option<Jid>,
+    /// The summary node the notification arrived on
+    /// (`urn:xmpp:pubsub-attachments:summary:1/<target-node>`).
+    pub node: String,
+    /// ItemID of the attached-to item the summary describes.
+    pub item_id: Option<String>,
+    pub summary: AttachmentSummaryEvent,
+}
+
+impl PubsubEvent {
+    /// The §7.2.2.1 retractions in this event, or `None` when nothing
+    /// was retracted.
+    pub fn retracted_items(&self) -> Option<PubsubRetractedItems> {
+        let item_ids: Vec<String> = self
+            .items
+            .iter()
+            .filter(|item| item.retracted)
+            .filter_map(|item| item.id.clone())
+            .collect();
+        if item_ids.is_empty() {
+            return None;
+        }
+        Some(PubsubRetractedItems {
+            service: self.from.clone(),
+            node: self.node.clone(),
+            item_ids,
+        })
+    }
+
+    /// The XEP-0470 attachment-summary payloads in this event, one
+    /// update per summarised item.
+    pub fn attachment_summaries(&self) -> Vec<PubsubAttachmentSummaryUpdate> {
+        self.items
+            .iter()
+            .filter_map(|item| {
+                let PubsubEventPayload::AttachmentSummary(summary) = &item.payload else {
+                    return None;
+                };
+                Some(PubsubAttachmentSummaryUpdate {
+                    service: self.from.clone(),
+                    node: self.node.clone(),
+                    item_id: item.id.clone(),
+                    summary: summary.clone(),
+                })
+            })
+            .collect()
+    }
+}
+
 pub fn parse_pubsub_events(message: &Element) -> Vec<PubsubEvent> {
     if message.name() != "message" {
         return Vec::new();
@@ -284,5 +352,90 @@ mod tests {
         assert_eq!(events[0].items[0].id.as_deref(), Some("story-1"));
         assert!(events[0].items[0].retracted);
         assert_eq!(events[0].items[0].payload, PubsubEventPayload::Empty);
+    }
+
+    #[test]
+    fn flattens_retractions_into_typed_client_event_payload() {
+        let event = PubsubEvent {
+            from: Some("community.example.com".parse().expect("valid jid")),
+            node: "urn:xmpp:pubsub-social-feed:stories:0".to_owned(),
+            items: vec![
+                PubsubEventItem {
+                    id: Some("story-1".to_owned()),
+                    retracted: true,
+                    payload: PubsubEventPayload::Empty,
+                },
+                PubsubEventItem {
+                    id: Some("story-2".to_owned()),
+                    retracted: false,
+                    payload: PubsubEventPayload::Empty,
+                },
+                PubsubEventItem {
+                    id: Some("story-3".to_owned()),
+                    retracted: true,
+                    payload: PubsubEventPayload::Empty,
+                },
+            ],
+        };
+        let retracted = event.retracted_items().expect("retractions present");
+        assert_eq!(
+            retracted.service,
+            Some("community.example.com".parse::<Jid>().expect("valid jid"))
+        );
+        assert_eq!(retracted.node, "urn:xmpp:pubsub-social-feed:stories:0");
+        assert_eq!(retracted.item_ids, vec!["story-1", "story-3"]);
+    }
+
+    #[test]
+    fn no_retractions_yields_no_client_event_payload() {
+        let event = PubsubEvent {
+            from: None,
+            node: "urn:test".to_owned(),
+            items: vec![PubsubEventItem {
+                id: Some("kept".to_owned()),
+                retracted: false,
+                payload: PubsubEventPayload::Empty,
+            }],
+        };
+        assert_eq!(event.retracted_items(), None);
+    }
+
+    #[test]
+    fn flattens_attachment_summaries_into_typed_client_event_payloads() {
+        let summary = AttachmentSummaryEvent {
+            reactions: vec![ReactionSummaryEvent {
+                emoji: "👍".to_owned(),
+                count: 2,
+                reactors: vec!["alice@example.com".parse().expect("valid jid")],
+            }],
+            noticed_count: Some(1),
+        };
+        let event = PubsubEvent {
+            from: Some("community.example.com".parse().expect("valid jid")),
+            node: "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0"
+                .to_owned(),
+            items: vec![
+                PubsubEventItem {
+                    id: Some("story-1".to_owned()),
+                    retracted: false,
+                    payload: PubsubEventPayload::AttachmentSummary(summary.clone()),
+                },
+                PubsubEventItem {
+                    id: Some("opaque".to_owned()),
+                    retracted: false,
+                    payload: PubsubEventPayload::Opaque {
+                        element: Element::builder("future", "urn:example:future").build(),
+                    },
+                },
+            ],
+        };
+        let updates = event.attachment_summaries();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].item_id.as_deref(), Some("story-1"));
+        assert_eq!(updates[0].summary, summary);
+        assert_eq!(
+            updates[0].node,
+            "urn:xmpp:pubsub-attachments:summary:1/urn:xmpp:pubsub-social-feed:stories:0"
+        );
     }
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/app_stanza.rs
@@ -105,11 +105,41 @@ impl XmppRuntime {
         }
 
         if let Some(ev) = messaging::parse(element) {
-            return vec![ClientEvent::Messaging(ev)];
+            let pubsub_events = pubsub_notification_events(&ev);
+            let mut events = vec![ClientEvent::Messaging(ev)];
+            events.extend(pubsub_events);
+            return events;
         }
 
         vec![ClientEvent::UnhandledStanza(element.clone())]
     }
+}
+
+/// Flatten the XEP-0060 notifications attached to a parsed message
+/// into standalone [`ClientEvent`]s: §7.2.2.1 item retractions and
+/// XEP-0470 attachment-summary updates. Emitted *alongside* the
+/// [`ClientEvent::Messaging`] event (which still carries the full
+/// `pubsub_events` list) so consumers that only care about these two
+/// state transitions need not unpack the message envelope.
+///
+/// Only the direct message path feeds this: carbon-unwrapped messages
+/// deliberately skip it because XEP-0280 carbons only cover
+/// chat-eligible messages — a pubsub service's headline notifications
+/// are never carbon-copied.
+fn pubsub_notification_events(event: &crate::messaging::MessagingEvent) -> Vec<ClientEvent> {
+    let crate::messaging::MessagingEvent::Message(message) = event else {
+        return Vec::new();
+    };
+    let mut events = Vec::new();
+    for pubsub_event in &message.pubsub_events {
+        if let Some(retracted) = pubsub_event.retracted_items() {
+            events.push(ClientEvent::PubsubItemsRetracted(retracted));
+        }
+        for summary in pubsub_event.attachment_summaries() {
+            events.push(ClientEvent::PubsubAttachmentSummary(summary));
+        }
+    }
+    events
 }
 
 impl XmppRuntime {

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -75,6 +75,50 @@ fn app_stanza_routes_jmi_message_to_typed_call_event() {
 }
 
 #[test]
+fn app_stanza_emits_standalone_pubsub_retract_and_summary_events() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    let stanza: Element = "<message xmlns='jabber:client' type='headline' \
+            from='community.waddle.test' to='alice@example.com'>\
+        <event xmlns='http://jabber.org/protocol/pubsub#event'>\
+          <items node='urn:xmpp:pubsub-social-feed:stories:0'>\
+            <retract id='story-1'/>\
+            <item id='story-2'>\
+              <summary xmlns='urn:xmpp:pubsub-attachments:summary:1'>\
+                <reactions><reaction count='2'>👍</reaction></reactions>\
+              </summary>\
+            </item>\
+          </items>\
+        </event>\
+    </message>"
+        .parse()
+        .unwrap();
+
+    let events = runtime.handle_app_stanza(&stanza);
+
+    // The message event still carries the full pubsub_events list …
+    assert!(matches!(
+        &events[0],
+        ClientEvent::Messaging(crate::messaging::MessagingEvent::Message(message))
+            if message.pubsub_events.len() == 1
+    ));
+    // … and the two state transitions are also emitted standalone.
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::PubsubItemsRetracted(retracted)
+            if retracted.node == "urn:xmpp:pubsub-social-feed:stories:0"
+                && retracted.item_ids == vec!["story-1".to_owned()]
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::PubsubAttachmentSummary(update)
+            if update.item_id.as_deref() == Some("story-2")
+                && update.summary.reactions.len() == 1
+                && update.summary.reactions[0].count == 2
+    )));
+    assert_eq!(events.len(), 3);
+}
+
+#[test]
 fn app_stanza_answers_client_caps_disco_info() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     runtime.snapshot.phase = SessionPhase::Established;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -56,9 +56,9 @@ export class WaddleClient {
     enable_push_notifications(service_jid: string, node: string): Promise<any>;
     /**
      * Fetch the latest items from the community Social Feed node on
-     * `spaces_jid` (typically `spaces.<domain>`). Returns an array of
-     * JsFeedEntry objects ordered as the server delivered them
-     * (newest first by `last_published`).
+     * `spaces_jid` — the community service (`community.<domain>`).
+     * Returns an array of JsFeedEntry objects ordered as the server
+     * delivered them (newest first by `last_published`).
      */
     feed_items(spaces_jid: string, max_items?: number | null): Promise<any>;
     /**

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=b5560fbc8560";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=82eec800cb2a";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=d6c66dc53011";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=d6c66dc53011";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=d6c66dc53011";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=b5560fbc8560";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=d6c66dc53011";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=b5560fbc8560";


### PR DESCRIPTION

## Review round 1 (3 confirmed, fixed in 811e853e)

- `community_service_jid` returned a JID as `String` on new pub API → now `Result<BareJid, jid::Error>` (typed-payloads rule).
- Subscribe was half a verb → `parse_pubsub_subscribe_result` (§6.1.6 node/jid/subid/state) and `build_pubsub_unsubscribe_iq` (optional `subid`) complete the round-trip so surface PRs consume a stable API.
- The "wire bytes pinned by existing wasm tests" claim was wrong for feed/stories/xcal (no shape tests existed) → dedicated shape-pin tests added for all three modules' items/publish/RSVP builders.

**Forward-consumed API note:** `community_service_jid`, the subscribe/unsubscribe round-trip, and `parse_pubsub_publish_result_item_id` have no callers in this PR by design — they are the groundwork surface consumed by PRs 1–4 (feed/stories/events/routes) and are each pinned by the dedicated XEP-0060 suite.

**Review round 2** (focused re-review of the fixes against XEP-0060, the pinned jid crate, and the server parser): no real issues.

## Verification (per round)
`cargo test`/`clippy -D warnings`/`fmt --check` for waddle-xmpp-client, -wasm, -ffi; wasm-pkg rebuilt (loader hash committed); `bun test` + `bun run lint` (knip) in chat/ — zero web behavior change; both bindings drift checks green (FFI shape unchanged). CI green on every pushed head.
