### PR TITLE
fix(chat): recover room joins during clustered ownership transitions

### DIFF
--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -222,8 +222,18 @@ type MamPagerDeps = {
   events: TypedEventBus<ClientEvents>;
   emitError: (event: XmppErrorEvent) => void;
   requireConnectedXmpp: () => Promise<MamWasmClient>;
-  /** Connect + switch/join so room history queries target a ready room. */
-  ensureRoomReady: (spaceId: string, channelId: string) => Promise<void>;
+  /**
+   * Connect + switch/join and return the exact validated room generation.
+   *
+   * A public room switch may resolve when a newer navigation supersedes it;
+   * room-scoped IQ callers must therefore receive the post-switch handle and
+   * room JID from the same readiness check instead of reacquiring a merely
+   * connected session afterward.
+   */
+  ensureRoomReady: (
+    spaceId: string,
+    channelId: string,
+  ) => Promise<{ xmpp: MamWasmClient; roomJid: string }>;
   roomJidForChannel: (channelId: string) => string;
   /** Identity + liveness gate for a specific WASM handle mid-pagination. */
   isCurrentConnected: (xmpp: MamWasmClient, sessionJid: string) => boolean;
@@ -435,9 +445,8 @@ export class MamPager {
   }
 
   async queryMamPage(spaceId: string, channelId: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
-    await this.deps.ensureRoomReady(spaceId, channelId);
-    const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.fetch_room_history_page?.(this.deps.roomJidForChannel(channelId), max, pageParam);
+    const { xmpp, roomJid } = await this.deps.ensureRoomReady(spaceId, channelId);
+    const page = await xmpp.fetch_room_history_page?.(roomJid, max, pageParam);
     if (!page) return { messages: [], complete: true };
     const result = this.roomPageToMessages(page);
     this.recordRoomWatermarks(result.messages);
@@ -445,9 +454,8 @@ export class MamPager {
   }
 
   async queryMamByThread(spaceId: string, channelId: string, threadId: string, max = 100): Promise<LiveRoomMessage[]> {
-    await this.deps.ensureRoomReady(spaceId, channelId);
-    const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.fetch_room_history_by_thread?.(this.deps.roomJidForChannel(channelId), threadId, max, null);
+    const { xmpp, roomJid } = await this.deps.ensureRoomReady(spaceId, channelId);
+    const page = await xmpp.fetch_room_history_by_thread?.(roomJid, threadId, max, null);
     if (!page) return [];
     const result = this.roomPageToMessages(page);
     this.recordRoomWatermarks(result.messages);
@@ -456,9 +464,8 @@ export class MamPager {
 
   async queryMamThreadPage(spaceId: string, channelId: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
     if (!threadId) return { messages: [], complete: true };
-    await this.deps.ensureRoomReady(spaceId, channelId);
-    const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.fetch_room_history_by_thread?.(this.deps.roomJidForChannel(channelId), threadId, max, pageParam.type === "before" ? pageParam.before : null);
+    const { xmpp, roomJid } = await this.deps.ensureRoomReady(spaceId, channelId);
+    const page = await xmpp.fetch_room_history_by_thread?.(roomJid, threadId, max, pageParam.type === "before" ? pageParam.before : null);
     if (!page) return { messages: [], complete: true };
     const result = this.roomPageToMessages(page);
     this.recordRoomWatermarks(result.messages);

--- a/chat/src/lib/xmpp/client-muc-admin.ts
+++ b/chat/src/lib/xmpp/client-muc-admin.ts
@@ -80,6 +80,7 @@ export type MucAdminWasmClient = {
 
 type MucAdminDeps = {
   requireConnectedXmpp: () => Promise<MucAdminWasmClient>;
+  requireReadyRoomXmpp: (roomJid: string) => Promise<MucAdminWasmClient>;
   roomJidForChannel: (channelId: string) => string;
   emitError: (event: XmppErrorEvent) => void;
 };
@@ -88,8 +89,8 @@ export class MucAdmin {
   constructor(private readonly deps: MucAdminDeps) {}
 
   async listRoomMembers(channelId: string, options?: ListRoomMembersOptions): Promise<MemberSummary[]> {
-    const xmpp = await this.deps.requireConnectedXmpp();
     const roomJid = options?.roomJid ?? this.deps.roomJidForChannel(channelId);
+    const xmpp = await this.deps.requireReadyRoomXmpp(roomJid);
     const listMembers = xmpp.list_room_members
       ? async (affiliation: "owner" | "admin" | "member" | "outcast") => await xmpp.list_room_members?.(roomJid, affiliation)
       : null;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -3,6 +3,11 @@ import {
   withSpan,
 } from "@/lib/telemetry";
 import { stanzaErrorContext } from "@/lib/xmpp/stanza-error-context";
+import {
+  MUC_JOIN_RETRY_DELAYS_MS,
+  MucJoinRejectedError,
+  MucJoinSelfPresenceTimeoutError,
+} from "@/lib/xmpp/muc-join-retry";
 import { inferredFileDisposition, type ExtensionLaunchDescriptor } from "@/lib/chat-ui";
 import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filters";
 import type { BroadcastShow } from "@/presence/effective-show";
@@ -208,6 +213,25 @@ type InboundWasmMessage = WasmMessage & {
 // take several seconds to deliver the roster. 110 is the definitive
 // resolve signal; this timeout only bounds genuinely stuck joins.
 const ROOM_SELF_PRESENCE_TIMEOUT_MS = 15_000;
+
+const EXPECTED_MUC_ACCESS_DENIAL_CONDITIONS = new Set([
+  "forbidden",
+  "not-allowed",
+  "not-authorized",
+  "registration-required",
+]);
+
+function isExpectedMucAccessDenial(error: MucJoinRejectedError): boolean {
+  return !!error.condition
+    && EXPECTED_MUC_ACCESS_DENIAL_CONDITIONS.has(error.condition);
+}
+
+class RoomSwitchSupersededError extends Error {
+  constructor() {
+    super("Room switch superseded");
+    this.name = "RoomSwitchSupersededError";
+  }
+}
 
 type XmppStreamErrorPayload = string | {
   detail?: string | null;
@@ -434,10 +458,15 @@ export class BrowserXmppClient {
   private currentRoom: string | null = null;
   private roomSwitchPromise: Promise<void> | null = null;
   private roomSwitchTarget: string | null = null;
+  private roomSwitchToken: symbol | null = null;
+  private roomSwitchCanceller: ((error: Error) => void) | null = null;
   private selfPingTimer: ReturnType<typeof setInterval> | null = null;
   private readonly joinedMucs = new Map<string, Promise<void>>();
   private readonly joinedMucJoinTokens = new Map<string, symbol>();
   private readonly joinedMucReady = new Set<string>();
+  private readonly mucJoinInFlightKeys = new Set<string>();
+  private readonly mucJoinRetryCancellers = new Map<symbol, (error: Error) => void>();
+  private roomSelfPresenceTimeoutMs = ROOM_SELF_PRESENCE_TIMEOUT_MS;
   private retainedJoinedRoomJids = new Set<string>();
   private autoJoinRoomJids: ReadonlyArray<string> = [];
   // Self-presence-confirmed (XEP-0045 status 110) room keys captured at
@@ -578,10 +607,8 @@ export class BrowserXmppClient {
       events: this.events,
       emitError: (event) => this.emitError(event),
       requireConnectedXmpp: () => this.requireConnectedXmpp(),
-      ensureRoomReady: async (spaceId, channelId) => {
-        await this.connect();
-        await this.switchRoom(spaceId, channelId);
-      },
+      ensureRoomReady: (spaceId, channelId) =>
+        this.requireJoinedRoom(spaceId, channelId),
       roomJidForChannel: (channelId) => this.roomJidForChannel(channelId),
       isCurrentConnected: (xmpp, sessionJid) =>
         this.xmpp === xmpp && this.connected && !this.destroying && this.session.jid === sessionJid,
@@ -593,6 +620,7 @@ export class BrowserXmppClient {
     });
     this.mucAdmin = new MucAdmin({
       requireConnectedXmpp: () => this.requireConnectedXmpp(),
+      requireReadyRoomXmpp: (roomJid) => this.requireReadyRoomXmpp(roomJid),
       roomJidForChannel: (channelId) => this.roomJidForChannel(channelId),
       emitError: (event) => this.emitError(event),
     });
@@ -610,12 +638,19 @@ export class BrowserXmppClient {
       requireConnectedXmpp: () => this.requireConnectedXmpp(),
       handleMucPresenceError: (presence) => this.handleMucPresenceError(presence),
       onOwnSelfPresence: (roomJid) => {
-        this.roomJoinWaiters.get(this.roomJoinKey(roomJid))?.resolve();
+        const key = this.roomJoinKey(roomJid);
+        // Self-presence is the synchronous phase boundary: once it lands,
+        // a following own-unavailable stanza must revoke the completed join
+        // instead of preserving it as still in flight. Promise continuations
+        // run later, so clear this before resolving the waiter.
+        this.mucJoinInFlightKeys.delete(key);
+        this.roomJoinWaiters.get(key)?.resolve();
         this.markMucReadyFromSelfPresence(roomJid);
       },
       onOwnUnavailable: (roomJid) => {
+        const key = this.roomJoinKey(roomJid);
         this.revokeMucReadiness(roomJid, {
-          keepPendingJoin: this.roomJoinWaiters.has(this.roomJoinKey(roomJid)),
+          keepPendingJoin: this.mucJoinInFlightKeys.has(key),
         });
       },
     });
@@ -673,6 +708,21 @@ export class BrowserXmppClient {
       waiter.reject(error);
     }
     this.roomJoinWaiters.clear();
+  }
+
+  private cancelMucJoinRetryWaiters(error: Error): void {
+    for (const cancel of [...this.mucJoinRetryCancellers.values()]) {
+      cancel(error);
+    }
+  }
+
+  private cancelRoomSwitch(error: Error): void {
+    const cancel = this.roomSwitchCanceller;
+    this.roomSwitchPromise = null;
+    this.roomSwitchTarget = null;
+    this.roomSwitchToken = null;
+    this.roomSwitchCanceller = null;
+    cancel?.(error);
   }
 
   private ownFullJidCandidates(): Set<string> {
@@ -744,25 +794,27 @@ export class BrowserXmppClient {
     if (!waiter) return false;
     if (errorNick !== waiter.requestedNick) return false;
 
-    waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
-    // Fully revoke — including the pending joinedMucs promise and its
-    // token — BEFORE emitting, so an error listener that synchronously
-    // retries the join starts a fresh one instead of awaiting the doomed
-    // rejected entry (ensureJoined's own catch cleanup only lands several
-    // microtasks later and its token guard makes this early delete safe).
-    this.revokeMucReadiness(room);
+    waiter.reject(new MucJoinRejectedError(stanzaErrorContext({
+      condition: presence.error_condition,
+      errorType: presence.error_type,
+      text: presence.error_text,
+    })));
+    return true;
+  }
+
+  private emitMucJoinRejection(
+    roomJid: string,
+    error: MucJoinRejectedError,
+    recoverable: boolean,
+  ): void {
     this.emitError({
       kind: "muc-join",
-      recoverable: true,
-      detail: `room join rejected — ${room}`,
-      roomLocalpart: jidLocalpart(room),
-      ...stanzaErrorContext({
-        condition: presence.error_condition,
-        errorType: presence.error_type,
-        text: presence.error_text,
-      }),
+      recoverable,
+      detail: `room join rejected — ${roomJid}`,
+      cause: error,
+      roomLocalpart: jidLocalpart(roomJid),
+      ...stanzaErrorContext(error),
     });
-    return true;
   }
 
   private revokeMucReadiness(roomJid: string, options: { keepPendingJoin?: boolean } = {}): void {
@@ -1109,9 +1161,10 @@ export class BrowserXmppClient {
     this.connected = false;
     this.connectPromise = null;
     this.currentRoom = null;
-    this.roomSwitchPromise = null;
-    this.roomSwitchTarget = null;
+    this.cancelRoomSwitch(new Error("XMPP disconnected while switching rooms"));
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
+    this.cancelMucJoinRetryWaiters(new Error("XMPP disconnected while retrying room join"));
+    this.mucJoinInFlightKeys.clear();
     this.uploadServiceJid = null;
     this.clearRoomPresenceCaches();
     this.retainedJoinedRoomJids.clear();
@@ -1170,10 +1223,8 @@ export class BrowserXmppClient {
     });
     const timeout = setTimeout(() => {
       this.roomJoinWaiters.delete(key);
-      const detail = `Timed out waiting for self-presence in ${roomJid}`;
-      this.emitError({ kind: "connect-timeout", recoverable: true, detail });
-      rejectJoin(new Error("Channel presence did not finish syncing. Try again in a moment."));
-    }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
+      rejectJoin(new MucJoinSelfPresenceTimeoutError());
+    }, this.roomSelfPresenceTimeoutMs);
     this.roomJoinWaiters.set(key, {
       promise,
       requestedNick,
@@ -1203,7 +1254,11 @@ export class BrowserXmppClient {
     this.presence.dispatchFocusedRoom();
   }
 
-  async ensureJoined(roomJid: string): Promise<void> {
+  ensureJoined(roomJid: string): Promise<void> {
+    return this.ensureJoinedWithToken(roomJid);
+  }
+
+  private async ensureJoinedWithToken(roomJid: string): Promise<void> {
     // Every join tracker keys on the canonical `roomJoinKey` (lowercased
     // bare JID) so case variants from topology vs. retained-room replay
     // resolve to a single entry (#1221). The raw `roomJid` still goes on
@@ -1222,10 +1277,21 @@ export class BrowserXmppClient {
       this.rememberJoinedRoom(roomJid);
       return;
     }
-    const promise = this.performMucJoin(roomJid);
     const joinToken = Symbol(key);
-    this.joinedMucs.set(key, promise);
     this.joinedMucJoinTokens.set(key, joinToken);
+    this.mucJoinInFlightKeys.add(key);
+    let resolveJoin!: () => void;
+    let rejectJoin!: (error: unknown) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveJoin = resolve;
+      rejectJoin = reject;
+    });
+    // Publish the canonical single-flight promise before entering the WASM
+    // binding. A binding may synchronously deliver queued presence callbacks
+    // while `join_room` is being invoked; those callbacks must be able to
+    // revoke this exact tracker without a later `set` resurrecting it.
+    this.joinedMucs.set(key, promise);
+    void this.performMucJoin(roomJid, joinToken).then(resolveJoin, rejectJoin);
     try {
       await promise;
       if (this.joinedMucJoinTokens.get(key) === joinToken) {
@@ -1234,11 +1300,45 @@ export class BrowserXmppClient {
       }
     } catch (err) {
       if (this.joinedMucJoinTokens.get(key) === joinToken) {
+        this.mucJoinInFlightKeys.delete(key);
         this.joinedMucs.delete(key);
         this.joinedMucJoinTokens.delete(key);
         this.joinedMucReady.delete(key);
+        if (err instanceof MucJoinRejectedError) {
+          // No retry remains (or the stanza type was terminal). Emit only
+          // after clearing the owning token so a listener-triggered explicit
+          // retry cannot inherit the rejected single-flight promise.
+          // Expected access-control denials are terminal for this join, but
+          // they are normal user-visible authorization outcomes rather than
+          // operator-pageable failures. Retryability remains driven solely by
+          // the stanza error type in `performMucJoin`.
+          this.emitMucJoinRejection(
+            roomJid,
+            err,
+            err.errorType === "wait"
+              || isExpectedMucAccessDenial(err),
+          );
+        } else if (err instanceof MucJoinSelfPresenceTimeoutError) {
+          // An ambiguous remote commit receives the same bounded retry budget
+          // as an explicit wait error. Emit only once that budget is
+          // exhausted; intermediate attempt timeouts are not Faro errors.
+          // The final event remains recoverable because a later explicit
+          // retry can succeed and must not be treated as a pageable terminal
+          // failure.
+          this.emitError({
+            kind: "connect-timeout",
+            recoverable: true,
+            detail: `Timed out waiting for self-presence in ${roomJid}`,
+            cause: err,
+            roomLocalpart: jidLocalpart(roomJid),
+          });
+        }
       }
       throw err;
+    } finally {
+      if (this.joinedMucJoinTokens.get(key) === joinToken) {
+        this.mucJoinInFlightKeys.delete(key);
+      }
     }
   }
 
@@ -1254,12 +1354,58 @@ export class BrowserXmppClient {
     this.resumePersistence.saveJoinedRooms([...this.retainedJoinedRoomJids]);
   }
 
-  private async performMucJoin(roomJid: string): Promise<void> {
+  private async performMucJoin(roomJid: string, joinToken: symbol): Promise<void> {
     const xmpp = this.xmpp;
     if (!xmpp) throw new Error("XMPP session is not ready");
     if (!xmpp.join_room && !xmpp.joinRoom) {
       throw new Error("XMPP client missing join_room binding");
     }
+
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        await this.performMucJoinAttempt(xmpp, roomJid);
+        return;
+      } catch (error) {
+        const retryable =
+          error instanceof MucJoinSelfPresenceTimeoutError
+          || (
+            error instanceof MucJoinRejectedError
+            && error.errorType === "wait"
+            && !isExpectedMucAccessDenial(error)
+          );
+        if (!retryable) {
+          throw error;
+        }
+        const retryDelayMs = MUC_JOIN_RETRY_DELAYS_MS[attempt];
+        if (retryDelayMs === undefined) throw error;
+
+        await this.waitBeforeMucJoinRetry(retryDelayMs, joinToken);
+        if (!this.isCurrentXmpp(xmpp)) {
+          throw new Error("XMPP connection changed while retrying room join");
+        }
+        // A wait-type rejection can race with delayed status-110 delivery
+        // from a remote room owner. If the first attempt did complete, do not
+        // send a duplicate join after the backoff.
+        const joinKey = this.roomJoinKey(roomJid);
+        if (this.joinedMucReady.has(joinKey)) return;
+        // Self-presence followed by own-unavailable can both arrive while
+        // this retry timer is asleep. The synchronous self-presence boundary
+        // clears the in-flight key; do not let the superseded sequence send a
+        // duplicate join after unavailable revoked its token.
+        if (
+          this.joinedMucJoinTokens.get(joinKey) !== joinToken
+          || !this.mucJoinInFlightKeys.has(joinKey)
+        ) {
+          throw new Error("Room became unavailable while retrying join");
+        }
+      }
+    }
+  }
+
+  private async performMucJoinAttempt(
+    xmpp: XmppClientInstance,
+    roomJid: string,
+  ): Promise<void> {
     const ready = this.waitForRoomSelfPresence(roomJid, this.session.username);
     const joinKey = this.roomJoinKey(roomJid);
     const joinWaiter = this.roomJoinWaiters.get(joinKey);
@@ -1281,9 +1427,37 @@ export class BrowserXmppClient {
     }
     if (!this.isCurrentXmpp(xmpp)) {
       await ready.catch(() => undefined);
-      return;
+      throw new Error("XMPP connection changed while joining room");
     }
     await ready;
+    if (
+      !this.isCurrentXmpp(xmpp)
+      || !this.joinedMucReady.has(joinKey)
+    ) {
+      throw new Error("Room became unavailable while joining");
+    }
+  }
+
+  private waitBeforeMucJoinRetry(delayMs: number, joinToken: symbol): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (outcome: "resolve" | "reject", error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (this.mucJoinRetryCancellers.get(joinToken) === cancel) {
+          this.mucJoinRetryCancellers.delete(joinToken);
+        }
+        if (outcome === "resolve") {
+          resolve();
+        } else {
+          reject(error ?? new Error("XMPP room join retry cancelled"));
+        }
+      };
+      const cancel = (error: Error) => finish("reject", error);
+      const timer = setTimeout(() => finish("resolve"), delayMs);
+      this.mucJoinRetryCancellers.set(joinToken, cancel);
+    });
   }
 
   async fanOutAutoJoin(roomJids: ReadonlyArray<string>, concurrency = 6): Promise<void> {
@@ -1323,48 +1497,126 @@ export class BrowserXmppClient {
   async switchRoom(_spaceId: string, channelId: string) {
     await this.connect();
     const nextRoom = this.roomJidForChannel(channelId);
+    await this.switchRoomTarget(nextRoom);
+  }
+
+  /**
+   * Switch to one already-resolved room JID.
+   *
+   * Callers that need a room-scoped handle resolve the channel mapping only
+   * after `connect()` and pass that exact snapshot through this boundary. This
+   * prevents topology discovery completing during connect from making the
+   * switch join one JID while the caller validates or queries another.
+   */
+  private async switchRoomTarget(nextRoom: string): Promise<void> {
     if (this.roomSwitchPromise) {
       if (this.roomSwitchTarget === nextRoom) return this.roomSwitchPromise;
-      await this.roomSwitchPromise.catch(() => undefined);
+      // Only detach the obsolete navigation. The canonical room join may
+      // also be awaited by autojoin, member-list readiness, or an outbound
+      // queue flush, so canceling it here would strand independent work.
+      this.cancelRoomSwitch(new RoomSwitchSupersededError());
     }
-    if (this.currentRoom === nextRoom) {
-      await this.ensureJoined(nextRoom);
-      this.dispatchFocusedRoomHandlers();
-      await this.flushQueuedRoomMessages(nextRoom);
-      return;
-    }
-    const promise = this.performRoomSwitch(nextRoom);
+    const switchToken = Symbol(nextRoom);
+    let cancelSwitch!: (error: Error) => void;
+    const cancelled = new Promise<never>((_resolve, reject) => {
+      cancelSwitch = reject;
+    });
+    let resolveSwitch!: () => void;
+    let rejectSwitch!: (error: unknown) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveSwitch = resolve;
+      rejectSwitch = reject;
+    });
     this.roomSwitchPromise = promise;
     this.roomSwitchTarget = nextRoom;
+    this.roomSwitchToken = switchToken;
+    this.roomSwitchCanceller = cancelSwitch;
+    // Publish the switch generation before entering the join binding. Presence
+    // callbacks may synchronously trigger another selection; that newer switch
+    // must be able to supersede this one without the old invocation restoring
+    // its promise or focus state afterward.
+    void this.performRoomSwitch(
+      nextRoom,
+      switchToken,
+      cancelled,
+    ).then(
+      resolveSwitch,
+      rejectSwitch,
+    );
     try {
       await promise;
     } finally {
       if (this.roomSwitchPromise === promise) {
         this.roomSwitchPromise = null;
         this.roomSwitchTarget = null;
+        this.roomSwitchToken = null;
+        this.roomSwitchCanceller = null;
       }
     }
   }
 
-  private async performRoomSwitch(nextRoom: string) {
+  private async performRoomSwitch(
+    nextRoom: string,
+    switchToken: symbol,
+    cancelled: Promise<never>,
+  ) {
     const xmpp = this.xmpp;
-    if (!xmpp) return;
+    if (!xmpp) {
+      throw new Error("XMPP connection changed while switching rooms");
+    }
+    // The existing timer belongs to the previously confirmed room. Stop it
+    // before publishing the new focus so it cannot ping `nextRoom/nick`
+    // while that room is still awaiting status 110 (or after the join is
+    // rejected). A successful join installs a fresh timer below.
+    this.stopSelfPing();
     this.currentRoom = nextRoom;
     this.dispatchFocusedRoomHandlers();
     try {
-      await withSpan(
-        "xmpp.room_switch",
-        { "conversation.kind": "room" },
-        () => this.ensureJoined(nextRoom),
-      );
+      await Promise.race([
+        withSpan(
+          "xmpp.room_switch",
+          { "conversation.kind": "room" },
+          () =>
+            this.ensureJoinedWithToken(nextRoom).catch((error: unknown) => {
+              if (error instanceof RoomSwitchSupersededError) return;
+              throw error;
+            }),
+        ),
+        cancelled,
+      ]);
+      if (!this.isCurrentXmpp(xmpp)) {
+        throw new Error("XMPP connection changed while switching rooms");
+      }
+      if (
+        this.roomSwitchToken !== switchToken
+        || this.currentRoom !== nextRoom
+      ) {
+        return;
+      }
+      this.dispatchFocusedRoomHandlers();
+      this.startSelfPing();
+      // Keep the public switch boundary cancellable through the queue flush.
+      // A disconnect or newer selection after status 110 must not leave
+      // downstream MAM/action callers waiting for stale transport work.
+      await Promise.race([
+        this.flushQueuedRoomMessages(nextRoom),
+        cancelled,
+      ]);
+      if (!this.isCurrentXmpp(xmpp)) {
+        throw new Error("XMPP connection changed while switching rooms");
+      }
+      if (
+        this.roomSwitchToken !== switchToken
+        || this.currentRoom !== nextRoom
+      ) {
+        return;
+      }
     } catch (err) {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (err instanceof RoomSwitchSupersededError) return;
+      if (!this.isCurrentXmpp(xmpp)) throw err;
+      if (this.roomSwitchToken !== switchToken) return;
       throw err;
     }
-    if (!this.isCurrentXmpp(xmpp)) return;
-    this.dispatchFocusedRoomHandlers();
-    this.startSelfPing();
-    await this.flushQueuedRoomMessages(nextRoom);
   }
 
   private canUseConnectedSession(): boolean {
@@ -1448,10 +1700,32 @@ export class BrowserXmppClient {
     return this.xmpp;
   }
 
-  private async requireJoinedRoom(spaceId: string, channelId: string): Promise<{ xmpp: XmppClientInstance; roomJid: string }> {
+  private async requireReadyRoomXmpp(roomJid: string): Promise<XmppClientInstance> {
+    const xmpp = await this.requireConnectedXmpp();
+    await this.ensureJoined(roomJid);
+    if (
+      !this.isCurrentXmpp(xmpp)
+      || !this.connected
+      || !this.joinedMucReady.has(this.roomJoinKey(roomJid))
+    ) {
+      throw new Error(`Room is not ready on the current XMPP connection: ${roomJid}`);
+    }
+    return xmpp;
+  }
+
+  private async requireJoinedRoom(_spaceId: string, channelId: string): Promise<{ xmpp: XmppClientInstance; roomJid: string }> {
+    await this.connect();
     const roomJid = this.roomJidForChannel(channelId);
-    await this.switchRoom(spaceId, channelId);
-    if (!this.xmpp || !this.connected || this.destroying || this.currentRoom !== roomJid) throw new Error(`Room is not ready: ${roomJid}`);
+    await this.switchRoomTarget(roomJid);
+    if (
+      !this.xmpp
+      || !this.connected
+      || this.destroying
+      || this.currentRoom !== roomJid
+      || !this.joinedMucReady.has(this.roomJoinKey(roomJid))
+    ) {
+      throw new Error(`Room is not ready: ${roomJid}`);
+    }
     return { xmpp: this.xmpp, roomJid };
   }
 
@@ -2267,7 +2541,21 @@ export class BrowserXmppClient {
 
   private startSelfPing() { this.stopSelfPing(); this.selfPingTimer = setInterval(() => { void this.doSelfPing(); }, 60000); }
   private stopSelfPing() { if (this.selfPingTimer) { clearInterval(this.selfPingTimer); this.selfPingTimer = null; } }
-  private async doSelfPing() { if (!this.xmpp?.send_raw_iq || !this.currentRoom) return; try { await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${this.currentRoom}/${this.session.username}"><ping xmlns="urn:xmpp:ping"/></iq>`); } catch { this.events.emit("roomDisconnect"); } }
+  private async doSelfPing() {
+    const roomJid = this.currentRoom;
+    if (
+      !this.xmpp?.send_raw_iq
+      || !roomJid
+      || !this.joinedMucReady.has(this.roomJoinKey(roomJid))
+    ) {
+      return;
+    }
+    try {
+      await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${roomJid}/${this.session.username}"><ping xmlns="urn:xmpp:ping"/></iq>`);
+    } catch {
+      this.events.emit("roomDisconnect");
+    }
+  }
   private handleMessageAck(id: string) { this.outboundQueue.handleAck(id); }
   private handleMessageFailed(id: string) { this.outboundQueue.handleFailed(id); }
   // `lifecycle` is the bare kind here — the emitted
@@ -2518,6 +2806,9 @@ export class BrowserXmppClient {
     clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
+    this.cancelMucJoinRetryWaiters(new Error("XMPP disconnected while retrying room join"));
+    this.mucJoinInFlightKeys.clear();
+    this.cancelRoomSwitch(new Error("XMPP disconnected while switching rooms"));
     // `joinedMucs` keys are already canonical `roomJoinKey`s (#1221).
     this.retainedJoinedRoomJids = new Set([
       ...this.retainedJoinedRoomJids,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -9,6 +9,11 @@ export type {
 } from "./client-pubsub";
 export { RoomMemberListUnavailableError } from "./client-muc-admin";
 export type { AdminUserEntry, AdminUsersPage } from "./client-muc-admin";
+export {
+  MUC_JOIN_RETRY_DELAYS_MS,
+  MucJoinRejectedError,
+  MucJoinSelfPresenceTimeoutError,
+} from "./muc-join-retry";
 // Admin V2 — types re-exported for consumption by SpacesPanel,
 // ChannelsPanel, and their detail drawers. The `*Ref` /
 // `*SetRoleResult` / `*SetAffiliationResult` / `*KickResult` shapes

--- a/chat/src/lib/xmpp/muc-join-retry.ts
+++ b/chat/src/lib/xmpp/muc-join-retry.ts
@@ -1,0 +1,52 @@
+import type { StanzaErrorContext } from "./stanza-error-context";
+import type { XmppStanzaErrorType } from "./types";
+
+/**
+ * A server-rejected XEP-0045 room join.
+ *
+ * The stanza context stays attached to the thrown error so callers can
+ * distinguish an RFC 6120 `wait` error from terminal auth/cancel/modify
+ * failures instead of relying on user-facing message text.
+ */
+export class MucJoinRejectedError extends Error {
+  readonly condition?: string;
+  readonly errorType?: XmppStanzaErrorType;
+  readonly text?: string;
+
+  constructor(context: StanzaErrorContext) {
+    super(
+      context.errorType === "wait"
+        ? "Channel presence is temporarily unavailable. Try again in a moment."
+        : "Channel presence was rejected.",
+    );
+    this.name = "MucJoinRejectedError";
+    this.condition = context.condition;
+    this.errorType = context.errorType;
+    this.text = context.errorText;
+  }
+}
+
+/**
+ * The room join produced no terminal stanza and no XEP-0045 status-110
+ * self-presence before the attempt deadline.
+ *
+ * Ordered-relay joins deliberately suppress a local error when the remote
+ * owner may already have committed the occupancy. Keeping this outcome typed
+ * lets the caller retry/resynchronize that ambiguous commit without treating
+ * unrelated transport and lifecycle failures as retryable.
+ */
+export class MucJoinSelfPresenceTimeoutError extends Error {
+  constructor() {
+    super("Channel presence did not finish syncing. Try again in a moment.");
+    this.name = "MucJoinSelfPresenceTimeoutError";
+  }
+}
+
+/**
+ * Bounded retries after the initial join attempt. The cumulative schedule
+ * deliberately includes an attempt after the server's five-second pending
+ * room-ownership reconciliation tick. Fixed delays keep the policy
+ * deterministic in production and make the state machine testable without
+ * random-number seams.
+ */
+export const MUC_JOIN_RETRY_DELAYS_MS = [250, 750, 1_500, 3_000, 6_000] as const;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -156,7 +156,7 @@ export const XMPP_ERROR_CONDITIONS = new Set([
 
 export interface XmppErrorEvent {
   kind: XmppErrorKind;
-  /** Whether the client expects to recover on its own without UI intervention. */
+  /** Whether the failure is transient or expected and should not page operators. */
   recoverable: boolean;
   /** Short, human-readable reason for local UI/debugging; sanitize before telemetry. */
   detail: string;

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -88,6 +88,25 @@ async function flushCallSideEffects(): Promise<void> {
   }
 }
 
+async function switchToReadyTestRoom(
+  client: BrowserXmppClient,
+  roomJid: string,
+): Promise<void> {
+  const channelId = "__call-teardown-ready-room__";
+  const internals = client as unknown as {
+    connected: boolean;
+    joinedMucs: Map<string, Promise<void>>;
+    joinedMucReady: Set<string>;
+    stopSelfPing: () => void;
+  };
+  internals.connected = true;
+  client.rememberRoomJidForChannel(channelId, roomJid);
+  internals.joinedMucs.set(roomJid, Promise.resolve());
+  internals.joinedMucReady.add(roomJid);
+  await client.switchRoom("w1", channelId);
+  internals.stopSelfPing();
+}
+
 function firstMockCallArg(fn: unknown, index: number): unknown {
   return (fn as { mock: { calls: unknown[][] } }).mock.calls[0]?.[index];
 }
@@ -2650,12 +2669,9 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      joinedMucs: Map<string, Promise<void>>;
-      performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
     client.currentRoom = "old@muc.test";
-    client.joinedMucs.set("new@muc.test", Promise.resolve());
     $callState.set({
       phase: "active",
       peer: "old@muc.test",
@@ -2666,7 +2682,7 @@ describe("MUC group call", () => {
       selfNick: "alice",
     });
 
-    await client.performRoomSwitch("new@muc.test");
+    await switchToReadyTestRoom(events.client, "new@muc.test");
 
     expect(operationOrder).toEqual([]);
     expect(xmpp.leave_room).not.toHaveBeenCalled();
@@ -2678,7 +2694,7 @@ describe("MUC group call", () => {
     });
   });
 
-  test("room switch bails out cleanly when a concurrent disconnect races the join", async () => {
+  test("room switch rejects cleanly when a concurrent disconnect races the join", async () => {
     const events = wireClientEvents();
     let releaseJoin: (() => void) | null = null;
     let joinStarted: (() => void) | null = null;
@@ -2701,18 +2717,22 @@ describe("MUC group call", () => {
     const xmpp = { leave_room, join_room, disconnect };
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
+      connected: boolean;
       currentRoom: string | null;
-      performRoomSwitch: (roomJid: string) => Promise<void>;
+      rememberRoomJidForChannel: (channelId: string, roomJid: string) => void;
+      switchRoom: (spaceId: string, channelId: string) => Promise<void>;
       disconnect: () => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
+    client.connected = true;
     client.currentRoom = "old@muc.test";
+    client.rememberRoomJidForChannel("new", "new@muc.test");
 
-    const switched = client.performRoomSwitch("new@muc.test");
+    const switched = client.switchRoom("w1", "new");
     await joinStartedWait;
     const disconnected = client.disconnect();
     releaseJoin?.();
-    await switched;
+    await expect(switched).rejects.toThrow("XMPP disconnected while switching rooms");
     await disconnected;
 
     expect(join_room).toHaveBeenCalledTimes(1);
@@ -2755,8 +2775,6 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      joinedMucs: Map<string, Promise<void>>;
-      performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
     const wiredXmpp = client.xmpp;
@@ -2769,9 +2787,7 @@ describe("MUC group call", () => {
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(1);
     const attemptSid = firstMockCallArg(send_muji_session_initiate, 1);
     expect(attemptSid).not.toBe("old@muc.test");
-    client.joinedMucs.set("new@muc.test", Promise.resolve());
-
-    await client.performRoomSwitch("new@muc.test");
+    await switchToReadyTestRoom(events.client, "new@muc.test");
 
     events.emitCall({
       kind: "session-accept",
@@ -2825,8 +2841,6 @@ describe("MUC group call", () => {
     const client = events.client as unknown as {
       xmpp: typeof xmpp;
       currentRoom: string | null;
-      joinedMucs: Map<string, Promise<void>>;
-      performRoomSwitch: (roomJid: string) => Promise<void>;
     };
     Object.assign(client.xmpp, xmpp);
     const wiredXmpp = client.xmpp;
@@ -2837,9 +2851,7 @@ describe("MUC group call", () => {
     await flushCallSideEffects();
     expect($callState.get().phase).toBe("muc-pending");
     expect(send_muji_session_initiate).toHaveBeenCalledTimes(0);
-    client.joinedMucs.set("new@muc.test", Promise.resolve());
-
-    await client.performRoomSwitch("new@muc.test");
+    await switchToReadyTestRoom(events.client, "new@muc.test");
 
     events.emitPresence({
       from: "old@muc.test/alice",

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -79,7 +79,10 @@ function createPager(
     events,
     emitError: (event) => errors.push(event),
     requireConnectedXmpp: async () => xmpp,
-    ensureRoomReady: async () => undefined,
+    ensureRoomReady: async (_spaceId, channelId) => ({
+      xmpp,
+      roomJid: `${channelId}@muc.example.com`,
+    }),
     roomJidForChannel: (channelId) => `${channelId}@muc.example.com`,
     isCurrentConnected: (candidate) =>
       overrides.currentXmpp ? overrides.currentXmpp() === candidate : xmpp === candidate,

--- a/chat/tests/client-muc-admin.test.ts
+++ b/chat/tests/client-muc-admin.test.ts
@@ -5,7 +5,7 @@
  * failure classification, and the snake_case translation of the admin
  * V2 wrappers — exercised against a fake WASM client.
  */
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   MucAdmin,
   RoomMemberListUnavailableError,
@@ -13,10 +13,14 @@ import {
 } from "../src/lib/xmpp/client-muc-admin";
 import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 
-function createAdmin(xmpp: MucAdminWasmClient) {
+function createAdmin(
+  xmpp: MucAdminWasmClient,
+  requireReadyRoomXmpp: (roomJid: string) => Promise<MucAdminWasmClient> = async () => xmpp,
+) {
   const errors: XmppErrorEvent[] = [];
   const admin = new MucAdmin({
     requireConnectedXmpp: async () => xmpp,
+    requireReadyRoomXmpp,
     roomJidForChannel: (channelId) => `${channelId}@muc.example.com`,
     emitError: (event) => errors.push(event),
   });
@@ -24,6 +28,49 @@ function createAdmin(xmpp: MucAdminWasmClient) {
 }
 
 describe("MucAdmin.listRoomMembers", () => {
+  test("waits for canonical room readiness before sending affiliation queries", async () => {
+    let releaseRoom: (() => void) | undefined;
+    const roomReady = new Promise<void>((resolve) => {
+      releaseRoom = resolve;
+    });
+    const requireReadyRoomXmpp = mock(async () => {
+      await roomReady;
+      return { list_room_members: listRoomMembers };
+    });
+    const listRoomMembers = mock(async () => []);
+    const { admin } = createAdmin(
+      { list_room_members: listRoomMembers },
+      requireReadyRoomXmpp,
+    );
+
+    const members = admin.listRoomMembers("general", {
+      roomJid: "room-123@muc.example.com",
+    });
+    await Promise.resolve();
+
+    expect(requireReadyRoomXmpp).toHaveBeenCalledWith("room-123@muc.example.com");
+    expect(listRoomMembers).not.toHaveBeenCalled();
+
+    releaseRoom?.();
+    await expect(members).resolves.toEqual([]);
+    expect(listRoomMembers).toHaveBeenCalledTimes(4);
+  });
+
+  test("propagates join rejection without sending affiliation queries", async () => {
+    const rejection = new Error("join rejected");
+    const listRoomMembers = mock(async () => []);
+    const { admin, errors } = createAdmin(
+      { list_room_members: listRoomMembers },
+      async () => {
+        throw rejection;
+      },
+    );
+
+    await expect(admin.listRoomMembers("general")).rejects.toBe(rejection);
+    expect(listRoomMembers).not.toHaveBeenCalled();
+    expect(errors).toEqual([]);
+  });
+
   test("aggregates members across all four affiliation queries", async () => {
     const queried: string[] = [];
     const { admin, errors } = createAdmin({

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -4,7 +4,17 @@ import { ref } from "vue";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
-import { BrowserXmppClient, roomBareJidFor, type DmConversationScope, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
+import {
+  BrowserXmppClient,
+  MUC_JOIN_RETRY_DELAYS_MS,
+  MucJoinRejectedError,
+  MucJoinSelfPresenceTimeoutError,
+  roomBareJidFor,
+  type DmConversationScope,
+  type InboxEntry,
+  type LiveDmMessage,
+  type RoomActivityEvent,
+} from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
@@ -94,6 +104,26 @@ function dmMessage(partial: Partial<LiveDmMessage> = {}): LiveDmMessage {
 
 async function settleReconnectCatchup(turns = 6): Promise<void> {
   for (let i = 0; i < turns; i += 1) await Promise.resolve();
+}
+
+async function settleUntil(predicate: () => boolean, turns = 20): Promise<void> {
+  for (let i = 0; i < turns; i += 1) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error("condition did not settle");
+}
+
+function markReadyTestRoom(client: BrowserXmppClient, roomJid: string): void {
+  const roomKey = roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+  const internals = client as unknown as {
+    currentRoom: string | null;
+    joinedMucs: Map<string, Promise<void>>;
+    joinedMucReady: Set<string>;
+  };
+  internals.currentRoom = roomJid;
+  internals.joinedMucs.set(roomKey, Promise.resolve());
+  internals.joinedMucReady.add(roomKey);
 }
 
 const originalWindow = globalThis.window;
@@ -541,20 +571,1204 @@ describe("client send readiness", () => {
     expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
   });
 
-  test("room join rejects on XEP-0045 MUC error presence instead of timing out", async () => {
+  test("expected MUC access denial is non-pageable and does not retry", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");
     const errors: XmppErrorEvent[] = [];
     const staleJoinVisibleAtEmit: boolean[] = [];
+    const retryDelays: number[] = [];
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = async (delayMs) => {
+      retryDelays.push(delayMs);
+    };
     client.onError((event) => {
       errors.push(event);
-      // A listener that synchronously retries the join must NOT observe
-      // the doomed promise still cached in joinedMucs (the emit is
-      // deferred one microtask so ensureJoined's catch cleans up first).
+      // A listener that synchronously retries a terminal join must NOT
+      // observe the rejected single-flight promise.
       staleJoinVisibleAtEmit.push(
         (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid),
       );
     });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      error_text?: string;
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> })
+      .ensureJoined(roomJid)
+      .catch((error: unknown) => error);
+    await Promise.resolve();
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(1);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "registration-required",
+      error_type: "auth",
+      error_text: "Membership required to join managed channel.",
+    });
+
+    const rejection = await joined;
+    expect(rejection).toBeInstanceOf(MucJoinRejectedError);
+    expect(rejection).toMatchObject({
+      condition: "registration-required",
+      errorType: "auth",
+      text: "Membership required to join managed channel.",
+    });
+    expect(normalizeError(rejection)).toContain("Channel presence was rejected");
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+    expect(retryDelays).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe("muc-join");
+    expect(errors[0].recoverable).toBe(true);
+    expect(errors[0].condition).toBe("registration-required");
+    expect(errors[0].errorType).toBe("auth");
+    expect(errors[0].errorText).toBe("Membership required to join managed channel.");
+    expect(errors[0].roomLocalpart).toBe("c1");
+    expect(staleJoinVisibleAtEmit).toEqual([false]);
+  });
+
+  test("access-denial conditions remain terminal even with a wait stanza type", async () => {
+    for (const condition of [
+      "forbidden",
+      "not-allowed",
+      "not-authorized",
+      "registration-required",
+    ]) {
+      const client = new BrowserXmppClient(session());
+      const roomJid = roomBareJidFor(session(), `denied-${condition}`);
+      const errors: XmppErrorEvent[] = [];
+      const retryDelays: number[] = [];
+      client.onError((event) => errors.push(event));
+      (client as unknown as {
+        waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+      }).waitBeforeMucJoinRetry = async (delayMs) => {
+        retryDelays.push(delayMs);
+      };
+      let onPresence: ((presence: {
+        from?: string;
+        presence_type: string;
+        error_condition?: string;
+        error_type?: string;
+      }) => void) | null = null;
+      const xmpp = {
+        join_room: mock(async () => undefined),
+        set_on_presence(cb: NonNullable<typeof onPresence>) {
+          onPresence = cb;
+        },
+      };
+      (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+      (client as unknown as { connected: boolean }).connected = true;
+      (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+      const joined = (client as unknown as {
+        ensureJoined: (roomJid: string) => Promise<void>;
+      }).ensureJoined(roomJid).catch((error: unknown) => error);
+      await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+      onPresence?.({
+        from: `${roomJid}/alice`,
+        presence_type: "error",
+        error_condition: condition,
+        error_type: "wait",
+      });
+
+      await expect(joined).resolves.toBeInstanceOf(MucJoinRejectedError);
+      expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+      expect(retryDelays).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({
+        kind: "muc-join",
+        recoverable: true,
+        condition,
+        errorType: "wait",
+      });
+    }
+  });
+
+  test("switching from a ready room never self-pings a denied room before status 110", async () => {
+    const client = new BrowserXmppClient(session());
+    const readyRoomJid = roomBareJidFor(session(), "c1");
+    const deniedRoomJid = roomBareJidFor(session(), "c2");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_raw_iq: mock(async () => "<iq type='result'/>"),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const readySwitch = client.switchRoom("w1", "c1");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${readyRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await readySwitch;
+    expect((client as unknown as { selfPingTimer: unknown }).selfPingTimer).not.toBeNull();
+
+    const deniedSwitch = client.switchRoom("w1", "c2").catch((error: unknown) => error);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    expect((client as unknown as { selfPingTimer: unknown }).selfPingTimer).toBeNull();
+    await (client as unknown as { doSelfPing: () => Promise<void> }).doSelfPing();
+    expect(xmpp.send_raw_iq).not.toHaveBeenCalled();
+
+    onPresence?.({
+      from: `${deniedRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "registration-required",
+      error_type: "auth",
+    });
+
+    await expect(deniedSwitch).resolves.toBeInstanceOf(MucJoinRejectedError);
+    await (client as unknown as { doSelfPing: () => Promise<void> }).doSelfPing();
+    expect(xmpp.send_raw_iq).not.toHaveBeenCalled();
+    expect(
+      (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(deniedRoomJid),
+    ).toBe(false);
+  });
+
+  test("switching rooms detaches a transient join retry without cancelling shared room readiness", async () => {
+    const client = new BrowserXmppClient(session());
+    const retryingRoomJid = roomBareJidFor(session(), "c1");
+    const nextRoomJid = roomBareJidFor(session(), "c2");
+    const errors: XmppErrorEvent[] = [];
+    client.onError((event) => errors.push(event));
+    let markRetryStarted!: () => void;
+    let releaseRetry!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    const retryGate = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    (client as unknown as {
+      waitBeforeMucJoinRetry: () => Promise<void>;
+    }).waitBeforeMucJoinRetry = async () => {
+      markRetryStarted();
+      await retryGate;
+    };
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_raw_iq: mock(async () => "<iq type='result'/>"),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const obsoleteSwitch = client.switchRoom("w1", "c1");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${retryingRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await retryStarted;
+    const retryingJoin = (client as unknown as {
+      joinedMucs: Map<string, Promise<void>>;
+    }).joinedMucs.get(retryingRoomJid);
+    expect(retryingJoin).toBeDefined();
+
+    const nextSwitch = client.switchRoom("w1", "c2");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    expect(xmpp.join_room.mock.calls[1]?.[0]).toBe(nextRoomJid);
+    expect(
+      (client as unknown as {
+        joinedMucs: Map<string, Promise<void>>;
+      }).joinedMucs.get(retryingRoomJid),
+    ).toBe(retryingJoin);
+
+    onPresence?.({
+      from: `${nextRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await expect(nextSwitch).resolves.toBeUndefined();
+    await expect(obsoleteSwitch).resolves.toBeUndefined();
+    expect((client as unknown as { currentRoom: string }).currentRoom).toBe(nextRoomJid);
+
+    // A delayed success from the superseded room may accurately restore that
+    // room's background occupancy, but it must not steal focus or the ping.
+    onPresence?.({
+      from: `${retryingRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    releaseRetry();
+    await expect(retryingJoin).resolves.toBeUndefined();
+    await (client as unknown as { doSelfPing: () => Promise<void> }).doSelfPing();
+    expect(xmpp.send_raw_iq).toHaveBeenCalledTimes(1);
+    expect(xmpp.send_raw_iq.mock.calls[0]?.[0]).toContain(`to="${nextRoomJid}/alice"`);
+    expect((client as unknown as { currentRoom: string }).currentRoom).toBe(nextRoomJid);
+    expect(errors).toEqual([]);
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("concurrent switches to the same target keep one join single-flight", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const first = client.switchRoom("w1", "c1");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    const second = client.switchRoom("w1", "c1");
+    await settleReconnectCatchup();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("a superseded A-B-A switch cannot send before A readiness is confirmed", async () => {
+    const client = new BrowserXmppClient(session());
+    const firstRoomJid = roomBareJidFor(session(), "c1");
+    const secondRoomJid = roomBareJidFor(session(), "c2");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_reaction: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const staleSend = client
+      .sendReaction("w1", "c1", "message-1", ["👍"])
+      .then(() => "sent", normalizeError);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+
+    // Queue both newer selections in the same task. Their connect()
+    // continuations run B then A, before the superseded first A switch
+    // resumes its caller.
+    const awaySwitch = client.switchRoom("w1", "c2");
+    const freshSwitch = client.switchRoom("w1", "c1");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+
+    expect(xmpp.join_room.mock.calls.map((call) => call[0])).toEqual([
+      firstRoomJid,
+      secondRoomJid,
+    ]);
+    expect(await staleSend).toBe(`Room is not ready: ${firstRoomJid}`);
+    expect(xmpp.send_reaction).not.toHaveBeenCalled();
+    await expect(awaySwitch).resolves.toBeUndefined();
+
+    // The detached B membership join remains valid background work too.
+    onPresence?.({
+      from: `${secondRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    onPresence?.({
+      from: `${firstRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(freshSwitch).resolves.toBeUndefined();
+    expect(xmpp.send_reaction).not.toHaveBeenCalled();
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("a superseded A-B MAM load cannot query the room selected before navigation", async () => {
+    const client = new BrowserXmppClient(session());
+    const firstRoomJid = roomBareJidFor(session(), "c1");
+    const secondRoomJid = roomBareJidFor(session(), "c2");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [],
+      is_complete: true,
+    }));
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      fetch_room_history_page: fetchRoomHistoryPage,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const staleMam = client
+      .queryMamPage("w1", "c1", 100, { type: "latest" })
+      .then(() => "queried", normalizeError);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+
+    const awaySwitch = client.switchRoom("w1", "c2");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+
+    expect(await staleMam).toBe(`Room is not ready: ${firstRoomJid}`);
+    expect(fetchRoomHistoryPage).not.toHaveBeenCalled();
+
+    // Complete both detached membership joins so no attempt timer survives
+    // the test. Neither completion may resurrect the superseded MAM caller.
+    onPresence?.({
+      from: `${firstRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    onPresence?.({
+      from: `${secondRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(awaySwitch).resolves.toBeUndefined();
+    await settleReconnectCatchup();
+    expect(fetchRoomHistoryPage).not.toHaveBeenCalled();
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("MAM joins and queries the same canonical room when topology lands during connect", async () => {
+    const client = new BrowserXmppClient(session());
+    const canonicalRoomJid = "canonical@rooms.example.com";
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [],
+      is_complete: true,
+    }));
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      fetch_room_history_page: fetchRoomHistoryPage,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const internals = client as unknown as {
+      connect: () => Promise<void>;
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internals.connect = mock(async () => {
+      internals.xmpp = xmpp;
+      internals.connected = true;
+      client.rememberRoomJidForChannel("c1", canonicalRoomJid);
+      internals.wireEvents(xmpp);
+    });
+
+    const page = client.queryMamPage("w1", "c1", 100, { type: "latest" });
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${canonicalRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(page).resolves.toEqual({
+      messages: [],
+      complete: true,
+    });
+    expect(xmpp.join_room).toHaveBeenCalledWith(canonicalRoomJid, "alice");
+    expect(fetchRoomHistoryPage).toHaveBeenCalledWith(
+      canonicalRoomJid,
+      100,
+      { type: "latest" },
+    );
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("a superseded A-B-A MAM load cannot query before the fresh A join is ready", async () => {
+    const client = new BrowserXmppClient(session());
+    const firstRoomJid = roomBareJidFor(session(), "c1");
+    const secondRoomJid = roomBareJidFor(session(), "c2");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [],
+      is_complete: true,
+    }));
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      fetch_room_history_page: fetchRoomHistoryPage,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const staleMam = client
+      .queryMamPage("w1", "c1", 100, { type: "latest" })
+      .then(() => "queried", normalizeError);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+
+    // Supersede the first A selection with B, then immediately select A
+    // again. Both background memberships remain valid work, but only the
+    // fresh A switch may authorize A's room-scoped MAM IQ.
+    const awaySwitch = client.switchRoom("w1", "c2");
+    const freshMam = client.queryMamPage("w1", "c1", 100, { type: "latest" });
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+
+    expect(xmpp.join_room.mock.calls.map((call) => call[0])).toEqual([
+      firstRoomJid,
+      secondRoomJid,
+    ]);
+    expect(await staleMam).toBe(`Room is not ready: ${firstRoomJid}`);
+    expect(fetchRoomHistoryPage).not.toHaveBeenCalled();
+    await expect(awaySwitch).resolves.toBeUndefined();
+
+    onPresence?.({
+      from: `${secondRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await settleReconnectCatchup();
+    expect(fetchRoomHistoryPage).not.toHaveBeenCalled();
+
+    onPresence?.({
+      from: `${firstRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(freshMam).resolves.toEqual({
+      messages: [],
+      complete: true,
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchRoomHistoryPage).toHaveBeenCalledWith(
+      firstRoomJid,
+      100,
+      { type: "latest" },
+    );
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("a handle lost immediately after connect rejects the room switch boundary", async () => {
+    const client = new BrowserXmppClient(session());
+    const internals = client as unknown as {
+      connect: () => Promise<void>;
+      xmpp: null;
+      connected: boolean;
+      roomSwitchPromise: Promise<void> | null;
+    };
+    internals.connect = mock(async () => {
+      internals.xmpp = null;
+      internals.connected = false;
+    });
+
+    await expect(client.switchRoom("w1", "c1")).rejects.toThrow(
+      "XMPP connection changed while switching rooms",
+    );
+    expect(internals.roomSwitchPromise).toBeNull();
+  });
+
+  test("connection replacement rejects a completed room switch boundary and rejoins on the fresh handle", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onOldPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const oldXmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onOldPresence>) {
+        onOldPresence = cb;
+      },
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    (client as unknown as { xmpp: typeof oldXmpp; connected: boolean }).xmpp = oldXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof oldXmpp) => void }).wireEvents(oldXmpp);
+
+    const staleSwitch = client.switchRoom("w1", "c1");
+    await settleUntil(() => oldXmpp.join_room.mock.calls.length === 1);
+    // Resolve the room boundary, then replace the handle in the same callback
+    // turn before the switch continuation can issue MAM/member/pin work.
+    onOldPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    (client as unknown as {
+      handleDisconnected: (xmpp: typeof oldXmpp) => void;
+    }).handleDisconnected(oldXmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+
+    await expect(staleSwitch).rejects.toThrow(
+      "XMPP disconnected while switching rooms",
+    );
+
+    let onFreshPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const freshXmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onFreshPresence>) {
+        onFreshPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof freshXmpp; connected: boolean }).xmpp = freshXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof freshXmpp) => void }).wireEvents(freshXmpp);
+
+    const freshSwitch = client.switchRoom("w1", "c1");
+    await settleUntil(() => freshXmpp.join_room.mock.calls.length === 1);
+    onFreshPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(freshSwitch).resolves.toBeUndefined();
+    expect(oldXmpp.join_room).toHaveBeenCalledTimes(1);
+    expect(freshXmpp.join_room).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { currentRoom: string }).currentRoom).toBe(roomJid);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+    (client as unknown as { stopSelfPing: () => void }).stopSelfPing();
+  });
+
+  test("disconnect during the post-join queue flush rejects the room switch boundary", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    let markFlushStarted!: () => void;
+    let releaseFlush!: () => void;
+    const flushStarted = new Promise<void>((resolve) => {
+      markFlushStarted = resolve;
+    });
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    const internals = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      flushQueuedRoomMessages: () => Promise<void>;
+      handleDisconnected: (xmpp: typeof xmpp) => void;
+      clearReconnectTimer: () => void;
+    };
+    internals.xmpp = xmpp;
+    internals.connected = true;
+    internals.flushQueuedRoomMessages = mock(async () => {
+      markFlushStarted();
+      await flushGate;
+    });
+    internals.wireEvents(xmpp);
+
+    const switched = client.switchRoom("w1", "c1");
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await flushStarted;
+
+    internals.handleDisconnected(xmpp);
+    internals.clearReconnectTimer();
+    await expect(switched).rejects.toThrow(
+      "XMPP disconnected while switching rooms",
+    );
+    releaseFlush();
+  });
+
+  test("disconnect cancels an already-ready room switch before its flush settles", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let markFlushStarted!: () => void;
+    let releaseFlush!: () => void;
+    const flushStarted = new Promise<void>((resolve) => {
+      markFlushStarted = resolve;
+    });
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    const xmpp = {
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    const internals = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      currentRoom: string;
+      joinedMucReady: Set<string>;
+      flushQueuedRoomMessages: () => Promise<void>;
+      handleDisconnected: (xmpp: typeof xmpp) => void;
+      clearReconnectTimer: () => void;
+    };
+    internals.xmpp = xmpp;
+    internals.connected = true;
+    internals.currentRoom = roomJid;
+    internals.joinedMucReady.add(roomJid);
+    internals.flushQueuedRoomMessages = mock(async () => {
+      markFlushStarted();
+      await flushGate;
+    });
+
+    const switched = client.switchRoom("w1", "c1");
+    await flushStarted;
+    internals.handleDisconnected(xmpp);
+    internals.clearReconnectTimer();
+
+    await expect(switched).rejects.toThrow(
+      "XMPP disconnected while switching rooms",
+    );
+    releaseFlush();
+  });
+
+  test("wait-type MUC join rejection retries and eventually succeeds", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const errors: XmppErrorEvent[] = [];
+    const retryDelays: number[] = [];
+    client.onError((event) => errors.push(event));
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = async (delayMs) => {
+      retryDelays.push(delayMs);
+    };
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(joined).resolves.toBeUndefined();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+    expect(retryDelays).toEqual([250]);
+    expect(errors).toEqual([]);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("self-presence timeout retries an ambiguous commit without an intermediate Faro error", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const errors: XmppErrorEvent[] = [];
+    const retryDelays: number[] = [];
+    client.onError((event) => errors.push(event));
+    (client as unknown as { roomSelfPresenceTimeoutMs: number })
+      .roomSelfPresenceTimeoutMs = 1;
+
+    let markRetryStarted!: () => void;
+    let releaseRetry!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = (delayMs) => {
+      retryDelays.push(delayMs);
+      markRetryStarted();
+      return new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+    };
+
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid);
+    await retryStarted;
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+    expect(errors).toEqual([]);
+
+    // Keep the second attempt open long enough to inject the owner-built
+    // status-110 response deterministically.
+    (client as unknown as { roomSelfPresenceTimeoutMs: number })
+      .roomSelfPresenceTimeoutMs = 1_000;
+    releaseRetry();
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(joined).resolves.toBeUndefined();
+    expect(retryDelays).toEqual([250]);
+    expect(errors).toEqual([]);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("self-presence timeouts exhaust the shared bounded retry budget and emit once", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const errors: XmppErrorEvent[] = [];
+    const retryDelays: number[] = [];
+    client.onError((event) => errors.push(event));
+    (client as unknown as { roomSelfPresenceTimeoutMs: number })
+      .roomSelfPresenceTimeoutMs = 1;
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = async (delayMs) => {
+      retryDelays.push(delayMs);
+    };
+    const xmpp = {
+      join_room: mock(async () => undefined),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const rejection = await (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(MucJoinSelfPresenceTimeoutError);
+    expect(xmpp.join_room).toHaveBeenCalledTimes(MUC_JOIN_RETRY_DELAYS_MS.length + 1);
+    expect(retryDelays).toEqual([...MUC_JOIN_RETRY_DELAYS_MS]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      kind: "connect-timeout",
+      recoverable: true,
+      detail: `Timed out waiting for self-presence in ${roomJid}`,
+      roomLocalpart: "c1",
+    });
+    expect(errors[0].cause).toBe(rejection);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+  });
+
+  test("late self-presence during backoff suppresses a duplicate join", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let releaseRetry!: () => void;
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = () => new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const joined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await settleUntil(() => typeof releaseRetry === "function");
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    releaseRetry();
+
+    await expect(joined).resolves.toBeUndefined();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("own unavailable during backoff preserves the canonical join single-flight", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let releaseRetry!: () => void;
+    let markRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = () => {
+      markRetryStarted();
+      return new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+    };
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const ensureJoined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined.bind(client);
+    const first = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_status_codes: [110],
+    });
+    await retryStarted;
+    const second = ensureJoined(roomJid);
+    await settleReconnectCatchup();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(1);
+
+    releaseRetry();
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+  });
+
+  test("a superseded retry cannot borrow a fresh join's in-flight marker", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let releaseRetry!: () => void;
+    let markRetryStarted!: () => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = () => {
+      markRetryStarted();
+      return new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+    };
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const ensureJoined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined.bind(client);
+    const first = ensureJoined(roomJid).then(() => "resolved", normalizeError);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await retryStarted;
+
+    // A delayed success immediately followed by own-unavailable revokes the
+    // sleeping sequence's token. A fresh caller may now start a new join
+    // before the old retry delay expires.
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_status_codes: [110],
+    });
+    const second = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+
+    releaseRetry();
+    await expect(first).resolves.toBe("Room became unavailable while retrying join");
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(true);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await expect(second).resolves.toBeUndefined();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("back-to-back self-presence and unavailable cannot restore stale room readiness", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const ensureJoined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined.bind(client);
+    const first = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
+
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "unavailable",
+      muc_status_codes: [110],
+    });
+
+    await expect(first).rejects.toThrow("Room became unavailable while joining");
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+
+    const second = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(second).resolves.toBeUndefined();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("synchronous self-presence and unavailable cannot resurrect a rejected join tracker", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    let joinAttempt = 0;
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => {
+        joinAttempt += 1;
+        if (joinAttempt !== 1) return;
+        // The WASM binding may synchronously drain queued callbacks before
+        // returning its Promise. The tracker must already be published when
+        // this available -> unavailable transition revokes the join.
+        onPresence?.({
+          from: `${roomJid}/alice`,
+          presence_type: "available",
+          muc_status_codes: [110],
+        });
+        onPresence?.({
+          from: `${roomJid}/alice`,
+          presence_type: "unavailable",
+          muc_status_codes: [110],
+        });
+      }),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const ensureJoined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined.bind(client);
+    await expect(ensureJoined(roomJid)).rejects.toThrow("Room became unavailable while joining");
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
+
+    const second = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+
+    await expect(second).resolves.toBeUndefined();
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
+  test("wait-type MUC join rejection exhausts its bounded retry budget", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const errors: XmppErrorEvent[] = [];
+    const retryDelays: number[] = [];
+    client.onError((event) => errors.push(event));
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = async (delayMs) => {
+      retryDelays.push(delayMs);
+    };
     let onPresence: ((presence: {
       from?: string;
       presence_type: string;
@@ -571,27 +1785,83 @@ describe("client send readiness", () => {
     (client as unknown as { connected: boolean }).connected = true;
     (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
 
-    const joined = (client as unknown as { ensureJoined: (roomJid: string) => Promise<void> }).ensureJoined(roomJid);
-    await Promise.resolve();
-    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(1);
+    const joined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid).catch((error: unknown) => error);
+    const totalAttempts = MUC_JOIN_RETRY_DELAYS_MS.length + 1;
+    for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
+      await settleUntil(() => xmpp.join_room.mock.calls.length === attempt);
+      onPresence?.({
+        from: `${roomJid}/alice`,
+        presence_type: "error",
+        error_condition: "resource-constraint",
+        error_type: "wait",
+      });
+    }
 
+    const rejection = await joined;
+    expect(rejection).toBeInstanceOf(MucJoinRejectedError);
+    expect(rejection).toMatchObject({
+      condition: "resource-constraint",
+      errorType: "wait",
+    });
+    expect(xmpp.join_room).toHaveBeenCalledTimes(totalAttempts);
+    expect(retryDelays).toEqual([...MUC_JOIN_RETRY_DELAYS_MS]);
+    expect(errors.map((error) => error.recoverable)).toEqual([true]);
+    expect(errors.every((error) => error.condition === "resource-constraint")).toBe(true);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
+    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
+  });
+
+  test("concurrent room join callers share one transient retry sequence", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const retryDelays: number[] = [];
+    (client as unknown as {
+      waitBeforeMucJoinRetry: (delayMs: number) => Promise<void>;
+    }).waitBeforeMucJoinRetry = async (delayMs) => {
+      retryDelays.push(delayMs);
+    };
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
+
+    const ensureJoined = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined.bind(client);
+    const first = ensureJoined(roomJid);
+    const second = ensureJoined(roomJid);
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 1);
     onPresence?.({
       from: `${roomJid}/alice`,
       presence_type: "error",
-      error_condition: "registration-required",
-      error_type: "auth",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await settleUntil(() => xmpp.join_room.mock.calls.length === 2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
     });
 
-    await expect(joined).rejects.toThrow("Channel presence was rejected");
-    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
-    expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
-    expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].kind).toBe("muc-join");
-    expect(errors[0].condition).toBe("registration-required");
-    expect(errors[0].errorType).toBe("auth");
-    expect(errors[0].roomLocalpart).toBe("c1");
-    expect(staleJoinVisibleAtEmit).toEqual([false]);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(xmpp.join_room).toHaveBeenCalledTimes(2);
+    expect(retryDelays).toEqual([250]);
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
   });
 
   test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {
@@ -722,6 +1992,84 @@ describe("client send readiness", () => {
     expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
   });
 
+  test("connection replacement during join backoff cannot send a stale retry", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+
+    let onOldPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const oldXmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onOldPresence>) {
+        onOldPresence = cb;
+      },
+      get_resume_state: () => null,
+      get_resume_state_handle: () => null,
+    };
+    (client as unknown as { xmpp: typeof oldXmpp; connected: boolean }).xmpp = oldXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof oldXmpp) => void }).wireEvents(oldXmpp);
+
+    const oldJoin = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid).catch((error: unknown) => error);
+    await settleUntil(() => oldXmpp.join_room.mock.calls.length === 1);
+    onOldPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await settleUntil(() =>
+      (client as unknown as {
+        mucJoinRetryCancellers: Set<(error: Error) => void>;
+      }).mucJoinRetryCancellers.size === 1
+    );
+
+    (client as unknown as {
+      handleDisconnected: (xmpp: typeof oldXmpp) => void;
+    }).handleDisconnected(oldXmpp);
+    (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
+
+    let onFreshPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      muc_status_codes?: number[];
+    }) => void) | null = null;
+    const freshXmpp = {
+      join_room: mock(async () => undefined),
+      set_on_presence(cb: NonNullable<typeof onFreshPresence>) {
+        onFreshPresence = cb;
+      },
+    };
+    (client as unknown as { xmpp: typeof freshXmpp; connected: boolean }).xmpp = freshXmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { wireEvents: (xmpp: typeof freshXmpp) => void }).wireEvents(freshXmpp);
+
+    const freshJoin = (client as unknown as {
+      ensureJoined: (roomJid: string) => Promise<void>;
+    }).ensureJoined(roomJid);
+    await settleUntil(() => freshXmpp.join_room.mock.calls.length === 1);
+    await settleReconnectCatchup();
+
+    expect(normalizeError(await oldJoin)).toBe("XMPP disconnected while retrying room join");
+    expect(oldXmpp.join_room).toHaveBeenCalledTimes(1);
+    expect(freshXmpp.join_room).toHaveBeenCalledTimes(1);
+    expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(true);
+
+    onFreshPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+    });
+    await expect(freshJoin).resolves.toBeUndefined();
+    expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(true);
+  });
+
   test("disconnect clears room join tokens so stale join resolution cannot mark ready", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");
@@ -745,7 +2093,7 @@ describe("client send readiness", () => {
     expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.size).toBe(0);
 
     resolveOldJoin();
-    await oldJoin;
+    await expect(oldJoin).rejects.toThrow("XMPP connection changed while joining room");
 
     expect((client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.has(roomJid)).toBe(false);
     expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
@@ -865,7 +2213,7 @@ describe("client send readiness", () => {
       presence_type: "available",
       muc_jid: (client as unknown as { fullJid: string }).fullJid,
     });
-    await settleReconnectCatchup();
+    await settleUntil(() => xmpp.send_groupchat_message.mock.calls.length === 1);
     expect(xmpp.send_groupchat_message).toHaveBeenCalledWith(
       roomJid,
       "after unavailable",
@@ -2359,6 +3707,7 @@ describe("client keepalive lifecycle", () => {
     (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
     (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
     (client as unknown as { connected: boolean }).connected = true;
+    markReadyTestRoom(client, roomJid);
     (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
     const fetchRoomHistoryByThread = mock(async () => ({
       messages: [roomWasmMessage({
@@ -2446,6 +3795,7 @@ describe("client keepalive lifecycle", () => {
     (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
     (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
     (client as unknown as { connected: boolean }).connected = true;
+    markReadyTestRoom(client, roomJid);
     (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
     const fetchRoomHistoryByThread = mock(async () => ({
       messages: [roomWasmMessage({
@@ -2710,6 +4060,7 @@ describe("client keepalive lifecycle", () => {
     (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
     (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
     (client as unknown as { connected: boolean }).connected = true;
+    markReadyTestRoom(client, roomJid);
     const catchup = (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup;
     catchup.onSessionStarted();
     const roomHandler = mock(() => undefined);

--- a/chat/tests/member-query.test.ts
+++ b/chat/tests/member-query.test.ts
@@ -23,9 +23,16 @@ function session(partial: Partial<WaddleSession> = {}): WaddleSession {
 
 function clientWithXmpp(xmpp: TestXmpp) {
   const client = new BrowserXmppClient(session());
-  (client as unknown as { connect: () => Promise<void>; xmpp: TestXmpp; connected: boolean }).connect = mock(async () => {});
-  (client as unknown as { connect: () => Promise<void>; xmpp: TestXmpp; connected: boolean }).xmpp = xmpp;
-  (client as unknown as { connect: () => Promise<void>; xmpp: TestXmpp; connected: boolean }).connected = true;
+  const internals = client as unknown as {
+    connect: () => Promise<void>;
+    requireReadyRoomXmpp: (roomJid: string) => Promise<TestXmpp>;
+    xmpp: TestXmpp;
+    connected: boolean;
+  };
+  internals.connect = mock(async () => {});
+  internals.requireReadyRoomXmpp = mock(async () => xmpp);
+  internals.xmpp = xmpp;
+  internals.connected = true;
   return client;
 }
 

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -555,6 +555,9 @@ async fn destroy_room_for_rollback(
         DestroyRoomOutcome::ReleaseBacklogFull => Err(internal_err(format!(
             "{rollback_context}: exact-release retry backlog is still full for {room_jid} after bounded redrive; room remains registered and rollback must be retried"
         ))),
+        DestroyRoomOutcome::ShutdownInProgress => Err(unavailable(format!(
+            "{rollback_context}: room shutdown is already in progress for {room_jid}; retry on another node"
+        ))),
     }
 }
 
@@ -2193,20 +2196,35 @@ async fn run_group_dm_leave(
         return Err(send_err("room actor ChangeAffiliation")(error));
     }
     for resource in resources {
-        if let Some(outcome) = actor
+        match actor
             .ask(LeaveByRealJid {
                 sender_jid: resource.clone(),
             })
             .await
-            .map_err(send_err("room actor LeaveByRealJid"))?
         {
-            broadcast_group_dm_leave(
-                state,
-                connections,
-                &resource,
-                live_resource_set.contains(&resource),
-                &outcome,
-            );
+            Ok(Some(outcome)) => {
+                broadcast_group_dm_leave(
+                    state,
+                    connections,
+                    &resource,
+                    live_resource_set.contains(&resource),
+                    &outcome,
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                // Membership, bookmark, and actor affiliation are already
+                // committed. A shutdown/retirement between mailbox messages
+                // makes occupancy cleanup redundant; reporting failure here
+                // would misrepresent the durable leave as uncommitted.
+                tracing::warn!(
+                    room = %args.room_jid,
+                    sender = %resource,
+                    %error,
+                    "group-DM leave committed; occupancy cleanup was skipped",
+                );
+                break;
+            }
         }
     }
 
@@ -2296,22 +2314,16 @@ async fn run_group_dm_rename(
         return Err(error);
     }
 
-    let members = match actor
-        .ask(ListAffiliations {
-            filter: Some(Affiliation::Member),
-        })
-        .await
-    {
-        Ok(members) => members,
-        Err(error) => {
-            if rollback_room_config_if_revision(&actor, expected_revision, previous_config.clone())
-                .await
-            {
-                let _ = upsert_group_dm_catalog(state, &channel_id, &previous_config).await;
-            }
-            return Err(send_err("room actor ListAffiliations")(error));
-        }
-    };
+    // The successful actor mutation returned one coherent snapshot before any
+    // catalog/bookmark writes. Reuse it for the recipient set instead of
+    // issuing a newly gated serving read after the catalog commit.
+    let mut members: Vec<_> = updated_snapshot
+        .room
+        .get_all_affiliations()
+        .into_iter()
+        .filter(|entry| entry.affiliation == Affiliation::Member)
+        .collect();
+    members.sort_by(|a, b| a.jid.cmp(&b.jid));
     let mut updated_bookmark_members = Vec::with_capacity(members.len());
     for member in &members {
         if !group_dm_room_config_revision_is_current(&actor, expected_revision).await {
@@ -2369,11 +2381,11 @@ async fn run_group_dm_rename(
             "group-DM rename was superseded by a newer update".to_string(),
         )))));
     }
-    let broadcast_snapshot = actor
-        .ask(waddle_xmpp::muc::room_actor::GetSnapshot)
-        .await
-        .map_err(send_err("room actor GetSnapshot"))?;
-    broadcast_group_dm_config_change(connections, &args.room_jid, &broadcast_snapshot);
+    // The rename is committed at this point. A post-commit serving read could
+    // be rejected by a shutdown seal and incorrectly report the committed
+    // operation as failed, so notification uses the admitted mutation's
+    // snapshot and remains best-effort.
+    broadcast_group_dm_config_change(connections, &args.room_jid, &updated_snapshot);
 
     Ok(GroupDmRenameResult {
         room_jid: args.room_jid.clone(),
@@ -3439,6 +3451,12 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
                 args.channel_jid
             )))
         }
+        Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ShutdownInProgress) => {
+            Some(unavailable(format!(
+                "room destroy refused for {}: this node is shutting down; retry deletion",
+                args.channel_jid
+            )))
+        }
         Err(error) => Some(send_err("room_registry ask DestroyRoom")(error)),
     };
     if let Some(error) = failure {
@@ -3855,6 +3873,18 @@ async fn run_kick(
         .ask(GetConfig)
         .await
         .map_err(send_err("room actor GetConfig"))?;
+    // Resolve the occupant before any durable membership change. A shutdown
+    // seal may land between actor messages; if this serving read were delayed
+    // until after the durable revoke, RoomSealed would otherwise strand the
+    // external membership change without reaching the compensation path.
+    let target_nick = actor
+        .ask(ListOccupants)
+        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
+        .await
+        .map_err(send_err("room actor ListOccupants"))?
+        .into_iter()
+        .find(|info| info.real_jid.to_bare() == args.occupant_jid)
+        .map(|info| info.nick);
     let caller_bare = caller_full.to_bare();
     let durable_previous_affiliation = if config.members_only {
         explicit_channel_affiliations_for_jids(state, &channel_id, [args.occupant_jid.clone()])
@@ -3879,22 +3909,11 @@ async fn run_kick(
         )
         .await?;
     }
-    // Resolve the occupant's nick — `ApplyAdminItems` looks up by nick
-    // in the role-change branch, so we must translate the caller's
-    // bare-JID handle into the room-nick first. If the target is not
-    // currently joined, there is no role-kick presence to broadcast.
-    // Private managed-channel kicks still keep the durable membership
-    // revocation above and synchronize the actor affiliation list.
-    let occupants = actor
-        .ask(ListOccupants)
-        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
-        .await
-        .map_err(send_err("room actor ListOccupants"))?;
-    let Some(target_nick) = occupants
-        .into_iter()
-        .find(|info| info.real_jid.to_bare() == args.occupant_jid)
-        .map(|info| info.nick)
-    else {
+    // `ApplyAdminItems` looks up by nick in the role-change branch. If the
+    // pre-revoke snapshot found no joined target, there is no role-kick
+    // presence to broadcast. Private managed-channel kicks still keep the
+    // durable revocation and synchronize the actor affiliation list.
+    let Some(target_nick) = target_nick else {
         if revoke_members_only_member {
             sync_private_kick_affiliation_revocation(
                 state,

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1325,6 +1325,11 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                     "cascade destroy refused for room {room_jid}: exact-release retry backlog is full; retry deletion"
                 ))
             }
+            Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ShutdownInProgress) => {
+                Some(format!(
+                    "cascade destroy refused for room {room_jid}: this node is shutting down; retry deletion"
+                ))
+            }
             Err(error) => Some(format!("cascade destroy failed for room {room_jid}: {error}")),
         };
         if let Some(message) = failure {

--- a/server/crates/waddle-server/src/clustering/behaviour.rs
+++ b/server/crates/waddle-server/src/clustering/behaviour.rs
@@ -7,10 +7,18 @@
 //! per-peer relay actors.
 
 use kameo::remote;
-use libp2p::allow_block_list::{self, AllowedPeers};
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::PeerId;
+use libp2p::{
+    allow_block_list::{self, AllowedPeers},
+    connection_limits,
+};
 use std::collections::HashSet;
+
+/// One inbound plus one outbound transport is the normal simultaneous-dial
+/// convergence shape. A third connection cannot improve reachability and
+/// would multiply the per-connection remote-messaging budget.
+const MAX_ESTABLISHED_CONNECTIONS_PER_PEER: u32 = 2;
 
 // `derive(NetworkBehaviour)` auto-generates the out-event enum named after the
 // struct — `WaddleBehaviourEvent` — with one variant per field.
@@ -24,6 +32,9 @@ pub struct WaddleBehaviour {
     /// composed behaviour denies the connection regardless of order; the
     /// position is for clarity).
     pub allowed: allow_block_list::Behaviour<AllowedPeers>,
+    /// Bound transport fan-out from one enrolled PeerId while retaining the
+    /// two connections required when both endpoints dial simultaneously.
+    pub connection_limits: connection_limits::Behaviour,
     /// kameo remote actors: request-response messaging plus the kademlia-based
     /// registry (demoted to node discovery only this phase).
     pub kameo: remote::Behaviour,
@@ -43,6 +54,10 @@ impl WaddleBehaviour {
         }
         Self {
             allowed,
+            connection_limits: connection_limits::Behaviour::new(
+                connection_limits::ConnectionLimits::default()
+                    .with_max_established_per_peer(Some(MAX_ESTABLISHED_CONNECTIONS_PER_PEER)),
+            ),
             kameo: remote::Behaviour::new(local_peer_id, messaging_config),
         }
     }

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -52,7 +52,8 @@
 //! claims).
 //!
 //! All CAS statements run on the dedicated control-plane pool
-//! ([`Database::control_plane_guard`], ADR-0017 element 4/12, Slice 0):
+//! ([`Database::control_plane_guard`] or
+//! [`Database::begin_control_plane`], ADR-0017 element 4/12, Slice 0):
 //! this per-node/per-entity liveness traffic must never queue behind fenced
 //! bulk writes, backstop fencing SELECTs, or claims-read storms on the main
 //! pool. `ensure_schema` is one-time startup DDL, not hot-path liveness
@@ -132,6 +133,36 @@ fn log_if_postgres_deadlock(error: &DatabaseError, entity_key: &str, statement: 
 /// in this slice decodes the key back, but a future slice safely could.
 fn entity_key(entity: &Entity) -> String {
     format!("{}:{}", entity.entity_type.as_db_str(), entity.id)
+}
+
+/// Domain-separate claim-entity locks from other advisory-lock users. A
+/// 64-bit hash collision can only serialize unrelated entities; it cannot
+/// weaken ownership safety.
+const CLAIM_ENTITY_LOCK_SEED: i64 = 0x5741_4444_4c45;
+
+/// Serialize a potentially absent claim INSERT with terminal reconciliation.
+///
+/// A row lock cannot cover a missing `clustering_claims` tuple. This
+/// transaction-scoped entity-key lock exists before the row does, so a
+/// terminal lookup issued after an acquisition has reached Postgres waits for
+/// that acquisition to commit or roll back before taking its snapshot.
+async fn lock_claim_entity(
+    tx: &mut crate::db::Transaction<'_>,
+    entity: &Entity,
+) -> Result<(), ClaimError> {
+    let mut rows = tx
+        .query(
+            r#"
+            /* claim_entity_serialization_lock */
+            SELECT pg_advisory_xact_lock(hashtextextended(?, ?))
+            "#,
+            crate::db_params![entity_key(entity), CLAIM_ENTITY_LOCK_SEED],
+        )
+        .await
+        .map_err(db_err)?;
+    rows.next().await.map_err(db_err)?;
+    drop(rows);
+    Ok(())
 }
 
 /// The inverse of [`entity_key`]: reconstruct an [`Entity`] from an encoded
@@ -634,7 +665,8 @@ impl ClaimStore for PostgresClaimStore {
         if !me.is_active() {
             return Err(ClaimError::AuthorityDisabled);
         }
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.begin_control_plane().await.map_err(db_err)?;
+        lock_claim_entity(&mut tx, entity).await?;
         // Acquire CAS (element 4): a fresh claim only inserts; a
         // still-live claim on the same entity leaves the row untouched and
         // affects zero rows.
@@ -650,7 +682,7 @@ impl ClaimStore for PostgresClaimStore {
         // every subsequent `acquire`/`steal_stale` call under ordinary
         // READ COMMITTED semantics by the time this node's drain loop
         // itself proceeds to iterate owned entities.
-        let mut inserted = conn
+        let mut inserted = tx
             .query(
                 r#"
                 INSERT INTO clustering_claims (entity, entity_type, node_id, node_epoch, claim_epoch)
@@ -673,15 +705,21 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        if let Some(row) = inserted.next().await.map_err(db_err)? {
-            return Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?));
+        let acquired = match inserted.next().await.map_err(db_err)? {
+            Some(row) => Some(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+            None => None,
+        };
+        drop(inserted);
+        if let Some(epoch) = acquired {
+            tx.commit().await.map_err(db_err)?;
+            return Ok(epoch);
         }
         // Zero rows affected: either a genuine conflict (someone already
         // holds this entity) or this node's own draining gate blocked the
         // INSERT before it ever reached `ON CONFLICT`. Distinguish with one
         // follow-up read — only ever taken on this already-cold "lost the
         // race" path, never the common uncontended-acquire case above.
-        let mut rows = conn
+        let mut rows = tx
             .query(
                 r#"
                 SELECT
@@ -695,7 +733,7 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        match rows.next().await.map_err(db_err)? {
+        let outcome = match rows.next().await.map_err(db_err)? {
             Some(row) => {
                 let claimed: bool = row.get(0).map_err(db_err)?;
                 let draining: bool = row.get(1).map_err(db_err)?;
@@ -712,7 +750,10 @@ impl ClaimStore for PostgresClaimStore {
                 }
             }
             None => Err(ClaimError::AlreadyClaimed),
-        }
+        };
+        drop(rows);
+        tx.commit().await.map_err(db_err)?;
+        outcome
     }
 
     async fn ensure_claimed(
@@ -1105,13 +1146,13 @@ impl ClaimStore for PostgresClaimStore {
         entity: &Entity,
     ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, ClaimError> {
         // Terminal orphan recovery can arrive here after its caller dropped
-        // a steal future. Locking the claim row makes this SELECT wait behind
-        // that detached UPDATE, so the returned version is post-commit (or
-        // post-rollback) rather than the unlocked pre-CAS snapshot. A stale
-        // room steal only updates an existing row, so the absent-row gap does
-        // not need predicate/range locking.
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let mut rows = conn
+        // a claim future. The entity advisory lock makes an absent-row lookup
+        // wait behind a fresh INSERT, while the row lock also waits behind a
+        // detached steal UPDATE. The returned version is therefore
+        // post-commit (or post-rollback) for both acquisition shapes.
+        let mut tx = self.db.begin_control_plane().await.map_err(db_err)?;
+        lock_claim_entity(&mut tx, entity).await?;
+        let mut rows = tx
             .query(
                 r#"
                 /* terminal_claim_reconciliation_lock */
@@ -1133,7 +1174,7 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        match rows.next().await.map_err(db_err)? {
+        let snapshot = match rows.next().await.map_err(db_err)? {
             Some(row) => {
                 let node_id: String = row.get(0).map_err(db_err)?;
                 let node_epoch: String = row.get(1).map_err(db_err)?;
@@ -1146,7 +1187,10 @@ impl ClaimStore for PostgresClaimStore {
                 }))
             }
             None => Ok(None),
-        }
+        };
+        drop(rows);
+        tx.commit().await.map_err(db_err)?;
+        snapshot
     }
 
     async fn fence(
@@ -4161,6 +4205,94 @@ mod tests {
 
     fn room_entity(id: &str) -> Entity {
         Entity::new(EntityType::RoomActor, id.to_string())
+    }
+
+    async fn wait_for_claim_entity_lock_waiters(db: &Database, expected: i64) {
+        let monitor = db.guard().await.expect("monitor guard");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let mut rows = monitor
+                    .query(
+                        r#"
+                        SELECT COUNT(*) FROM pg_stat_activity
+                        WHERE pid <> pg_backend_pid()
+                          AND query LIKE '%claim_entity_serialization_lock%'
+                          AND wait_event_type = 'Lock'
+                        "#,
+                        (),
+                    )
+                    .await
+                    .expect("inspect entity-lock waiters");
+                let blocked = rows
+                    .next()
+                    .await
+                    .expect("read waiter count")
+                    .expect("waiter count row")
+                    .get::<i64>(0)
+                    .expect("waiter count");
+                if blocked >= expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("expected claim entity-lock waiters");
+    }
+
+    #[tokio::test]
+    async fn terminal_claim_lookup_waits_for_an_in_flight_absent_row_acquire() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        store.register(&owner, None).await.expect("register owner");
+        let entity = room_entity("terminal-insert-barrier@muc.example.com");
+
+        // Hold the entity key before any claim row exists. Queue the real
+        // acquire first, then terminal reconciliation, to model shutdown
+        // observing an acquisition whose response future timed out while its
+        // INSERT was already pending in Postgres.
+        let mut blocker = store
+            .db
+            .begin_control_plane()
+            .await
+            .expect("begin entity-lock blocker");
+        lock_claim_entity(&mut blocker, &entity)
+            .await
+            .expect("hold entity lock");
+
+        let acquire_store = PostgresClaimStore::new(store.db.clone());
+        let acquire_entity = entity.clone();
+        let acquire_owner = owner.clone();
+        let acquire =
+            tokio::spawn(
+                async move { acquire_store.acquire(&acquire_entity, &acquire_owner).await },
+            );
+        wait_for_claim_entity_lock_waiters(&store.db, 1).await;
+
+        let lookup_store = PostgresClaimStore::new(store.db.clone());
+        let lookup_entity = entity.clone();
+        let lookup = tokio::spawn(async move {
+            lookup_store
+                .current_claim_after_pending_writes(&lookup_entity)
+                .await
+        });
+        wait_for_claim_entity_lock_waiters(&store.db, 2).await;
+
+        blocker.commit().await.expect("release entity-lock blocker");
+        let acquired_epoch = acquire
+            .await
+            .expect("acquire task joined")
+            .expect("acquire committed");
+        let snapshot = lookup
+            .await
+            .expect("lookup task joined")
+            .expect("terminal lookup")
+            .expect("fresh claim is visible");
+        assert_eq!(snapshot.owner, owner);
+        assert_eq!(snapshot.claim_epoch, acquired_epoch);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -1,5 +1,5 @@
-//! Graceful per-entity claim drain + rollout-aware acquire placement
-//! (ADR-0017 Phase 3 Slice 10, element 4's drain sequence). The
+//! Graceful claim drain + rollout-aware acquire placement (ADR-0017 Phase 3
+//! Slice 10, element 4's drain sequence). The
 //! drain-observability deliverable below (drain-duration histogram,
 //! `claims_released_on_drain`/`claims_abandoned_on_drain` counters, alert
 //! on nonzero abandonment) is the ADR's own Phase 3 Implementation Plan
@@ -8,15 +8,15 @@
 //! this doc comment previously carried — corrected, per the phase plan's
 //! Slice 10 FIX 5(a) council-adjudicated pass).
 //!
-//! **Locked spec** (element 4, quoted in the phase plan's Slice 10 section):
-//! per-entity, not phase-ordered drain — mark the node draining in `nodes`
-//! (stop acquiring NEW claims, keep serving already-owned ones); for each
-//! owned entity, complete its final fenced write(s) *while still holding the
-//! claim*, then release; batched via [`ClaimStore::release_many`] (one
-//! round-trip, not one-at-a-time, given the ~18k modeled claims a full
-//! cluster carries); **no** global "promote what remains" step after
-//! release — releasing first and completing a write second is the exact
-//! fencing violation element 4 forbids.
+//! **Production refinement of the element 4 invariant:** mark the node
+//! draining in `nodes` (stop acquiring NEW claims, keep serving already-owned
+//! ones), close the process-wide room admission fence, then inventory, seal,
+//! and hard-retire every locally-owned room while its exact claim is still
+//! held. Only a clean, revalidated fence authorizes one all-or-none
+//! [`ClaimStore::release_many`] for the complete room batch. Any uncertain
+//! seal/retirement, timeout, or fatal fence abandons every room claim for
+//! lease-TTL recovery; there is no partial room release. `UserActor` claims
+//! use the separate post-authority-disable verified-release phase below.
 //!
 //! **Composes with, does not replace, the existing Q6 SM-session drain**
 //! (`server::session_janitors::spawn_graceful_shutdown_drain`,
@@ -28,95 +28,326 @@
 //! drain paths concurrently would be exactly the double-drain hazard the
 //! phase plan's Slice 10 "interaction with existing drain" note warns
 //! against — one path could release a claim the other path's promotion is
-//! still mid-write under. Only [`EntityType::RoomActor`] (and, forward-
-//! looking, `UserActor` once a later phase wires production claims for it)
-//! is drained here.
+//! still mid-write under. [`EntityType::RoomActor`] is drained by the
+//! ordinary seal phase; [`EntityType::UserActor`] uses the separate
+//! post-authority-disable quiescence phase in
+//! [`run_disabled_user_shutdown_drain`].
 
+use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 
-use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, NodeIdentity};
+use waddle_xmpp::ownership::{ClaimStore, DisabledNodeIdentity, EntityType, NodeIdentity};
+
+#[cfg(test)]
+use waddle_xmpp::ownership::Entity;
 
 use super::claims::NodeLeaseStore;
 use super::metrics;
 use super::self_fence::{mark_draining_bounded, LocallyClaimedEntities};
+use crate::server::room_serving_quiescence::RoomServingFence;
 
 #[cfg(test)]
-use super::self_fence::run_shutdown_drain_with_heartbeat;
+use super::self_fence::{run_shutdown_drain_with_heartbeat, ShutdownDrainTiming};
 
 /// Upper bound on how long [`mark_draining_bounded`] itself is allowed to
 /// take within the overall drain budget — a hung flag-flip must not eat the
-/// whole per-entity release budget.
+/// whole room-batch release budget.
 const MARK_DRAINING_BOUND: Duration = Duration::from_secs(2);
 
-/// Run the Slice 10 graceful drain sequence to completion (or until
-/// `budget` is exhausted) for every locally-owned, eligible entity. Called
-/// exactly once per fence/shutdown, from every ordinary-shutdown branch in
-/// [`super::self_fence::run_node_lease`]'s `'tick` loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RoomShutdownDrainOutcome {
+    Released,
+    Abandoned,
+}
+
+async fn abandon_room_batch(
+    local_claims: &Arc<dyn LocallyClaimedEntities>,
+    room_count: usize,
+    start: Instant,
+) -> RoomShutdownDrainOutcome {
+    if !local_claims.abandon_room_shutdown().await {
+        tracing::warn!(
+            "clustering drain: terminal no-release registry barrier could not be confirmed; \
+             process shutdown still proceeds without releasing room claims"
+        );
+    }
+    if room_count != 0 {
+        metrics::record_claims_abandoned_on_drain(room_count as u64);
+    }
+    metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
+    RoomShutdownDrainOutcome::Abandoned
+}
+
+/// Run the Slice 10 graceful room drain sequence to completion (or until
+/// `budget` is exhausted) for the complete locally-owned `RoomActor` batch.
+/// Called exactly once per fence/shutdown by
+/// [`super::self_fence::run_node_lease_authorized`].
 ///
 /// Sequence: (1) mark this node draining — [`super::claims`]'s
 /// `acquire`/`steal_stale` CAS gate then atomically refuses any NEW claim
 /// under this node's identity, while claims it already holds keep being
-/// served (never revoked by this function); (2) for each owned, eligible
-/// entity, call [`LocallyClaimedEntities::seal_before_release`] to complete
-/// (or confirm already-complete) its final fenced write, and — **strictly
-/// after that call returns successfully, never before** — append it to the
-/// release batch (the batch-entry-only-after-commit invariant, major fix
-/// 13 in the phase plan); (3) once every eligible entity has been sealed or
-/// the budget is exhausted, release everything sealed in ONE
-/// [`ClaimStore::release_many`] call. An entity whose seal did not
-/// complete within budget is left claimed — abandoned, not lost: the claim
-/// stays fenced-safe and is reclaimed later by another node's orphan
-/// reaper, or by this node itself once its own lease naturally lapses.
+/// served (never revoked by this function); (2) for each owned room, call
+/// [`LocallyClaimedEntities::seal_before_release`] and hard
+/// retirement to complete (or confirm already-complete) its final fenced
+/// work; (3) revalidate the consumed process-wide [`RoomServingFence`]; and
+/// (4) only when *every* room passed, release the complete set in one
+/// [`ClaimStore::release_many`] call. One failed/retained/timed-out room,
+/// fatal fence, or invalid release fence selects terminal no-release mode
+/// for the whole set. Claims remain fenced-safe and are reclaimed after this
+/// node lease expires.
 pub(crate) async fn run_shutdown_drain<L>(
     lease: &L,
     claim_store: &Arc<dyn ClaimStore>,
     identity: &NodeIdentity,
     local_claims: &Arc<dyn LocallyClaimedEntities>,
     budget: Duration,
-) where
+    fence: RoomServingFence,
+    fatal_fence: &CancellationToken,
+) -> RoomShutdownDrainOutcome
+where
     L: NodeLeaseStore + Send + Sync,
 {
     let start = Instant::now();
+    if fatal_fence.is_cancelled() || !fence.is_current_clean() {
+        tracing::warn!(
+            "clustering drain: room-serving release fence is invalid or a fatal fence is active; \
+             selecting terminal no-release mode"
+        );
+        return abandon_room_batch(local_claims, 0, start).await;
+    }
     mark_draining_bounded(lease, identity, MARK_DRAINING_BOUND.min(budget)).await;
 
     let deadline = start + budget;
-    let owned = local_claims.owned().await;
-    let mut to_release: Vec<Entity> = Vec::new();
-    let mut abandoned: u64 = 0;
+    if fatal_fence.is_cancelled() || !fence.is_current_clean() {
+        tracing::warn!(
+            "clustering drain: release authorization was invalidated while marking the node \
+             draining; leaving every room claim held"
+        );
+        return abandon_room_batch(local_claims, 0, start).await;
+    }
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let room_shutdown_started = tokio::time::timeout(remaining, local_claims.begin_room_shutdown())
+        .await
+        .unwrap_or(false);
+    if !room_shutdown_started {
+        tracing::warn!(
+            "clustering drain: terminal RoomActor admission gate could not be confirmed; \
+             leaving every room claim held"
+        );
+        return abandon_room_batch(local_claims, 0, start).await;
+    }
 
-    for entity in owned {
-        // Only entities this generic loop owns draining for — see the
-        // module doc for why `SmSession` is deliberately excluded (the
-        // existing Q6 drain owns those) and `UserActor` has no production
-        // claim-acquisition call site yet (deviation 34).
-        if entity.entity_type != EntityType::RoomActor {
-            continue;
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        tracing::warn!("clustering drain: budget exhausted before RoomActor ownership inventory");
+        return abandon_room_batch(local_claims, 0, start).await;
+    }
+    let owned =
+        match tokio::time::timeout(remaining, local_claims.owned_of_type(EntityType::RoomActor))
+            .await
+        {
+            Ok(owned) => owned,
+            Err(_) => {
+                tracing::warn!(
+                    "clustering drain: RoomActor ownership inventory timed out; \
+                 leaving room claims held"
+                );
+                return abandon_room_batch(local_claims, 0, start).await;
+            }
+        };
+    let mut seen = HashSet::with_capacity(owned.len());
+    let rooms: Vec<_> = owned
+        .into_iter()
+        .filter(|entity| entity.entity_type == EntityType::RoomActor)
+        .filter(|entity| seen.insert(entity.clone()))
+        .collect();
+    let room_count = rooms.len();
+
+    for entity in &rooms {
+        if fatal_fence.is_cancelled() || !fence.is_current_clean() {
+            tracing::warn!(
+                "clustering drain: release authorization was invalidated before all rooms \
+                 were sealed; abandoning the complete room batch"
+            );
+            return abandon_room_batch(local_claims, room_count, start).await;
         }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             tracing::warn!(
-                entity_id = %entity.id,
-                "clustering drain: budget exhausted before this entity's seal even started; \
-                 leaving it claimed (fenced-safe, reclaimed later)"
+                count = room_count,
+                "clustering drain: budget exhausted before remaining RoomActor seals; \
+                 abandoning the complete room batch"
             );
-            abandoned += 1;
-            continue;
+            return abandon_room_batch(local_claims, room_count, start).await;
         }
-        let sealed = tokio::time::timeout(remaining, local_claims.seal_before_release(&entity))
+        let sealed = tokio::time::timeout(remaining, local_claims.seal_before_release(entity))
             .await
             .unwrap_or(false);
-        if sealed {
-            // Batch-entry-only-after-commit invariant (major fix 13): this
-            // entity enters `to_release` strictly after `seal_before_release`
-            // — which performs/confirms the entity's final fenced write —
-            // has already returned `true`, never before.
+        if !sealed {
+            tracing::warn!(
+                entity_id = %entity.id,
+                "clustering drain: a room seal failed or timed out; abandoning the complete \
+                 room batch"
+            );
+            return abandon_room_batch(local_claims, room_count, start).await;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let retired = if remaining.is_zero() {
+            false
+        } else {
+            tokio::time::timeout(remaining, local_claims.retire_room_after_shutdown(entity))
+                .await
+                .unwrap_or(false)
+        };
+        if !retired {
+            tracing::warn!(
+                entity_id = %entity.id,
+                "clustering drain: a sealed RoomActor could not be hard-retired; abandoning \
+                 the complete room batch"
+            );
+            return abandon_room_batch(local_claims, room_count, start).await;
+        }
+    }
+
+    if fatal_fence.is_cancelled() || !fence.is_current_clean() {
+        tracing::warn!(
+            count = room_count,
+            "clustering drain: release authorization was invalidated after retirement; \
+             abandoning the complete room batch"
+        );
+        return abandon_room_batch(local_claims, room_count, start).await;
+    }
+
+    if !rooms.is_empty() {
+        let attempted = rooms.len() as u64;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!(
+                count = attempted,
+                "clustering drain: budget exhausted before release_many; \
+                 abandoning the complete room batch"
+            );
+            return abandon_room_batch(local_claims, room_count, start).await;
+        } else {
+            // This is the only room-claim-release-authorizing call in the
+            // shutdown graph. `RoomServingFence` is non-Clone and consumed by
+            // this function, so the all-or-none batch cannot be replayed.
+            match tokio::time::timeout(remaining, claim_store.release_many(&rooms, identity)).await
+            {
+                Ok(Ok(())) => metrics::record_claims_released_on_drain(attempted),
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        %error,
+                        count = attempted,
+                        "clustering drain: release_many failed; entities remain claimed \
+                         (fenced-safe, reclaimed later)"
+                    );
+                    return abandon_room_batch(local_claims, room_count, start).await;
+                }
+                Err(_) => {
+                    // A cancelled database DELETE may have committed. Do not
+                    // replay this epoch-blind batch; either outcome is safe
+                    // because the node is already marked draining.
+                    tracing::warn!(
+                        count = attempted,
+                        "clustering drain: release_many timed out with an ambiguous commit \
+                         outcome; not retrying the batch"
+                    );
+                    return abandon_room_batch(local_claims, room_count, start).await;
+                }
+            }
+        }
+    }
+    if fatal_fence.is_cancelled() || !fence.is_current_clean() {
+        tracing::warn!(
+            count = room_count,
+            "clustering drain: terminal safety changed while the release batch was in flight; \
+             selecting terminal abandon mode without replaying the batch"
+        );
+        return abandon_room_batch(local_claims, 0, start).await;
+    }
+    metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
+    RoomShutdownDrainOutcome::Released
+}
+
+/// Retire and release locally-owned `UserActor` claims after publication
+/// authority has been terminally disabled.
+///
+/// This is a separate second drain phase because `UserActor` has no durable
+/// final-write seal. Its handoff barrier is local quiescence instead: exact
+/// owner demotion plus acknowledged connection teardown, followed by a
+/// verification that neither actor nor connection registry can still route
+/// the user. [`DisabledNodeIdentity`] proves that no same-incarnation actor
+/// can be published between that verification and [`ClaimStore::release_many`].
+/// Any failed, timed-out, or unverifiable retirement is left claimed for
+/// ordinary fenced reclaim.
+pub(crate) async fn run_disabled_user_shutdown_drain(
+    claim_store: &Arc<dyn ClaimStore>,
+    disabled_identity: &DisabledNodeIdentity,
+    local_claims: &Arc<dyn LocallyClaimedEntities>,
+    budget: Duration,
+) {
+    if budget.is_zero() {
+        tracing::warn!(
+            "clustering user drain: no shutdown budget remains; leaving UserActor claims held"
+        );
+        return;
+    }
+
+    let start = Instant::now();
+    let deadline = start + budget;
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let owned =
+        match tokio::time::timeout(remaining, local_claims.owned_of_type(EntityType::UserActor))
+            .await
+        {
+            Ok(owned) => owned,
+            Err(_) => {
+                tracing::warn!(
+                    "clustering user drain: local ownership snapshot timed out; \
+                 leaving UserActor claims held"
+                );
+                return;
+            }
+        };
+    let mut seen = HashSet::with_capacity(owned.len());
+    let users: Vec<_> = owned
+        .into_iter()
+        .filter(|entity| entity.entity_type == EntityType::UserActor)
+        .filter(|entity| seen.insert(entity.clone()))
+        .collect();
+
+    let mut to_release = Vec::new();
+    let mut abandoned = 0u64;
+    let mut users = users.into_iter();
+    while let Some(entity) = users.next() {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            let skipped = 1u64 + users.count() as u64;
+            tracing::warn!(
+                count = skipped,
+                "clustering user drain: budget exhausted before remaining retirements; \
+                 leaving their claims held"
+            );
+            abandoned += skipped;
+            break;
+        }
+        let retired = tokio::time::timeout(
+            remaining,
+            local_claims.retire_user_after_authority_disabled(&entity, disabled_identity),
+        )
+        .await
+        .unwrap_or(false);
+        if retired {
             to_release.push(entity);
         } else {
             tracing::warn!(
                 entity_id = %entity.id,
-                "clustering drain: seal_before_release failed or timed out; leaving this \
-                 entity claimed (fenced-safe, reclaimed later)"
+                "clustering user drain: exact actor/resource retirement failed or timed out; \
+                 leaving the claim held"
             );
             abandoned += 1;
         }
@@ -124,25 +355,49 @@ pub(crate) async fn run_shutdown_drain<L>(
 
     if !to_release.is_empty() {
         let attempted = to_release.len() as u64;
-        match claim_store.release_many(&to_release, identity).await {
-            Ok(()) => {
-                metrics::record_claims_released_on_drain(attempted);
-            }
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    count = attempted,
-                    "clustering drain: release_many failed; entities remain claimed \
-                     (fenced-safe, reclaimed later)"
-                );
-                abandoned += attempted;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            tracing::warn!(
+                count = attempted,
+                "clustering user drain: budget exhausted before release_many; \
+                 verified-retired claims remain held"
+            );
+            abandoned += attempted;
+        } else {
+            match tokio::time::timeout(
+                remaining,
+                claim_store.release_many(&to_release, disabled_identity.prior_identity()),
+            )
+            .await
+            {
+                Ok(Ok(())) => metrics::record_claims_released_on_drain(attempted),
+                Ok(Err(error)) => {
+                    tracing::warn!(
+                        %error,
+                        count = attempted,
+                        "clustering user drain: release_many failed; claims remain held"
+                    );
+                    abandoned += attempted;
+                }
+                Err(_) => {
+                    // Dropping a database DELETE future can make its commit
+                    // outcome ambiguous. Never replay the epoch-blind batch:
+                    // publication authority is already terminally disabled
+                    // and the users are locally quiescent, so either outcome
+                    // is safe and any retained rows can expire normally.
+                    tracing::warn!(
+                        count = attempted,
+                        "clustering user drain: release_many timed out with an ambiguous \
+                         commit outcome; not retrying the batch"
+                    );
+                    abandoned += attempted;
+                }
             }
         }
     }
     if abandoned > 0 {
         metrics::record_claims_abandoned_on_drain(abandoned);
     }
-    metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
 }
 
 /// Rollout-aware claim-acquisition backoff decision (ADR-0017 Phase 3 Slice
@@ -235,7 +490,10 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
-    use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, InProcessClaimStore, NodeIdentity};
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, ClaimError, ClaimSnapshot, ExactReleaseOutcome, InProcessClaimStore,
+        NodeIdentity, ResumeIdentityProof, StalePredicate,
+    };
 
     // --- rollout_backoff_delay: pure-function coverage -----------------
 
@@ -401,6 +659,15 @@ mod tests {
                 }
             }
         }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, _entity: &Entity) -> bool {
+            self.demote_calls.fetch_add(1, Ordering::SeqCst);
+            true
+        }
     }
 
     fn room(id: &str) -> Entity {
@@ -411,11 +678,50 @@ mod tests {
         Entity::new(EntityType::SmSession, id.to_string())
     }
 
+    fn user(id: &str) -> Entity {
+        Entity::new(EntityType::UserActor, id.to_string())
+    }
+
     fn identity() -> NodeIdentity {
         NodeIdentity::new(
             uuid::Uuid::new_v4().to_string(),
             uuid::Uuid::new_v4().to_string(),
         )
+    }
+
+    fn clean_room_serving_fence() -> RoomServingFence {
+        use crate::server::room_serving_quiescence::{
+            RoomServingQuiescence, RoomServingTerminalOutcome,
+        };
+
+        let (_admission, closer) = RoomServingQuiescence::create();
+        closer.close();
+        match closer.finalize() {
+            RoomServingTerminalOutcome::Clean(fence) => fence,
+            outcome => panic!("test room-serving fence must be clean: {outcome:?}"),
+        }
+    }
+
+    async fn run_test_shutdown_drain<L>(
+        lease: &L,
+        claim_store: &Arc<dyn ClaimStore>,
+        identity: &NodeIdentity,
+        local_claims: &Arc<dyn LocallyClaimedEntities>,
+        budget: Duration,
+    ) -> RoomShutdownDrainOutcome
+    where
+        L: NodeLeaseStore + Send + Sync,
+    {
+        run_shutdown_drain(
+            lease,
+            claim_store,
+            identity,
+            local_claims,
+            budget,
+            clean_room_serving_fence(),
+            &CancellationToken::new(),
+        )
+        .await
     }
 
     #[tokio::test]
@@ -435,14 +741,15 @@ mod tests {
             .expect("acquire room b");
         let sm_c_epoch = claim_store.acquire(&sm_c, &me).await.expect("acquire sm c");
 
+        let retire_calls = Arc::new(AtomicU32::new(0));
         let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
             owned: vec![room_a.clone(), room_b.clone(), sm_c.clone()],
             outcome: SealOutcome::Succeed,
             seal_calls: Arc::new(Mutex::new(Vec::new())),
-            demote_calls: Arc::new(AtomicU32::new(0)),
+            demote_calls: Arc::clone(&retire_calls),
         });
 
-        run_shutdown_drain(
+        run_test_shutdown_drain(
             &NoopLease,
             &claim_store,
             &me,
@@ -473,6 +780,11 @@ mod tests {
             "the sm_session entity must be left untouched by the generic drain loop \
              (owned by the separate Q6 SM drain path instead)"
         );
+        assert_eq!(
+            retire_calls.load(Ordering::SeqCst),
+            2,
+            "every released RoomActor must be hard-retired after sealing"
+        );
     }
 
     #[tokio::test]
@@ -489,7 +801,7 @@ mod tests {
             demote_calls: Arc::new(AtomicU32::new(0)),
         });
 
-        run_shutdown_drain(
+        run_test_shutdown_drain(
             &NoopLease,
             &claim_store,
             &me,
@@ -504,6 +816,544 @@ mod tests {
                 .await
                 .unwrap_or(false),
             "a failed seal must leave the claim held, not release it"
+        );
+    }
+
+    struct OneFailedSealClaims {
+        rooms: Vec<Entity>,
+        failed: Entity,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for OneFailedSealClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            self.rooms.clone()
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn abandon_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn seal_before_release(&self, entity: &Entity) -> bool {
+            entity != &self.failed
+        }
+
+        async fn retire_room_after_shutdown(&self, _entity: &Entity) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn one_failed_seal_abandons_every_room_without_a_partial_release() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let first = room("first-seals@muc.example.com");
+        let second = room("second-fails@muc.example.com");
+        let first_epoch = claim_store.acquire(&first, &me).await.expect("first claim");
+        let second_epoch = claim_store
+            .acquire(&second, &me)
+            .await
+            .expect("second claim");
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(OneFailedSealClaims {
+            rooms: vec![first.clone(), second.clone()],
+            failed: second.clone(),
+        });
+
+        let outcome = run_test_shutdown_drain(
+            &NoopLease,
+            &claim_store,
+            &me,
+            &local_claims,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert_eq!(outcome, RoomShutdownDrainOutcome::Abandoned);
+        assert!(
+            claim_store
+                .fence(&first, &me, first_epoch)
+                .await
+                .unwrap_or(false),
+            "a room sealed before a later failure must still remain claimed"
+        );
+        assert!(
+            claim_store
+                .fence(&second, &me, second_epoch)
+                .await
+                .unwrap_or(false),
+            "the failed room must remain claimed"
+        );
+    }
+
+    #[tokio::test]
+    async fn fatal_fence_forces_abandon_before_any_room_release() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let entity = room("fatal-fence@muc.example.com");
+        let epoch = claim_store.acquire(&entity, &me).await.expect("claim");
+        let seal_calls = Arc::new(Mutex::new(Vec::new()));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
+            owned: vec![entity.clone()],
+            outcome: SealOutcome::Succeed,
+            seal_calls: Arc::clone(&seal_calls),
+            demote_calls: Arc::new(AtomicU32::new(0)),
+        });
+        let fatal_fence = CancellationToken::new();
+        fatal_fence.cancel();
+
+        let outcome = run_shutdown_drain(
+            &NoopLease,
+            &claim_store,
+            &me,
+            &local_claims,
+            Duration::from_secs(5),
+            clean_room_serving_fence(),
+            &fatal_fence,
+        )
+        .await;
+
+        assert_eq!(outcome, RoomShutdownDrainOutcome::Abandoned);
+        assert!(seal_calls.lock().expect("seal call lock").is_empty());
+        assert!(
+            claim_store
+                .fence(&entity, &me, epoch)
+                .await
+                .unwrap_or(false),
+            "fatal fencing must preserve every room claim"
+        );
+    }
+
+    struct FailedRoomRetirementClaims {
+        room: Entity,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for FailedRoomRetirementClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            vec![self.room.clone()]
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn seal_before_release(&self, entity: &Entity) -> bool {
+            entity == &self.room
+        }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, entity: &Entity) -> bool {
+            assert_eq!(entity, &self.room);
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_never_releases_a_sealed_room_while_its_actor_remains_live() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let entity = room("retirement-fails@muc.example.com");
+        let epoch = claim_store.acquire(&entity, &me).await.expect("acquire");
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FailedRoomRetirementClaims {
+            room: entity.clone(),
+        });
+
+        run_test_shutdown_drain(
+            &NoopLease,
+            &claim_store,
+            &me,
+            &local_claims,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(
+            claim_store
+                .fence(&entity, &me, epoch)
+                .await
+                .unwrap_or(false),
+            "a sealed room whose actor cannot be retired must remain claimed"
+        );
+    }
+
+    struct FakeUserRetirementClaims {
+        owned: Vec<Entity>,
+        releasable: Vec<Entity>,
+        retire_calls: Arc<Mutex<Vec<Entity>>>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for FakeUserRetirementClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            self.owned.clone()
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn retire_user_after_authority_disabled(
+            &self,
+            entity: &Entity,
+            _disabled_identity: &DisabledNodeIdentity,
+        ) -> bool {
+            self.retire_calls
+                .lock()
+                .expect("retire call lock")
+                .push(entity.clone());
+            self.releasable.contains(entity)
+        }
+    }
+
+    struct UserOnlyInventoryClaims {
+        user: Entity,
+        inventory_calls: Arc<Mutex<Vec<EntityType>>>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for UserOnlyInventoryClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            panic!("the UserActor drain must not enumerate all entity registries")
+        }
+
+        async fn owned_of_type(&self, entity_type: EntityType) -> Vec<Entity> {
+            self.inventory_calls
+                .lock()
+                .expect("inventory call lock")
+                .push(entity_type);
+            match entity_type {
+                EntityType::UserActor => vec![self.user.clone()],
+                EntityType::RoomActor | EntityType::SmSession => {
+                    panic!("the UserActor drain queried an unrelated entity inventory")
+                }
+            }
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn retire_user_after_authority_disabled(
+            &self,
+            entity: &Entity,
+            _disabled_identity: &DisabledNodeIdentity,
+        ) -> bool {
+            entity == &self.user
+        }
+    }
+
+    struct HangingReleaseClaimStore {
+        inner: Arc<InProcessClaimStore>,
+        release_calls: AtomicU32,
+    }
+
+    #[async_trait]
+    impl ClaimStore for HangingReleaseClaimStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim(entity).await
+        }
+
+        async fn current_claim_after_pending_writes(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim_after_pending_writes(entity).await
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_exact(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<ExactReleaseOutcome, ClaimError> {
+            self.inner.release_exact(entity, me, mine).await
+        }
+
+        async fn release_many(
+            &self,
+            _entities: &[Entity],
+            _me: &NodeIdentity,
+        ) -> Result<(), ClaimError> {
+            self.release_calls.fetch_add(1, Ordering::SeqCst);
+            std::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_user_drain_releases_only_verified_retired_user_claims() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let released_user = user("released@example.com");
+        let retained_user = user("retained@example.com");
+        let untouched_room = room("room@muc.example.com");
+        let released_epoch = claim_store
+            .acquire(&released_user, &me)
+            .await
+            .expect("acquire releasable user");
+        let retained_epoch = claim_store
+            .acquire(&retained_user, &me)
+            .await
+            .expect("acquire retained user");
+        let room_epoch = claim_store
+            .acquire(&untouched_room, &me)
+            .await
+            .expect("acquire room");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(me.clone());
+        let disabled_identity = live_identity.disable().await;
+        let retire_calls = Arc::new(Mutex::new(Vec::new()));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeUserRetirementClaims {
+            // Duplicate input proves the release batch is canonicalized.
+            owned: vec![
+                released_user.clone(),
+                retained_user.clone(),
+                untouched_room.clone(),
+                released_user.clone(),
+            ],
+            releasable: vec![released_user.clone()],
+            retire_calls: Arc::clone(&retire_calls),
+        });
+
+        run_disabled_user_shutdown_drain(
+            &claim_store,
+            &disabled_identity,
+            &local_claims,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(
+            !claim_store
+                .fence(&released_user, &me, released_epoch)
+                .await
+                .unwrap_or(true),
+            "verified-retired UserActor claim must be released"
+        );
+        assert!(
+            claim_store
+                .fence(&retained_user, &me, retained_epoch)
+                .await
+                .unwrap_or(false),
+            "failed retirement must leave the UserActor claim held"
+        );
+        assert!(
+            claim_store
+                .fence(&untouched_room, &me, room_epoch)
+                .await
+                .unwrap_or(false),
+            "the disabled user phase must not touch RoomActor claims"
+        );
+        assert_eq!(
+            *retire_calls.lock().expect("retire call lock"),
+            vec![released_user, retained_user],
+            "each canonical UserActor must be retired exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_user_drain_uses_only_the_user_actor_inventory() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let entity = user("typed-inventory@example.com");
+        let epoch = claim_store
+            .acquire(&entity, &me)
+            .await
+            .expect("acquire user");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(me.clone());
+        let disabled_identity = live_identity.disable().await;
+        let inventory_calls = Arc::new(Mutex::new(Vec::new()));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(UserOnlyInventoryClaims {
+            user: entity.clone(),
+            inventory_calls: Arc::clone(&inventory_calls),
+        });
+
+        run_disabled_user_shutdown_drain(
+            &claim_store,
+            &disabled_identity,
+            &local_claims,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            *inventory_calls.lock().expect("inventory call lock"),
+            vec![EntityType::UserActor]
+        );
+        assert!(
+            !claim_store.fence(&entity, &me, epoch).await.unwrap_or(true),
+            "the user-specific inventory must still reach retirement and release"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_user_drain_bounds_a_hanging_release_without_retrying() {
+        let inner = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let retired_user = user("release-hangs@example.com");
+        let epoch = inner
+            .acquire(&retired_user, &me)
+            .await
+            .expect("acquire user");
+        let hanging_store = Arc::new(HangingReleaseClaimStore {
+            inner: Arc::clone(&inner),
+            release_calls: AtomicU32::new(0),
+        });
+        let claim_store: Arc<dyn ClaimStore> = hanging_store.clone();
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(me.clone());
+        let disabled_identity = live_identity.disable().await;
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeUserRetirementClaims {
+            owned: vec![retired_user.clone()],
+            releasable: vec![retired_user.clone()],
+            retire_calls: Arc::new(Mutex::new(Vec::new())),
+        });
+        let budget = Duration::from_millis(50);
+
+        let drain = tokio::spawn(async move {
+            run_disabled_user_shutdown_drain(
+                &claim_store,
+                &disabled_identity,
+                &local_claims,
+                budget,
+            )
+            .await;
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(budget * 2).await;
+        drain.await.expect("bounded user drain");
+
+        assert_eq!(
+            hanging_store.release_calls.load(Ordering::SeqCst),
+            1,
+            "an ambiguous timed-out release must never be replayed"
+        );
+        assert!(
+            inner
+                .fence(&retired_user, &me, epoch)
+                .await
+                .unwrap_or(false),
+            "the hanging fake never committed, so timeout must leave its claim held"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn room_drain_bounds_a_hanging_release_without_retrying() {
+        let inner = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let entity = room("release-hangs@muc.example.com");
+        let epoch = inner.acquire(&entity, &me).await.expect("acquire room");
+        let hanging_store = Arc::new(HangingReleaseClaimStore {
+            inner: Arc::clone(&inner),
+            release_calls: AtomicU32::new(0),
+        });
+        let claim_store: Arc<dyn ClaimStore> = hanging_store.clone();
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
+            owned: vec![entity.clone()],
+            outcome: SealOutcome::Succeed,
+            seal_calls: Arc::new(Mutex::new(Vec::new())),
+            demote_calls: Arc::new(AtomicU32::new(0)),
+        });
+        let budget = Duration::from_millis(50);
+        let task_me = me.clone();
+
+        let drain = tokio::spawn(async move {
+            run_test_shutdown_drain(&NoopLease, &claim_store, &task_me, &local_claims, budget)
+                .await;
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(budget * 2).await;
+        drain.await.expect("bounded room drain");
+
+        assert_eq!(
+            hanging_store.release_calls.load(Ordering::SeqCst),
+            1,
+            "an ambiguous timed-out room release must never be replayed"
+        );
+        assert!(
+            inner.fence(&entity, &me, epoch).await.unwrap_or(false),
+            "the hanging fake never committed, so timeout must leave its room claim held"
         );
     }
 
@@ -524,7 +1374,8 @@ mod tests {
         let budget = Duration::from_millis(50);
         let task_me = me.clone();
         let drain = tokio::spawn(async move {
-            run_shutdown_drain(&NoopLease, &claim_store, &task_me, &local_claims, budget).await;
+            run_test_shutdown_drain(&NoopLease, &claim_store, &task_me, &local_claims, budget)
+                .await;
             claim_store
         });
         tokio::time::advance(budget * 4).await;
@@ -563,7 +1414,7 @@ mod tests {
             demote_calls: Arc::new(AtomicU32::new(0)),
         });
 
-        run_shutdown_drain(
+        run_test_shutdown_drain(
             &NoopLease,
             &claim_store,
             &me,
@@ -662,7 +1513,7 @@ mod tests {
         // below must fit inside.
         let budget = Duration::from_secs(5);
         let start = Instant::now();
-        run_shutdown_drain(&NoopLease, &claim_store, &me, &local_claims, budget).await;
+        run_test_shutdown_drain(&NoopLease, &claim_store, &me, &local_claims, budget).await;
         let elapsed = start.elapsed();
 
         assert!(
@@ -768,6 +1619,14 @@ mod tests {
             tokio::time::sleep(self.seal_delay).await;
             true
         }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, _entity: &Entity) -> bool {
+            true
+        }
     }
 
     /// ADR-0017 Phase 3 Slice 10 FIX 2 (council-adjudicated): the ordering
@@ -829,6 +1688,7 @@ mod tests {
         // independent pool.
         let claim_store: Arc<dyn ClaimStore> =
             Arc::new(super::super::claims::PostgresClaimStore::new(db.clone()));
+        let fatal_fence = CancellationToken::new();
 
         // Structured concurrency, no `tokio::spawn`: `drain_future` and the
         // polling loop below both only ever take `&claim_store_typed`
@@ -842,8 +1702,12 @@ mod tests {
             &claim_store,
             &me,
             &local_claims,
-            claim_release_budget,
-            lease_ttl,
+            ShutdownDrainTiming {
+                claim_release_budget,
+                lease_ttl,
+            },
+            clean_room_serving_fence(),
+            &fatal_fence,
         ));
         let mut drain_future = drain_future;
 

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -22,20 +22,22 @@
 //! registry is created later in `server/http.rs`, then wired into the handle
 //! that `start_if_enabled` already handed to `run_node_lease`.
 
+use std::collections::HashSet;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use jid::{BareJid, FullJid};
 use kameo::actor::ActorRef;
-use waddle_xmpp::muc::room_actor::HealthCheck;
+use waddle_xmpp::muc::room_actor::{HealthCheck, RoomSealState, SealForShutdown};
 use waddle_xmpp::muc::RoomRegistry;
-use waddle_xmpp::ownership::{Entity, EntityType};
+use waddle_xmpp::ownership::{DisabledNodeIdentity, Entity, EntityType};
 use waddle_xmpp::registry::user_actor::HealthCheck as UserHealthCheck;
 use waddle_xmpp::registry::{
     ConnectionRegistry, DemoteUserActor, DemoteUserActorIfOwner, DemotedUserResource,
     ForceDetachOutcome, ForceDetachRequest, GetResources, GetUserForLocalClaim, ListUsers,
-    ListUsersOwnedBy, UserRegistryActor,
+    ListUsersOwnedBy, RetireUserActorAfterAuthorityDisabled,
+    RetireUserActorAfterAuthorityDisabledOutcome, UserRegistryActor,
 };
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 
@@ -284,11 +286,14 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         // `owned()` is documented as "local bookkeeping only, never a
         // Postgres read" — `list_rooms()` is exactly that: an in-memory
         // enumeration of this process's live `RoomActor`s (an actor ask,
-        // hence `async`, but no Postgres round-trip). Every
-        // locally-spawned room always holds this node's claim by
-        // construction (the registry's `GetOrCreateRoom`/`CreateRoom`/
-        // `CreateInstantRoom` acquire the claim before spawning), so this
-        // enumeration is exactly the owned-entity set.
+        // hence `async`, but no Postgres round-trip). During terminal
+        // shutdown it intentionally also includes dead entries whose exact
+        // claim must remain inventoried: they cannot answer the seal barrier,
+        // so the drain abandons them for node-expiry recovery rather than
+        // releasing unsafely. Every locally-spawned room always holds this
+        // node's claim by construction (the registry's `GetOrCreateRoom`/
+        // `CreateRoom`/`CreateInstantRoom` acquire the claim before
+        // spawning), so this enumeration is exactly the owned-entity set.
         match registry.list_rooms().await {
             Ok(mut jids) => {
                 if let Ok(pending) = registry.list_pending_room_release_jids().await {
@@ -421,18 +426,23 @@ impl LocallyClaimedEntities for RoomLocalClaims {
     /// no confirmation that a mutation already queued ahead of the drain
     /// snapshot has finished its final fenced write).
     ///
-    /// Issues the SAME `HealthCheck` ask [`Self::health_check`] above uses,
-    /// as a genuine mailbox-ordering barrier: kameo serializes each actor's
-    /// mailbox strictly in order (see [`HealthCheck`]'s own doc comment),
-    /// and every mutation handler this actor exposes
-    /// (`UpdateConfig`/`RollbackConfigIfRevision`/
-    /// `UpdateGroupDmConfigByMember`/`SetSubject`/`ChangeAffiliation`, and
-    /// the affiliation-bulk-apply path) synchronously `.await`s its own
-    /// `gate_mutation()` check and durable persist call
-    /// (`persist_config`/`persist_subject`/`persist_affiliation`) before
-    /// returning a reply — so a mutation enqueued ahead of this ask has
-    /// already run its handler to completion, including its durable write's
-    /// commit, by the time this ask's own reply lands. A room with no live
+    /// Issues a typed [`SealForShutdown`] ask as a mailbox-ordering barrier:
+    /// kameo serializes each actor's mailbox strictly in order, so every
+    /// serving handler enqueued ahead of the seal has finished before the
+    /// reply. In particular, durability-gated config/subject/affiliation/admin
+    /// and invite handlers synchronously await their ownership check and
+    /// fenced persist before returning, proving their final write completed.
+    ///
+    /// Once installed, the central actor gate and typed handler outcomes
+    /// refuse the full post-seal serving surface: joins; leaves and other
+    /// occupancy, presence, Muji, and in-call updates; pin/config/admin/
+    /// affiliation/invite mutations; restore/hydration; destruction; and both
+    /// legacy broadcast and current dispatch-chain traffic preparation.
+    /// Self-ping and occupant authorization reads also fail closed. Harmless
+    /// read-only diagnostics remain available until the actor is hard-retired,
+    /// then the exact claim is released.
+    ///
+    /// A room with no live
     /// local actor to ask, or one whose ask fails or times out (wedged),
     /// reports unsealed (`false`): [`crate::clustering::drain::
     /// run_shutdown_drain`] then leaves that claim held —
@@ -461,12 +471,123 @@ impl LocallyClaimedEntities for RoomLocalClaims {
             );
             return false;
         };
-        actor_ref
-            .ask(HealthCheck)
-            .mailbox_timeout(ROOM_HEALTH_CHECK_TIMEOUT)
-            .reply_timeout(ROOM_HEALTH_CHECK_TIMEOUT)
+        matches!(
+            actor_ref
+                .ask(SealForShutdown)
+                .mailbox_timeout(ROOM_HEALTH_CHECK_TIMEOUT)
+                .reply_timeout(ROOM_HEALTH_CHECK_TIMEOUT)
+                .await,
+            Ok(RoomSealState::Shutdown | RoomSealState::OwnershipLost)
+        )
+    }
+
+    async fn begin_room_shutdown(&self) -> bool {
+        let Some(registry) = self.registry.get() else {
+            // An unwired registry cannot own or publish rooms.
+            return true;
+        };
+        match registry.drain_room_ownership_for_shutdown(Vec::new()).await {
+            Ok(outcome) => {
+                tracing::debug!(
+                    released = outcome.released,
+                    preserved_live = outcome.preserved_live,
+                    retained = outcome.retained,
+                    "RoomLocalClaims: terminal room ownership admission gate is active"
+                );
+                if outcome.released != 0 {
+                    tracing::error!(
+                        released = outcome.released,
+                        "RoomLocalClaims: registry terminal barrier unexpectedly released claims; \
+                         refusing process-wide batch release"
+                    );
+                    return false;
+                }
+                if outcome.retained != 0 {
+                    tracing::warn!(
+                        retained = outcome.retained,
+                        "RoomLocalClaims: terminal room ownership reconciliation retained \
+                         ambiguous responsibility; refusing all room claim releases"
+                    );
+                    return false;
+                }
+                true
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "RoomLocalClaims: could not confirm terminal room ownership admission gate; \
+                     preserving every live room claim"
+                );
+                false
+            }
+        }
+    }
+
+    async fn abandon_room_shutdown(&self) -> bool {
+        let Some(registry) = self.registry.get() else {
+            // An unwired registry cannot own or publish rooms.
+            return true;
+        };
+        match registry
+            .abandon_room_ownership_for_shutdown(Vec::new())
             .await
-            .is_ok()
+        {
+            Ok(outcome) => {
+                tracing::warn!(
+                    preserved_live = outcome.preserved_live,
+                    retained = outcome.retained,
+                    "RoomLocalClaims: terminal no-release mode selected; every room claim \
+                     remains held for node-expiry recovery"
+                );
+                outcome.released == 0
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "RoomLocalClaims: terminal no-release registry barrier could not be \
+                     confirmed; no room release will be attempted"
+                );
+                false
+            }
+        }
+    }
+
+    async fn retire_room_after_shutdown(&self, entity: &Entity) -> bool {
+        let Some(registry) = self.registry.get() else {
+            return false;
+        };
+        let Some(room_jid) = Self::room_jid(entity) else {
+            return false;
+        };
+        match registry.get_room(room_jid.clone()).await {
+            Ok(Some(actor_ref)) => {
+                actor_ref.kill();
+                actor_ref.wait_for_shutdown().await;
+                if actor_ref.is_alive() {
+                    tracing::warn!(
+                        room = %room_jid,
+                        "RoomLocalClaims: hard-killed RoomActor still reports alive; \
+                         preserving its claim"
+                    );
+                    return false;
+                }
+                tracing::debug!(
+                    room = %room_jid,
+                    "RoomLocalClaims: hard-retired sealed RoomActor before claim release"
+                );
+                true
+            }
+            Ok(None) => true,
+            Err(error) => {
+                tracing::warn!(
+                    room = %room_jid,
+                    %error,
+                    "RoomLocalClaims: could not resolve RoomActor for terminal retirement; \
+                     preserving its claim"
+                );
+                false
+            }
+        }
     }
 }
 
@@ -582,9 +703,9 @@ impl UserLocalClaims {
         }
     }
 
-    async fn force_detach_resources(&self, bare_jid: &BareJid, resources: Vec<FullJid>) {
+    async fn force_detach_resources(&self, bare_jid: &BareJid, resources: Vec<FullJid>) -> bool {
         if resources.is_empty() {
-            return;
+            return true;
         }
         let Some(connection_registry) = self.connection_registry.get() else {
             tracing::warn!(
@@ -592,7 +713,7 @@ impl UserLocalClaims {
                 resource_count = resources.len(),
                 "UserLocalClaims::demote: no ConnectionRegistry wired; cannot force-detach live resources"
             );
-            return;
+            return false;
         };
         let entries = resources
             .into_iter()
@@ -602,14 +723,14 @@ impl UserLocalClaims {
                     .map(|entry| (jid, entry))
             })
             .collect();
-        self.force_detach_entries(bare_jid, entries).await;
+        self.force_detach_entries(bare_jid, entries).await
     }
 
     async fn force_detach_exact_resources(
         &self,
         bare_jid: &BareJid,
         resources: Vec<DemotedUserResource>,
-    ) {
+    ) -> bool {
         self.force_detach_entries(
             bare_jid,
             resources
@@ -617,17 +738,18 @@ impl UserLocalClaims {
                 .map(|resource| (resource.jid, resource.entry))
                 .collect(),
         )
-        .await;
+        .await
     }
 
     async fn force_detach_entries(
         &self,
         bare_jid: &BareJid,
         entries: Vec<(FullJid, waddle_xmpp::registry::ConnectionEntry)>,
-    ) {
+    ) -> bool {
         let Some(connection_registry) = self.connection_registry.get() else {
-            return;
+            return false;
         };
+        let mut retirement_verified = true;
         for (jid, entry) in entries {
             let owner = entry.carbons_handle();
             let (ack, ack_rx) = tokio::sync::oneshot::channel();
@@ -647,19 +769,36 @@ impl UserLocalClaims {
                     }
                     Ok(Ok(ForceDetachOutcome::IdentityMismatch)) => {
                         remove_after_wait = false;
+                        retirement_verified = false;
                         tracing::warn!(
                             jid = %jid,
                             requester = %bare_jid,
                             "UserLocalClaims::demote: force-detach identity mismatch; leaving registry entry untouched"
                         );
                     }
-                    Ok(Err(_closed)) => {
+                    Ok(Ok(ForceDetachOutcome::Unavailable)) => {
+                        remove_after_wait = false;
+                        retirement_verified = false;
                         tracing::warn!(
                             jid = %jid,
-                            "UserLocalClaims::demote: force-detach ack channel closed before response; leaving registry entry for connection-owned cleanup"
+                            "UserLocalClaims::demote: force-detach unavailable; preserving \
+                             the registry entry and UserActor claim"
+                        );
+                    }
+                    Ok(Err(_closed)) => {
+                        // A remote mirror's forwarding task can disappear
+                        // while the actual WebSocket on its socket node stays
+                        // live. A dropped ack therefore proves nothing about
+                        // teardown; preserve both route and claim.
+                        retirement_verified = false;
+                        tracing::warn!(
+                            jid = %jid,
+                            "UserLocalClaims::demote: accepted force-detach request lost its ack \
+                             sender; preserving the registry entry and UserActor claim"
                         );
                     }
                     Err(_elapsed) => {
+                        retirement_verified = false;
                         tracing::warn!(
                             jid = %jid,
                             timeout_ms = USER_FORCE_DETACH_ACK_TIMEOUT.as_millis() as u64,
@@ -667,11 +806,23 @@ impl UserLocalClaims {
                         );
                     }
                 },
-                Err(error) => {
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_request)) => {
+                    // This may be a dead remote-forwarder task rather than
+                    // the socket-owning task itself. Without an authoritative
+                    // remote reply there is no teardown proof.
+                    retirement_verified = false;
                     tracing::warn!(
                         jid = %jid,
-                        ?error,
-                        "UserLocalClaims::demote: force-detach request could not be queued; leaving registry entry for connection-owned cleanup"
+                        "UserLocalClaims::demote: force-detach receiver is closed; preserving the \
+                         registry entry and UserActor claim"
+                    );
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_request)) => {
+                    retirement_verified = false;
+                    tracing::warn!(
+                        jid = %jid,
+                        "UserLocalClaims::demote: force-detach channel is full; leaving registry \
+                         entry for connection-owned cleanup"
                     );
                 }
             }
@@ -686,13 +837,14 @@ impl UserLocalClaims {
                 );
             }
         }
+        retirement_verified
     }
 }
 
 #[async_trait]
 impl LocallyClaimedEntities for UserLocalClaims {
     async fn owned(&self) -> Vec<Entity> {
-        let mut owned = Vec::new();
+        let mut owned = HashSet::new();
         if let Some(registry) = self.registry.get() {
             match registry
                 .ask(ListUsers)
@@ -718,12 +870,10 @@ impl LocallyClaimedEntities for UserLocalClaims {
         if let Some(connection_registry) = self.connection_registry.get() {
             for jid in connection_registry.list_connections() {
                 let entity = Entity::new(EntityType::UserActor, jid.to_bare().to_string());
-                if !owned.contains(&entity) {
-                    owned.push(entity);
-                }
+                owned.insert(entity);
             }
         }
-        owned
+        owned.into_iter().collect()
     }
 
     async fn demote(&self, entity: &Entity) {
@@ -764,7 +914,7 @@ impl LocallyClaimedEntities for UserLocalClaims {
                 );
             }
         }
-        self.force_detach_resources(&bare_jid, resources).await;
+        let _ = self.force_detach_resources(&bare_jid, resources).await;
     }
 
     async fn health_check(&self, entity: &Entity) -> bool {
@@ -822,6 +972,126 @@ impl LocallyClaimedEntities for UserLocalClaims {
         }
     }
 
+    async fn retire_user_after_authority_disabled(
+        &self,
+        entity: &Entity,
+        disabled_identity: &DisabledNodeIdentity,
+    ) -> bool {
+        let Some(registry) = self.registry.get() else {
+            tracing::warn!(
+                %entity,
+                "UserLocalClaims shutdown retirement cannot verify UserActor absence: \
+                 no UserRegistryActor is wired"
+            );
+            return false;
+        };
+        let Some(connection_registry) = self.connection_registry.get() else {
+            tracing::warn!(
+                %entity,
+                "UserLocalClaims shutdown retirement cannot verify connection quiescence: \
+                 no ConnectionRegistry is wired"
+            );
+            return false;
+        };
+        let Some(bare_jid) = Self::user_jid(entity) else {
+            return false;
+        };
+
+        let demoted = match registry
+            .ask(RetireUserActorAfterAuthorityDisabled {
+                bare_jid: bare_jid.clone(),
+                disabled_identity: disabled_identity.clone(),
+            })
+            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .await
+        {
+            Ok(RetireUserActorAfterAuthorityDisabledOutcome::Retired(demoted)) => Some(demoted),
+            Ok(RetireUserActorAfterAuthorityDisabledOutcome::AlreadyAbsent) => None,
+            Ok(RetireUserActorAfterAuthorityDisabledOutcome::AuthorityNotDisabled) => {
+                tracing::warn!(
+                    jid = %bare_jid,
+                    "UserLocalClaims shutdown retirement proof was rejected by UserRegistryActor"
+                );
+                return false;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %bare_jid,
+                    ?error,
+                    "UserLocalClaims shutdown retirement could not demote the exact UserActor"
+                );
+                return false;
+            }
+        };
+
+        let mut retirement_verified = match demoted {
+            Some(demoted) => {
+                self.force_detach_exact_resources(&bare_jid, demoted.resources)
+                    .await
+            }
+            None => true,
+        };
+
+        // Catch a connection that reached the DashMap before its
+        // authoritative UserActor mirror. The disabled publication barrier
+        // prevents that in-flight bind from successfully publishing a new
+        // same-incarnation actor/claim, so retiring the current exact
+        // ConnectionRegistry entries cannot race a legitimate replacement.
+        if retirement_verified {
+            let remaining_resources =
+                Self::connection_registry_resources(connection_registry, &bare_jid);
+            retirement_verified = self
+                .force_detach_resources(&bare_jid, remaining_resources)
+                .await;
+        }
+
+        let actor_absent = match registry
+            .ask(GetUserForLocalClaim {
+                bare_jid: bare_jid.clone(),
+            })
+            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .await
+        {
+            Ok(None) => true,
+            Ok(Some(_)) => {
+                tracing::warn!(
+                    jid = %bare_jid,
+                    "UserLocalClaims shutdown retirement left a UserActor registered; \
+                     preserving its claim"
+                );
+                false
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %bare_jid,
+                    ?error,
+                    "UserLocalClaims shutdown retirement could not verify UserActor absence; \
+                     preserving its claim"
+                );
+                false
+            }
+        };
+        let connections_absent =
+            Self::connection_registry_resources(connection_registry, &bare_jid).is_empty();
+        if !connections_absent {
+            tracing::warn!(
+                jid = %bare_jid,
+                "UserLocalClaims shutdown retirement left live ConnectionRegistry resources; \
+                 preserving its claim"
+            );
+        }
+        if !retirement_verified {
+            tracing::warn!(
+                jid = %bare_jid,
+                "UserLocalClaims shutdown retirement observed an unverified force-detach \
+                 outcome; preserving its claim"
+            );
+        }
+        actor_absent && connections_absent && retirement_verified
+    }
+
     async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
         let Some(registry) = self.registry.get() else {
             return;
@@ -851,7 +1121,8 @@ impl LocallyClaimedEntities for UserLocalClaims {
                 .await
             {
                 Ok(Some(demoted)) => {
-                    self.force_detach_exact_resources(&bare_jid, demoted.resources)
+                    let _ = self
+                        .force_detach_exact_resources(&bare_jid, demoted.resources)
                         .await;
                     tracing::warn!(
                         jid = %bare_jid,
@@ -900,6 +1171,14 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
         owned.extend(self.room.owned().await);
         owned.extend(self.user.owned().await);
         owned
+    }
+
+    async fn owned_of_type(&self, entity_type: EntityType) -> Vec<Entity> {
+        match entity_type {
+            EntityType::SmSession => self.sm.owned().await,
+            EntityType::RoomActor => self.room.owned().await,
+            EntityType::UserActor => self.user.owned().await,
+        }
     }
 
     async fn demote(&self, entity: &Entity) {
@@ -1004,6 +1283,34 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
             EntityType::RoomActor => self.room.seal_before_release(entity).await,
             EntityType::UserActor => self.user.seal_before_release(entity).await,
         }
+    }
+
+    async fn begin_room_shutdown(&self) -> bool {
+        self.room.begin_room_shutdown().await
+    }
+
+    async fn abandon_room_shutdown(&self) -> bool {
+        self.room.abandon_room_shutdown().await
+    }
+
+    async fn retire_room_after_shutdown(&self, entity: &Entity) -> bool {
+        if entity.entity_type != EntityType::RoomActor {
+            return false;
+        }
+        self.room.retire_room_after_shutdown(entity).await
+    }
+
+    async fn retire_user_after_authority_disabled(
+        &self,
+        entity: &Entity,
+        disabled_identity: &DisabledNodeIdentity,
+    ) -> bool {
+        if entity.entity_type != EntityType::UserActor {
+            return false;
+        }
+        self.user
+            .retire_user_after_authority_disabled(entity, disabled_identity)
+            .await
     }
 }
 
@@ -1381,6 +1688,328 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn user_shutdown_retirement_quiesces_both_registries_before_release() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("node-a", "epoch-a");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity.clone());
+        let claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store,
+                node_identity: live_identity.clone(),
+            })
+            .await
+            .expect("wire user claims");
+
+        let jid: FullJid = "shutdown-retire@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = jid.to_bare();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("connection task owns force-detach receiver");
+        let force_detach_task = tokio::spawn(async move {
+            let request = force_detach_rx.recv().await.expect("force-detach request");
+            let _ = request.ack.send(ForceDetachOutcome::NotPersisted);
+        });
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry,
+            })
+            .await
+            .expect("register user resource");
+
+        let disabled_identity = live_identity.disable().await;
+        assert_eq!(disabled_identity.prior_identity(), &identity);
+        let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
+        assert!(
+            user_local_claims
+                .retire_user_after_authority_disabled(&entity, &disabled_identity)
+                .await,
+            "a claim is releasable only after both registries are quiescent"
+        );
+        force_detach_task.await.expect("force-detach task");
+
+        assert!(!connection_registry.is_connected(&jid));
+        assert!(registry
+            .ask(waddle_xmpp::registry::GetUserForLocalClaim { bare_jid })
+            .await
+            .expect("inspect user")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn unavailable_remote_force_detach_preserves_the_user_claim_boundary() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("node-a", "epoch-a");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity);
+        let claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store,
+                node_identity: live_identity.clone(),
+            })
+            .await
+            .expect("wire user claims");
+
+        let jid: FullJid = "remote-unavailable@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = jid.to_bare();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("remote force-detach forwarder owns the receiver");
+        let force_detach_task = tokio::spawn(async move {
+            let request = force_detach_rx.recv().await.expect("force-detach request");
+            let _ = request.ack.send(ForceDetachOutcome::Unavailable);
+        });
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry,
+            })
+            .await
+            .expect("register user resource");
+
+        let disabled_identity = live_identity.disable().await;
+        let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
+        assert!(
+            !user_local_claims
+                .retire_user_after_authority_disabled(&entity, &disabled_identity)
+                .await,
+            "an unavailable relay result is not proof that the remote WebSocket closed"
+        );
+        force_detach_task.await.expect("force-detach task");
+        assert!(
+            connection_registry.is_connected(&jid),
+            "the unverified remote route must remain registered so claim release fails closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_shutdown_retirement_rejects_a_disabled_proof_from_another_source() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("node-a", "epoch-a");
+        let registry_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity.clone());
+        let claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store,
+                node_identity: registry_identity.clone(),
+            })
+            .await
+            .expect("wire user claims");
+
+        let jid: FullJid = "wrong-proof@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = jid.to_bare();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry,
+            })
+            .await
+            .expect("register user resource");
+
+        let separate_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity);
+        let foreign_proof = separate_identity.disable().await;
+        let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
+        assert!(
+            !user_local_claims
+                .retire_user_after_authority_disabled(&entity, &foreign_proof)
+                .await,
+            "matching node/epoch text from another identity source must not authorize retirement"
+        );
+
+        assert!(registry_identity.current().is_active());
+        assert!(connection_registry.is_connected(&jid));
+        assert!(registry
+            .ask(waddle_xmpp::registry::GetUserForLocalClaim { bare_jid })
+            .await
+            .expect("inspect user")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn user_shutdown_retirement_fails_closed_when_a_resource_cannot_detach() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("node-a", "epoch-a");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity);
+        let claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store,
+                node_identity: live_identity.clone(),
+            })
+            .await
+            .expect("wire user claims");
+
+        let jid: FullJid = "shutdown-stuck@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = jid.to_bare();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("connection task owns force-detach receiver");
+        let force_detach_task = tokio::spawn(async move {
+            let request = force_detach_rx.recv().await.expect("force-detach request");
+            let _ = request.ack.send(ForceDetachOutcome::IdentityMismatch);
+        });
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry,
+            })
+            .await
+            .expect("register user resource");
+
+        let disabled_identity = live_identity.disable().await;
+        let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
+        assert!(
+            !user_local_claims
+                .retire_user_after_authority_disabled(&entity, &disabled_identity)
+                .await,
+            "a residual ConnectionRegistry resource must veto claim release"
+        );
+        force_detach_task.await.expect("force-detach task");
+        assert!(
+            connection_registry.is_connected(&jid),
+            "failed retirement leaves the resource for connection-owned cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_shutdown_retirement_preserves_entries_when_detach_control_disappears() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("node-a", "epoch-a");
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity);
+        let claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store,
+                node_identity: live_identity.clone(),
+            })
+            .await
+            .expect("wire user claims");
+
+        let closed_jid: FullJid = "shutdown-closed@example.com/closed"
+            .parse()
+            .expect("valid full JID");
+        let accepted_jid: FullJid = "shutdown-closed@example.com/accepted"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = closed_jid.to_bare();
+
+        let (closed_tx, _closed_rx) = tokio::sync::mpsc::channel(4);
+        let closed_owner = connection_registry.register(closed_jid.clone(), closed_tx);
+        let closed_entry = connection_registry
+            .entry_if_owner(&closed_jid, &closed_owner)
+            .expect("closed-control entry");
+        drop(
+            closed_entry
+                .take_force_detach_rx()
+                .expect("connection task owns closed-control receiver"),
+        );
+
+        let (accepted_tx, _accepted_rx) = tokio::sync::mpsc::channel(4);
+        let accepted_owner = connection_registry.register(accepted_jid.clone(), accepted_tx);
+        let accepted_entry = connection_registry
+            .entry_if_owner(&accepted_jid, &accepted_owner)
+            .expect("accepted-control entry");
+        let mut accepted_force_detach_rx = accepted_entry
+            .take_force_detach_rx()
+            .expect("connection task owns accepted-control receiver");
+        let accepted_task = tokio::spawn(async move {
+            let request = accepted_force_detach_rx
+                .recv()
+                .await
+                .expect("accepted force-detach request");
+            drop(request);
+        });
+
+        for (jid, entry) in [
+            (closed_jid.clone(), closed_entry),
+            (accepted_jid.clone(), accepted_entry),
+        ] {
+            registry
+                .ask(waddle_xmpp::registry::RegisterUserResource { jid, entry })
+                .await
+                .expect("register user resource");
+        }
+
+        let disabled_identity = live_identity.disable().await;
+        let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
+        assert!(
+            !user_local_claims
+                .retire_user_after_authority_disabled(&entity, &disabled_identity)
+                .await,
+            "a dead remote-forwarder receiver or dropped ack does not prove that the remote \
+             WebSocket closed, so shutdown must preserve the claim"
+        );
+        accepted_task.await.expect("accepted detach task");
+
+        assert!(connection_registry.is_connected(&closed_jid));
+        assert!(connection_registry.is_connected(&accepted_jid));
+        assert!(registry
+            .ask(waddle_xmpp::registry::GetUserForLocalClaim { bare_jid })
+            .await
+            .expect("inspect user")
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn combined_local_claims_routes_user_actor_operations() {
         let sm_local_claims = SmSessionLocalClaims::new();
         let room_local_claims = RoomLocalClaims::new();
@@ -1549,6 +2178,102 @@ mod tests {
         assert!(killed, "demote must hard-kill the deposed RoomActor");
     }
 
+    #[tokio::test]
+    async fn room_shutdown_gate_prevents_replacement_before_claim_release() {
+        let room_local_claims = RoomLocalClaims::new();
+        let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+            "muc.example.com".to_string(),
+            test_occupant_id_secret(),
+            None,
+        );
+        room_local_claims.wire(registry.clone());
+
+        let room_jid: jid::BareJid = "shutdown-gated@muc.example.com".parse().expect("valid jid");
+        let actor_ref = registry
+            .get_or_create_room(
+                room_jid.clone(),
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                waddle_xmpp::muc::RoomConfig::default(),
+            )
+            .await
+            .expect("create room")
+            .actor_ref;
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+
+        assert!(
+            room_local_claims.begin_room_shutdown().await,
+            "terminal room admission gate must be confirmed before inventory"
+        );
+        assert!(room_local_claims.seal_before_release(&entity).await);
+        assert_eq!(
+            actor_ref
+                .ask(waddle_xmpp::muc::room_actor::GetRoomSealState)
+                .await
+                .expect("typed actor seal"),
+            waddle_xmpp::muc::room_actor::RoomSealState::Shutdown,
+            "the drain barrier must install the terminal actor seal before retirement"
+        );
+        assert!(
+            actor_ref.is_alive(),
+            "the shutdown seal must take effect while the actor is still alive"
+        );
+        let late_join = actor_ref
+            .ask(waddle_xmpp::muc::room_actor::Join {
+                nick: "late".to_string(),
+                real_jid: "late@example.com/resource".parse().expect("full jid"),
+                role: waddle_xmpp::Role::Participant,
+                affiliation: waddle_xmpp::Affiliation::Member,
+            })
+            .await;
+        assert!(matches!(
+            late_join,
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
+        let late_update = actor_ref
+            .ask(waddle_xmpp::muc::room_actor::UpdateConfig {
+                config: waddle_xmpp::muc::RoomConfig {
+                    persistent: true,
+                    ..waddle_xmpp::muc::RoomConfig::default()
+                },
+            })
+            .await;
+        assert!(matches!(
+            late_update,
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner
+            ))
+        ));
+        assert!(
+            room_local_claims.retire_room_after_shutdown(&entity).await,
+            "a sealed live room must be hard-retired"
+        );
+        assert!(!actor_ref.is_alive());
+
+        let replacement = registry
+            .get_or_create_room(
+                room_jid.clone(),
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                waddle_xmpp::muc::RoomConfig::default(),
+            )
+            .await;
+        assert!(
+            matches!(
+                replacement,
+                Err(
+                    waddle_xmpp::muc::RoomRegistryError::OwnershipUnavailable(ref jid)
+                        | waddle_xmpp::muc::RoomRegistryError::RoomActorStateLost(ref jid)
+                )
+                    if *jid == room_jid
+            ),
+            "terminal drain must not allow a replacement actor before claim release: \
+             {replacement:?}"
+        );
+    }
+
     // -----------------------------------------------------------------
     // ADR-0017 Phase 3 Slice 10 FIX 1 (council-adjudicated): the real
     // `seal_before_release` barrier. Mirrors the `health_check` test
@@ -1649,6 +2374,7 @@ mod tests {
     struct RecordingDurableStore {
         started: Arc<tokio::sync::Notify>,
         persisted: Arc<std::sync::atomic::AtomicBool>,
+        save_calls: Arc<std::sync::atomic::AtomicUsize>,
     }
 
     fn expected_local_room_fence(
@@ -1703,6 +2429,8 @@ mod tests {
                 return Box::pin(async move { Err(error) });
             }
             Box::pin(async move {
+                self.save_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 self.started.notify_one();
                 tokio::time::sleep(Duration::from_millis(150)).await;
                 self.persisted
@@ -1762,7 +2490,7 @@ mod tests {
     /// dequeued and its handler is running. The test waits for that
     /// signal (proving `UpdateConfig`'s handler is now suspended inside
     /// the still-in-flight persist call) before issuing the
-    /// `seal_before_release` ask — so `HealthCheck` cannot itself be
+    /// `seal_before_release` ask — so `SealForShutdown` cannot itself be
     /// dequeued and answered until `UpdateConfig`'s handler, persist
     /// `.await` and all, has returned.
     #[tokio::test]
@@ -1777,10 +2505,12 @@ mod tests {
 
         let started = Arc::new(tokio::sync::Notify::new());
         let persisted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let save_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let durable_store: std::sync::Arc<dyn waddle_xmpp::muc::MucDurableStore> =
             std::sync::Arc::new(RecordingDurableStore {
                 started: Arc::clone(&started),
                 persisted: Arc::clone(&persisted),
+                save_calls: Arc::clone(&save_calls),
             });
         registry
             .wire_clustering_claims(
@@ -1847,5 +2577,29 @@ mod tests {
             .await
             .expect("update task")
             .expect("UpdateConfig must have succeeded");
+
+        assert_eq!(
+            actor_ref
+                .ask(waddle_xmpp::muc::room_actor::GetRoomSealState)
+                .await
+                .expect("typed shutdown seal"),
+            waddle_xmpp::muc::room_actor::RoomSealState::Shutdown
+        );
+        let late_update = actor_ref
+            .ask(waddle_xmpp::muc::room_actor::UpdateConfig {
+                config: waddle_xmpp::muc::RoomConfig::default(),
+            })
+            .await;
+        assert!(matches!(
+            late_update,
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner
+            ))
+        ));
+        assert_eq!(
+            save_calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a mutation queued after the terminal seal must not begin another durable write"
+        );
     }
 }

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -554,18 +554,52 @@ impl ClusteringHandles {
 /// with connection drain but completing before process exit," per element
 /// 4's drain sequence text — rather than a fire-and-forget background task
 /// racing shutdown with no ordering guarantee at all.
-pub struct ClusteringShutdown(Option<tokio::task::JoinHandle<()>>);
+#[derive(Debug)]
+pub(crate) enum ClusteringShutdownDecision {
+    Release(crate::server::room_serving_quiescence::RoomServingFence),
+    Abandon,
+}
+
+pub struct ClusteringShutdown {
+    decision: Option<tokio::sync::oneshot::Sender<ClusteringShutdownDecision>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
 
 impl ClusteringShutdown {
-    /// Await the node-lease loop's own exit, bounded by `budget` so a
-    /// wedged drain task cannot hang process shutdown forever — a timeout
-    /// here is logged and the process proceeds to exit anyway: any
-    /// un-released claims are simply fenced-safe and reclaimed later by
-    /// another node's orphan reaper (`claims_abandoned_on_drain` already
-    /// counts them). A `None` inner handle (clustering disabled, or a
-    /// build without the `clustering` feature) returns immediately.
+    /// Compatibility fail-closed await used by callers that have no terminal
+    /// room-serving fence. It always authorizes `Abandon`, never release.
     pub async fn await_drain(self, budget: Duration) {
-        let Some(handle) = self.0 else {
+        self.authorize_and_await(ClusteringShutdownDecision::Abandon, budget)
+            .await;
+    }
+
+    /// Deliver the one-shot terminal room-claim decision, then await the
+    /// node-lease loop's own exit.
+    ///
+    /// The node-lease task marks itself draining and keeps renewing its
+    /// heartbeat after process shutdown begins while it waits for this
+    /// decision. Only [`ClusteringShutdownDecision::Release`] carries the
+    /// unforgeable process-wide room-serving fence; a closed sender is
+    /// interpreted as [`ClusteringShutdownDecision::Abandon`].
+    pub(crate) async fn authorize_and_await(
+        mut self,
+        mut decision: ClusteringShutdownDecision,
+        budget: Duration,
+    ) {
+        if matches!(
+            &decision,
+            ClusteringShutdownDecision::Release(fence) if !fence.is_current_clean()
+        ) {
+            tracing::warn!(
+                "clustering: room-serving fence was invalidated before authorization; \
+                 abandoning room claims"
+            );
+            decision = ClusteringShutdownDecision::Abandon;
+        }
+        if let Some(sender) = self.decision.take() {
+            let _ = sender.send(decision);
+        }
+        let Some(handle) = self.task else {
             return;
         };
         if tokio::time::timeout(budget, handle).await.is_err() {
@@ -588,14 +622,21 @@ impl ClusteringShutdown {
 /// up the owned libp2p swarm (later slices) and returns live handles onto
 /// the same `ClaimStore`/node-identity the node-lease loop itself uses,
 /// plus the node-lease task's own join handle (Slice 10).
-pub async fn start_if_enabled(
+pub(crate) async fn start_if_enabled(
     config: &ClusteringConfig,
     db: &Database,
     stop_token: &CancellationToken,
     readiness: ClusteringReadiness,
+    room_serving: crate::server::room_serving_quiescence::RoomServingHandle,
 ) -> Result<(ClusteringHandles, ClusteringShutdown), ClusteringError> {
     if !config.enabled {
-        return Ok((ClusteringHandles::default(), ClusteringShutdown(None)));
+        return Ok((
+            ClusteringHandles::default(),
+            ClusteringShutdown {
+                decision: None,
+                task: None,
+            },
+        ));
     }
 
     let driver = db.driver();
@@ -605,7 +646,7 @@ pub async fn start_if_enabled(
     // failure and is reported before the Postgres prerequisite.
     #[cfg(not(feature = "clustering"))]
     {
-        let _ = (db, stop_token, driver, readiness);
+        let _ = (db, stop_token, driver, readiness, room_serving);
         Err(ClusteringError::FeatureNotCompiled)
     }
 
@@ -631,6 +672,9 @@ pub async fn start_if_enabled(
             clustering_stop.clone(),
             &config.messaging,
         );
+        // Wire release safety before the relay actor/swarm can accept its
+        // first room-capable message.
+        ordered_relay_delivery_bridge.wire_room_serving(room_serving);
         // ADR-0017 Phase 3 Slice 7: constructed empty for the same
         // construction-order reason as `resume_bridge` — the MUC room
         // registry doesn't exist yet at this point in startup (it is
@@ -779,7 +823,8 @@ pub async fn start_if_enabled(
         // `server/mod.rs` can await this node's graceful drain (which this
         // task runs on its own exit) actually completing before process
         // exit — see `ClusteringShutdown`'s doc comment.
-        let node_lease_task = tokio::spawn(self_fence::run_node_lease(
+        let (shutdown_decision, shutdown_decision_rx) = tokio::sync::oneshot::channel();
+        let node_lease_task = tokio::spawn(self_fence::run_node_lease_authorized(
             node_lease,
             node_identity,
             clustering_stop,
@@ -799,8 +844,15 @@ pub async fn start_if_enabled(
                 claim_store: Arc::new(claims::PostgresClaimStore::new(db.clone())),
                 claim_release_budget: config.node_lease.claim_release_budget,
             },
+            shutdown_decision_rx,
         ));
-        Ok((handles, ClusteringShutdown(Some(node_lease_task))))
+        Ok((
+            handles,
+            ClusteringShutdown {
+                decision: Some(shutdown_decision),
+                task: Some(node_lease_task),
+            },
+        ))
     }
 }
 

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -31,14 +31,15 @@ use super::route_bridge::{
     RemoteResourceRouteOutcome, RemoteResourceRouteTarget, RemoteResourceSocketGeneration,
     RemoteResourceStateSnapshot, RemoteResourceStateUpdate, RemoteUserSideEffect,
 };
-use super::self_fence::LocallyClaimedEntities;
+use super::self_fence::{ConnectedPeerCount, LocallyClaimedEntities};
 use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
 use kameo::error::RemoteSendError;
 use kameo::message::{Context, Message};
 use kameo::{Actor, RemoteActor, Reply};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
@@ -59,6 +60,43 @@ const LOCAL_FORCE_DETACH_ACK_TIMEOUT: Duration = Duration::from_secs(10);
 /// kademlia name (O(1) registrations per node, never per entity).
 pub fn relay_name(node_id: &NodeId) -> String {
     format!("waddle-relay/{node_id}")
+}
+
+/// Read-only per-peer transport multiplicity maintained by the swarm.
+///
+/// The production isolation decision deliberately uses [`ConnectedPeerCount`]
+/// instead: one or two transports to the same peer are equivalent for
+/// reachability. This finer snapshot exists for the fault-gated cluster
+/// harness so its simultaneous cross-dial regression can prove that both
+/// authenticated transports were established and retained.
+#[derive(Clone, Default)]
+pub struct ConnectedTransportCounts(Arc<RwLock<HashMap<libp2p::PeerId, u32>>>);
+
+impl ConnectedTransportCounts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set(&self, peer_id: libp2p::PeerId, count: u32) {
+        let mut counts = self
+            .0
+            .write()
+            .expect("connected transport count lock poisoned");
+        if count == 0 {
+            counts.remove(&peer_id);
+        } else {
+            counts.insert(peer_id, count);
+        }
+    }
+
+    pub fn get(&self, peer_id: &libp2p::PeerId) -> u32 {
+        self.0
+            .read()
+            .expect("connected transport count lock poisoned")
+            .get(peer_id)
+            .copied()
+            .unwrap_or(0)
+    }
 }
 
 /// Backoff between supervised respawn/re-registration attempts.
@@ -139,6 +177,12 @@ async fn register_relay_actor(
 #[remote_actor(id = "waddle.clustering.relay-actor.v1")]
 pub struct RelayActor {
     node_id: NodeId,
+    /// Read-only peer-level connectivity snapshot used by the fault-gated
+    /// subprocess probe to prove it did not repair a missing route itself.
+    connected_peers: ConnectedPeerCount,
+    /// Read-only transport multiplicity for the exact target peer, used only
+    /// by the fault-gated simultaneous cross-dial harness.
+    connected_transports: ConnectedTransportCounts,
     /// When false (production), the fault-injection messages are inert acks.
     fault_injection: bool,
     /// ADR-0017 Phase 3 Slice 6: this node's bridge to its own live
@@ -159,6 +203,8 @@ pub struct RelayActor {
 impl RelayActor {
     pub fn new(
         node_id: NodeId,
+        connected_peers: ConnectedPeerCount,
+        connected_transports: ConnectedTransportCounts,
         fault_injection: bool,
         resume_bridge: Arc<ResumeStealBridge>,
         room_local_claims: Arc<RoomLocalClaims>,
@@ -166,6 +212,8 @@ impl RelayActor {
     ) -> Self {
         Self {
             node_id,
+            connected_peers,
+            connected_transports,
             fault_injection,
             resume_bridge,
             room_local_claims,
@@ -258,8 +306,14 @@ async fn finish_ordered_reservation(
                     .lock()
                     .await
                     .commit_reserved_with_replies(*reserved, client_replies),
-                Ok(Err(reason)) => receiver.lock().await.abort_reserved(*reserved, reason),
+                Ok(Err(reason)) => {
+                    if reason == OrderedRelayNackReason::MaybeCommitted {
+                        delivery_bridge.mark_unsafe_to_release();
+                    }
+                    receiver.lock().await.abort_reserved(*reserved, reason)
+                }
                 Err(_) => {
+                    delivery_bridge.mark_unsafe_to_release();
                     tracing::warn!(
                         timeout_ms = delivery_timeout.as_millis(),
                         channel = ?envelope.channel,
@@ -305,12 +359,54 @@ impl Message<RelayDeliverOrdered> for RelayActor {
     ) -> Self::Reply {
         let receiver = Arc::clone(&self.ordered_receiver);
         let delivery_bridge = Arc::clone(&self.ordered_delivery_bridge);
+        let room_scope = delivery_bridge.try_room_serving_scope();
         let reservation = receiver.lock().await.reserve(msg.envelope);
-        ctx.spawn(async move {
-            let reply = finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
-            record_ordered_relay_reply(&reply);
-            reply
-        })
+        match room_scope {
+            Ok(Some(mut scope)) => {
+                // Arm before Context::spawn so a never-polled or aborted
+                // delegated future still latches terminal release unsafe.
+                scope.arm();
+                ctx.spawn(async move {
+                    let reply =
+                        finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
+                    record_ordered_relay_reply(&reply);
+                    if matches!(
+                        &reply,
+                        OrderedRelayReply::Nack(nack)
+                            if nack.reason == OrderedRelayNackReason::MaybeCommitted
+                    ) {
+                        scope.poison();
+                    } else {
+                        scope.complete_clean();
+                    }
+                    reply
+                })
+            }
+            Ok(None) => {
+                // Unit-test-only unwired bridges retain the legacy path.
+                ctx.spawn(async move {
+                    let reply =
+                        finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
+                    record_ordered_relay_reply(&reply);
+                    reply
+                })
+            }
+            Err(error) => ctx.spawn(async move {
+                tracing::debug!(
+                    ?error,
+                    "ordered relay receiver rejected room-capable delivery during shutdown"
+                );
+                let reply = match reservation {
+                    OrderedRelayReservation::Reserved(reserved) => receiver
+                        .lock()
+                        .await
+                        .abort_reserved(*reserved, OrderedRelayNackReason::Unreachable),
+                    OrderedRelayReservation::Completed(reply) => reply,
+                };
+                record_ordered_relay_reply(&reply);
+                reply
+            }),
+        }
     }
 }
 
@@ -477,7 +573,38 @@ impl Message<RelayRouteRemoteResourceStanza> for RelayActor {
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.route_remote_resource_stanza_on_owner(msg).await })
+        match bridge.try_room_serving_scope() {
+            Ok(Some(mut scope)) => {
+                scope.arm();
+                ctx.spawn(async move {
+                    let reply = bridge.route_remote_resource_stanza_on_owner(msg).await;
+                    if matches!(
+                        reply.outcome,
+                        RemoteResourceRouteOutcome::MaybeCommitted
+                            | RemoteResourceRouteOutcome::JoinMaybeCommitted
+                    ) {
+                        bridge.mark_unsafe_to_release();
+                        scope.poison();
+                    } else {
+                        scope.complete_clean();
+                    }
+                    reply
+                })
+            }
+            Ok(None) => {
+                ctx.spawn(async move { bridge.route_remote_resource_stanza_on_owner(msg).await })
+            }
+            Err(error) => ctx.spawn(async move {
+                tracing::debug!(
+                    ?error,
+                    "remote-resource route rejected room-capable delivery during shutdown"
+                );
+                RelayRouteRemoteResourceStanzaReply {
+                    outcome: RemoteResourceRouteOutcome::Unavailable,
+                    replies: Vec::new(),
+                }
+            }),
+        }
     }
 }
 
@@ -687,6 +814,53 @@ pub struct RelaySleep {
     pub millis: u64,
 }
 
+/// Harness fault injection: make this relay resolve and ping another node's
+/// relay. This proves an exact subprocess-to-subprocess direction rather than
+/// merely proving that the test process can reach both nodes independently.
+/// Inert unless fault injection is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayProbePeer {
+    pub node_id: NodeId,
+    #[serde(with = "peer_id_serde")]
+    pub peer_id: libp2p::PeerId,
+}
+
+mod peer_id_serde {
+    use libp2p::PeerId;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(peer_id: &PeerId, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&peer_id.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<PeerId, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Reply to [`RelayProbePeer`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Reply)]
+pub enum RelayProbePeerReply {
+    Disabled,
+    Reachable {
+        node_id: NodeId,
+        source_connected_peers_before: i64,
+        source_connections_to_target_before: u32,
+    },
+    Unreachable {
+        source_connected_peers_before: i64,
+        source_connections_to_target_before: u32,
+    },
+}
+
 /// Reply to the fault-injection messages: whether the fault was applied
 /// (false = fault injection disabled on this node).
 #[derive(Debug, Clone, Serialize, Deserialize, Reply)]
@@ -738,19 +912,80 @@ impl Message<RelaySleep> for RelayActor {
     }
 }
 
+#[kameo::remote_message("waddle.clustering.relay.probe_peer.v1")]
+impl Message<RelayProbePeer> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayProbePeerReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayProbePeer,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if !self.fault_injection {
+            return ctx.spawn(async { RelayProbePeerReply::Disabled });
+        }
+        let source_connected_peers_before = self.connected_peers.get();
+        let source_connections_to_target_before = self.connected_transports.get(&msg.peer_id);
+        if msg.node_id == self.node_id {
+            let node_id = self.node_id.clone();
+            return ctx.spawn(async move {
+                RelayProbePeerReply::Reachable {
+                    node_id,
+                    source_connected_peers_before,
+                    source_connections_to_target_before,
+                }
+            });
+        }
+
+        // Delegate the nested remote ask so this relay's mailbox remains
+        // available to answer the other endpoint's RelayPing. Running both
+        // directions inline can make A wait for a ping queued behind A's
+        // probe while B waits for the reciprocal queued ping.
+        ctx.spawn(async move {
+            let mut peer = RelayHandle::new(msg.node_id, CancellationToken::new());
+            match peer.ping().await {
+                Ok(pong) => RelayProbePeerReply::Reachable {
+                    node_id: pong.node_id,
+                    source_connected_peers_before,
+                    source_connections_to_target_before,
+                },
+                Err(_) => RelayProbePeerReply::Unreachable {
+                    source_connected_peers_before,
+                    source_connections_to_target_before,
+                },
+            }
+        })
+    }
+}
+
+/// Complete dependency set for one supervised relay lifetime.
+pub(super) struct RelaySupervisorInputs {
+    pub(super) node_id: NodeId,
+    pub(super) connected_peers: ConnectedPeerCount,
+    pub(super) connected_transports: ConnectedTransportCounts,
+    pub(super) fault_injection: bool,
+    pub(super) stop_token: CancellationToken,
+    pub(super) resume_bridge: Arc<ResumeStealBridge>,
+    pub(super) room_local_claims: Arc<RoomLocalClaims>,
+    pub(super) ordered_delivery_bridge: Arc<OrderedRelayDeliveryBridge>,
+}
+
 /// Spawn the node's relay actor under supervision: register it in kademlia
 /// under [`relay_name`], respawn it if it ever stops unexpectedly, and
 /// **re-register under the same name** on every respawn (kameo auto-registers
 /// removal on actor stop, so re-registration is mandatory, not optional).
 /// Stops cleanly when `stop_token` fires.
-pub fn spawn_supervised(
-    node_id: NodeId,
-    fault_injection: bool,
-    stop_token: CancellationToken,
-    resume_bridge: Arc<ResumeStealBridge>,
-    room_local_claims: Arc<RoomLocalClaims>,
-    ordered_delivery_bridge: Arc<OrderedRelayDeliveryBridge>,
-) -> RelayRegistrationTrigger {
+pub(super) fn spawn_supervised(inputs: RelaySupervisorInputs) -> RelayRegistrationTrigger {
+    let RelaySupervisorInputs {
+        node_id,
+        connected_peers,
+        connected_transports,
+        fault_injection,
+        stop_token,
+        resume_bridge,
+        room_local_claims,
+        ordered_delivery_bridge,
+    } = inputs;
     let (trigger_tx, mut trigger_rx) = mpsc::channel(1);
     tokio::spawn(async move {
         let name = relay_name(&node_id);
@@ -762,6 +997,8 @@ pub fn spawn_supervised(
             }
             let actor_ref: ActorRef<RelayActor> = RelayActor::spawn(RelayActor::new(
                 node_id.clone(),
+                connected_peers.clone(),
+                connected_transports.clone(),
                 fault_injection,
                 Arc::clone(&resume_bridge),
                 Arc::clone(&room_local_claims),
@@ -1191,6 +1428,34 @@ impl RelayHandle {
         let remote_ref = self.resolve().await?;
         remote_ref
             .ask(&RelaySleep { millis })
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+            .map_err(send_error)
+    }
+
+    /// Harness: ask this node's relay to resolve and ping `node_id`.
+    pub async fn probe_peer(
+        &mut self,
+        node_id: NodeId,
+        peer_id: libp2p::PeerId,
+    ) -> Result<RelayProbePeerReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.probe_peer_inner(node_id, peer_id) => result,
+        }
+    }
+
+    async fn probe_peer_inner(
+        &mut self,
+        node_id: NodeId,
+        peer_id: libp2p::PeerId,
+    ) -> Result<RelayProbePeerReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        remote_ref
+            .ask(&RelayProbePeer { node_id, peer_id })
             .mailbox_timeout(self.mailbox_timeout)
             .reply_timeout(self.reply_timeout)
             .await
@@ -2172,6 +2437,8 @@ mod tests {
         resume_bridge.wire(Arc::clone(&registry));
         let actor_ref: kameo::actor::ActorRef<RelayActor> = RelayActor::spawn(RelayActor::new(
             NodeId::new("node-under-test".to_string()),
+            ConnectedPeerCount::new(),
+            ConnectedTransportCounts::new(),
             false,
             resume_bridge,
             RoomLocalClaims::new(),

--- a/server/crates/waddle-server/src/clustering/resume_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/resume_bridge.rs
@@ -143,6 +143,7 @@ impl ResumeStealBridge {
             // identically to not-live-locally so the asker re-checks
             // persistence and retries.
             Ok(Ok(ForceDetachOutcome::NotPersisted)) => LocalForcedDetachOutcome::NotLiveLocally,
+            Ok(Ok(ForceDetachOutcome::Unavailable)) => LocalForcedDetachOutcome::NotLiveLocally,
             // The connection's task died mid-flight without answering, or
             // this bridge's own bounded wait elapsed first — either way,
             // conservative: report not-live-locally so the asker re-checks

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -24,8 +24,8 @@ use waddle_xmpp::ownership::{
 use waddle_xmpp::protocol::CarbonKind;
 use waddle_xmpp::registry::{
     BroadcastOutcome, ConnectionEntry, ConnectionRegistry, DeliveryKind, ForceDetachOutcome,
-    ForceDetachRequest, OutboundStanza, PresenceState, RegisterUserResourceIfOwnerOrAbsent,
-    UnregisterUserResource, UserRegistryActor,
+    ForceDetachRequest, OutboundStanza, PresenceState,
+    RegisterUserResourceIfOwnerOrAbsentUnderAuthority, UnregisterUserResource, UserRegistryActor,
 };
 use waddle_xmpp::roster::{RosterItem, RosterVersion};
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
@@ -89,6 +89,12 @@ pub struct OrderedRelayDeliveryServices {
     pub sm_session_registry: Arc<InMemorySmSessionRegistry>,
     pub blocking_storage: Arc<dyn BlockingStorage>,
     pub web_socket_state: Weak<WebSocketState>,
+}
+
+fn mark_services_unsafe_to_release(services: &OrderedRelayDeliveryServices) {
+    if let Some(state) = services.web_socket_state.upgrade() {
+        state.deps.room_serving.mark_unsafe_to_release();
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -326,6 +332,7 @@ impl From<FullJidDeliveryOutcome> for RemoteResourceRouteOutcome {
             FullJidDeliveryOutcome::QueuedDetached => Self::QueuedDetached,
             FullJidDeliveryOutcome::Unavailable => Self::Unavailable,
             FullJidDeliveryOutcome::Dropped => Self::Dropped,
+            FullJidDeliveryOutcome::MaybeEnqueued => Self::MaybeCommitted,
             FullJidDeliveryOutcome::MaybeCommitted => Self::MaybeCommitted,
         }
     }
@@ -440,16 +447,27 @@ struct RemoteDeliverySeed {
     is_iq: bool,
 }
 
+#[cfg(test)]
+struct RemoteOwnerPublicationTestPause {
+    reached: tokio::sync::oneshot::Sender<()>,
+    resume: tokio::sync::oneshot::Receiver<()>,
+}
+
 /// Construction-order bridge plus shared sender sequencing state.
 pub struct OrderedRelayDeliveryBridge {
     services: OnceLock<Arc<OrderedRelayDeliveryServices>>,
     origin_signer: OnceLock<RelayOriginSigner>,
+    room_serving: OnceLock<crate::server::room_serving_quiescence::RoomServingHandle>,
     sender_state: Mutex<OrderedRelaySenderState>,
     channel_locks: Mutex<HashMap<OrderedRelayChannel, Arc<Mutex<()>>>>,
     remote_socket_resources: Mutex<HashMap<jid::FullJid, RemoteSocketRegistration>>,
     remote_socket_generations: Mutex<HashMap<jid::FullJid, RemoteResourceSocketGeneration>>,
     remote_owner_resources: Mutex<HashMap<jid::FullJid, RemoteOwnerRegistration>>,
     remote_owner_registration_locks: Mutex<HashMap<jid::FullJid, Arc<Mutex<()>>>>,
+    #[cfg(test)]
+    test_muc_proxy_route_decision: Mutex<Option<MucProxyRouteDecision>>,
+    #[cfg(test)]
+    test_remote_owner_publication_pause: Mutex<Option<RemoteOwnerPublicationTestPause>>,
     stop_token: CancellationToken,
     mailbox_timeout: Duration,
     reply_timeout: Duration,
@@ -520,12 +538,17 @@ impl OrderedRelayDeliveryBridge {
         Arc::new(Self {
             services: OnceLock::new(),
             origin_signer: OnceLock::new(),
+            room_serving: OnceLock::new(),
             sender_state: Mutex::new(OrderedRelaySenderState::default()),
             channel_locks: Mutex::new(HashMap::new()),
             remote_socket_resources: Mutex::new(HashMap::new()),
             remote_socket_generations: Mutex::new(HashMap::new()),
             remote_owner_resources: Mutex::new(HashMap::new()),
             remote_owner_registration_locks: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            test_muc_proxy_route_decision: Mutex::new(None),
+            #[cfg(test)]
+            test_remote_owner_publication_pause: Mutex::new(None),
             stop_token,
             // WebSocket stanza dispatch has a 15s wedge backstop. Full-JID
             // ordered delivery must resolve before that backstop can cancel
@@ -545,6 +568,71 @@ impl OrderedRelayDeliveryBridge {
                  ignoring duplicate service bundle"
             );
         }
+    }
+
+    /// Wire the process-wide release-safety latch after startup constructs the
+    /// clustering bridge. Relay ambiguity must poison terminal release but
+    /// must not stop live admission.
+    pub(crate) fn wire_room_serving(
+        &self,
+        room_serving: crate::server::room_serving_quiescence::RoomServingHandle,
+    ) {
+        if self.room_serving.set(room_serving).is_err() {
+            tracing::error!(
+                "OrderedRelayDeliveryBridge::wire_room_serving called more than once; \
+                 ignoring duplicate room-serving capability"
+            );
+        }
+    }
+
+    pub(crate) fn mark_unsafe_to_release(&self) {
+        if let Some(room_serving) = self.room_serving.get() {
+            room_serving.mark_unsafe_to_release();
+        }
+    }
+
+    pub(crate) fn try_room_serving_scope(
+        &self,
+    ) -> Result<
+        Option<crate::server::room_serving_quiescence::RoomServingScope>,
+        crate::server::room_serving_quiescence::RoomServingAdmissionError,
+    > {
+        self.room_serving
+            .get()
+            .map(|room_serving| room_serving.try_scope().map(Some))
+            .unwrap_or(Ok(None))
+    }
+
+    fn observe_relay_error(&self, error: &RelayAskError) {
+        if ask_error_maybe_committed(error) {
+            self.mark_unsafe_to_release();
+        }
+    }
+
+    fn observe_muc_outcome(&self, outcome: &OrderedRelayMucProxyOutcome) {
+        if matches!(
+            outcome,
+            OrderedRelayMucProxyOutcome::MaybeCommitted
+                | OrderedRelayMucProxyOutcome::JoinMaybeCommitted
+        ) {
+            self.mark_unsafe_to_release();
+        }
+    }
+
+    fn observe_muc_decision(&self, decision: &MucProxyRouteDecision) {
+        if let MucProxyRouteDecision::Attempted(outcome) = decision {
+            self.observe_muc_outcome(outcome);
+        }
+    }
+
+    #[cfg(test)]
+    async fn set_test_remote_owner_publication_pause(
+        &self,
+        reached: tokio::sync::oneshot::Sender<()>,
+        resume: tokio::sync::oneshot::Receiver<()>,
+    ) {
+        *self.test_remote_owner_publication_pause.lock().await =
+            Some(RemoteOwnerPublicationTestPause { reached, resume });
     }
 
     pub fn wire_origin_signer(&self, keypair: Keypair) {
@@ -684,7 +772,20 @@ impl OrderedRelayDeliveryBridge {
             };
 
             if let Some(handoff) = origin.handoff.clone() {
+                let mut room_scope = match self.try_room_serving_scope() {
+                    Ok(scope) => scope,
+                    Err(error) => {
+                        tracing::debug!(
+                            ?error,
+                            "ordered-relay deferred full-JID delivery rejected during shutdown"
+                        );
+                        return Some(FullJidDeliveryOutcome::Dropped);
+                    }
+                };
                 if handoff.mark_deferred() {
+                    if let Some(scope) = room_scope.as_mut() {
+                        scope.arm();
+                    }
                     let bridge = Arc::clone(self);
                     let origin_stanza = stanza.clone();
                     let outcome_target = target.clone();
@@ -711,6 +812,13 @@ impl OrderedRelayDeliveryBridge {
                             .map(|outcome| replies_for_origin_handoff(&origin_stanza, outcome))
                             .unwrap_or_default();
                         handoff.complete(replies);
+                        if let Some(scope) = room_scope {
+                            if delivery_outcome.is_some_and(FullJidDeliveryOutcome::is_ambiguous) {
+                                scope.poison();
+                            } else {
+                                scope.complete_clean();
+                            }
+                        }
                     });
                     return Some(FullJidDeliveryOutcome::Delivered);
                 }
@@ -809,21 +917,38 @@ impl OrderedRelayDeliveryBridge {
             };
 
             if let Some(handoff) = origin.handoff.clone() {
+                let mut room_scope = match self.try_room_serving_scope() {
+                    Ok(scope) => scope,
+                    Err(error) => {
+                        tracing::debug!(
+                            ?error,
+                            "ordered-relay deferred bare-JID delivery rejected during shutdown"
+                        );
+                        return Some(FullJidDeliveryOutcome::Dropped);
+                    }
+                };
                 if handoff.mark_deferred() {
+                    if let Some(scope) = room_scope.as_mut() {
+                        scope.arm();
+                    }
                     let bridge = Arc::clone(self);
                     let origin_stanza = stanza.clone();
                     tokio::spawn(async move {
-                        let replies = bridge
+                        let delivery_outcome = bridge
                             .deliver_seeded_remote(seed, true)
                             .await
-                            .map(|outcome| {
-                                replies_for_origin_handoff(
-                                    &origin_stanza,
-                                    caller_delivery_outcome(outcome),
-                                )
-                            })
+                            .map(caller_delivery_outcome);
+                        let replies = delivery_outcome
+                            .map(|outcome| replies_for_origin_handoff(&origin_stanza, outcome))
                             .unwrap_or_default();
                         handoff.complete(replies);
+                        if let Some(scope) = room_scope {
+                            if delivery_outcome.is_some_and(FullJidDeliveryOutcome::is_ambiguous) {
+                                scope.poison();
+                            } else {
+                                scope.complete_clean();
+                            }
+                        }
                     });
                     return Some(FullJidDeliveryOutcome::Delivered);
                 }
@@ -851,6 +976,22 @@ impl OrderedRelayDeliveryBridge {
             .into_attempted()
     }
 
+    /// Deterministic unit-test seam for the WebSocket MUC caller. Production
+    /// still always goes through the authoritative claim lookup and ordered
+    /// relay path below.
+    #[cfg(test)]
+    pub(crate) async fn set_test_muc_proxy_outcome(&self, outcome: OrderedRelayMucProxyOutcome) {
+        self.set_test_muc_proxy_route_decision(MucProxyRouteDecision::Attempted(outcome))
+            .await;
+    }
+
+    /// Deterministic unit-test seam for typed preflight failures that do not
+    /// attempt a relay send.
+    #[cfg(test)]
+    pub(crate) async fn set_test_muc_proxy_route_decision(&self, decision: MucProxyRouteDecision) {
+        *self.test_muc_proxy_route_decision.lock().await = Some(decision);
+    }
+
     /// Typed variant of [`Self::try_proxy_muc_remote`] (#1249): reports
     /// WHY no relay was attempted instead of a flat `None`, so the
     /// disconnect-cleanup path can converge (forget vs retry) per case.
@@ -861,8 +1002,13 @@ impl OrderedRelayDeliveryBridge {
         kind: OrderedRelayMucProxyKind,
         origin: &OrderedRelayRouteOrigin,
     ) -> MucProxyRouteDecision {
+        #[cfg(test)]
+        if let Some(decision) = self.test_muc_proxy_route_decision.lock().await.take() {
+            self.observe_muc_decision(&decision);
+            return decision;
+        }
         if let Some(remote_origin) = remote_resource_origin(origin) {
-            return match Arc::clone(self)
+            let decision = match Arc::clone(self)
                 .route_remote_resource_origin_muc(
                     remote_origin,
                     RemoteResourceRouteTarget::MucProxy {
@@ -880,9 +1026,14 @@ impl OrderedRelayDeliveryBridge {
                 // remote-resource path — the bridge is not wired yet.
                 None => MucProxyRouteDecision::RoomClaimUnavailable,
             };
+            self.observe_muc_decision(&decision);
+            return decision;
         }
-        self.try_proxy_muc_remote_from_local_origin_decision(room_jid, stanza, kind, origin)
-            .await
+        let decision = self
+            .try_proxy_muc_remote_from_local_origin_decision(room_jid, stanza, kind, origin)
+            .await;
+        self.observe_muc_decision(&decision);
+        decision
     }
 
     async fn try_proxy_muc_remote_from_local_origin(
@@ -892,9 +1043,14 @@ impl OrderedRelayDeliveryBridge {
         kind: OrderedRelayMucProxyKind,
         origin: &OrderedRelayRouteOrigin,
     ) -> Option<OrderedRelayMucProxyOutcome> {
-        self.try_proxy_muc_remote_from_local_origin_decision(room_jid, stanza, kind, origin)
+        let outcome = self
+            .try_proxy_muc_remote_from_local_origin_decision(room_jid, stanza, kind, origin)
             .await
-            .into_attempted()
+            .into_attempted();
+        if let Some(outcome) = &outcome {
+            self.observe_muc_outcome(outcome);
+        }
+        outcome
     }
 
     async fn try_proxy_muc_remote_from_local_origin_decision(
@@ -999,6 +1155,7 @@ impl OrderedRelayDeliveryBridge {
             return MucProxyRouteDecision::RoomClaimUnavailable;
         };
         if outcome.maybe_committed {
+            self.mark_unsafe_to_release();
             if kind == OrderedRelayMucProxyKind::JoinPresence && outcome.join_repair_allowed {
                 self.forget_channel(&retry_channel).await;
                 let retry = Arc::clone(self)
@@ -1031,6 +1188,7 @@ impl OrderedRelayDeliveryBridge {
                         }
                         FullJidDeliveryOutcome::Unavailable
                         | FullJidDeliveryOutcome::Dropped
+                        | FullJidDeliveryOutcome::MaybeEnqueued
                         | FullJidDeliveryOutcome::MaybeCommitted => {}
                     }
                 }
@@ -1048,6 +1206,7 @@ impl OrderedRelayDeliveryBridge {
                             }
                             FullJidDeliveryOutcome::Unavailable
                             | FullJidDeliveryOutcome::Dropped
+                            | FullJidDeliveryOutcome::MaybeEnqueued
                             | FullJidDeliveryOutcome::MaybeCommitted => {}
                         }
                     }
@@ -1065,7 +1224,8 @@ impl OrderedRelayDeliveryBridge {
             }
             FullJidDeliveryOutcome::Unavailable => OrderedRelayMucProxyOutcome::Unavailable,
             FullJidDeliveryOutcome::Dropped => OrderedRelayMucProxyOutcome::Dropped,
-            FullJidDeliveryOutcome::MaybeCommitted => {
+            FullJidDeliveryOutcome::MaybeEnqueued | FullJidDeliveryOutcome::MaybeCommitted => {
+                self.mark_unsafe_to_release();
                 if kind == OrderedRelayMucProxyKind::JoinPresence {
                     OrderedRelayMucProxyOutcome::JoinMaybeCommitted
                 } else {
@@ -1123,6 +1283,7 @@ impl OrderedRelayDeliveryBridge {
         {
             Ok(reply) => reply,
             Err(error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %jid,
                     owner_node = %user_owner.as_str(),
@@ -1139,13 +1300,16 @@ impl OrderedRelayDeliveryBridge {
                     .entry_if_owner(jid, &owner)
                     .is_none()
                 {
-                    let _ = handle
+                    let unregister = handle
                         .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
                             jid: jid.clone(),
                             registration_id,
                             socket_generation,
                         })
                         .await;
+                    if let Err(error) = &unregister {
+                        self.observe_relay_error(error);
+                    }
                     return RemoteResourceRegisterOutcome::Failed;
                 }
                 self.remote_socket_resources.lock().await.insert(
@@ -1175,20 +1339,19 @@ impl OrderedRelayDeliveryBridge {
         owner: &Arc<AtomicBool>,
     ) {
         let registration = {
-            let mut registrations = self.remote_socket_resources.lock().await;
-            match registrations.get(jid) {
-                Some(registration) if Arc::ptr_eq(&registration.owner, owner) => {
-                    registrations.remove(jid)
-                }
-                _ => None,
-            }
+            self.remote_socket_resources
+                .lock()
+                .await
+                .get(jid)
+                .filter(|registration| Arc::ptr_eq(&registration.owner, owner))
+                .cloned()
         };
         let Some(registration) = registration else {
             return;
         };
         let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
             .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
-        if let Err(error) = handle
+        match handle
             .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
                 jid: jid.clone(),
                 registration_id: registration.registration_id,
@@ -1196,12 +1359,25 @@ impl OrderedRelayDeliveryBridge {
             })
             .await
         {
-            tracing::warn!(
-                jid = %jid,
-                %error,
-                "clustered remote-resource unregister ask failed; owner-side stale \
-                 entry will self-heal on closed-channel delivery"
-            );
+            Ok(_) => {
+                self.remove_remote_socket_registration_if_current(jid, &registration)
+                    .await;
+            }
+            Err(error) => {
+                self.observe_relay_error(&error);
+                // Retain the exact registration as a local teardown tombstone.
+                // Normal callers have already owner-gated the
+                // ConnectionRegistry entry away. If the owner later asks
+                // during drain, the retained owner token lets this node prove
+                // `NotLive`; erasing it here would collapse that proof into an
+                // ambiguous map miss.
+                tracing::warn!(
+                    jid = %jid,
+                    %error,
+                    "clustered remote-resource unregister ask failed; retaining exact \
+                     local teardown proof until owner-side stale entry self-heals"
+                );
+            }
         }
     }
 
@@ -1245,6 +1421,7 @@ impl OrderedRelayDeliveryBridge {
                     .await;
             }
             Err(error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %jid,
                     %error,
@@ -1339,26 +1516,24 @@ impl OrderedRelayDeliveryBridge {
             Ok(RelayRemoteUserSideEffectReply {
                 status: RelayRemoteUserSideEffectStatus::StaleRegistration,
             }) => {
-                self.remove_remote_socket_registration_if_current(source_jid, &registration)
+                self.detach_stale_remote_socket_resource(source_jid, &registration)
                     .await;
                 false
             }
             Ok(RelayRemoteUserSideEffectReply {
                 status: RelayRemoteUserSideEffectStatus::Unavailable,
             }) => false,
-            Err(RelayAskError::Send {
-                effect: RelaySendEffect::MaybeCommitted,
-                message,
-                ..
-            }) => {
+            Err(error) if ask_error_maybe_committed(&error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %source_jid,
-                    %message,
+                    %error,
                     "clustered remote-user side-effect relay may have committed; suppressing local fallback"
                 );
                 true
             }
             Err(error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %source_jid,
                     %error,
@@ -1554,6 +1729,16 @@ impl OrderedRelayDeliveryBridge {
             }
         }
 
+        // Terminal UserActor drain disables this exact authority source before
+        // it inventories both registration views and releases claims. Hold
+        // the read side across the actor publication, ConnectionRegistry
+        // insertion, and every rollback, so an in-flight relay task cannot
+        // publish a resource after drain verification.
+        let Some(publication_guard) = services.node_identity.guard_if_current(&me).await else {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        };
         let (tx, rx) = mpsc::channel(REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE);
         let entry = ConnectionEntry::new(tx);
         apply_remote_resource_state(&entry, &msg.state);
@@ -1561,16 +1746,22 @@ impl OrderedRelayDeliveryBridge {
         let force_detach_rx = entry.take_force_detach_rx();
         match services
             .user_registry
-            .ask(RegisterUserResourceIfOwnerOrAbsent {
+            .ask(RegisterUserResourceIfOwnerOrAbsentUnderAuthority {
                 jid: msg.jid.clone(),
                 entry: entry.clone(),
                 owner: owner.clone(),
+                publication_permit: publication_guard.permit(),
             })
             .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
             .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
             .await
         {
             Ok(true) => {
+                #[cfg(test)]
+                if let Some(pause) = self.test_remote_owner_publication_pause.lock().await.take() {
+                    let _ = pause.reached.send(());
+                    let _ = pause.resume.await;
+                }
                 let registration = RemoteOwnerRegistration {
                     registration_id: msg.registration_id,
                     socket_node: msg.socket_node.clone(),
@@ -1637,6 +1828,12 @@ impl OrderedRelayDeliveryBridge {
                     %error,
                     "clustered remote-resource owner registration failed"
                 );
+                // `reply_timeout` does not cancel an already-enqueued
+                // UserRegistry/UserActor registration. Queue an owner-gated
+                // rollback while the outer publication guard is still held;
+                // UserRegistry mailbox ordering makes it follow any late
+                // register without touching a racing replacement.
+                let _ = unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await;
                 RelayRemoteResourceRegistrationReply {
                     status: RelayRemoteResourceRegistrationStatus::Unavailable,
                 }
@@ -1971,7 +2168,20 @@ impl OrderedRelayDeliveryBridge {
     ) -> Option<FullJidDeliveryOutcome> {
         let outcome_log = route_outcome_log(&target);
         if let Some(handoff) = origin.handoff.clone() {
+            let mut room_scope = match self.try_room_serving_scope() {
+                Ok(scope) => scope,
+                Err(error) => {
+                    tracing::debug!(
+                        ?error,
+                        "remote-resource deferred route rejected during shutdown"
+                    );
+                    return Some(FullJidDeliveryOutcome::Dropped);
+                }
+            };
             if handoff.mark_deferred() {
+                if let Some(scope) = room_scope.as_mut() {
+                    scope.arm();
+                }
                 let bridge = Arc::clone(&self);
                 let origin_stanza = origin_stanza.clone();
                 tokio::spawn(async move {
@@ -1981,6 +2191,13 @@ impl OrderedRelayDeliveryBridge {
                         .unwrap_or(FullJidDeliveryOutcome::Dropped);
                     log_remote_resource_route_outcome(&outcome_log, outcome);
                     handoff.complete(replies_for_origin_handoff(&origin_stanza, outcome));
+                    if let Some(scope) = room_scope {
+                        if outcome.is_ambiguous() {
+                            scope.poison();
+                        } else {
+                            scope.complete_clean();
+                        }
+                    }
                 });
                 return Some(FullJidDeliveryOutcome::Delivered);
             }
@@ -2165,14 +2382,18 @@ impl OrderedRelayDeliveryBridge {
         let mut handle =
             RelayHandle::new(remote_origin.user_owner.clone(), self.stop_token.clone())
                 .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
-        handle
+        let result = handle
             .route_remote_resource_stanza(RelayRouteRemoteResourceStanza {
                 source_jid: remote_origin.jid.clone(),
                 registration_id: remote_origin.registration_id,
                 socket_generation: remote_origin.socket_generation,
                 target,
             })
-            .await
+            .await;
+        if let Err(error) = &result {
+            self.observe_relay_error(error);
+        }
+        result
     }
 
     async fn route_remote_resource_target_from_local_origin(
@@ -2276,10 +2497,14 @@ impl OrderedRelayDeliveryBridge {
         };
         let me = services.node_identity.current();
         if snapshot.owner_lease_fresh && snapshot.owner == me {
-            match crate::server::dual_registration::mirror_register_outcome(
+            let Some(publication_guard) = services.node_identity.guard_if_current(&me).await else {
+                return RemoteResourceOriginRefresh::Failed;
+            };
+            match crate::server::dual_registration::mirror_register_outcome_under_authority(
                 &services.user_registry,
                 remote_origin.jid.clone(),
                 entry,
+                publication_guard.permit(),
             )
             .await
             {
@@ -2582,6 +2807,7 @@ impl OrderedRelayDeliveryBridge {
                 None
             }
             Err(error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %target,
                     message_id = stanza_message_id(stanza),
@@ -2608,7 +2834,7 @@ impl OrderedRelayDeliveryBridge {
     ) -> RelayForceDetachRemoteUserResourceReply {
         let Some(services) = self.services.get().cloned() else {
             return RelayForceDetachRemoteUserResourceReply {
-                outcome: ForceDetachOutcome::NotPersisted,
+                outcome: ForceDetachOutcome::Unavailable,
                 status: RelayRemoteResourceForceDetachStatus::Unknown,
             };
         };
@@ -2621,8 +2847,8 @@ impl OrderedRelayDeliveryBridge {
         };
         let Some(registration) = registration else {
             return RelayForceDetachRemoteUserResourceReply {
-                outcome: ForceDetachOutcome::NotPersisted,
-                status: RelayRemoteResourceForceDetachStatus::NotLive,
+                outcome: ForceDetachOutcome::Unavailable,
+                status: RelayRemoteResourceForceDetachStatus::Unknown,
             };
         };
         let Some(entry) = services
@@ -2641,7 +2867,7 @@ impl OrderedRelayDeliveryBridge {
         };
         if entry.force_detach_sender().try_send(request).is_err() {
             return RelayForceDetachRemoteUserResourceReply {
-                outcome: ForceDetachOutcome::NotPersisted,
+                outcome: ForceDetachOutcome::Unavailable,
                 status: RelayRemoteResourceForceDetachStatus::Unknown,
             };
         }
@@ -2659,8 +2885,12 @@ impl OrderedRelayDeliveryBridge {
                     ForceDetachOutcome::IdentityMismatch,
                     RelayRemoteResourceForceDetachStatus::Refused,
                 ),
+                Ok(Ok(ForceDetachOutcome::Unavailable)) => (
+                    ForceDetachOutcome::Unavailable,
+                    RelayRemoteResourceForceDetachStatus::Unknown,
+                ),
                 Ok(Err(_)) | Err(_) => (
-                    ForceDetachOutcome::NotPersisted,
+                    ForceDetachOutcome::Unavailable,
                     RelayRemoteResourceForceDetachStatus::Unknown,
                 ),
             };
@@ -2675,26 +2905,42 @@ impl OrderedRelayDeliveryBridge {
         let Some(services) = self.services.get().cloned() else {
             return;
         };
-        {
-            let mut registrations = self.remote_socket_resources.lock().await;
-            if registrations.get(jid).is_some_and(|current| {
-                current.registration_id == registration.registration_id
-                    && current.socket_generation == registration.socket_generation
-            }) {
-                registrations.remove(jid);
-            }
-        }
         let Some(entry) = services
             .connection_registry
             .entry_if_owner(jid, &registration.owner)
         else {
+            self.remove_remote_socket_registration_if_current(jid, registration)
+                .await;
             return;
         };
-        let (ack, _ack_rx) = tokio::sync::oneshot::channel();
-        let _ = entry.force_detach_sender().try_send(ForceDetachRequest {
+        let (ack, ack_rx) = tokio::sync::oneshot::channel();
+        if let Err(error) = entry.force_detach_sender().try_send(ForceDetachRequest {
             requester_bare_jid: jid.to_bare(),
             ack,
-        });
+        }) {
+            tracing::warn!(
+                jid = %jid,
+                ?error,
+                "clustered stale remote-resource detach could not be queued; retaining \
+                 registration because the socket may still be live"
+            );
+            return;
+        }
+        match tokio::time::timeout(self.reply_timeout, ack_rx).await {
+            Ok(Ok(ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted)) => {
+                self.remove_remote_socket_registration_if_current(jid, registration)
+                    .await;
+            }
+            Ok(Ok(ForceDetachOutcome::IdentityMismatch | ForceDetachOutcome::Unavailable))
+            | Ok(Err(_))
+            | Err(_) => {
+                tracing::warn!(
+                    jid = %jid,
+                    "clustered stale remote-resource detach was not authoritatively \
+                     acknowledged; retaining registration"
+                );
+            }
+        }
     }
 
     async fn retire_remote_owner_registration(
@@ -2741,6 +2987,7 @@ impl OrderedRelayDeliveryBridge {
                 return true;
             }
             Err(error) => {
+                self.observe_relay_error(&error);
                 tracing::warn!(
                     jid = %jid,
                     ?error,
@@ -2826,7 +3073,21 @@ impl OrderedRelayDeliveryBridge {
         let outbound_socket_node = socket_node.clone();
         tokio::spawn(async move {
             while let Some(outbound) = rx.recv().await {
-                forward_remote_resource_outbound(
+                let mut room_scope = match outbound_bridge.try_room_serving_scope() {
+                    Ok(scope) => scope,
+                    Err(error) => {
+                        tracing::debug!(
+                            jid = %outbound_jid,
+                            ?error,
+                            "dropping queued remote-resource outbound after room admission closed"
+                        );
+                        continue;
+                    }
+                };
+                if let Some(scope) = room_scope.as_mut() {
+                    scope.arm();
+                }
+                let ambiguous = forward_remote_resource_outbound(
                     &outbound_bridge,
                     &outbound_jid,
                     registration_id,
@@ -2834,13 +3095,35 @@ impl OrderedRelayDeliveryBridge {
                     outbound,
                 )
                 .await;
+                if let Some(scope) = room_scope {
+                    if ambiguous {
+                        scope.poison();
+                    } else {
+                        scope.complete_clean();
+                    }
+                }
             }
         });
         if let Some(mut force_detach_rx) = force_detach_rx {
             let control_bridge = Arc::clone(self);
             tokio::spawn(async move {
                 while let Some(request) = force_detach_rx.recv().await {
-                    forward_remote_resource_force_detach(
+                    let mut room_scope = match control_bridge.try_room_serving_scope() {
+                        Ok(scope) => scope,
+                        Err(error) => {
+                            tracing::debug!(
+                                jid = %jid,
+                                ?error,
+                                "refusing queued remote-resource force-detach after room admission closed"
+                            );
+                            let _ = request.ack.send(ForceDetachOutcome::Unavailable);
+                            continue;
+                        }
+                    };
+                    if let Some(scope) = room_scope.as_mut() {
+                        scope.arm();
+                    }
+                    let ambiguous = forward_remote_resource_force_detach(
                         &control_bridge,
                         &jid,
                         registration_id,
@@ -2848,6 +3131,13 @@ impl OrderedRelayDeliveryBridge {
                         request,
                     )
                     .await;
+                    if let Some(scope) = room_scope {
+                        if ambiguous {
+                            scope.poison();
+                        } else {
+                            scope.complete_clean();
+                        }
+                    }
                 }
             });
         }
@@ -3159,6 +3449,9 @@ impl OrderedRelayDeliveryBridge {
                     prepared.is_iq,
                 )
                 .await;
+                if maybe_committed {
+                    self.mark_unsafe_to_release();
+                }
                 self.apply_nack_channel_action(prepared.channel, channel_action)
                     .await;
                 let join_repair_allowed =
@@ -3183,6 +3476,7 @@ impl OrderedRelayDeliveryBridge {
                 }
             }
             Err(error) => {
+                self.observe_relay_error(&error);
                 if matches!(error, RelayAskError::NotFound { .. }) {
                     self.sender_state
                         .lock()
@@ -3517,14 +3811,14 @@ async fn forward_remote_resource_outbound(
     registration_id: RemoteResourceRegistrationId,
     socket_node: &NodeId,
     outbound: OutboundStanza,
-) {
+) -> bool {
     if outbound.pending_row_id.is_some() {
         tracing::warn!(
             jid = %jid,
             "clustered remote-resource forwarder received pending-delivery \
              flush frame; dropping to avoid breaking SM row ack accounting"
         );
-        return;
+        return false;
     }
     let kind = outbound.kind;
     let frame = RemoteResourceOutboundFrame {
@@ -3541,7 +3835,7 @@ async fn forward_remote_resource_outbound(
     {
         Ok(RelayRemoteResourceFrameReply {
             status: RelayRemoteResourceFrameStatus::Delivered,
-        }) => {}
+        }) => false,
         Ok(RelayRemoteResourceFrameReply {
             status: RelayRemoteResourceFrameStatus::Unavailable,
         }) => {
@@ -3552,6 +3846,7 @@ async fn forward_remote_resource_outbound(
             bridge
                 .cleanup_remote_owner_resource_if_registration(jid, registration_id)
                 .await;
+            false
         }
         Ok(reply) => {
             tracing::debug!(
@@ -3559,8 +3854,11 @@ async fn forward_remote_resource_outbound(
                 status = ?reply.status,
                 "clustered remote-resource forwarder did not deliver frame"
             );
+            false
         }
         Err(error) => {
+            let ambiguous = ask_error_maybe_committed(&error);
+            bridge.observe_relay_error(&error);
             tracing::warn!(
                 jid = %jid,
                 %error,
@@ -3571,6 +3869,7 @@ async fn forward_remote_resource_outbound(
                     .cleanup_remote_owner_resource_if_registration(jid, registration_id)
                     .await;
             }
+            ambiguous
         }
     }
 }
@@ -3581,28 +3880,55 @@ async fn forward_remote_resource_force_detach(
     registration_id: RemoteResourceRegistrationId,
     socket_node: &NodeId,
     request: ForceDetachRequest,
-) {
+) -> bool {
     let mut handle = RelayHandle::new(socket_node.clone(), bridge.stop_token.clone())
         .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
-    let outcome = match handle
+    let result = handle
         .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
             jid: jid.clone(),
             registration_id,
             requester_bare_jid: request.requester_bare_jid,
         })
-        .await
-    {
-        Ok(reply) => reply.outcome,
-        Err(error) => {
-            tracing::warn!(
-                jid = %jid,
-                %error,
-                "clustered remote-resource force-detach relay ask failed"
-            );
-            ForceDetachOutcome::NotPersisted
-        }
-    };
+        .await;
+    let ambiguous = result.as_ref().is_err_and(ask_error_maybe_committed);
+    if let Err(error) = &result {
+        bridge.observe_relay_error(error);
+        tracing::warn!(
+            jid = %jid,
+            %error,
+            "clustered remote-resource force-detach relay ask failed"
+        );
+    }
+    let outcome = verified_remote_force_detach_outcome(result);
     let _ = request.ack.send(outcome);
+    ambiguous
+}
+
+/// Translate the relay's status into the only proof the local claim-retirement
+/// path may trust.
+///
+/// `Detached` and `NotLive` prove the remote socket is no longer live.
+/// `Unknown` and every ask failure—including shutdown cancellation—do not.
+/// Returning [`ForceDetachOutcome::Unavailable`] for the latter keeps
+/// `UserLocalClaims` fail-closed instead of releasing a claim while a remote
+/// WebSocket may still be serving it.
+fn verified_remote_force_detach_outcome(
+    result: Result<RelayForceDetachRemoteUserResourceReply, super::relay::RelayAskError>,
+) -> ForceDetachOutcome {
+    match result {
+        Ok(reply) => match reply.status {
+            RelayRemoteResourceForceDetachStatus::Detached => match reply.outcome {
+                ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted => reply.outcome,
+                ForceDetachOutcome::IdentityMismatch | ForceDetachOutcome::Unavailable => {
+                    ForceDetachOutcome::Unavailable
+                }
+            },
+            RelayRemoteResourceForceDetachStatus::NotLive => ForceDetachOutcome::NotPersisted,
+            RelayRemoteResourceForceDetachStatus::Refused => ForceDetachOutcome::IdentityMismatch,
+            RelayRemoteResourceForceDetachStatus::Unknown => ForceDetachOutcome::Unavailable,
+        },
+        Err(_) => ForceDetachOutcome::Unavailable,
+    }
 }
 
 impl OrderedRelayDeliveryBridge {
@@ -3621,7 +3947,8 @@ impl OrderedRelayDeliveryBridge {
                     Ok(())
                 }
                 FullJidDeliveryOutcome::Dropped => Err(OrderedRelayNackReason::Backpressure),
-                FullJidDeliveryOutcome::MaybeCommitted => {
+                FullJidDeliveryOutcome::MaybeEnqueued | FullJidDeliveryOutcome::MaybeCommitted => {
+                    self.mark_unsafe_to_release();
                     Err(OrderedRelayNackReason::MaybeCommitted)
                 }
                 FullJidDeliveryOutcome::Unavailable => {
@@ -3642,7 +3969,10 @@ impl OrderedRelayDeliveryBridge {
         {
             FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => Ok(()),
             FullJidDeliveryOutcome::Dropped => Err(OrderedRelayNackReason::Backpressure),
-            FullJidDeliveryOutcome::MaybeCommitted => Err(OrderedRelayNackReason::MaybeCommitted),
+            FullJidDeliveryOutcome::MaybeEnqueued | FullJidDeliveryOutcome::MaybeCommitted => {
+                self.mark_unsafe_to_release();
+                Err(OrderedRelayNackReason::MaybeCommitted)
+            }
             FullJidDeliveryOutcome::Unavailable => Err(OrderedRelayNackReason::TargetUnavailable),
         }
     }
@@ -3693,7 +4023,12 @@ async fn deliver_reserved_full_jid_peer_live_only(
                 %error,
                 "ordered relay: live-only full-JID IQ peer delivery failed"
             );
-            Err(OrderedRelayNackReason::InFlight)
+            if crate::server::routes::interpret::actor_send_maybe_enqueued(&error) {
+                mark_services_unsafe_to_release(services);
+                Err(OrderedRelayNackReason::MaybeCommitted)
+            } else {
+                Err(OrderedRelayNackReason::InFlight)
+            }
         }
     }
 }
@@ -3753,7 +4088,8 @@ async fn deliver_reserved_bare_presence_direct(
                 landed = true;
             }
             FullJidDeliveryOutcome::Unavailable | FullJidDeliveryOutcome::Dropped => {}
-            FullJidDeliveryOutcome::MaybeCommitted => {
+            FullJidDeliveryOutcome::MaybeEnqueued | FullJidDeliveryOutcome::MaybeCommitted => {
+                mark_services_unsafe_to_release(services);
                 landed = true;
             }
         }
@@ -3890,6 +4226,7 @@ async fn route_local_bare_jid_with_timeout(
                 Ok(Ok(())) => Ok(Vec::new()),
                 Ok(Err(())) => Err(OrderedRelayNackReason::ParseFailure),
                 Err(_) => {
+                    mark_services_unsafe_to_release(services);
                     tracing::warn!(
                         bare_jid = %target,
                         timeout_ms = ORDERED_RECEIVER_DELIVERY_TIMEOUT.as_millis(),
@@ -3914,6 +4251,7 @@ async fn route_local_bare_jid_with_timeout(
     {
         Ok(replies) => Ok(replies),
         Err(_) => {
+            mark_services_unsafe_to_release(services);
             tracing::warn!(
                 bare_jid = %target,
                 timeout_ms = ORDERED_RECEIVER_DELIVERY_TIMEOUT.as_millis(),
@@ -4332,7 +4670,7 @@ async fn deliver_reserved_muc_groupchat(
             handoff: None,
         }),
     );
-    let outcome = tokio::time::timeout(
+    let outcome = match tokio::time::timeout(
         ORDERED_RECEIVER_DELIVERY_TIMEOUT,
         crate::server::routes::interpret::dispatch_muc_to_room_for_relay(
             &deps,
@@ -4341,7 +4679,13 @@ async fn deliver_reserved_muc_groupchat(
         ),
     )
     .await
-    .map_err(|_| OrderedRelayNackReason::MaybeCommitted)?;
+    {
+        Ok(outcome) => outcome,
+        Err(_) => {
+            state.deps.room_serving.mark_unsafe_to_release();
+            return Err(OrderedRelayNackReason::MaybeCommitted);
+        }
+    };
     Ok(outcome
         .frames
         .into_iter()
@@ -4805,6 +5149,7 @@ fn replies_for_origin_handoff(stanza: &Stanza, outcome: FullJidDeliveryOutcome) 
         FullJidDeliveryOutcome::Delivered
         | FullJidDeliveryOutcome::QueuedDetached
         | FullJidDeliveryOutcome::Dropped
+        | FullJidDeliveryOutcome::MaybeEnqueued
         | FullJidDeliveryOutcome::MaybeCommitted => Vec::new(),
     }
 }
@@ -4832,9 +5177,11 @@ fn channel_diversion_for_ask_error(error: &RelayAskError) -> Option<OrderedRelay
             failure: RelaySendFailure::MailboxFull,
             ..
         } => Some(OrderedRelayDiversionReason::Backpressure),
-        RelayAskError::Send { .. } | RelayAskError::Cancelled => {
-            Some(OrderedRelayDiversionReason::Unreachable)
-        }
+        RelayAskError::Send { .. } => Some(OrderedRelayDiversionReason::Unreachable),
+        // The biased stop-token branch may win after the ask was enqueued.
+        // Preserve that ambiguity instead of treating cancellation as a
+        // confirmed transport failure.
+        RelayAskError::Cancelled => Some(OrderedRelayDiversionReason::MaybeCommitted),
     }
 }
 
@@ -4872,7 +5219,7 @@ fn outcome_for_ask_error(error: &RelayAskError, is_iq: bool) -> Option<FullJidDe
     );
     match error {
         RelayAskError::NotFound { .. } => None,
-        RelayAskError::Cancelled => Some(FullJidDeliveryOutcome::Dropped),
+        RelayAskError::Cancelled => Some(FullJidDeliveryOutcome::MaybeCommitted),
         RelayAskError::Send { effect, .. } => Some(match effect {
             RelaySendEffect::NoEffect => definite_no_effect_outcome(is_iq),
             RelaySendEffect::MaybeCommitted => FullJidDeliveryOutcome::MaybeCommitted,
@@ -4883,10 +5230,11 @@ fn outcome_for_ask_error(error: &RelayAskError, is_iq: bool) -> Option<FullJidDe
 fn ask_error_maybe_committed(error: &RelayAskError) -> bool {
     matches!(
         error,
-        RelayAskError::Send {
-            effect: RelaySendEffect::MaybeCommitted,
-            ..
-        }
+        RelayAskError::Cancelled
+            | RelayAskError::Send {
+                effect: RelaySendEffect::MaybeCommitted,
+                ..
+            }
     )
 }
 
@@ -4899,6 +5247,246 @@ mod tests {
     use std::collections::HashSet;
     use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, InProcessClaimStore, NodeIdentity};
     use xmpp_parsers::message::{Lang, Message};
+
+    #[test]
+    fn cancelled_remote_force_detach_is_not_teardown_proof() {
+        assert_eq!(
+            verified_remote_force_detach_outcome(Err(RelayAskError::Cancelled)),
+            ForceDetachOutcome::Unavailable,
+            "clustering shutdown cancellation must preserve the UserActor claim while the \
+             remote WebSocket may still be live"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_owner_publication_blocks_disable_until_both_views_are_visible() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        services
+            .user_registry
+            .ask(waddle_xmpp::registry::WireUserClusteringClaims {
+                claim_store: Arc::clone(&services.claim_store),
+                node_identity: services.node_identity.clone(),
+            })
+            .await
+            .expect("wire the same publication authority into UserRegistry");
+
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let (publication_reached, publication_reached_rx) = tokio::sync::oneshot::channel();
+        let (publication_resume, publication_resume_rx) = tokio::sync::oneshot::channel();
+        bridge
+            .set_test_remote_owner_publication_pause(publication_reached, publication_resume_rx)
+            .await;
+
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let socket_generation = RemoteResourceSocketGeneration::next(None);
+        let register_task = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            async move {
+                bridge
+                    .register_remote_user_resource_on_owner(RelayRegisterRemoteUserResource {
+                        jid: target_full(),
+                        registration_id,
+                        socket_generation,
+                        socket_node: NodeId::new("socket-node".to_string()),
+                        state: RemoteResourceStateSnapshot {
+                            carbons_enabled: false,
+                            roster_interested: false,
+                            blocklist_interested: false,
+                            presence_available: false,
+                            presence_priority: 0,
+                            presence_state: None,
+                        },
+                    })
+                    .await
+            }
+        });
+
+        publication_reached_rx
+            .await
+            .expect("registration pauses after the UserActor publication");
+        let actor = services
+            .user_registry
+            .ask(waddle_xmpp::registry::GetUser {
+                bare_jid: target_bare(),
+            })
+            .await
+            .expect("query user registry")
+            .expect("UserActor is already published");
+        assert!(
+            actor
+                .ask(waddle_xmpp::registry::GetConnectionEntry { jid: target_full() })
+                .await
+                .expect("query actor resource")
+                .is_some(),
+            "the pause must sit after the first authoritative view"
+        );
+        assert!(
+            services
+                .connection_registry
+                .get_entry(&target_full())
+                .is_none(),
+            "the ConnectionRegistry publication must still be pending"
+        );
+
+        let (disable_started, disable_started_rx) = tokio::sync::oneshot::channel();
+        let mut disable_task = tokio::spawn({
+            let node_identity = services.node_identity.clone();
+            async move {
+                let _ = disable_started.send(());
+                node_identity.disable().await
+            }
+        });
+        disable_started_rx
+            .await
+            .expect("terminal disable task started");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut disable_task)
+                .await
+                .is_err(),
+            "terminal disable must wait while a remote registration is between views"
+        );
+
+        publication_resume
+            .send(())
+            .expect("resume the guarded ConnectionRegistry publication");
+        let reply = register_task.await.expect("registration task completed");
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let disabled = disable_task
+            .await
+            .expect("disable completes after publication");
+        assert!(services.node_identity.owns_disabled(&disabled));
+        assert!(
+            services
+                .connection_registry
+                .get_entry(&target_full())
+                .is_some(),
+            "disable may complete only after the second authoritative view is visible"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_remote_socket_bookkeeping_is_not_socket_teardown_proof() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let target = target_full();
+        let (tx, _rx) = mpsc::channel(1);
+        let entry = ConnectionEntry::new(tx);
+        let owner = entry.carbons_handle();
+        services
+            .connection_registry
+            .register_entry(target.clone(), entry);
+
+        let reply = bridge
+            .force_detach_remote_user_resource_on_socket(RelayForceDetachRemoteUserResource {
+                jid: target.clone(),
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                requester_bare_jid: target.to_bare(),
+            })
+            .await;
+
+        assert_eq!(reply.outcome, ForceDetachOutcome::Unavailable);
+        assert_eq!(reply.status, RelayRemoteResourceForceDetachStatus::Unknown);
+        assert!(
+            services
+                .connection_registry
+                .entry_if_owner(&target, &owner)
+                .is_some(),
+            "a live connection must not be classified NotLive solely because \
+             auxiliary remote-socket bookkeeping is absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_remote_socket_registration_survives_unacknowledged_detach() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let target = target_full();
+        let (tx, _rx) = mpsc::channel(1);
+        let entry = ConnectionEntry::new(tx);
+        let owner = entry.carbons_handle();
+        let force_detach_sender = entry.force_detach_sender();
+        loop {
+            let (ack, _ack_rx) = tokio::sync::oneshot::channel();
+            if force_detach_sender
+                .try_send(ForceDetachRequest {
+                    requester_bare_jid: target.to_bare(),
+                    ack,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+        services
+            .connection_registry
+            .register_entry(target.clone(), entry);
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            owner,
+            user_owner: NodeId::new("owner-node".to_string()),
+        };
+        bridge
+            .remote_socket_resources
+            .lock()
+            .await
+            .insert(target.clone(), registration.clone());
+
+        bridge
+            .detach_stale_remote_socket_resource(&target, &registration)
+            .await;
+
+        assert!(
+            bridge
+                .remote_socket_resources
+                .lock()
+                .await
+                .contains_key(&target),
+            "failed detach enqueue is ambiguous and must retain the exact registration"
+        );
+    }
 
     struct StaticNodeLease {
         origin: NodeIdentity,
@@ -6200,7 +6788,12 @@ mod tests {
         assert!(!ask_error_allows_target_refresh(&RelayAskError::Cancelled));
         assert_eq!(
             channel_diversion_for_ask_error(&RelayAskError::Cancelled),
-            Some(OrderedRelayDiversionReason::Unreachable)
+            Some(OrderedRelayDiversionReason::MaybeCommitted)
         );
+        assert_eq!(
+            outcome_for_ask_error(&RelayAskError::Cancelled, true),
+            Some(FullJidDeliveryOutcome::MaybeCommitted)
+        );
+        assert!(ask_error_maybe_committed(&RelayAskError::Cancelled));
     }
 }

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -28,12 +28,13 @@ use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 use waddle_xmpp::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, NodeIdentity, SharedNodeIdentity,
+    ClaimEpoch, ClaimError, ClaimStore, DisabledNodeIdentity, Entity, EntityType, NodeIdentity,
+    SharedNodeIdentity,
 };
 
 use super::claims::NodeLeaseStore;
 use super::metrics;
-use super::ClusteringReadiness;
+use super::{ClusteringReadiness, ClusteringShutdownDecision};
 use crate::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
 
 /// Readable snapshot of the swarm's current connected-peer count (Phase 2
@@ -117,6 +118,20 @@ pub trait LocallyClaimedEntities: Send + Sync {
     /// enumeration itself is still pure in-memory bookkeeping, never a
     /// Postgres round-trip.
     async fn owned(&self) -> Vec<Entity>;
+
+    /// Snapshot one entity kind without requiring unrelated registries to
+    /// answer.
+    ///
+    /// The default preserves compatibility for single-kind implementations.
+    /// Composite implementations must override this so a wedged RoomRegistry
+    /// cannot consume a UserActor drain's inventory budget (and vice versa).
+    async fn owned_of_type(&self, entity_type: EntityType) -> Vec<Entity> {
+        self.owned()
+            .await
+            .into_iter()
+            .filter(|entity| entity.entity_type == entity_type)
+            .collect()
+    }
 
     /// Demote local state for an entity Postgres no longer attributes to
     /// this node (claim stolen, or this node's own claim row is gone).
@@ -252,6 +267,59 @@ pub trait LocallyClaimedEntities: Send + Sync {
     async fn seal_before_release(&self, entity: &Entity) -> bool {
         let _ = entity;
         true
+    }
+
+    /// Permanently stop local `RoomActor` claim acquisition and publication
+    /// before the graceful room inventory is taken.
+    ///
+    /// The shutdown drain must establish this terminal registry gate before
+    /// retiring any actor. Otherwise a queued room request can publish a new
+    /// actor after the inventory snapshot or after an old actor is killed.
+    /// Implementations fail closed unless they can prove the gate is active.
+    async fn begin_room_shutdown(&self) -> bool {
+        false
+    }
+
+    /// Irreversibly select terminal no-release handling for every local room
+    /// claim. Implementations must close room admission, stop/inventory
+    /// detached registry work, and retain all claims for node-expiry recovery.
+    ///
+    /// This is used for an explicit shutdown `Abandon` decision and for every
+    /// failed precondition after a release fence was issued. It must never
+    /// perform a claim release itself.
+    async fn abandon_room_shutdown(&self) -> bool {
+        false
+    }
+
+    /// Hard-retire one sealed room after [`Self::begin_room_shutdown`] has
+    /// permanently disabled replacement publication.
+    ///
+    /// Returning `true` authorizes the caller to release the room claim.
+    /// A live actor must never survive that release.
+    async fn retire_room_after_shutdown(&self, entity: &Entity) -> bool {
+        let _ = entity;
+        false
+    }
+
+    /// Retire one `UserActor` and every connection resource it owns after
+    /// publication authority has been terminally disabled, then verify that
+    /// neither local registry can still route the user.
+    ///
+    /// This is deliberately separate from [`Self::seal_before_release`].
+    /// User claims cannot be released while the live identity can still
+    /// publish a same-incarnation replacement between the retirement check
+    /// and the batched release. Requiring [`DisabledNodeIdentity`] makes the
+    /// post-authority-disable ordering explicit and unforgeable outside
+    /// [`SharedNodeIdentity::disable`]. Implementations return `false` on
+    /// any timeout, teardown failure, or residual actor/resource; shutdown
+    /// then leaves the claim held for ordinary fenced reclaim.
+    async fn retire_user_after_authority_disabled(
+        &self,
+        entity: &Entity,
+        disabled_identity: &DisabledNodeIdentity,
+    ) -> bool {
+        let _ = (entity, disabled_identity);
+        false
     }
 }
 
@@ -413,11 +481,11 @@ pub struct NodeLeaseRunConfig {
     /// mint a fresh swarm keypair, so the PeerId binding intentionally stays
     /// stable across a self-fence.
     pub peer_id: Option<String>,
-    /// ADR-0017 Phase 3 Slice 10: the graceful per-entity claim-release
-    /// drain's time budget (`ClusteringNodeLeaseConfig::claim_release_budget`,
-    /// `claimReleaseBudget` in the ADR's own text) — bound on
-    /// [`crate::clustering::drain::run_shutdown_drain`], called from every
-    /// ordinary-shutdown branch in [`run_node_lease`]'s `'tick` loop below.
+    /// ADR-0017 Phase 3 Slice 10: the total graceful claim-drain budget
+    /// (`ClusteringNodeLeaseConfig::claim_release_budget`,
+    /// `claimReleaseBudget` in the ADR's own text). Its first half caps the
+    /// all-or-none `RoomActor` batch; unused room time plus the second half
+    /// is available to the separate verified `UserActor` release phase.
     pub claim_release_budget: Duration,
 }
 
@@ -452,6 +520,95 @@ where
                 "clustering: marking node-lease row draining timed out; row ages out via \
                  its own lapsed heartbeat"
             );
+        }
+    }
+}
+
+/// Best-effort local retirement inside the still-live claim-release
+/// deadline. Exact-owner cleanup gets a bounded first attempt, then each
+/// entity kind receives a reserved share of the remaining time. A wedged
+/// room registry therefore cannot hang shutdown or starve UserActor cleanup.
+async fn demote_local_claims_before_deadline(
+    local_claims: &dyn LocallyClaimedEntities,
+    identities: &[&NodeIdentity],
+    deadline: tokio::time::Instant,
+) {
+    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+    let exact_owner_budget = remaining / 2;
+    let exact_owner_deadline = tokio::time::Instant::now() + exact_owner_budget;
+    let identity_count = identities.len();
+    for (index, identity) in identities.iter().enumerate() {
+        let remaining = exact_owner_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let identities_left =
+            u32::try_from(identity_count - index).expect("identity count fits in u32");
+        let identity_budget = remaining / identities_left;
+        if !identity_budget.is_zero()
+            && tokio::time::timeout(identity_budget, local_claims.demote_owned_by(identity))
+                .await
+                .is_err()
+        {
+            tracing::warn!(
+                node_id = %identity.node_id,
+                "clustering: exact-owner local cleanup exceeded its shutdown budget"
+            );
+        }
+    }
+
+    let entity_types = [
+        EntityType::SmSession,
+        EntityType::RoomActor,
+        EntityType::UserActor,
+    ];
+    let entity_type_count = entity_types.len();
+    for (index, entity_type) in entity_types.into_iter().enumerate() {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        let types_left = u32::try_from(entity_type_count - index).expect("only three entity types");
+        let type_budget = remaining / types_left;
+        if type_budget.is_zero() {
+            continue;
+        }
+        let type_deadline = tokio::time::Instant::now() + type_budget;
+        let entities = match tokio::time::timeout(
+            type_budget,
+            local_claims.owned_of_type(entity_type),
+        )
+        .await
+        {
+            Ok(entities) => entities,
+            Err(_elapsed) => {
+                tracing::warn!(
+                    ?entity_type,
+                    "clustering: local inventory exceeded its reserved shutdown cleanup budget"
+                );
+                continue;
+            }
+        };
+        for entity in entities {
+            let remaining = type_deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                tracing::warn!(
+                    ?entity_type,
+                    "clustering: local demotion exhausted its reserved shutdown cleanup budget"
+                );
+                break;
+            }
+            if tokio::time::timeout(remaining, local_claims.demote(&entity))
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    entity_type = ?entity.entity_type,
+                    entity_id = %entity.id,
+                    "clustering: local demotion exceeded its reserved shutdown cleanup budget"
+                );
+                break;
+            }
         }
     }
 }
@@ -645,8 +802,9 @@ impl Drop for InlineReclaimReservation<'_> {
 /// [`run_node_lease`]'s `'tick` loop previously did
 /// `crate::clustering::drain::run_shutdown_drain(..).await; return;`
 /// directly — the instant shutdown fired, heartbeat renewal stopped dead,
-/// and the whole per-entity drain (sealing/releasing owned `RoomActor`
-/// claims, bounded by `claim_release_budget`) ran with this node's
+/// and the whole room-batch drain (sealing/retiring all owned `RoomActor`
+/// claims before an all-or-none release, bounded by
+/// `claim_release_budget`) ran with this node's
 /// `clustering_nodes` row frozen at whatever heartbeat it last landed.
 /// Element 4's drain sequence requires a draining node to "stay live in
 /// `nodes`" (heartbeat fresh, draining flag set) for as long as it is
@@ -676,23 +834,75 @@ impl Drop for InlineReclaimReservation<'_> {
 /// visible as live for as long as this node is still legitimately
 /// finishing its own writes, not to re-run the ordinary fencing-loss
 /// handling mid-drain.
+pub(super) struct ShutdownDrainTiming {
+    pub(super) claim_release_budget: Duration,
+    pub(super) lease_ttl: Duration,
+}
+
 pub(super) async fn run_shutdown_drain_with_heartbeat<L>(
     lease: &L,
     claim_store: &Arc<dyn ClaimStore>,
     identity: &NodeIdentity,
+    local_claims: &Arc<dyn LocallyClaimedEntities>,
+    timing: ShutdownDrainTiming,
+    fence: crate::server::room_serving_quiescence::RoomServingFence,
+    fatal_fence: &CancellationToken,
+) -> crate::clustering::drain::RoomShutdownDrainOutcome
+where
+    L: NodeLeaseStore + Send + Sync,
+{
+    run_with_shutdown_heartbeat(
+        lease,
+        identity,
+        crate::clustering::drain::run_shutdown_drain(
+            lease,
+            claim_store,
+            identity,
+            local_claims,
+            timing.claim_release_budget,
+            fence,
+            fatal_fence,
+        ),
+        timing.lease_ttl,
+    )
+    .await
+}
+
+async fn run_disabled_user_drain_with_heartbeat<L>(
+    lease: &L,
+    claim_store: &Arc<dyn ClaimStore>,
+    disabled_identity: &DisabledNodeIdentity,
     local_claims: &Arc<dyn LocallyClaimedEntities>,
     claim_release_budget: Duration,
     lease_ttl: Duration,
 ) where
     L: NodeLeaseStore + Send + Sync,
 {
-    let drain = std::pin::pin!(crate::clustering::drain::run_shutdown_drain(
+    run_with_shutdown_heartbeat(
         lease,
-        claim_store,
-        identity,
-        local_claims,
-        claim_release_budget,
-    ));
+        disabled_identity.prior_identity(),
+        crate::clustering::drain::run_disabled_user_shutdown_drain(
+            claim_store,
+            disabled_identity,
+            local_claims,
+            claim_release_budget,
+        ),
+        lease_ttl,
+    )
+    .await;
+}
+
+async fn run_with_shutdown_heartbeat<L, F, T>(
+    lease: &L,
+    identity: &NodeIdentity,
+    drain: F,
+    lease_ttl: Duration,
+) -> T
+where
+    L: NodeLeaseStore + Send + Sync,
+    F: std::future::Future<Output = T>,
+{
+    let drain = std::pin::pin!(drain);
     let mut drain = drain;
 
     // Renew comfortably inside `lease_ttl` — halved, floored at a tiny 10ms
@@ -717,8 +927,8 @@ pub(super) async fn run_shutdown_drain_with_heartbeat<L>(
     loop {
         tokio::select! {
             biased;
-            _ = &mut drain => {
-                return;
+            output = &mut drain => {
+                return output;
             }
             _ = ticker.tick() => {
                 match lease.heartbeat(identity, lease_ttl).await {
@@ -809,6 +1019,8 @@ struct TerminalFenceContext<'a, L> {
     readiness: &'a ClusteringReadiness,
     stop_token: &'a CancellationToken,
     fatal_fence: &'a CancellationToken,
+    shutdown_decision:
+        &'a tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<ClusteringShutdownDecision>>>,
     control_plane_budget: Duration,
 }
 
@@ -828,11 +1040,6 @@ where
         // identity authoritative while mailbox seal barriers complete the
         // final fenced writes for already-owned rooms.
         self.readiness.set_ready(false);
-        if self.fatal_fence.is_cancelled() {
-            self.finish(identity, identity).await;
-            return;
-        }
-
         let mark_draining = std::pin::pin!(mark_draining_bounded(
             self.lease,
             identity,
@@ -847,36 +1054,116 @@ where
             _ = mark_draining => {}
         }
 
-        let drain = std::pin::pin!(run_shutdown_drain_with_heartbeat(
-            self.lease,
-            claim_store,
-            identity,
-            self.local_claims,
-            claim_release_budget,
-            lease_ttl,
-        ));
-        tokio::select! {
-            biased;
-            _ = self.fatal_fence.cancelled() => {
+        let decision = {
+            let receiver = self.shutdown_decision.lock().await.take();
+            let wait = async {
+                let Some(receiver) = receiver else {
+                    return ClusteringShutdownDecision::Abandon;
+                };
+                tokio::select! {
+                    biased;
+                    _ = self.fatal_fence.cancelled() => ClusteringShutdownDecision::Abandon,
+                    decision = receiver => {
+                        decision.unwrap_or(ClusteringShutdownDecision::Abandon)
+                    }
+                }
+            };
+            run_with_shutdown_heartbeat(self.lease, identity, wait, lease_ttl).await
+        };
+
+        if matches!(&decision, ClusteringShutdownDecision::Abandon)
+            || self.fatal_fence.is_cancelled()
+        {
+            let abandon = tokio::time::timeout(
+                claim_release_budget,
+                self.local_claims.abandon_room_shutdown(),
+            );
+            let _ = run_with_shutdown_heartbeat(self.lease, identity, abandon, lease_ttl).await;
+            if self.fatal_fence.is_cancelled() {
                 self.finish(identity, identity).await;
                 return;
             }
-            _ = drain => {}
         }
 
-        // Only after every successful seal has been released may the
-        // publication barrier reject the remaining identity. Exact demotion
-        // retires anything the bounded drain deliberately abandoned.
-        self.live_identity.disable().await;
-        self.local_claims.demote_owned_by(identity).await;
-        for entity in self.local_claims.owned().await {
-            self.local_claims.demote(&entity).await;
+        let release_deadline = tokio::time::Instant::now() + claim_release_budget;
+        // Keep one configured total budget, but cap rooms at its first half.
+        // A fast room phase donates its unused time to users below; a wedged
+        // room can no longer consume the UserActor retirement opportunity.
+        let room_release_budget = claim_release_budget / 2;
+        match decision {
+            ClusteringShutdownDecision::Release(fence) if !room_release_budget.is_zero() => {
+                run_shutdown_drain_with_heartbeat(
+                    self.lease,
+                    claim_store,
+                    identity,
+                    self.local_claims,
+                    ShutdownDrainTiming {
+                        claim_release_budget: room_release_budget,
+                        lease_ttl,
+                    },
+                    fence,
+                    self.fatal_fence,
+                )
+                .await;
+            }
+            ClusteringShutdownDecision::Release(_fence) => {
+                let _ = self.local_claims.abandon_room_shutdown().await;
+            }
+            ClusteringShutdownDecision::Abandon => {}
         }
+        if self.fatal_fence.is_cancelled() {
+            self.finish(identity, identity).await;
+            return;
+        }
+
+        // Only after the room phase has reached a terminal result — either
+        // the complete batch was released or every room claim was abandoned
+        // for TTL recovery — may the publication barrier reject the
+        // remaining identity. UserActor retirement must happen on the far
+        // side of that barrier: otherwise an in-flight bind can publish a
+        // same-incarnation replacement after the local quiescence check but
+        // before release_many.
+        let disabled_identity = self.live_identity.disable().await;
+        let user_release_budget =
+            release_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if !user_release_budget.is_zero() {
+            let user_drain = std::pin::pin!(run_disabled_user_drain_with_heartbeat(
+                self.lease,
+                claim_store,
+                &disabled_identity,
+                self.local_claims,
+                user_release_budget,
+                lease_ttl,
+            ));
+            tokio::select! {
+                biased;
+                _ = self.fatal_fence.cancelled() => {
+                    self.finish(identity, identity).await;
+                    return;
+                }
+                _ = user_drain => {}
+            }
+        }
+
+        // Exact demotion retires anything either bounded phase deliberately
+        // abandoned. Failed UserActor retirement remains durably claimed and
+        // is reclaimed only after this node lease expires.
+        demote_local_claims_before_deadline(
+            self.local_claims.as_ref(),
+            &[identity],
+            release_deadline,
+        )
+        .await;
     }
 
     async fn finish(&self, prior_identity: &NodeIdentity, registered_identity: &NodeIdentity) {
         self.readiness.set_ready(false);
         self.stop_token.cancel();
+        let _ = tokio::time::timeout(
+            self.control_plane_budget,
+            self.local_claims.abandon_room_shutdown(),
+        )
+        .await;
 
         // A registration call is deliberately allowed to finish instead of
         // being cancellation-dropped: once it returns, rotate through a
@@ -884,12 +1171,21 @@ where
         // Disabled is a typed terminal state: publication guards and claim
         // stores both reject it for the rest of this clustering lifetime.
         self.live_identity.disable().await;
-        self.local_claims.demote_owned_by(prior_identity).await;
+        let cleanup_deadline = tokio::time::Instant::now() + self.control_plane_budget;
         if registered_identity != prior_identity {
-            self.local_claims.demote_owned_by(registered_identity).await;
-        }
-        for entity in self.local_claims.owned().await {
-            self.local_claims.demote(&entity).await;
+            demote_local_claims_before_deadline(
+                self.local_claims.as_ref(),
+                &[prior_identity, registered_identity],
+                cleanup_deadline,
+            )
+            .await;
+        } else {
+            demote_local_claims_before_deadline(
+                self.local_claims.as_ref(),
+                &[prior_identity],
+                cleanup_deadline,
+            )
+            .await;
         }
         mark_draining_bounded(self.lease, prior_identity, self.control_plane_budget).await;
         if registered_identity != prior_identity {
@@ -939,11 +1235,66 @@ async fn run_pre_ready_heartbeat<L>(
     }
 }
 
+/// Drive the production node-lease loop without ever authorizing graceful
+/// claim release.
+///
+/// This public fail-closed entry point exists for the external clustering
+/// harness, which must exercise heartbeat and veto behavior directly but
+/// cannot possess the server's process-wide room-serving fence. On shutdown
+/// every local claim is abandoned for ordinary node-expiry recovery.
+pub async fn run_node_lease_fail_closed<L>(
+    lease: L,
+    identity: NodeIdentity,
+    stop_token: CancellationToken,
+    run_config: NodeLeaseRunConfig,
+) where
+    L: NodeLeaseStore + Send + Sync + 'static,
+{
+    let (decision, decision_rx) = tokio::sync::oneshot::channel();
+    decision
+        .send(ClusteringShutdownDecision::Abandon)
+        .expect("node-lease shutdown decision receiver remains live");
+    run_node_lease_authorized(lease, identity, stop_token, run_config, decision_rx).await;
+}
+
+#[cfg(test)]
+fn clean_test_room_serving_fence() -> crate::server::room_serving_quiescence::RoomServingFence {
+    use crate::server::room_serving_quiescence::{
+        RoomServingQuiescence, RoomServingTerminalOutcome,
+    };
+
+    let (_admission, closer) = RoomServingQuiescence::create();
+    closer.close();
+    match closer.finalize() {
+        RoomServingTerminalOutcome::Clean(fence) => fence,
+        outcome => panic!("test room-serving fence must be clean: {outcome:?}"),
+    }
+}
+
+#[cfg(test)]
 pub async fn run_node_lease<L>(
+    lease: L,
+    identity: NodeIdentity,
+    stop_token: CancellationToken,
+    run_config: NodeLeaseRunConfig,
+) where
+    L: NodeLeaseStore + Send + Sync + 'static,
+{
+    let (decision, decision_rx) = tokio::sync::oneshot::channel();
+    decision
+        .send(ClusteringShutdownDecision::Release(
+            clean_test_room_serving_fence(),
+        ))
+        .expect("test shutdown decision receiver remains live");
+    run_node_lease_authorized(lease, identity, stop_token, run_config, decision_rx).await;
+}
+
+pub(crate) async fn run_node_lease_authorized<L>(
     lease: L,
     mut identity: NodeIdentity,
     stop_token: CancellationToken,
     run_config: NodeLeaseRunConfig,
+    shutdown_decision: tokio::sync::oneshot::Receiver<ClusteringShutdownDecision>,
 ) where
     L: NodeLeaseStore + Send + Sync + 'static,
 {
@@ -961,6 +1312,7 @@ pub async fn run_node_lease<L>(
     } = run_config;
     let lease = Arc::new(lease);
     let fatal_fence = readiness.fatal_fence_token();
+    let shutdown_decision = tokio::sync::Mutex::new(Some(shutdown_decision));
     let terminal_fence_context = TerminalFenceContext {
         lease: lease.as_ref(),
         live_identity: &live_identity,
@@ -968,6 +1320,7 @@ pub async fn run_node_lease<L>(
         readiness: &readiness,
         stop_token: &stop_token,
         fatal_fence: &fatal_fence,
+        shutdown_decision: &shutdown_decision,
         control_plane_budget: config.heartbeat_interval,
     };
     // Seed the shared handle with the identity this loop starts under —
@@ -1304,16 +1657,35 @@ pub async fn run_node_lease<L>(
         // Fatal recovery ambiguity is terminal for this clustering lifetime.
         // Disable the shared identity before taking the final ownership
         // snapshot: `rotate` waits for every old-identity publication guard,
-        // then rejects any later SM/RoomActor publication under that owner.
-        // This is the quiescence barrier that makes the following one-shot
-        // demotion sweep complete even while recovery workers are winding
-        // down.
+        // then rejects any later publication under that owner. Local
+        // retirement is bounded and reserves time per entity kind, so a
+        // wedged registry cannot hang terminal shutdown or starve UserActor
+        // cleanup.
         if terminal_fence {
             readiness.set_ready(false);
             stop_token.cancel();
+            let _ = tokio::time::timeout(
+                terminal_fence_context.control_plane_budget,
+                local_claims.abandon_room_shutdown(),
+            )
+            .await;
             let superseded_identity = identity.clone();
             live_identity.disable().await;
-            local_claims.demote_owned_by(&superseded_identity).await;
+            let cleanup_deadline =
+                tokio::time::Instant::now() + terminal_fence_context.control_plane_budget;
+            demote_local_claims_before_deadline(
+                local_claims.as_ref(),
+                &[&superseded_identity],
+                cleanup_deadline,
+            )
+            .await;
+            mark_draining_bounded(
+                lease.as_ref(),
+                &identity,
+                terminal_fence_context.control_plane_budget,
+            )
+            .await;
+            return;
         }
 
         // Self-fenced (either trigger): stop serving before the lease
@@ -1329,10 +1701,6 @@ pub async fn run_node_lease<L>(
         // it as live (FIX 1(c) already excludes draining rows regardless
         // of heartbeat freshness).
         mark_draining_bounded(lease.as_ref(), &identity, config.heartbeat_interval).await;
-
-        if terminal_fence {
-            return;
-        }
 
         // FIX 1(a): mint the fresh re-registration identity ONCE per
         // fence — every retry below (including hysteresis-rejected ones)
@@ -1838,6 +2206,35 @@ mod tests {
         }
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_heartbeat_continues_while_terminal_decision_is_pending() {
+        let heartbeat_calls = Arc::new(AtomicU32::new(0));
+        let recorded_calls = Arc::clone(&heartbeat_calls);
+        let lease = FakeLease::new(Box::new(move || {
+            recorded_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        }));
+        let me = identity();
+        let lease_ttl = Duration::from_millis(100);
+
+        let decision = run_with_shutdown_heartbeat(
+            &lease,
+            &me,
+            async {
+                tokio::time::sleep(Duration::from_millis(260)).await;
+                ClusteringShutdownDecision::Abandon
+            },
+            lease_ttl,
+        )
+        .await;
+
+        assert!(matches!(decision, ClusteringShutdownDecision::Abandon));
+        assert!(
+            heartbeat_calls.load(Ordering::SeqCst) >= 4,
+            "the node lease must remain fresh for the entire authorization wait"
+        );
+    }
+
     #[async_trait]
     impl NodeLeaseStore for FakeLease {
         async fn list_orphaned_room_actor_claims_page(
@@ -1975,6 +2372,120 @@ mod tests {
             tokio::time::advance(step).await;
             tokio::task::yield_now().await;
         }
+    }
+
+    struct ReservedUserDrainClaims {
+        room: Entity,
+        user: Entity,
+        user_retired: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for ReservedUserDrainClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            std::future::pending().await
+        }
+
+        async fn owned_of_type(&self, entity_type: EntityType) -> Vec<Entity> {
+            match entity_type {
+                EntityType::RoomActor => vec![self.room.clone()],
+                EntityType::UserActor => vec![self.user.clone()],
+                EntityType::SmSession => Vec::new(),
+            }
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn seal_before_release(&self, entity: &Entity) -> bool {
+            assert_eq!(entity, &self.room);
+            std::future::pending().await
+        }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, entity: &Entity) -> bool {
+            assert_eq!(entity, &self.room);
+            true
+        }
+
+        async fn retire_user_after_authority_disabled(
+            &self,
+            entity: &Entity,
+            _disabled_identity: &DisabledNodeIdentity,
+        ) -> bool {
+            assert_eq!(entity, &self.user);
+            self.user_retired.store(true, Ordering::SeqCst);
+            true
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wedged_room_drain_preserves_half_the_budget_for_user_claim_release() {
+        let lease = FakeLease::new(Box::new(|| Ok(true)));
+        let me = identity();
+        let room = Entity::new(EntityType::RoomActor, "wedged@muc.example.com");
+        let user = Entity::new(EntityType::UserActor, "alice@example.com");
+        let claim_store: Arc<dyn ClaimStore> =
+            Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        let room_epoch = claim_store.acquire(&room, &me).await.expect("acquire room");
+        let user_epoch = claim_store.acquire(&user, &me).await.expect("acquire user");
+        let user_retired = Arc::new(AtomicBool::new(false));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(ReservedUserDrainClaims {
+            room: room.clone(),
+            user: user.clone(),
+            user_retired: Arc::clone(&user_retired),
+        });
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let fatal_fence = CancellationToken::new();
+        let live_identity = SharedNodeIdentity::new(me.clone());
+        let (decision, decision_rx) = tokio::sync::oneshot::channel();
+        decision
+            .send(ClusteringShutdownDecision::Release(
+                clean_test_room_serving_fence(),
+            ))
+            .expect("terminal decision receiver remains live");
+        let shutdown_decision = tokio::sync::Mutex::new(Some(decision_rx));
+        let context = TerminalFenceContext {
+            lease: &lease,
+            live_identity: &live_identity,
+            local_claims: &local_claims,
+            readiness: &readiness,
+            stop_token: &stop_token,
+            fatal_fence: &fatal_fence,
+            shutdown_decision: &shutdown_decision,
+            control_plane_budget: Duration::from_millis(10),
+        };
+        let total_budget = Duration::from_millis(100);
+
+        tokio::time::timeout(
+            total_budget * 2,
+            context.shutdown(&claim_store, &me, total_budget, Duration::from_secs(1)),
+        )
+        .await
+        .expect("shutdown must not fall back to the wedged aggregate inventory");
+
+        assert!(
+            claim_store
+                .fence(&room, &me, room_epoch)
+                .await
+                .unwrap_or(false),
+            "the wedged room must remain claimed"
+        );
+        assert!(user_retired.load(Ordering::SeqCst));
+        assert!(
+            !claim_store
+                .fence(&user, &me, user_epoch)
+                .await
+                .unwrap_or(true),
+            "the reserved second half must retire and release the UserActor claim"
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -2547,6 +3058,14 @@ mod tests {
             self.healthy.load(Ordering::SeqCst)
         }
 
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, _entity: &Entity) -> bool {
+            true
+        }
+
         async fn hydrate_reclaimed(
             &self,
             entities: &[(
@@ -2600,6 +3119,39 @@ mod tests {
         exact_demoted_owners: Arc<std::sync::Mutex<Vec<NodeIdentity>>>,
     }
 
+    struct HangingFatalCleanupClaims {
+        user: Entity,
+        user_demoted: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for HangingFatalCleanupClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            std::future::pending().await
+        }
+
+        async fn owned_of_type(&self, entity_type: EntityType) -> Vec<Entity> {
+            match entity_type {
+                EntityType::UserActor => vec![self.user.clone()],
+                EntityType::SmSession | EntityType::RoomActor => Vec::new(),
+            }
+        }
+
+        async fn demote(&self, entity: &Entity) {
+            if entity == &self.user {
+                self.user_demoted.store(true, Ordering::SeqCst);
+            }
+        }
+
+        async fn demote_owned_by(&self, _owner: &NodeIdentity) {
+            std::future::pending().await
+        }
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+    }
+
     #[async_trait]
     impl LocallyClaimedEntities for BlockingSealLocalClaims {
         async fn owned(&self) -> Vec<Entity> {
@@ -2622,6 +3174,14 @@ mod tests {
         async fn seal_before_release(&self, _entity: &Entity) -> bool {
             self.seal_started.notify_one();
             self.seal_release.notified().await;
+            true
+        }
+
+        async fn begin_room_shutdown(&self) -> bool {
+            true
+        }
+
+        async fn retire_room_after_shutdown(&self, _entity: &Entity) -> bool {
             true
         }
     }
@@ -3106,6 +3666,58 @@ mod tests {
             stop_token.is_cancelled(),
             "sibling clustering tasks stop only after local authority is demoted"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fatal_fence_bounds_a_wedged_exact_owner_registry_and_reaches_user_cleanup() {
+        let interval = Duration::from_millis(60);
+        let initial_identity = identity();
+        let user_demoted = Arc::new(AtomicBool::new(false));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(HangingFatalCleanupClaims {
+            user: user_actor_entity("fatal-user-after-wedged-room"),
+            user_demoted: Arc::clone(&user_demoted),
+        });
+        let readiness = ClusteringReadiness::new();
+        let fatal_fence = readiness.fatal_fence_token();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            FakeLease::new(Box::new(|| Ok(true))),
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: SharedNodeIdentity::new(initial_identity),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        fatal_fence.cancel();
+        advance_until(Duration::from_millis(10), 30, || task.is_finished()).await;
+        task.await
+            .expect("fatal cleanup must return within its control-plane budget");
+
+        assert!(
+            user_demoted.load(Ordering::SeqCst),
+            "a wedged exact-owner registry must not starve reserved UserActor cleanup"
+        );
+        assert!(!readiness.is_ready());
+        assert!(stop_token.is_cancelled());
     }
 
     #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -22,7 +22,9 @@ use kameo::remote::{self, registry};
 use libp2p::identity::Keypair;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
+use relay::ConnectedTransportCounts;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -42,6 +44,11 @@ const ALLOWLIST_CHANNEL_CAPACITY: usize = 4;
 /// connections, and libp2p's ~10s default would close them between discovery
 /// traffic and force a re-dial per interaction.
 const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Poll cadence for the fault-gated cross-dial barrier. This is deliberately
+/// much shorter than the harness's one-second dial interval so releasing the
+/// barrier does not dominate the regression's wall clock.
+const FAULT_DIAL_BARRIER_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// Failures while building or starting the swarm. Human-facing `Display` text
 /// is surfaced at server startup.
@@ -301,6 +308,11 @@ async fn bring_up(
     }
 
     let connected_peers = ConnectedPeerCount::new();
+    let connected_transports = ConnectedTransportCounts::new();
+    let fault_dial_barrier = config
+        .fault_dial_barrier_dir
+        .clone()
+        .map(|root| FaultDialBarrier::new(root, local_peer_id));
     let bootstrap_peers = config.bootstrap_peers.clone();
     // The node's single kademlia registration: its supervised relay actor.
     // Its first registration may occur before the first peer connection, so
@@ -309,31 +321,36 @@ async fn bring_up(
     if config.fault_injection {
         tracing::warn!(
             "clustering fault injection is ENABLED: any enrolled peer can crash this node's \
-             relay or stall its mailbox — test harnesses only, never production"
+             relay, stall its mailbox, or make it probe another peer — test harnesses only, \
+             never production"
         );
     }
-    let relay_registration = relay::spawn_supervised(
-        node_id.clone(),
-        config.fault_injection,
-        stop_token.clone(),
+    let relay_registration = relay::spawn_supervised(relay::RelaySupervisorInputs {
+        node_id: node_id.clone(),
+        connected_peers: connected_peers.clone(),
+        connected_transports: connected_transports.clone(),
+        fault_injection: config.fault_injection,
+        stop_token: stop_token.clone(),
         resume_bridge,
         room_local_claims,
-        ordered_relay_delivery_bridge,
-    );
+        ordered_delivery_bridge: ordered_relay_delivery_bridge,
+    });
 
-    tokio::spawn(run_event_loop(
+    tokio::spawn(run_event_loop(EventLoopInputs {
         swarm,
         bootstrap_peers,
-        config.dial_interval,
-        AllowlistRefresh {
+        dial_interval: config.dial_interval,
+        allowlist: AllowlistRefresh {
             store: allowlist,
             current: enrolled,
             interval: config.allowlist_refresh_interval,
         },
         relay_registration,
-        connected_peers.clone(),
-        stop_token.clone(),
-    ));
+        connected_peers: connected_peers.clone(),
+        connected_transports,
+        fault_dial_barrier,
+        stop_token: stop_token.clone(),
+    }));
 
     let handle = SwarmHandle {
         local_peer_id,
@@ -363,6 +380,63 @@ struct AllowlistRefresh {
     /// behaviour.
     current: HashSet<PeerId>,
     interval: Duration,
+}
+
+/// Deterministic, fault-gated first-dial barrier for the multi-process
+/// simultaneous cross-dial regression.
+///
+/// The harness creates `release`, then each node queues exactly one bootstrap
+/// dial, writes `dialed-<local-peer-id>`, and temporarily stops polling its
+/// swarm. Once both markers exist the harness creates `drive`; both swarms
+/// resume with their outbound dial futures already queued. That makes the
+/// two-transport condition an established precondition instead of a scheduler
+/// coincidence.
+struct FaultDialBarrier {
+    root: PathBuf,
+    marker: PathBuf,
+    released: bool,
+    dial_submitted: bool,
+    driving: bool,
+}
+
+impl FaultDialBarrier {
+    fn new(root: PathBuf, local_peer_id: PeerId) -> Self {
+        let marker = root.join(format!("dialed-{local_peer_id}"));
+        Self {
+            root,
+            marker,
+            released: false,
+            dial_submitted: false,
+            driving: false,
+        }
+    }
+
+    fn refresh(&mut self) {
+        self.released |= self.root.join("release").is_file();
+        self.driving |= self.root.join("drive").is_file();
+    }
+
+    fn allows_dial(&self) -> bool {
+        self.released && (!self.dial_submitted || self.driving)
+    }
+
+    fn allows_swarm_poll(&self) -> bool {
+        !self.dial_submitted || self.driving
+    }
+
+    async fn mark_dial_submitted(&mut self) {
+        if self.dial_submitted {
+            return;
+        }
+        self.dial_submitted = true;
+        if let Err(error) = tokio::fs::write(&self.marker, b"queued\n").await {
+            tracing::error!(
+                path = %self.marker.display(),
+                %error,
+                "failed to publish clustering fault dial-barrier marker"
+            );
+        }
+    }
 }
 
 /// A leased keypair slot whose heartbeat has not started yet: held across
@@ -621,26 +695,41 @@ async fn release_slot_bounded<L>(
     }
 }
 
+/// Complete state handed to the long-lived swarm event loop.
+struct EventLoopInputs {
+    swarm: Swarm<WaddleBehaviour>,
+    bootstrap_peers: Vec<ClusteringBootstrapConfig>,
+    dial_interval: Duration,
+    allowlist: AllowlistRefresh,
+    relay_registration: relay::RelayRegistrationTrigger,
+    connected_peers: ConnectedPeerCount,
+    connected_transports: ConnectedTransportCounts,
+    fault_dial_barrier: Option<FaultDialBarrier>,
+    stop_token: CancellationToken,
+}
+
 /// Drive the swarm until `stop_token` (the clustering scope, a child of the
 /// process shutdown token) fires: dial seed peers on a timer, refresh the
 /// peer allowlist on a timer (revoking removed peers), feed swarm events to
 /// the handler, and stop cleanly on shutdown — whether that shutdown is the
 /// whole process draining or just this node self-fencing its lease.
-async fn run_event_loop(
-    mut swarm: Swarm<WaddleBehaviour>,
-    bootstrap_peers: Vec<ClusteringBootstrapConfig>,
-    dial_interval: Duration,
-    mut allowlist: AllowlistRefresh,
-    relay_registration: relay::RelayRegistrationTrigger,
-    connected_peers: ConnectedPeerCount,
-    stop_token: CancellationToken,
-) {
+async fn run_event_loop(inputs: EventLoopInputs) {
+    let EventLoopInputs {
+        mut swarm,
+        bootstrap_peers,
+        dial_interval,
+        mut allowlist,
+        relay_registration,
+        connected_peers,
+        connected_transports,
+        mut fault_dial_barrier,
+        stop_token,
+    } = inputs;
     // Peers we currently hold a connection to (authoritative from connection
     // events), peers observed to enter the kademlia routing table, and the
     // remote address of every live connection (so the bootstrap dial loop can
     // skip endpoints it is already connected to instead of churning a fresh
-    // connection every interval that the duplicate-PeerId defense then
-    // closes).
+    // connection every interval).
     let mut connected: HashSet<PeerId> = HashSet::new();
     let mut routing_peers: HashSet<PeerId> = HashSet::new();
     let mut conn_addrs: HashMap<libp2p::swarm::ConnectionId, Multiaddr> = HashMap::new();
@@ -650,14 +739,16 @@ async fn run_event_loop(
     // disconnected peer stays redialable). Lets the dial loop skip a seed
     // whose owner is connected *inbound-only* — `conn_addrs` alone cannot,
     // because an inbound connection's remote address is an ephemeral source
-    // port that never matches the seed addr, so every interval would churn a
-    // duplicate connection for the duplicate-PeerId defense to close.
+    // port that never matches the seed addr, so every interval would churn an
+    // unnecessary additional connection.
     let mut addr_owners: HashMap<Multiaddr, PeerId> = HashMap::new();
 
     // `interval` fires its first tick immediately, so the first dial round
     // happens right away rather than after a full interval.
     let mut dial_timer = tokio::time::interval(dial_interval);
     dial_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut fault_dial_barrier_timer = tokio::time::interval(FAULT_DIAL_BARRIER_POLL_INTERVAL);
+    fault_dial_barrier_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
     // The startup path already loaded the enrolled set synchronously before
     // this loop started, so the first periodic refresh is deferred one full
     // interval (`interval_at`) instead of immediately re-reading the table.
@@ -707,12 +798,23 @@ async fn run_event_loop(
     }
 
     loop {
+        let dial_allowed = fault_dial_barrier
+            .as_ref()
+            .is_none_or(FaultDialBarrier::allows_dial);
+        let swarm_poll_allowed = fault_dial_barrier
+            .as_ref()
+            .is_none_or(FaultDialBarrier::allows_swarm_poll);
         tokio::select! {
             _ = stop_token.cancelled() => {
                 tracing::info!("clustering swarm event loop stopping (shutdown)");
                 break;
             }
-            _ = dial_timer.tick() => {
+            _ = fault_dial_barrier_timer.tick(), if fault_dial_barrier.is_some() => {
+                if let Some(barrier) = fault_dial_barrier.as_mut() {
+                    barrier.refresh();
+                }
+            }
+            _ = dial_timer.tick(), if dial_allowed => {
                 if !bootstrap_peers.is_empty() {
                     if let Some(guard) = InFlightGuard::try_claim(&dns_in_flight) {
                         let seeds = bootstrap_peers.clone();
@@ -751,13 +853,13 @@ async fn run_event_loop(
             Some(enrolled) = allowlist_rx.recv() => {
                 apply_allowlist(&mut swarm, &mut allowlist, enrolled);
             }
-            Some(addr) = dial_rx.recv() => {
+            Some(addr) = dial_rx.recv(), if dial_allowed => {
                 // Skip endpoints we already hold a connection to: redialing a
-                // connected peer every interval would just mint a duplicate
-                // connection for the duplicate-PeerId defense to close. Two
-                // checks: an outbound connection's remote address matches the
-                // seed addr directly; an inbound-only peer is recognized via
-                // the addr's last known owner.
+                // connected peer every interval would just mint an
+                // unnecessary additional connection. Two checks: an outbound
+                // connection's remote address matches the seed addr directly;
+                // an inbound-only peer is recognized via the addr's last
+                // known owner.
                 if conn_addrs.values().any(|connected_addr| *connected_addr == addr) {
                     continue;
                 }
@@ -768,11 +870,18 @@ async fn run_event_loop(
                     continue;
                 }
                 metrics::record_bootstrap_dial();
-                if let Err(error) = swarm.dial(addr.clone()) {
-                    tracing::debug!(%addr, %error, "clustering bootstrap dial failed");
+                match swarm.dial(addr.clone()) {
+                    Ok(()) => {
+                        if let Some(barrier) = fault_dial_barrier.as_mut() {
+                            barrier.mark_dial_submitted().await;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(%addr, %error, "clustering bootstrap dial failed");
+                    }
                 }
             }
-            event = swarm.select_next_some() => {
+            event = swarm.select_next_some(), if swarm_poll_allowed => {
                 handle_swarm_event(
                     &mut swarm,
                     event,
@@ -783,6 +892,7 @@ async fn run_event_loop(
                         addr_owners: &mut addr_owners,
                         relay_registration: &relay_registration,
                         connected_peers: &connected_peers,
+                        connected_transports: &connected_transports,
                     },
                 );
             }
@@ -833,17 +943,34 @@ fn apply_allowlist(
 
 /// Record a newly connected peer, updating the connected-peer gauge (and the
 /// readable [`ConnectedPeerCount`] ADR-0017 Phase 3 Slice 2's isolation
-/// check reads) on the first connection to that peer.
+/// check reads) on the first connection to that peer. Returns whether this
+/// was the peer's first live connection.
 fn track_peer_connected(
     peer_id: PeerId,
     connected: &mut HashSet<PeerId>,
     connected_peers: &ConnectedPeerCount,
-) {
+) -> bool {
     if connected.insert(peer_id) {
         metrics::record_connected_peers(connected.len() as i64);
         connected_peers.set(connected.len() as i64);
         tracing::debug!(%peer_id, "clustering peer connected");
+        true
+    } else {
+        false
     }
+}
+
+/// Apply libp2p's authoritative live-connection count after an establishment
+/// before updating peer-level first-connection bookkeeping.
+fn track_peer_connection_established(
+    peer_id: PeerId,
+    num_established: u32,
+    connected: &mut HashSet<PeerId>,
+    connected_peers: &ConnectedPeerCount,
+    connected_transports: &ConnectedTransportCounts,
+) -> bool {
+    connected_transports.set(peer_id, num_established);
+    track_peer_connected(peer_id, connected, connected_peers)
 }
 
 /// Record a peer whose last connection closed, updating the connected-peer
@@ -860,6 +987,24 @@ fn track_peer_disconnected(
     }
 }
 
+/// Apply libp2p's connection-close count to peer-level bookkeeping. Returns
+/// whether the event closed the peer's last live transport connection.
+fn track_peer_connection_closed(
+    peer_id: PeerId,
+    num_established: u32,
+    connected: &mut HashSet<PeerId>,
+    connected_peers: &ConnectedPeerCount,
+    connected_transports: &ConnectedTransportCounts,
+) -> bool {
+    connected_transports.set(peer_id, num_established);
+    if num_established == 0 {
+        track_peer_disconnected(peer_id, connected, connected_peers);
+        true
+    } else {
+        false
+    }
+}
+
 struct SwarmEventBookkeeping<'a> {
     connected: &'a mut HashSet<PeerId>,
     routing_peers: &'a mut HashSet<PeerId>,
@@ -867,11 +1012,10 @@ struct SwarmEventBookkeeping<'a> {
     addr_owners: &'a mut HashMap<Multiaddr, PeerId>,
     relay_registration: &'a relay::RelayRegistrationTrigger,
     connected_peers: &'a ConnectedPeerCount,
+    connected_transports: &'a ConnectedTransportCounts,
 }
 
-/// Update local peer bookkeeping and metrics from a single swarm event. Takes
-/// `&mut swarm` so it can close duplicate connections (duplicate-PeerId
-/// defense-in-depth, ADR element 3).
+/// Update local peer bookkeeping and metrics from a single swarm event.
 fn handle_swarm_event(
     swarm: &mut Swarm<WaddleBehaviour>,
     event: SwarmEvent<WaddleBehaviourEvent>,
@@ -885,6 +1029,7 @@ fn handle_swarm_event(
             peer_id,
             connection_id,
             endpoint,
+            num_established,
             ..
         } => {
             state
@@ -905,18 +1050,19 @@ fn handle_swarm_event(
                     .addr_owners
                     .insert(endpoint.get_remote_address().clone(), peer_id);
             }
-            // Duplicate-PeerId defense-in-depth (ADR element 3): the
-            // keypair-slot lease already guarantees a unique PeerId per live
-            // node, so a second concurrent connection to an already-connected
-            // peer is unexpected — keep the first, reject the new one.
-            if state.connected.contains(&peer_id) {
-                tracing::warn!(
-                    %peer_id,
-                    "clustering: rejecting duplicate connection to already-connected peer"
-                );
-                swarm.close_connection(connection_id);
-            } else {
-                track_peer_connected(peer_id, state.connected, state.connected_peers);
+            // libp2p may establish multiple authenticated transport
+            // connections to one PeerId when both sides dial concurrently.
+            // Keep every connection: independently choosing and closing a
+            // "duplicate" on each endpoint can make the peers retain opposite
+            // links, after which both closes tear down the entire relationship.
+            // Peer bookkeeping remains first/last-connection based.
+            if track_peer_connection_established(
+                peer_id,
+                num_established.get(),
+                state.connected,
+                state.connected_peers,
+                state.connected_transports,
+            ) {
                 state.relay_registration.trigger();
             }
         }
@@ -932,8 +1078,13 @@ fn handle_swarm_event(
             // must be redialable (the skip would be wrong), and pruning here
             // keeps the map bounded by *connected* peers under pod churn
             // instead of accumulating every address ever dialed.
-            if num_established == 0 {
-                track_peer_disconnected(peer_id, state.connected, state.connected_peers);
+            if track_peer_connection_closed(
+                peer_id,
+                num_established,
+                state.connected,
+                state.connected_peers,
+                state.connected_transports,
+            ) {
                 state.addr_owners.retain(|_, owner| *owner != peer_id);
             }
         }
@@ -1008,6 +1159,65 @@ mod tests {
         )
         .await
         .expect("open scratch sqlite")
+    }
+
+    #[test]
+    fn additional_connection_keeps_first_peer_bookkeeping_without_double_counting() {
+        let peer = libp2p::identity::Keypair::generate_ed25519()
+            .public()
+            .to_peer_id();
+        let mut connected = HashSet::new();
+        let connected_peers = ConnectedPeerCount::new();
+        let connected_transports = ConnectedTransportCounts::new();
+
+        assert!(
+            track_peer_connection_established(
+                peer,
+                1,
+                &mut connected,
+                &connected_peers,
+                &connected_transports,
+            ),
+            "the first of two cross-dial connections marks the peer connected"
+        );
+        assert_eq!(connected_transports.get(&peer), 1);
+        assert!(
+            !track_peer_connection_established(
+                peer,
+                2,
+                &mut connected,
+                &connected_peers,
+                &connected_transports,
+            ),
+            "the oppositely ordered cross-dial connection is retained without \
+             counting a second peer"
+        );
+        assert_eq!(connected, HashSet::from([peer]));
+        assert_eq!(connected_peers.get(), 1);
+        assert_eq!(connected_transports.get(&peer), 2);
+
+        // Closing either transport while the other remains must not remove
+        // the peer. Only libp2p's last-connection event removes it.
+        assert!(!track_peer_connection_closed(
+            peer,
+            1,
+            &mut connected,
+            &connected_peers,
+            &connected_transports,
+        ));
+        assert_eq!(connected, HashSet::from([peer]));
+        assert_eq!(connected_peers.get(), 1);
+        assert_eq!(connected_transports.get(&peer), 1);
+        assert!(track_peer_connection_closed(
+            peer,
+            0,
+            &mut connected,
+            &connected_peers,
+            &connected_transports,
+        ));
+        assert!(connected.is_empty());
+        assert_eq!(connected_peers.get(), 0);
+        assert_eq!(connected_transports.get(&peer), 0);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -178,8 +178,9 @@ pub struct ClusteringConfig {
     /// does not have to wait out the full production default in real
     /// wall-clock time.
     pub orphan_reaper_interval: Duration,
-    /// Enable the relay's fault-injection message set (crash/sleep) for the
-    /// multi-process cluster harness (`WADDLE_CLUSTERING_FAULT_INJECTION`).
+    /// Enable the relay's fault-injection message set (crash/sleep/peer probe)
+    /// for the multi-process cluster harness
+    /// (`WADDLE_CLUSTERING_FAULT_INJECTION`).
     /// Never enable in production: it lets any enrolled peer stop this node's
     /// relay or hold its mailbox.
     pub fault_injection: bool,
@@ -187,6 +188,11 @@ pub struct ClusteringConfig {
     /// (`WADDLE_CLUSTERING_NODE_ID_FILE`) so the harness can resolve this
     /// node's relay name — mirrors the `WADDLE_HTTP_PORT_FILE` convention.
     pub node_id_file: Option<std::path::PathBuf>,
+    /// Harness-only filesystem barrier that makes two subprocesses queue
+    /// their first bootstrap dial before either swarm advances the handshake
+    /// (`WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR`). Requires
+    /// `fault_injection`; absent in production.
+    pub fault_dial_barrier_dir: Option<std::path::PathBuf>,
     /// Node-lease (`clustering_nodes`) heartbeat/TTL timing (ADR-0017 Phase 3
     /// Slice 2, Q6): a **second**, conceptually distinct lease from
     /// `lease` above — that one guards a leased keypair-pool slot (libp2p
@@ -259,6 +265,7 @@ impl std::fmt::Debug for ClusteringConfig {
             .field("orphan_reaper_interval", &self.orphan_reaper_interval)
             .field("fault_injection", &self.fault_injection)
             .field("node_id_file", &self.node_id_file)
+            .field("fault_dial_barrier_dir", &self.fault_dial_barrier_dir)
             .field("node_lease", &self.node_lease)
             .field("self_fence", &self.self_fence)
             .field("steal_intent", &self.steal_intent)
@@ -485,6 +492,7 @@ impl Default for ClusteringConfig {
             orphan_reaper_interval: Duration::from_secs(120),
             fault_injection: false,
             node_id_file: None,
+            fault_dial_barrier_dir: None,
             node_lease: ClusteringNodeLeaseConfig::default(),
             self_fence: ClusteringSelfFenceConfig::default(),
             steal_intent: ClusteringStealIntentConfig::default(),
@@ -790,6 +798,16 @@ impl ClusteringConfig {
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
             .map(std::path::PathBuf::from);
+        let fault_dial_barrier_dir = vars
+            .get("WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
+        if fault_dial_barrier_dir.is_some() && !fault_injection {
+            return Err("WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR requires \
+                 WADDLE_CLUSTERING_FAULT_INJECTION=true"
+                .to_string());
+        }
         // FIX 6: moved from a raw `std::env::var` read at the `mod.rs`
         // clustering-bringup call site into the typed config pipeline, like
         // every sibling var — trimmed, empty ⇒ `None`, never a parse
@@ -1000,6 +1018,7 @@ impl ClusteringConfig {
             orphan_reaper_interval,
             fault_injection,
             node_id_file,
+            fault_dial_barrier_dir,
             node_lease: ClusteringNodeLeaseConfig {
                 heartbeat_interval: node_lease_heartbeat_interval,
                 lease_ttl: node_lease_ttl,
@@ -1819,6 +1838,10 @@ mod tests {
             ("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "2000"),
             ("WADDLE_CLUSTERING_FAULT_INJECTION", "true"),
             ("WADDLE_CLUSTERING_NODE_ID_FILE", "/tmp/node-id"),
+            (
+                "WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR",
+                "/tmp/dial-barrier",
+            ),
         ])
         .unwrap();
         assert_eq!(config.dial_interval.as_millis(), 2000);
@@ -1827,15 +1850,27 @@ mod tests {
             config.node_id_file,
             Some(std::path::PathBuf::from("/tmp/node-id"))
         );
+        assert_eq!(
+            config.fault_dial_barrier_dir,
+            Some(std::path::PathBuf::from("/tmp/dial-barrier"))
+        );
 
         let defaults = ClusteringConfig::from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
         assert_eq!(defaults.dial_interval.as_secs(), 15);
         assert!(!defaults.fault_injection);
         assert!(defaults.node_id_file.is_none());
+        assert!(defaults.fault_dial_barrier_dir.is_none());
 
         let err =
             ClusteringConfig::from_vars([("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "0")]).unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_DIAL_INTERVAL_MS"));
+
+        let err = ClusteringConfig::from_vars([(
+            "WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR",
+            "/tmp/dial-barrier",
+        )])
+        .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_FAULT_INJECTION"));
     }
 
     // FIX 6: `pod_template_hash` moved from a raw `std::env::var` read at the

--- a/server/crates/waddle-server/src/db/backend.rs
+++ b/server/crates/waddle-server/src/db/backend.rs
@@ -452,7 +452,8 @@ impl ConnectionGuard {
     }
 }
 
-/// A database transaction obtained from [`Database::begin`].
+/// A database transaction obtained from [`Database::begin`] or
+/// [`Database::begin_control_plane`].
 ///
 /// Holds a single pooled connection so multiple `execute` calls observe each
 /// other's writes atomically. Drop without calling [`Transaction::commit`] to

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -264,6 +264,19 @@ impl Database {
         }
     }
 
+    /// Begin a transaction on the dedicated control-plane pool.
+    ///
+    /// Claim coordination normally uses single autocommit statements through
+    /// [`Database::control_plane_guard`]. Use this only when multiple
+    /// control-plane statements must share transaction-scoped coordination,
+    /// such as an entity-key advisory lock followed by a claim CAS.
+    pub async fn begin_control_plane(&self) -> Result<Transaction<'_>, DatabaseError> {
+        match &self.control_plane_backend {
+            Some(backend) => Transaction::begin(backend).await,
+            None => Err(DatabaseError::ControlPlanePoolUnavailable),
+        }
+    }
+
     /// Begin a database transaction.
     ///
     /// Multiple statements executed against the returned [`Transaction`]

--- a/server/crates/waddle-server/src/server/dual_registration.rs
+++ b/server/crates/waddle-server/src/server/dual_registration.rs
@@ -44,9 +44,10 @@ use jid::FullJid;
 use kameo::actor::ActorRef;
 use kameo::error::SendError;
 use tracing::warn;
+use waddle_xmpp::ownership::CurrentNodeIdentityPermit;
 use waddle_xmpp::registry::{
-    ConnectionEntry, RegisterUserResource, UnregisterUserResource, UserRegistryActor,
-    UserRegistryError,
+    ConnectionEntry, RegisterUserResource, RegisterUserResourceUnderAuthority,
+    UnregisterUserResource, UserRegistryActor, UserRegistryError,
 };
 
 /// Upper bound on how long the fail-closed register `ask` may wait for the
@@ -126,6 +127,43 @@ pub(crate) async fn mirror_register_outcome(
                 "dual-registration: authoritative register into user_registry \
                  actor failed; rolling back DashMap registration and failing \
                  the bind"
+            );
+            MirrorRegisterOutcome::Failed
+        }
+    }
+}
+
+/// Authoritative local-bind mirror that reuses a weak permit minted from the
+/// publication guard acquired before the ConnectionRegistry insertion.
+///
+/// The caller retains the real guard through rollback enqueue. The actor
+/// message cannot keep terminal disable blocked if this bounded ask times out.
+pub(crate) async fn mirror_register_outcome_under_authority(
+    user_registry: &ActorRef<UserRegistryActor>,
+    jid: FullJid,
+    entry: ConnectionEntry,
+    publication_permit: CurrentNodeIdentityPermit,
+) -> MirrorRegisterOutcome {
+    match user_registry
+        .ask(RegisterUserResourceUnderAuthority {
+            jid: jid.clone(),
+            entry,
+            publication_permit,
+        })
+        .mailbox_timeout(BIND_REGISTER_TIMEOUT)
+        .reply_timeout(BIND_REGISTER_TIMEOUT)
+        .await
+    {
+        Ok(()) => MirrorRegisterOutcome::Registered,
+        Err(SendError::HandlerError(UserRegistryError::ClaimHeldByAnotherNode(_))) => {
+            MirrorRegisterOutcome::ForeignOwner
+        }
+        Err(error) => {
+            warn!(
+                jid = %jid,
+                %error,
+                "dual-registration: guarded authoritative register into user_registry \
+                 actor failed; rolling back DashMap registration and failing the bind"
             );
             MirrorRegisterOutcome::Failed
         }

--- a/server/crates/waddle-server/src/server/fixed_account.rs
+++ b/server/crates/waddle-server/src/server/fixed_account.rs
@@ -19,6 +19,12 @@ pub(crate) fn fixed_test_account_enabled() -> bool {
         .unwrap_or(false)
 }
 
+fn fixed_test_account_seeding_enabled() -> bool {
+    std::env::var("WADDLE_TEST_FIXED_ACCOUNT_SEED")
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(true)
+}
+
 pub(crate) async fn ensure_fixed_test_account(
     db_pool: &Arc<DatabasePool>,
     xmpp_config: &XmppConfig,
@@ -27,7 +33,6 @@ pub(crate) async fn ensure_fixed_test_account(
     if !enabled {
         return Ok(());
     }
-
     if !xmpp_config.enabled {
         anyhow::bail!("WADDLE_TEST_FIXED_ACCOUNT_ENABLED=true requires WADDLE_XMPP_ENABLED=true");
     }
@@ -35,6 +40,14 @@ pub(crate) async fn ensure_fixed_test_account(
         anyhow::bail!(
             "WADDLE_TEST_FIXED_ACCOUNT_ENABLED=true requires WADDLE_NATIVE_AUTH_ENABLED=true"
         );
+    }
+    // Multi-process integration tests may provision the shared accounts once
+    // before concurrently starting several servers. Keep the fixed-account
+    // permission backend enabled while skipping its deliberately destructive
+    // delete-and-recreate seeding on those concurrent starts.
+    if !fixed_test_account_seeding_enabled() {
+        info!("Skipping fixed native test-account seeding");
+        return Ok(());
     }
 
     let username = std::env::var("WADDLE_TEST_FIXED_ACCOUNT_USERNAME")

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -48,11 +48,12 @@ pub(crate) struct HttpServerDeps {
     /// graceful_shutdown closure and mints per-connection guards in
     /// the WebSocket accept path (issue #1091).
     pub(crate) shutdown_handle: waddle_ecdysis::ShutdownHandle,
-    /// Q6 graceful-shutdown drain completion signal — fired by the
-    /// drain task when it finishes promoting unacked queues. The
-    /// HTTP server's graceful_shutdown closure waits on this after
-    /// stop_token cancels so the runtime doesn't tear down mid-drain.
-    pub(crate) drain_complete: Arc<tokio::sync::Notify>,
+    /// Level-triggered Q6 completion signal. The startup coordinator awaits
+    /// this explicitly after Axum exits.
+    pub(crate) drain_complete: tokio_util::sync::CancellationToken,
+    /// Stop-path-only capability used to close room admission before Axum
+    /// begins draining accepted requests.
+    pub(crate) room_serving_close: crate::server::room_serving_quiescence::RoomServingCloseHandle,
 }
 
 /// Start the HTTP server with graceful shutdown support.
@@ -67,6 +68,7 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         listener,
         shutdown_handle,
         drain_complete,
+        room_serving_close,
     } = deps;
 
     let stop_token = shutdown_handle.stop_token();
@@ -79,6 +81,7 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         acme_http01_challenge_service,
         shutdown_handle,
         drain_complete: drain_complete.clone(),
+        room_serving_close: room_serving_close.clone(),
     })
     .await?;
 
@@ -96,9 +99,8 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             stop_token.cancelled().await;
-            info!("HTTP server received shutdown signal; awaiting SM Q6 drain");
-            drain_complete.notified().await;
-            info!("HTTP server: SM drain complete; draining connections");
+            room_serving_close.close();
+            info!("HTTP server received shutdown signal; stopped accepting new work");
         })
         .await?;
 
@@ -198,7 +200,8 @@ pub(crate) struct RouterDeps {
     pub(crate) pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
     pub(crate) acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
     pub(crate) shutdown_handle: waddle_ecdysis::ShutdownHandle,
-    pub(crate) drain_complete: Arc<tokio::sync::Notify>,
+    pub(crate) drain_complete: tokio_util::sync::CancellationToken,
+    pub(crate) room_serving_close: crate::server::room_serving_quiescence::RoomServingCloseHandle,
 }
 
 /// Create the Axum router with all routes and middleware.
@@ -212,6 +215,7 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         acme_http01_challenge_service,
         shutdown_handle,
         drain_complete,
+        room_serving_close,
     } = deps;
     let shutdown_stop_token = shutdown_handle.stop_token();
     // Create auth broker state
@@ -304,7 +308,8 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
     spawn_graceful_shutdown_drain(
         Arc::clone(&websocket_state),
         shutdown_stop_token,
-        Arc::clone(&drain_complete),
+        drain_complete,
+        room_serving_close,
     );
 
     let extension_webhooks_router =
@@ -719,6 +724,7 @@ async fn create_websocket_state(
     let websocket_state = Arc::new(WebSocketState {
         deps: WebSocketDeps {
             app_state: state.clone(),
+            room_serving: state.room_serving.clone(),
             auth_state: auth_state.clone(),
             transport_security: routes::websocket::TransportSecurity::from_public_websocket_url(
                 &xmpp_config.public_websocket_url,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -11,6 +11,7 @@ mod health;
 mod http;
 pub(crate) mod profile_publish_route;
 mod room_registry_gauge;
+pub(crate) mod room_serving_quiescence;
 mod session_janitors;
 mod state;
 pub(crate) mod state_inventory;
@@ -58,7 +59,7 @@ use fixed_account::{ensure_fixed_test_account, fixed_test_account_enabled};
 use http::{create_websocket_mam_storage, start_http_server, HttpServerDeps};
 use kameo::actor::Spawn;
 use std::{net::SocketAddr, sync::Arc};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Start both HTTP and XMPP servers with Ecdysis graceful restart support.
 ///
@@ -88,6 +89,12 @@ pub async fn start_with_config(
     // Set up Ecdysis graceful shutdown coordinator
     let shutdown = waddle_ecdysis::GracefulShutdown::from_env();
     let stop_token = shutdown.stop_token();
+    // Construct the process-wide room-serving gate before any producer.
+    // Startup keeps the sole terminal closer; request/background graphs get
+    // only admission or stop-path capabilities.
+    let (room_serving, room_serving_closer) =
+        room_serving_quiescence::RoomServingQuiescence::create();
+    let room_serving_close = room_serving_closer.close_handle();
 
     // Acquire listeners: inherited from parent process, or bind fresh.
     // Two explicit paths — no silent fallback.
@@ -204,6 +211,7 @@ pub async fn start_with_config(
         db_pool.global(),
         &stop_token,
         clustering_readiness.clone(),
+        room_serving.clone(),
     )
     .await?;
 
@@ -263,6 +271,7 @@ pub async fn start_with_config(
         server_owner_jids,
         clustering_readiness,
         clustering_claims: clustering_handles,
+        room_serving: room_serving.clone(),
     }));
     // ADR-0017 Phase 3 Slice 7 FIX 1: co-location-check MAM storage against
     // the clustering global database and enable fenced groupchat-archive
@@ -287,12 +296,10 @@ pub async fn start_with_config(
     let acme_http01_challenge_service = acme_runtime
         .as_ref()
         .map(|runtime| runtime.http01_challenge_service.clone());
-    // Coordinates the Q6 SM-drain task's completion back to the HTTP
-    // server's graceful_shutdown closure. The drain task notifies on
-    // exit (RAII guard); the HTTP graceful_shutdown awaits it after
-    // stop_token cancels so axum doesn't tear down mid-drain.
-    let drain_complete = Arc::new(tokio::sync::Notify::new());
-    let http_drain_complete = Arc::clone(&drain_complete);
+    // Level-triggered Q6 completion. Cancellation remains observable when the
+    // drain finishes before the post-Axum waiter is installed.
+    let drain_complete = tokio_util::sync::CancellationToken::new();
+    let http_drain_complete = drain_complete.clone();
     let http_pubsub_database_storage = Arc::clone(&pubsub_database_storage);
     let http_handle = tokio::spawn(async move {
         start_http_server(HttpServerDeps {
@@ -305,6 +312,7 @@ pub async fn start_with_config(
             listener: http_listener,
             shutdown_handle: http_shutdown_handle,
             drain_complete: http_drain_complete,
+            room_serving_close,
         })
         .await
     });
@@ -329,11 +337,7 @@ pub async fn start_with_config(
         info!(signal = ?signal, "Shutdown lifecycle complete");
     });
 
-    // Wait for the HTTP server to fully exit. axum's
-    // `graceful_shutdown` closure (in `start_http_server`) is what
-    // waits on the SM Q6 drain via `drain_complete.notified()`, so
-    // letting `http_handle` drive the exit guarantees the runtime
-    // doesn't tear down mid-drain.
+    // Wait for Axum to stop accepting and drain accepted connection futures.
     let result = match http_handle.await {
         Ok(Ok(())) => {
             info!("HTTP server stopped (graceful drain complete)");
@@ -342,18 +346,75 @@ pub async fn start_with_config(
         Ok(Err(e)) => Err(e),
         Err(e) => Err(anyhow::anyhow!("HTTP server task failed: {}", e)),
     };
-    // ADR-0017 Phase 3 Slice 10: the clustering node-lease loop runs its
-    // own per-entity graceful drain (mark draining, seal + batch-release
-    // owned `RoomActor` claims) on this same `stop_token` firing, in
-    // parallel with the HTTP/SM drain just awaited above — but element 4's
-    // drain sequence requires it "completing before process exit," not
-    // merely racing shutdown in the background. A small fixed margin atop
-    // the configured budget covers this await's own task-exit/logging
-    // overhead beyond the drain loop's own internal budget bound; a no-op
-    // (returns immediately) when clustering is disabled.
+    // An unexpected HTTP exit must enter the same fail-closed shutdown path
+    // as a signal; otherwise producers and the node-lease heartbeat would
+    // remain live while startup returns an error.
+    if !stop_token.is_cancelled() {
+        stop_token.cancel();
+    }
+    room_serving_closer.close();
+
+    // Q6 runs independently from Axum connection drain. Await its
+    // level-triggered completion explicitly after HTTP exit. A router-start
+    // failure can occur before the drain task exists, so bound this await and
+    // make terminal release unsafe rather than hanging forever.
+    let room_drain_budget = session_janitors::max_drain_duration_from_env();
+    if tokio::time::timeout(room_drain_budget, drain_complete.cancelled())
+        .await
+        .is_ok()
+    {
+        info!("SM Q6 drain completion observed after HTTP exit");
+    } else {
+        room_serving_closer.poison();
+        warn!(
+            budget_ms = room_drain_budget.as_millis() as u64,
+            "SM Q6 drain completion was not observed; room claims will be abandoned"
+        );
+    }
+
+    // Root admission is closed and all producer-specific drains have run.
+    // Wait for every counted connection, relay receiver, webhook dispatch,
+    // and periodic producer before constructing the sole release decision.
+    let room_wait = room_serving_closer
+        .wait_for_zero_for(room_drain_budget)
+        .await;
+    let clustering_decision = match room_wait {
+        room_serving_quiescence::RoomServingWaitOutcome::Quiescent => {
+            match room_serving_closer.finalize() {
+                room_serving_quiescence::RoomServingTerminalOutcome::Clean(fence) => {
+                    crate::clustering::ClusteringShutdownDecision::Release(fence)
+                }
+                room_serving_quiescence::RoomServingTerminalOutcome::AdmissionStillOpen {
+                    active_scopes,
+                }
+                | room_serving_quiescence::RoomServingTerminalOutcome::Active { active_scopes }
+                | room_serving_quiescence::RoomServingTerminalOutcome::Poisoned { active_scopes } =>
+                {
+                    warn!(
+                        active_scopes,
+                        "Room-serving finalization was not clean; room claims will be abandoned"
+                    );
+                    crate::clustering::ClusteringShutdownDecision::Abandon
+                }
+            }
+        }
+        room_serving_quiescence::RoomServingWaitOutcome::AdmissionStillOpen { active_scopes }
+        | room_serving_quiescence::RoomServingWaitOutcome::Poisoned { active_scopes }
+        | room_serving_quiescence::RoomServingWaitOutcome::TimedOut { active_scopes } => {
+            warn!(
+                active_scopes,
+                "Room-serving quiescence was not clean; room claims will be abandoned"
+            );
+            crate::clustering::ClusteringShutdownDecision::Abandon
+        }
+    };
+
+    // Deliver exactly one release-or-abandon decision after process-wide root
+    // quiescence. The node-lease loop keeps heartbeating while it waits.
     const CLUSTERING_DRAIN_AWAIT_MARGIN: std::time::Duration = std::time::Duration::from_secs(2);
     clustering_shutdown
-        .await_drain(
+        .authorize_and_await(
+            clustering_decision,
             server_config.clustering.node_lease.claim_release_budget
                 + CLUSTERING_DRAIN_AWAIT_MARGIN,
         )

--- a/server/crates/waddle-server/src/server/room_serving_quiescence.rs
+++ b/server/crates/waddle-server/src/server/room_serving_quiescence.rs
@@ -1,0 +1,878 @@
+//! Process-wide admission and quiescence fence for room-capable work.
+//!
+//! The fence deliberately separates admission ([`RoomServingHandle`]) from
+//! shutdown authority ([`RoomServingCloser`]). Every admitted operation owns
+//! one [`RoomServingScope`]. A scope starts unarmed so callers can acquire
+//! before a shutdown check, then decide whether the selected path is actually
+//! room-capable. Once armed, it must be completed explicitly. Dropping an
+//! armed scope because its future was cancelled, aborted, or panicked marks
+//! the eventual release unsafe synchronously and permanently. That ambiguity
+//! does not stop the live server: only the explicit shutdown close operation
+//! closes admission and cancels producers.
+//!
+//! A normal Rust return is not automatically a clean completion. Some normal
+//! protocol outcomes (for example, `MaybeCommitted`) still carry an ambiguous
+//! room-side effect. Callers must classify their outcome before invoking
+//! [`RoomServingScope::complete_clean`]. [`RoomServingScope::run_clean`] is
+//! only a convenience for audited futures whose every returned output,
+//! including typed errors, is fully settled.
+
+use std::future::Future;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Construct the two capabilities for one process-wide room-serving fence.
+pub(crate) struct RoomServingQuiescence;
+
+impl RoomServingQuiescence {
+    pub(crate) fn create() -> (RoomServingHandle, RoomServingCloser) {
+        let inner = Arc::new(Inner {
+            state: Mutex::new(State {
+                admission_open: true,
+                active_scopes: 0,
+                unsafe_to_release: false,
+                generation: 0,
+            }),
+            changed: tokio::sync::Notify::new(),
+            producer_cancel: CancellationToken::new(),
+        });
+        (
+            RoomServingHandle {
+                inner: Arc::clone(&inner),
+            },
+            RoomServingCloser { inner },
+        )
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    state: Mutex<State>,
+    changed: tokio::sync::Notify,
+    producer_cancel: CancellationToken,
+}
+
+impl Inner {
+    /// A poisoned std mutex means a panic crossed a gate critical section.
+    /// Recover the data only after making the whole fence fail closed.
+    fn lock_state(&self) -> MutexGuard<'_, State> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => {
+                let mut state = poisoned.into_inner();
+                state.admission_open = false;
+                if !state.unsafe_to_release {
+                    state.generation = state.generation.wrapping_add(1);
+                }
+                state.unsafe_to_release = true;
+                self.producer_cancel.cancel();
+                self.changed.notify_waiters();
+                state
+            }
+        }
+    }
+
+    fn status(&self) -> RoomServingStatus {
+        let state = self.lock_state();
+        RoomServingStatus {
+            admission_open: state.admission_open,
+            active_scopes: state.active_scopes,
+            unsafe_to_release: state.unsafe_to_release,
+        }
+    }
+
+    fn clean_fence(self: &Arc<Self>) -> Option<RoomServingFence> {
+        let state = self.lock_state();
+        if state.admission_open || state.unsafe_to_release || state.active_scopes != 0 {
+            return None;
+        }
+        Some(RoomServingFence {
+            inner: Arc::clone(self),
+            generation: state.generation,
+        })
+    }
+
+    fn finish_scope(&self, poison: bool) {
+        let mut fatal_close = false;
+        {
+            let mut state = self.lock_state();
+            match state.active_scopes.checked_sub(1) {
+                Some(active_scopes) => state.active_scopes = active_scopes,
+                None => {
+                    // Counter underflow is an internal correctness failure.
+                    // Keep the count at zero, close admission, and poison.
+                    state.admission_open = false;
+                    if !state.unsafe_to_release {
+                        state.generation = state.generation.wrapping_add(1);
+                    }
+                    state.unsafe_to_release = true;
+                    fatal_close = true;
+                }
+            }
+            if poison {
+                if !state.unsafe_to_release {
+                    state.generation = state.generation.wrapping_add(1);
+                }
+                state.unsafe_to_release = true;
+            }
+        }
+        if fatal_close {
+            self.producer_cancel.cancel();
+        }
+        self.changed.notify_waiters();
+    }
+
+    fn poison(&self) {
+        {
+            let mut state = self.lock_state();
+            if !state.unsafe_to_release {
+                state.generation = state.generation.wrapping_add(1);
+            }
+            state.unsafe_to_release = true;
+        }
+        self.changed.notify_waiters();
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    admission_open: bool,
+    active_scopes: usize,
+    /// Sticky evidence that an admitted operation may have produced an
+    /// unaccounted room-side effect. This forbids terminal release but does
+    /// not interrupt live traffic.
+    unsafe_to_release: bool,
+    /// Changes when the gate first closes and whenever a clean generation is
+    /// invalidated by poison. A fence is useful only for this exact value and
+    /// this exact [`Inner`] allocation.
+    generation: u64,
+}
+
+/// Cloneable capability used by request and background-work producers.
+#[derive(Clone, Debug)]
+pub(crate) struct RoomServingHandle {
+    inner: Arc<Inner>,
+}
+
+impl RoomServingHandle {
+    /// Admit one potential room-serving operation.
+    ///
+    /// Admission and shutdown closure use the same mutex, making their race
+    /// linearizable: a scope is either counted before closure or rejected
+    /// after it. The returned scope is intentionally unarmed.
+    pub(crate) fn try_scope(&self) -> Result<RoomServingScope, RoomServingAdmissionError> {
+        let mut state = self.inner.lock_state();
+        if !state.admission_open {
+            return Err(if state.unsafe_to_release {
+                RoomServingAdmissionError::Poisoned
+            } else {
+                RoomServingAdmissionError::Closed
+            });
+        }
+        let Some(active_scopes) = state.active_scopes.checked_add(1) else {
+            state.admission_open = false;
+            state.generation = state.generation.wrapping_add(1);
+            state.unsafe_to_release = true;
+            drop(state);
+            self.inner.producer_cancel.cancel();
+            self.inner.changed.notify_waiters();
+            return Err(RoomServingAdmissionError::Poisoned);
+        };
+        state.active_scopes = active_scopes;
+        drop(state);
+        Ok(RoomServingScope {
+            inner: Arc::clone(&self.inner),
+            state: ScopeState::Unarmed,
+        })
+    }
+
+    /// Admit and arm a task before giving it to Tokio.
+    ///
+    /// The task factory receives the armed scope and must move it into the
+    /// returned future. It must call [`RoomServingScope::complete_clean`] only
+    /// after classifying its final outcome as settled. Returning while the
+    /// scope is still armed poisons the fence, as do panic and task abort.
+    pub(crate) fn spawn<T, F, Fut>(
+        &self,
+        task: F,
+    ) -> Result<JoinHandle<T>, RoomServingAdmissionError>
+    where
+        T: Send + 'static,
+        F: FnOnce(RoomServingScope) -> Fut,
+        Fut: Future<Output = T> + Send + 'static,
+    {
+        let mut scope = self.try_scope()?;
+        scope.arm();
+        let future = task(scope);
+        Ok(tokio::spawn(future))
+    }
+
+    /// Cancellation observed by periodic/background producers.
+    ///
+    /// Closure cancels this token before the terminal registry barrier, so a
+    /// producer can stop admitting new work and unwind its already-counted
+    /// scope. The token is shared; callers must treat it as read-only.
+    pub(crate) fn producer_cancellation(&self) -> CancellationToken {
+        self.inner.producer_cancel.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn status(&self) -> RoomServingStatus {
+        self.inner.status()
+    }
+
+    /// Record an ambiguous room-side effect without stopping live admission.
+    ///
+    /// This cloneable capability is intentionally one-way: request/relay
+    /// graphs may make terminal release unsafe, but only the single-owner
+    /// closer can stop admission or mint a clean release fence.
+    pub(crate) fn mark_unsafe_to_release(&self) {
+        self.inner.poison();
+    }
+}
+
+/// Single-owner shutdown capability. It cannot mint serving scopes.
+#[derive(Debug)]
+pub(crate) struct RoomServingCloser {
+    inner: Arc<Inner>,
+}
+
+impl RoomServingCloser {
+    /// Cloneable capability that may close admission but cannot wait or mint
+    /// the terminal release fence.
+    pub(crate) fn close_handle(&self) -> RoomServingCloseHandle {
+        RoomServingCloseHandle {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Close admission and signal background producers. Idempotent.
+    pub(crate) fn close(&self) -> RoomServingStatus {
+        self.close_handle().close()
+    }
+
+    /// Mark eventual release unsafe without interrupting the live server.
+    pub(crate) fn poison(&self) {
+        self.inner.poison();
+    }
+
+    /// Wait for a closed fence to reach a clean zero within `budget`.
+    ///
+    /// An unsafe generation still waits for its counted work to unwind before
+    /// returning `Poisoned`; ambiguity forbids release, but does not justify
+    /// tearing the runtime out from under active operations.
+    /// Calling this before [`Self::close`] is a misuse and never reports a
+    /// clean fence.
+    pub(crate) async fn wait_for_zero_for(&self, budget: Duration) -> RoomServingWaitOutcome {
+        let deadline = tokio::time::Instant::now() + budget;
+        loop {
+            // Register before reading state. `enable` puts this waiter in
+            // Notify's queue, closing the notify-between-read-and-await race.
+            let changed = self.inner.changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+
+            let status = self.inner.status();
+            if status.admission_open {
+                return RoomServingWaitOutcome::AdmissionStillOpen {
+                    active_scopes: status.active_scopes,
+                };
+            }
+            if status.active_scopes == 0 {
+                return if status.unsafe_to_release {
+                    RoomServingWaitOutcome::Poisoned { active_scopes: 0 }
+                } else {
+                    RoomServingWaitOutcome::Quiescent
+                };
+            }
+
+            if tokio::time::timeout_at(deadline, changed).await.is_err() {
+                // Crossing the deadline is itself terminal. Even if the last
+                // scope completes concurrently, the timeout wins this
+                // linearization point and invalidates the generation before
+                // any later code could mint a clean release capability.
+                let active_scopes = self.inner.status().active_scopes;
+                self.poison();
+                return RoomServingWaitOutcome::TimedOut { active_scopes };
+            }
+        }
+    }
+
+    /// Consume the shutdown capability and mint the only claim-release proof.
+    ///
+    /// Callers first wait for root scopes, then complete terminal room
+    /// registry preparation, poisoning this closer on ambiguity. Finalization
+    /// rechecks the root gate atomically after that preparation and is the
+    /// only operation that can construct a fence.
+    pub(crate) fn finalize(self) -> RoomServingTerminalOutcome {
+        let status = self.inner.status();
+        if status.unsafe_to_release {
+            return RoomServingTerminalOutcome::Poisoned {
+                active_scopes: status.active_scopes,
+            };
+        }
+        if status.admission_open {
+            return RoomServingTerminalOutcome::AdmissionStillOpen {
+                active_scopes: status.active_scopes,
+            };
+        }
+        if status.active_scopes != 0 {
+            return RoomServingTerminalOutcome::Active {
+                active_scopes: status.active_scopes,
+            };
+        }
+        match self.inner.clean_fence() {
+            Some(fence) => RoomServingTerminalOutcome::Clean(fence),
+            None => {
+                let status = self.inner.status();
+                if status.unsafe_to_release {
+                    RoomServingTerminalOutcome::Poisoned {
+                        active_scopes: status.active_scopes,
+                    }
+                } else {
+                    RoomServingTerminalOutcome::Active {
+                        active_scopes: status.active_scopes,
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Cloneable stop-path capability. It can close root admission immediately,
+/// but cannot wait, poison, finalize, or mint a release fence.
+#[derive(Clone, Debug)]
+pub(crate) struct RoomServingCloseHandle {
+    inner: Arc<Inner>,
+}
+
+impl RoomServingCloseHandle {
+    pub(crate) fn close(&self) -> RoomServingStatus {
+        {
+            let mut state = self.inner.lock_state();
+            if state.admission_open {
+                state.admission_open = false;
+                state.generation = state.generation.wrapping_add(1);
+            }
+        }
+        self.inner.producer_cancel.cancel();
+        self.inner.changed.notify_waiters();
+        self.inner.status()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RoomServingStatus {
+    pub(crate) admission_open: bool,
+    pub(crate) active_scopes: usize,
+    pub(crate) unsafe_to_release: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RoomServingAdmissionError {
+    Closed,
+    Poisoned,
+}
+
+#[derive(Debug)]
+pub(crate) enum RoomServingWaitOutcome {
+    Quiescent,
+    AdmissionStillOpen { active_scopes: usize },
+    Poisoned { active_scopes: usize },
+    TimedOut { active_scopes: usize },
+}
+
+#[derive(Debug)]
+pub(crate) enum RoomServingTerminalOutcome {
+    Clean(RoomServingFence),
+    AdmissionStillOpen { active_scopes: usize },
+    Active { active_scopes: usize },
+    Poisoned { active_scopes: usize },
+}
+
+/// Unforgeable proof that one exact gate generation was closed, safe to
+/// release, and had no active scopes.
+///
+/// The private fields bind the proof to both the gate allocation and its
+/// terminal generation. This type is intentionally not `Clone`: the shutdown
+/// coordinator moves the sole release capability into the drain API.
+#[derive(Debug)]
+pub(crate) struct RoomServingFence {
+    inner: Arc<Inner>,
+    generation: u64,
+}
+
+impl RoomServingFence {
+    /// Revalidate immediately before a claim-authorizing action.
+    ///
+    /// A later explicit poison changes the generation and invalidates an
+    /// already-issued fence. Admission cannot reopen.
+    pub(crate) fn is_current_clean(&self) -> bool {
+        let state = self.inner.lock_state();
+        !state.admission_open
+            && !state.unsafe_to_release
+            && state.active_scopes == 0
+            && state.generation == self.generation
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScopeState {
+    Unarmed,
+    Armed,
+    Finished,
+}
+
+/// One counted room-serving operation.
+#[derive(Debug)]
+pub(crate) struct RoomServingScope {
+    inner: Arc<Inner>,
+    state: ScopeState,
+}
+
+impl RoomServingScope {
+    /// Mark this scope room-capable. Idempotent.
+    pub(crate) fn arm(&mut self) {
+        if self.state == ScopeState::Unarmed {
+            self.state = ScopeState::Armed;
+        }
+    }
+
+    /// Confirm that the operation and all room-side effects are settled.
+    pub(crate) fn complete_clean(mut self) {
+        self.inner.finish_scope(false);
+        self.state = ScopeState::Finished;
+    }
+
+    /// Explicitly fail closed for a normally-returned ambiguous outcome.
+    pub(crate) fn poison(mut self) {
+        self.inner.finish_scope(true);
+        self.state = ScopeState::Finished;
+    }
+
+    /// Run a future for which every normal output is known to be settled.
+    ///
+    /// Cancellation, abort, or panic drops the armed scope and poisons.
+    pub(crate) async fn run_clean<F>(mut self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        self.arm();
+        let output = future.await;
+        self.complete_clean();
+        output
+    }
+}
+
+impl Drop for RoomServingScope {
+    fn drop(&mut self) {
+        match self.state {
+            ScopeState::Unarmed => self.inner.finish_scope(false),
+            ScopeState::Armed => self.inner.finish_scope(true),
+            ScopeState::Finished => {}
+        }
+        self.state = ScopeState::Finished;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WAIT: Duration = Duration::from_secs(1);
+
+    #[tokio::test]
+    async fn close_rejects_new_admission_and_waits_for_a_clean_scope() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let mut scope = handle.try_scope().expect("admitted before close");
+        scope.arm();
+
+        assert_eq!(
+            closer.close(),
+            RoomServingStatus {
+                admission_open: false,
+                active_scopes: 1,
+                unsafe_to_release: false,
+            }
+        );
+        assert_eq!(
+            handle.try_scope().expect_err("closed admission"),
+            RoomServingAdmissionError::Closed
+        );
+
+        scope.complete_clean();
+        assert_clean(wait_and_finalize(closer).await);
+    }
+
+    #[tokio::test]
+    async fn unarmed_drop_is_clean() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        drop(handle.try_scope().expect("admitted"));
+        closer.close();
+
+        assert_clean(wait_and_finalize(closer).await);
+    }
+
+    #[tokio::test]
+    async fn normal_typed_error_can_be_explicitly_completed_clean() {
+        #[derive(Debug, PartialEq, Eq)]
+        struct SettledError;
+
+        let (handle, closer) = RoomServingQuiescence::create();
+        let scope = handle.try_scope().expect("admitted");
+        let outcome: Result<(), SettledError> = scope.run_clean(async { Err(SettledError) }).await;
+        assert_eq!(outcome, Err(SettledError));
+
+        closer.close();
+        assert_clean(wait_and_finalize(closer).await);
+    }
+
+    #[tokio::test]
+    async fn normal_ambiguous_return_left_incomplete_poisons() {
+        #[derive(Debug, PartialEq, Eq)]
+        enum Delivery {
+            MaybeCommitted,
+        }
+
+        let (handle, closer) = RoomServingQuiescence::create();
+        let producer_cancel = handle.producer_cancellation();
+        let mut scope = handle.try_scope().expect("admitted");
+        scope.arm();
+        let outcome = async { Delivery::MaybeCommitted }.await;
+        assert_eq!(outcome, Delivery::MaybeCommitted);
+        drop(scope);
+
+        assert_eq!(
+            handle.status(),
+            RoomServingStatus {
+                admission_open: true,
+                active_scopes: 0,
+                unsafe_to_release: true,
+            }
+        );
+        assert!(
+            !producer_cancel.is_cancelled(),
+            "ambiguity must not stop live producers"
+        );
+        drop(
+            handle
+                .try_scope()
+                .expect("live admission continues after ambiguity"),
+        );
+        closer.close();
+        assert!(matches!(
+            closer.wait_for_zero_for(WAIT).await,
+            RoomServingWaitOutcome::Poisoned { active_scopes: 0 }
+        ));
+        assert_eq!(
+            handle
+                .try_scope()
+                .expect_err("explicit close stops admission"),
+            RoomServingAdmissionError::Poisoned
+        );
+    }
+
+    #[tokio::test]
+    async fn aborting_spawned_armed_task_poisons() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let task = handle
+            .spawn(|scope| async move {
+                let _scope = scope;
+                std::future::pending::<()>().await;
+            })
+            .expect("spawn admitted");
+        task.abort();
+        let error = task.await.expect_err("task was aborted");
+        assert!(error.is_cancelled());
+
+        assert!(
+            !handle.producer_cancellation().is_cancelled(),
+            "task ambiguity must not stop live producers"
+        );
+        drop(
+            handle
+                .try_scope()
+                .expect("task ambiguity must not close live admission"),
+        );
+        closer.close();
+        assert!(matches!(
+            closer.wait_for_zero_for(WAIT).await,
+            RoomServingWaitOutcome::Poisoned { active_scopes: 0 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn panic_in_spawned_armed_task_poisons() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let task = handle
+            .spawn(|scope| async move {
+                let _scope = scope;
+                panic!("injected task panic");
+            })
+            .expect("spawn admitted");
+        let error = task.await.expect_err("task panicked");
+        assert!(error.is_panic());
+
+        assert!(
+            !handle.producer_cancellation().is_cancelled(),
+            "task ambiguity must not stop live producers"
+        );
+        drop(
+            handle
+                .try_scope()
+                .expect("task ambiguity must not close live admission"),
+        );
+        closer.close();
+        assert!(matches!(
+            closer.wait_for_zero_for(WAIT).await,
+            RoomServingWaitOutcome::Poisoned { active_scopes: 0 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn deadline_timeout_is_terminal_even_after_later_completion() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let mut scope = handle.try_scope().expect("admitted");
+        scope.arm();
+        closer.close();
+
+        assert!(matches!(
+            closer.wait_for_zero_for(Duration::ZERO).await,
+            RoomServingWaitOutcome::TimedOut { active_scopes: 1 }
+        ));
+        assert!(handle.status().unsafe_to_release);
+
+        scope.complete_clean();
+        assert!(handle.status().unsafe_to_release);
+        assert_eq!(
+            handle
+                .try_scope()
+                .expect_err("timed-out generation stays poisoned"),
+            RoomServingAdmissionError::Poisoned
+        );
+        assert!(matches!(
+            closer.finalize(),
+            RoomServingTerminalOutcome::Poisoned { active_scopes: 0 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn wait_before_close_never_reports_a_clean_fence() {
+        let (_handle, closer) = RoomServingQuiescence::create();
+        assert!(matches!(
+            closer.wait_for_zero_for(WAIT).await,
+            RoomServingWaitOutcome::AdmissionStillOpen { active_scopes: 0 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_cancels_background_producers() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let producer_cancel = handle.producer_cancellation();
+        assert!(!producer_cancel.is_cancelled());
+
+        closer.close();
+        producer_cancel.cancelled().await;
+        assert!(producer_cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn waiter_does_not_miss_clean_completion_notification() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let mut scope = handle.try_scope().expect("admitted");
+        scope.arm();
+        closer.close();
+
+        let waiter = tokio::spawn(async move {
+            let outcome = closer.wait_for_zero_for(WAIT).await;
+            (closer, outcome)
+        });
+        tokio::task::yield_now().await;
+        scope.complete_clean();
+
+        let (closer, outcome) = waiter.await.expect("waiter task");
+        assert!(matches!(outcome, RoomServingWaitOutcome::Quiescent));
+        assert_clean(closer.finalize());
+    }
+
+    async fn wait_and_finalize(closer: RoomServingCloser) -> RoomServingTerminalOutcome {
+        let outcome = closer.wait_for_zero_for(WAIT).await;
+        assert!(matches!(outcome, RoomServingWaitOutcome::Quiescent));
+        closer.finalize()
+    }
+
+    fn assert_clean(outcome: RoomServingTerminalOutcome) {
+        let RoomServingTerminalOutcome::Clean(fence) = outcome else {
+            panic!("expected clean fence, got {outcome:?}");
+        };
+        assert!(fence.is_current_clean());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_and_acquire_race_is_linearizable() {
+        for _ in 0..256 {
+            let (handle, closer) = RoomServingQuiescence::create();
+            let start = Arc::new(tokio::sync::Barrier::new(2));
+            let acquire = tokio::spawn({
+                let handle = handle.clone();
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    handle.try_scope()
+                }
+            });
+            let close = tokio::spawn({
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    let status = closer.close();
+                    (closer, status)
+                }
+            });
+
+            let admitted = acquire.await.expect("acquire task");
+            let (closer, closed) = close.await.expect("close task");
+            assert!(!closed.admission_open);
+            match admitted {
+                Ok(scope) => {
+                    assert_eq!(closed.active_scopes, 1);
+                    drop(scope);
+                }
+                Err(RoomServingAdmissionError::Closed) => {
+                    assert_eq!(closed.active_scopes, 0);
+                }
+                Err(RoomServingAdmissionError::Poisoned) => {
+                    panic!("race must not poison a healthy gate");
+                }
+            }
+            assert_clean(wait_and_finalize(closer).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_counts_scope_before_child_is_polled() {
+        let (handle, closer) = RoomServingQuiescence::create();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let task = handle
+            .spawn(|scope| async move {
+                let _ = release_rx.await;
+                scope.complete_clean();
+            })
+            .expect("spawn admitted");
+
+        // This observation is synchronous with `spawn` returning; the child
+        // does not need to have received a poll for its scope to be counted.
+        assert_eq!(handle.status().active_scopes, 1);
+        closer.close();
+        assert_eq!(
+            handle.try_scope().expect_err("closed before child release"),
+            RoomServingAdmissionError::Closed
+        );
+
+        release_tx.send(()).expect("release child");
+        task.await.expect("child task");
+        assert_clean(wait_and_finalize(closer).await);
+    }
+
+    #[tokio::test]
+    async fn later_poison_invalidates_an_issued_clean_fence() {
+        let (_handle, closer) = RoomServingQuiescence::create();
+        closer.close();
+        assert!(matches!(
+            closer.wait_for_zero_for(WAIT).await,
+            RoomServingWaitOutcome::Quiescent
+        ));
+        let RoomServingTerminalOutcome::Clean(fence) = closer.finalize() else {
+            panic!("expected clean fence");
+        };
+        assert!(fence.is_current_clean());
+
+        fence.inner.poison();
+        assert!(!fence.is_current_clean());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn completion_and_deadline_race_never_mints_an_invalid_fence() {
+        for _ in 0..256 {
+            let (handle, closer) = RoomServingQuiescence::create();
+            let mut scope = handle.try_scope().expect("admitted");
+            scope.arm();
+            closer.close();
+            let start = Arc::new(tokio::sync::Barrier::new(2));
+            let waiter = tokio::spawn({
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    let outcome = closer.wait_for_zero_for(Duration::ZERO).await;
+                    (closer, outcome)
+                }
+            });
+            let completion = tokio::spawn({
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    scope.complete_clean();
+                }
+            });
+
+            let (closer, outcome) = waiter.await.expect("waiter");
+            completion.await.expect("completion");
+            match outcome {
+                RoomServingWaitOutcome::Quiescent => {
+                    let terminal = closer.finalize();
+                    assert_clean(terminal);
+                    assert!(!handle.status().unsafe_to_release);
+                }
+                RoomServingWaitOutcome::TimedOut { .. } => {
+                    assert!(handle.status().unsafe_to_release);
+                    assert!(matches!(
+                        closer.finalize(),
+                        RoomServingTerminalOutcome::Poisoned { .. }
+                    ));
+                }
+                other => panic!("unexpected race outcome: {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_poison_and_deadline_race_never_mints_a_fence() {
+        for _ in 0..256 {
+            let (handle, closer) = RoomServingQuiescence::create();
+            let mut scope = handle.try_scope().expect("admitted");
+            scope.arm();
+            closer.close();
+            let start = Arc::new(tokio::sync::Barrier::new(2));
+            let waiter = tokio::spawn({
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    let outcome = closer.wait_for_zero_for(Duration::ZERO).await;
+                    (closer, outcome)
+                }
+            });
+            let poison = tokio::spawn({
+                let start = Arc::clone(&start);
+                async move {
+                    start.wait().await;
+                    scope.poison();
+                }
+            });
+
+            let (closer, outcome) = waiter.await.expect("waiter");
+            poison.await.expect("poison");
+            assert!(matches!(
+                outcome,
+                RoomServingWaitOutcome::Poisoned { .. } | RoomServingWaitOutcome::TimedOut { .. }
+            ));
+            assert!(handle.status().unsafe_to_release);
+            assert!(matches!(
+                closer.finalize(),
+                RoomServingTerminalOutcome::Poisoned { .. }
+            ));
+        }
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/extension_webhooks.rs
+++ b/server/crates/waddle-server/src/server/routes/extension_webhooks.rs
@@ -222,7 +222,11 @@ async fn provider_webhook_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
-    match accept_provider_webhook(websocket_state, path, &headers, body.as_ref()).await {
+    let scope = match websocket_state.deps.room_serving.try_scope() {
+        Ok(scope) => scope,
+        Err(_) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    };
+    match accept_provider_webhook(websocket_state, path, &headers, body.as_ref(), scope).await {
         Ok(accepted) => (StatusCode::ACCEPTED, Json(accepted)).into_response(),
         Err(error) => webhook_error_response(error),
     }
@@ -233,6 +237,7 @@ async fn accept_provider_webhook(
     path: ProviderIngressPath,
     headers: &HeaderMap,
     body: &[u8],
+    mut room_scope: crate::server::room_serving_quiescence::RoomServingScope,
 ) -> Result<WebhookAccepted, WebhookError> {
     if body.is_empty() {
         return Err(WebhookError::EmptyBody);
@@ -301,6 +306,11 @@ async fn accept_provider_webhook(
         delivery_id: delivery_id.clone(),
         payload,
     };
+    // Validation failures above are settled and leave the admission scope
+    // unarmed. From the delivery-ledger insert onward the request can enqueue
+    // room-capable extension work, so cancellation/ambiguity must latch
+    // terminal release unsafe.
+    room_scope.arm();
     let payload_sha256 = hex::encode(Sha256::digest(body));
     let inserted = record_provider_delivery(
         &websocket_state,
@@ -310,6 +320,7 @@ async fn accept_provider_webhook(
     )
     .await?;
     if !inserted {
+        room_scope.complete_clean();
         return Ok(WebhookAccepted {
             accepted: true,
             provider: provider.into_string(),
@@ -337,6 +348,7 @@ async fn accept_provider_webhook(
                 event,
             )
             .await;
+            room_scope.complete_clean();
         });
 
     Ok(WebhookAccepted {

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -203,7 +203,9 @@ use room_subject::{
     persist_room_subject_event, PersistRoomSubjectEventOutcome, PersistRoomSubjectRequest,
 };
 pub(crate) use route_to_connection::{fallback_reply_for_undeliverable_iq, route_to_connection};
-pub(crate) use routing::{deliver_direct_to_full, deliver_peer_to_full, FullJidDeliveryOutcome};
+pub(crate) use routing::{
+    actor_send_maybe_enqueued, deliver_direct_to_full, deliver_peer_to_full, FullJidDeliveryOutcome,
+};
 use routing::{
     deliver_peer_to_live_only, deliver_to_detached, run_fanout_recipient_pass,
     run_headless_recipient_pass, FanoutPassResult,

--- a/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
@@ -127,6 +127,11 @@ pub(crate) async fn send_carbons_to_registry(
         if let Some(outcome) =
             try_deliver_registered_remote_resource(web_socket_state, &target, &stanza).await
         {
+            if outcome.is_ambiguous() {
+                if let Some(state) = web_socket_state {
+                    state.deps.room_serving.mark_unsafe_to_release();
+                }
+            }
             match outcome {
                 FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => {
                     debug!(target = %target, kind = ?kind, "SendCarbons: delivered to remote resource");
@@ -143,6 +148,13 @@ pub(crate) async fn send_carbons_to_registry(
                         target = %target,
                         kind = ?kind,
                         "SendCarbons: remote target backpressured or relay failed, dropping"
+                    );
+                }
+                FullJidDeliveryOutcome::MaybeEnqueued => {
+                    warn!(
+                        target = %target,
+                        kind = ?kind,
+                        "SendCarbons: remote target delivery may still be enqueued; suppressing fallback"
                     );
                 }
                 #[cfg(feature = "clustering")]

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -5,6 +5,18 @@ use xmpp_parsers::iq::Iq;
 type OrderedRelayDeliveryFuture<'a> =
     Pin<Box<dyn Future<Output = Option<FullJidDeliveryOutcome>> + Send + 'a>>;
 
+fn observe_delivery_outcome(
+    deps: &Deps<'_>,
+    outcome: FullJidDeliveryOutcome,
+) -> FullJidDeliveryOutcome {
+    if outcome.is_ambiguous() {
+        if let Some(state) = deps.web_socket_state {
+            state.deps.room_serving.mark_unsafe_to_release();
+        }
+    }
+    outcome
+}
+
 /// RFC 6121 §8.5.2.1.1 bare-JID destination selection: the candidate set and
 /// priority ranking come from the actor-authoritative `UserActor` alone
 /// (ADR-0017 Phase 3 Slice 9 retires the transitional Slice-1 DashMap
@@ -329,8 +341,10 @@ async fn route_dm_to_full_jid(
                     // argument. `Dropped` (full channel /
                     // maybe-enqueued failure) stays terminal to avoid
                     // double delivery.
-                    let live_outcome =
-                        deliver_peer_to_live_only(deps.user_registry, &full, stanza.as_ref()).await;
+                    let live_outcome = observe_delivery_outcome(
+                        deps,
+                        deliver_peer_to_live_only(deps.user_registry, &full, stanza.as_ref()).await,
+                    );
                     if live_outcome != FullJidDeliveryOutcome::Unavailable {
                         return Vec::new();
                     }
@@ -904,6 +918,7 @@ fn deliver_full_jid_via_ordered_relay<'a>(
             bridge
                 .try_deliver_full_jid_remote(target, stanza, origin)
                 .await
+                .map(|outcome| observe_delivery_outcome(deps, outcome))
         }
         #[cfg(not(feature = "clustering"))]
         {
@@ -926,9 +941,12 @@ async fn deliver_peer_to_full_with_registered_remote(
     )
     .await
     {
-        return outcome;
+        return observe_delivery_outcome(deps, outcome);
     }
-    deliver_peer_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await
+    observe_delivery_outcome(
+        deps,
+        deliver_peer_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await,
+    )
 }
 
 async fn deliver_direct_to_full_with_registered_remote(
@@ -944,9 +962,12 @@ async fn deliver_direct_to_full_with_registered_remote(
     )
     .await
     {
-        return outcome;
+        return observe_delivery_outcome(deps, outcome);
     }
-    deliver_direct_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await
+    observe_delivery_outcome(
+        deps,
+        deliver_direct_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await,
+    )
 }
 
 async fn deliver_registered_remote_resource(
@@ -967,6 +988,7 @@ async fn deliver_registered_remote_resource(
         bridge
             .try_deliver_registered_remote_resource(target, stanza, kind)
             .await
+            .map(|outcome| observe_delivery_outcome(deps, outcome))
     }
     #[cfg(not(feature = "clustering"))]
     {
@@ -994,6 +1016,7 @@ fn deliver_bare_jid_via_ordered_relay<'a>(
             bridge
                 .try_deliver_bare_jid_remote(target, stanza, origin)
                 .await
+                .map(|outcome| observe_delivery_outcome(deps, outcome))
         }
         #[cfg(not(feature = "clustering"))]
         {

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -398,11 +398,13 @@ pub(crate) enum FullJidDeliveryOutcome {
     /// Confirmed offline: no live channel and no detached session to fall
     /// back to.
     Unavailable,
-    /// Dropped for an ambiguous/transient reason: full channel, a storage
-    /// error while recording to detached, or a terminal ask failure
-    /// classified `MaybeEnqueued` (never routed to detached, to avoid
-    /// double-delivery).
+    /// Dropped for a settled transient reason: full channel or a storage
+    /// error while recording to detached.
     Dropped,
+    /// The `UserActor` ask may already be in its mailbox and may still commit
+    /// after the reply wait failed. Callers suppress fallback and must mark
+    /// terminal room-claim release unsafe.
+    MaybeEnqueued,
     /// The relay ask may have reached the target and committed the delivery,
     /// but the sender did not observe the reply. Callers must suppress local
     /// or headless fallback to avoid duplicate user-visible effects.
@@ -415,8 +417,18 @@ impl FullJidDeliveryOutcome {
         match self {
             Self::Delivered | Self::QueuedDetached => true,
             Self::Unavailable | Self::Dropped => false,
+            Self::MaybeEnqueued => true,
             #[cfg(feature = "clustering")]
             Self::MaybeCommitted => true,
+        }
+    }
+
+    pub(crate) fn is_ambiguous(self) -> bool {
+        match self {
+            Self::MaybeEnqueued => true,
+            #[cfg(feature = "clustering")]
+            Self::MaybeCommitted => true,
+            Self::Delivered | Self::QueuedDetached | Self::Unavailable | Self::Dropped => false,
         }
     }
 }
@@ -442,7 +454,7 @@ fn detached_after_routing_failure(outcome: DetachedDeliveryOutcome) -> FullJidDe
     match outcome {
         DetachedDeliveryOutcome::Queued => FullJidDeliveryOutcome::QueuedDetached,
         DetachedDeliveryOutcome::Unavailable | DetachedDeliveryOutcome::Failed => {
-            FullJidDeliveryOutcome::Dropped
+            FullJidDeliveryOutcome::MaybeEnqueued
         }
     }
 }
@@ -463,6 +475,10 @@ fn classify_send_error<M, E>(error: &kameo::error::SendError<M, E>) -> ActorSend
             ActorSendFailure::MaybeEnqueued
         }
     }
+}
+
+pub(crate) fn actor_send_maybe_enqueued<M, E>(error: &kameo::error::SendError<M, E>) -> bool {
+    classify_send_error(error) == ActorSendFailure::MaybeEnqueued
 }
 
 /// Deliver one stanza to one resource through the authoritative `UserActor`
@@ -788,7 +804,7 @@ pub(super) async fn deliver_peer_to_live_only(
                     "live-only delivery: TrySendPeer failed terminally (possibly \
                      enqueued); dropping to avoid double-delivery"
                 );
-                FullJidDeliveryOutcome::Dropped
+                FullJidDeliveryOutcome::MaybeEnqueued
             }
         },
     }

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -99,6 +99,21 @@ async fn livekit_webhook_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    let scope = match state.deps.room_serving.try_scope() {
+        Ok(scope) => scope,
+        Err(_) => return StatusCode::SERVICE_UNAVAILABLE,
+    };
+    scope
+        .run_clean(livekit_webhook_inner(state, seen, headers, body))
+        .await
+}
+
+async fn livekit_webhook_inner(
+    state: Arc<WebSocketState>,
+    seen: Arc<SeenEventIds>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
     let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
         warn!("LiveKit webhook received but no SFU is configured; dropping");
         return StatusCode::SERVICE_UNAVAILABLE;
@@ -216,16 +231,29 @@ fn is_muc_call(call_id: &str) -> bool {
 /// tick after [`RECONCILE_INTERVAL`].
 pub fn spawn_reconciliation_task(state: Arc<WebSocketState>, reconciler: Arc<dyn SfuReconciler>) {
     let grace = chrono::Duration::seconds(RECONCILE_GRACE_SECONDS);
-    tokio::spawn(async move {
+    let producer_cancel = state.deps.room_serving.producer_cancellation();
+    let room_serving = state.deps.room_serving.clone();
+    let spawn = room_serving.spawn(move |scope| async move {
         let mut ticker = tokio::time::interval(RECONCILE_INTERVAL);
         // Drop the immediate first tick `interval` yields so we don't
         // reconcile at boot before any call exists.
         ticker.tick().await;
         loop {
-            ticker.tick().await;
-            reconcile_once(&state, reconciler.as_ref(), grace).await;
+            tokio::select! {
+                biased;
+                _ = producer_cancel.cancelled() => {
+                    scope.complete_clean();
+                    return;
+                }
+                _ = ticker.tick() => {
+                    reconcile_once(&state, reconciler.as_ref(), grace).await;
+                }
+            }
         }
     });
+    if let Err(error) = spawn {
+        warn!(?error, "LiveKit reconciliation producer was not admitted");
+    }
 }
 
 /// One reconciliation pass: sweep registry ghosts via the reconciler,

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -61,6 +61,9 @@ pub(crate) async fn clear_muji_presence_for_departure(
             return;
         }
         Err(error) => {
+            if super::interpret::actor_send_maybe_enqueued(&error) {
+                state.deps.room_serving.mark_unsafe_to_release();
+            }
             warn!(
                 room = %room_jid,
                 identity = %full_jid,

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -40,6 +40,8 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         muc_domain.to_string(),
         occupant_id_secret.clone(),
     ));
+    let (room_serving, _room_serving_closer) =
+        crate::server::room_serving_quiescence::RoomServingQuiescence::create();
     let app_state = Arc::new(AppState::new_with_deps(AppStateDeps {
         db_pool: Arc::clone(&db_pool),
         blob_storage,
@@ -57,6 +59,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         server_owner_jids: Arc::from(Vec::<jid::BareJid>::new()),
         clustering_readiness: crate::clustering::ClusteringReadiness::new(),
         clustering_claims: crate::clustering::ClusteringHandles::default(),
+        room_serving,
     }));
 
     (Arc::new(UploadState::new(app_state)), upload_dir)

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -3,7 +3,9 @@ use super::{
     replay::drain_outbound_into_replay, state::WsConnState, stream_management::sm_show_from_name,
 };
 use waddle_xmpp::muc::room_actor::{LeaveOutcome, SealGuard};
-use waddle_xmpp::muc::room_registry_actor::{RoomAcquisition, RoomRegistryError};
+use waddle_xmpp::muc::room_registry_actor::{
+    DestroyRoomIfInactiveOutcome, RoomAcquisition, RoomRegistryError,
+};
 use waddle_xmpp::muc::RoomRegistry;
 use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
@@ -266,8 +268,20 @@ pub(crate) async fn maybe_evict_empty_room(
         )
         .await
     {
-        Ok(destroyed) => destroyed,
+        Ok(DestroyRoomIfInactiveOutcome::Destroyed) => true,
+        Ok(DestroyRoomIfInactiveOutcome::Retained) => false,
+        Ok(DestroyRoomIfInactiveOutcome::MaybeSealed) => {
+            state.deps.room_serving.mark_unsafe_to_release();
+            warn!(
+                room = %room_jid,
+                "Guarded destroy may have sealed the room without returning a reply"
+            );
+            return false;
+        }
         Err(error) => {
+            if error == RoomRegistryError::Timeout {
+                state.deps.room_serving.mark_unsafe_to_release();
+            }
             warn!(room = %room_jid, error = %error, "Failed guarded destroy of empty room");
             return false;
         }
@@ -785,6 +799,9 @@ async fn cleanup_muc_presence_with_origin(
             Ok(None) => {}
             Err(error) => {
                 completed = false;
+                if crate::server::routes::interpret::actor_send_maybe_enqueued(&error) {
+                    state.deps.room_serving.mark_unsafe_to_release();
+                }
                 warn!(
                     room = %room_jid,
                     jid = %jid,
@@ -1130,6 +1147,19 @@ async fn acquire_remote_muc_cleanup_origin(
             inbound_sequence: 0,
             handoff: None,
         }),
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::registry::UserRegistryError::ClaimHeldByAnotherNode(_),
+        )) => {
+            // This is the expected steady state when another live resource
+            // keeps the bare-JID UserActor claim on its node. The membership
+            // remains retained for the next reconciliation pass; do not turn
+            // that bounded retry loop into a production warning every 30s.
+            debug!(
+                jid = %jid,
+                "remote MUC cleanup deferred while UserActor claim is held elsewhere"
+            );
+            None
+        }
         Err(error) => {
             warn!(
                 jid = %jid,

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -37,6 +37,20 @@ async fn xmpp_websocket_handler(
     uri: axum::http::Uri,
     State(state): State<Arc<WebSocketState>>,
 ) -> Response {
+    // Count room-capable admission before either shutdown check. The room gate
+    // and Ecdysis guard then cover the same upgrade race: shutdown either
+    // observes this accepted connection or this request is rejected.
+    let mut room_scope = match state.deps.room_serving.try_scope() {
+        Ok(scope) => scope,
+        Err(error) => {
+            info!(
+                ?error,
+                "Rejecting XMPP WebSocket upgrade: room serving is closed"
+            );
+            return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
+
     // Graceful shutdown gate (issue #1091). The guard is minted BEFORE
     // the stop-token check: the upgrade handshake spans a client
     // round-trip, so a check-then-mint order would let a connection be
@@ -69,8 +83,15 @@ async fn xmpp_websocket_handler(
         let _enter = established_span.enter();
     }
 
-    ws.protocols(["xmpp"])
-        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
+    ws.protocols(["xmpp"]).on_upgrade(move |socket| async move {
+        // The scope stays unarmed while Axum is negotiating the upgrade. If
+        // the upgrade is never established, its drop is a clean non-operation.
+        // Once established, cancellation/panic anywhere through connection
+        // cleanup makes terminal release unsafe.
+        room_scope.arm();
+        handle_xmpp_websocket(socket, state, connection_guard).await;
+        room_scope.complete_clean();
+    })
 }
 
 fn connection_established_span(query: Option<&str>) -> Option<tracing::Span> {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -267,6 +267,17 @@ async fn handle_xmpp_frame_impl(
             // an IQ get/set gets a conformant resource-constraint/wait error and
             // message/presence are dropped (logged + metered).
             let backstop = StanzaBackstop::capture(&stanza, phase.bound_jid());
+            let mut room_scope = match state.deps.room_serving.try_scope() {
+                Ok(scope) => scope,
+                Err(error) => {
+                    warn!(?error, "Rejecting inbound stanza: room serving is closed");
+                    if let Some(inbound_sequence) = reserved_inbound_for_sm {
+                        sm_inbound_completion.abandon(inbound_sequence);
+                    }
+                    return Vec::new();
+                }
+            };
+            room_scope.arm();
             let dispatch = async {
                 match *stanza {
                     Stanza::Iq(iq) => {
@@ -320,11 +331,21 @@ async fn handle_xmpp_frame_impl(
                 }
             };
             let (responses, disposition) = match run_with_backstop(backstop, dispatch).await {
-                Ok(responses) => (responses, InboundDisposition::Handled),
+                Ok(responses) => {
+                    room_scope.complete_clean();
+                    (responses, InboundDisposition::Handled)
+                }
                 Err(StanzaTimeout::HandledIq(reply)) => {
+                    // The dispatch future was cancelled after it may already
+                    // have committed a room-side effect. Keep serving live
+                    // traffic, but permanently forbid a clean claim release.
+                    room_scope.poison();
                     (vec![element_to_xml(reply)], InboundDisposition::Handled)
                 }
-                Err(StanzaTimeout::Unhandled) => (Vec::new(), InboundDisposition::Unhandled),
+                Err(StanzaTimeout::Unhandled) => {
+                    room_scope.poison();
+                    (Vec::new(), InboundDisposition::Unhandled)
+                }
             };
             settle_inbound_dispatch(
                 disposition,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/full_jid_forward.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/full_jid_forward.rs
@@ -57,10 +57,16 @@ pub(super) async fn route_full_jid_iq(
             .try_deliver_full_jid_remote(&target, &stanza, origin)
             .await
         {
+            if outcome.is_ambiguous() {
+                state.deps.room_serving.mark_unsafe_to_release();
+            }
             return match outcome {
                 crate::server::routes::interpret::FullJidDeliveryOutcome::Delivered
                 | crate::server::routes::interpret::FullJidDeliveryOutcome::QueuedDetached
-                | crate::server::routes::interpret::FullJidDeliveryOutcome::Dropped => Vec::new(),
+                | crate::server::routes::interpret::FullJidDeliveryOutcome::Dropped
+                | crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeEnqueued => {
+                    Vec::new()
+                }
                 #[cfg(feature = "clustering")]
                 crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeCommitted => {
                     Vec::new()
@@ -78,10 +84,16 @@ pub(super) async fn route_full_jid_iq(
             )
             .await
         {
+            if outcome.is_ambiguous() {
+                state.deps.room_serving.mark_unsafe_to_release();
+            }
             return match outcome {
                 crate::server::routes::interpret::FullJidDeliveryOutcome::Delivered
                 | crate::server::routes::interpret::FullJidDeliveryOutcome::QueuedDetached
-                | crate::server::routes::interpret::FullJidDeliveryOutcome::Dropped => Vec::new(),
+                | crate::server::routes::interpret::FullJidDeliveryOutcome::Dropped
+                | crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeEnqueued => {
+                    Vec::new()
+                }
                 #[cfg(feature = "clustering")]
                 crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeCommitted => {
                     Vec::new()

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -312,7 +312,8 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 // answer retryable, never a false success.
                 Ok(
                     waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
-                    | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
+                    | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull
+                    | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ShutdownInProgress,
                 ) => {
                     return vec![build_iq_error_xml_typed(
                         id,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/group_dm_invite.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/group_dm_invite.rs
@@ -140,6 +140,21 @@ pub(super) async fn handle_group_dm_mediated_invite(
             "Invitee is already a group-DM member.",
         )]);
     }
+    // Capture display metadata while the actor is still serving. Everything
+    // below may create archive, membership, affiliation, bookmark, and invite
+    // ledger state; a newly gated GetConfig after those commits must not turn
+    // a successful grant into a partial failure.
+    let room_name = match room_actor.ask(GetConfig).await {
+        Ok(config) => config.name,
+        Err(_) => {
+            return Some(vec![error_reply(
+                incoming,
+                bound_jid,
+                GroupDmInviteError::InternalServerError,
+                "Internal server error.",
+            )]);
+        }
+    };
 
     let requested_access =
         waddle_xmpp::xep::xep_waddle_group_dm::history_access_from_mediated_invite(&inbound_invite)
@@ -212,10 +227,6 @@ pub(super) async fn handle_group_dm_mediated_invite(
             "Internal server error.",
         )]);
     }
-    let room_name = match room_actor.ask(GetConfig).await {
-        Ok(config) => config.name,
-        Err(_) => room_jid.to_string(),
-    };
     let shared_room_name = {
         let trimmed = room_name.trim();
         (!trimmed.is_empty()).then_some(trimmed)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
@@ -252,7 +252,8 @@ async fn handle_muc_private_message(
         // duplicate-visible error. Unavailable/Dropped never count.
         let session_handled = match outcome {
             crate::server::routes::interpret::FullJidDeliveryOutcome::Delivered
-            | crate::server::routes::interpret::FullJidDeliveryOutcome::QueuedDetached => true,
+            | crate::server::routes::interpret::FullJidDeliveryOutcome::QueuedDetached
+            | crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeEnqueued => true,
             #[cfg(feature = "clustering")]
             crate::server::routes::interpret::FullJidDeliveryOutcome::MaybeCommitted => true,
             crate::server::routes::interpret::FullJidDeliveryOutcome::Unavailable
@@ -323,18 +324,25 @@ async fn deliver_pm_to_session(
             )
             .await
         {
+            if outcome.is_ambiguous() {
+                state.deps.room_serving.mark_unsafe_to_release();
+            }
             return outcome;
         }
     }
     #[cfg(not(feature = "clustering"))]
     let _ = state;
-    crate::server::routes::interpret::deliver_direct_to_full(
+    let outcome = crate::server::routes::interpret::deliver_direct_to_full(
         deps.user_registry,
         deps.sm_session_registry,
         target,
         stanza,
     )
-    .await
+    .await;
+    if outcome.is_ambiguous() {
+        state.deps.room_serving.mark_unsafe_to_release();
+    }
+    outcome
 }
 
 /// XEP-0045 §7.8.2 mediated decline, hardened per #1264:

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -117,10 +117,13 @@ fn sync_resolver_affiliation_on_rejection(
         existing_room_actor,
         scheduler,
         None,
+        None,
         room_jid,
         jid,
-        affiliation,
-        expected_admission_revision,
+        crate::server::routes::websocket::ResolverAffiliationSyncWork {
+            affiliation,
+            expected_admission_revision,
+        },
     );
 }
 
@@ -128,17 +131,13 @@ fn sync_resolver_affiliation_on_rejection_with_registry(
     existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
     scheduler: &std::sync::Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
     room_registry: Option<RoomRegistry>,
+    room_serving: Option<&crate::server::room_serving_quiescence::RoomServingHandle>,
     room_jid: &BareJid,
     jid: BareJid,
-    affiliation: Affiliation,
-    expected_admission_revision: u64,
+    work: crate::server::routes::websocket::ResolverAffiliationSyncWork,
 ) {
     let Some(actor) = existing_room_actor else {
         return;
-    };
-    let work = crate::server::routes::websocket::ResolverAffiliationSyncWork {
-        affiliation,
-        expected_admission_revision,
     };
     let worker = match scheduler.schedule(room_jid, &jid, actor.id(), work) {
         crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Started(worker) => {
@@ -184,25 +183,58 @@ fn sync_resolver_affiliation_on_rejection_with_registry(
     // they never consult the registry and therefore cannot create a room.
     // Reusing the captured revision makes every delayed attempt harmless once
     // a newer admission or affiliation mutation has landed.
-    tokio::spawn(run_resolver_affiliation_sync_worker(
-        actor,
-        room_registry,
-        room_jid,
-        jid,
-        *worker,
-    ));
+    let worker = *worker;
+    if let Some(room_serving) = room_serving {
+        let ambiguity_marker = room_serving.clone();
+        let log_room_jid = room_jid.clone();
+        let log_jid = jid.clone();
+        if let Err(error) = room_serving.spawn(move |scope| async move {
+            let ambiguous = run_resolver_affiliation_sync_worker(
+                actor,
+                room_registry,
+                Some(ambiguity_marker),
+                room_jid,
+                jid,
+                worker,
+            )
+            .await;
+            if ambiguous {
+                scope.poison();
+            } else {
+                scope.complete_clean();
+            }
+        }) {
+            debug!(
+                room = %log_room_jid,
+                jid = %log_jid,
+                ?error,
+                "Skipped resolver affiliation repair because room admission is closed"
+            );
+        }
+    } else {
+        tokio::spawn(run_resolver_affiliation_sync_worker(
+            actor,
+            room_registry,
+            None,
+            room_jid,
+            jid,
+            worker,
+        ));
+    }
 }
 
 async fn run_resolver_affiliation_sync_worker(
     actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
     room_registry: Option<RoomRegistry>,
+    room_serving: Option<crate::server::room_serving_quiescence::RoomServingHandle>,
     room_jid: BareJid,
     jid: BareJid,
     mut worker: crate::server::routes::websocket::state::ResolverAffiliationSyncWorker,
-) {
+) -> bool {
     let mut work = worker.current();
     let mut effective_admission_revision = worker.effective_admission_revision();
     let mut attempt = 1usize;
+    let mut ambiguous = false;
     loop {
         let result = actor
             .ask(waddle_xmpp::muc::room_actor::SyncResolverAffiliation {
@@ -220,7 +252,7 @@ async fn run_resolver_affiliation_sync_worker(
                 admission_revision,
             }) => {
                 let Some(next) = worker.finish_applied_or_take_update(admission_revision) else {
-                    return;
+                    return ambiguous;
                 };
                 work = next;
                 effective_admission_revision = worker.effective_admission_revision();
@@ -259,14 +291,20 @@ async fn run_resolver_affiliation_sync_worker(
                                 room = %room_jid,
                                 "Rejected-join repair observed a room already absent or replaced"
                             ),
-                            Err(error) => warn!(
-                                room = %room_jid,
-                                %error,
-                                "Failed to reap deposed room after rejected-join affiliation repair"
-                            ),
+                            Err(error) => {
+                                ambiguous = true;
+                                if let Some(room_serving) = &room_serving {
+                                    room_serving.mark_unsafe_to_release();
+                                }
+                                warn!(
+                                    room = %room_jid,
+                                    %error,
+                                    "Failed to reap deposed room after rejected-join affiliation repair"
+                                );
+                            }
                         }
                     }
-                    return;
+                    return ambiguous;
                 }
                 let disposition = if outcome
                     == waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable
@@ -276,7 +314,7 @@ async fn run_resolver_affiliation_sync_worker(
                     crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::InvalidatingOutcome
                 };
                 let Some(next) = worker.finish_terminal_or_take_update(disposition) else {
-                    return;
+                    return ambiguous;
                 };
                 work = next;
                 effective_admission_revision = worker.effective_admission_revision();
@@ -307,7 +345,7 @@ async fn run_resolver_affiliation_sync_worker(
                 let Some(next) = worker.finish_terminal_or_take_update(
                     crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::NonMutatingExhaustion,
                 ) else {
-                    return;
+                    return ambiguous;
                 };
                 work = next;
                 effective_admission_revision = worker.effective_admission_revision();
@@ -315,6 +353,12 @@ async fn run_resolver_affiliation_sync_worker(
                 continue;
             }
             Err(error) => {
+                if crate::server::routes::interpret::actor_send_maybe_enqueued(&error) {
+                    ambiguous = true;
+                    if let Some(room_serving) = &room_serving {
+                        room_serving.mark_unsafe_to_release();
+                    }
+                }
                 warn!(
                     room = %room_jid,
                     attempt,
@@ -324,7 +368,7 @@ async fn run_resolver_affiliation_sync_worker(
                 let Some(next) = worker.finish_terminal_or_take_update(
                     crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::InvalidatingOutcome,
                 ) else {
-                    return;
+                    return ambiguous;
                 };
                 work = next;
                 effective_admission_revision = worker.effective_admission_revision();
@@ -468,6 +512,8 @@ async fn try_deliver_registered_remote_resource(
 enum RemoteMucJoinDecision {
     Delivered(Vec<Stanza>),
     MaybeCommitted,
+    RetryableNoEffect,
+    LocalRoomOrUnclaimed,
 }
 
 #[cfg(feature = "clustering")]
@@ -480,19 +526,101 @@ enum RemoteMucLeaveDecision {
 
 #[cfg(feature = "clustering")]
 fn remote_muc_join_decision(
-    outcome: Option<crate::clustering::route_bridge::OrderedRelayMucProxyOutcome>,
-) -> Option<RemoteMucJoinDecision> {
-    match outcome {
-        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(replies)) => {
-            Some(RemoteMucJoinDecision::Delivered(replies))
+    decision: crate::clustering::route_bridge::MucProxyRouteDecision,
+) -> RemoteMucJoinDecision {
+    use crate::clustering::route_bridge::{MucProxyRouteDecision, OrderedRelayMucProxyOutcome};
+
+    match decision {
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(replies)) => {
+            RemoteMucJoinDecision::Delivered(replies)
         }
-        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted)
-        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted) => {
-            Some(RemoteMucJoinDecision::MaybeCommitted)
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::MaybeCommitted)
+        | MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::JoinMaybeCommitted) => {
+            RemoteMucJoinDecision::MaybeCommitted
         }
-        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
-        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped)
-        | None => None,
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Unavailable)
+        | MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Dropped)
+        | MucProxyRouteDecision::RoomClaimUnavailable
+        | MucProxyRouteDecision::OriginUnavailable => RemoteMucJoinDecision::RetryableNoEffect,
+        MucProxyRouteDecision::LocalRoom | MucProxyRouteDecision::RoomUnclaimed => {
+            RemoteMucJoinDecision::LocalRoomOrUnclaimed
+        }
+    }
+}
+
+#[cfg(feature = "clustering")]
+async fn try_proxy_remote_muc_join(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+    nick: &str,
+    presence_show: Option<crate::notification_activity::NotificationPresenceShow>,
+    origin: &crate::server::routes::interpret::OrderedRelayRouteOrigin,
+) -> RemoteMucJoinDecision {
+    let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    else {
+        // `ClusteringHandles` deliberately uses an absent bridge to mean
+        // runtime clustering is disabled, including an all-features binary
+        // running in portable single-node mode. The frame layer still
+        // constructs typed origin provenance in that build, so the origin
+        // alone cannot be used as proof that a cluster route is required.
+        return RemoteMucJoinDecision::LocalRoomOrUnclaimed;
+    };
+
+    let mut presence = xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None);
+    presence.from = Some(jid::Jid::from(sender_jid.clone()));
+    presence.to = room_jid
+        .clone()
+        .with_resource_str(nick)
+        .ok()
+        .map(jid::Jid::from);
+    if let Some(show) = presence_show {
+        presence.show = Some(show.to_xep0045());
+    }
+    let stanza = Stanza::Presence(presence);
+    let _remote_muc_membership_guard = state
+        .deps
+        .protocol
+        .remote_muc_memberships
+        .lock_membership(sender_jid, room_jid)
+        .await;
+    let decision = remote_muc_join_decision(
+        bridge
+            .try_proxy_muc_remote_decision(
+                room_jid,
+                &stanza,
+                crate::clustering::ordered_relay::OrderedRelayMucProxyKind::JoinPresence,
+                origin,
+            )
+            .await,
+    );
+    match decision {
+        RemoteMucJoinDecision::Delivered(replies) => {
+            state
+                .deps
+                .protocol
+                .remote_muc_memberships
+                .record_join(sender_jid, room_jid, nick);
+            RemoteMucJoinDecision::Delivered(replies)
+        }
+        RemoteMucJoinDecision::MaybeCommitted => {
+            // The remote owner may already have mutated room state. Retain
+            // cleanup responsibility while the client retries/resynchronizes
+            // instead of returning a local error that would claim no effect.
+            state
+                .deps
+                .protocol
+                .remote_muc_memberships
+                .record_join(sender_jid, room_jid, nick);
+            RemoteMucJoinDecision::MaybeCommitted
+        }
+        RemoteMucJoinDecision::RetryableNoEffect => RemoteMucJoinDecision::RetryableNoEffect,
+        RemoteMucJoinDecision::LocalRoomOrUnclaimed => RemoteMucJoinDecision::LocalRoomOrUnclaimed,
     }
 }
 
@@ -521,50 +649,71 @@ mod tests {
     use super::*;
 
     #[test]
-    fn remote_muc_join_decision_suppresses_errors_for_uncertain_commit() {
+    fn remote_muc_join_decision_preserves_typed_route_outcomes() {
+        use crate::clustering::route_bridge::{MucProxyRouteDecision, OrderedRelayMucProxyOutcome};
+
         assert!(matches!(
-            remote_muc_join_decision(Some(
+            remote_muc_join_decision(MucProxyRouteDecision::Attempted(
+                OrderedRelayMucProxyOutcome::Delivered(vec![Stanza::Presence(
+                    xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None,)
+                ),]),
+            )),
+            RemoteMucJoinDecision::Delivered(_)
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::Attempted(
+                OrderedRelayMucProxyOutcome::MaybeCommitted,
+            )),
+            RemoteMucJoinDecision::MaybeCommitted
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::Attempted(
+                OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
+            )),
+            RemoteMucJoinDecision::MaybeCommitted
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::Attempted(
+                OrderedRelayMucProxyOutcome::Unavailable,
+            )),
+            RemoteMucJoinDecision::RetryableNoEffect
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::Attempted(
+                OrderedRelayMucProxyOutcome::Dropped,
+            )),
+            RemoteMucJoinDecision::RetryableNoEffect
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::RoomClaimUnavailable),
+            RemoteMucJoinDecision::RetryableNoEffect
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::OriginUnavailable),
+            RemoteMucJoinDecision::RetryableNoEffect
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::LocalRoom),
+            RemoteMucJoinDecision::LocalRoomOrUnclaimed
+        ));
+        assert!(matches!(
+            remote_muc_join_decision(MucProxyRouteDecision::RoomUnclaimed),
+            RemoteMucJoinDecision::LocalRoomOrUnclaimed
+        ));
+    }
+
+    #[test]
+    fn remote_muc_join_decision_keeps_delivered_replies() {
+        let decision = remote_muc_join_decision(
+            crate::clustering::route_bridge::MucProxyRouteDecision::Attempted(
                 crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(vec![
                     Stanza::Presence(xmpp_parsers::presence::Presence::new(
                         xmpp_parsers::presence::Type::None,
                     )),
                 ]),
-            )),
-            Some(RemoteMucJoinDecision::Delivered(_))
-        ));
-        assert!(matches!(
-            remote_muc_join_decision(Some(
-                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted,
-            )),
-            Some(RemoteMucJoinDecision::MaybeCommitted)
-        ));
-        assert!(matches!(
-            remote_muc_join_decision(Some(
-                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
-            )),
-            Some(RemoteMucJoinDecision::MaybeCommitted)
-        ));
-        assert!(remote_muc_join_decision(Some(
-            crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable,
-        ))
-        .is_none());
-        assert!(remote_muc_join_decision(Some(
-            crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped,
-        ))
-        .is_none());
-        assert!(remote_muc_join_decision(None).is_none());
-    }
-
-    #[test]
-    fn remote_muc_join_decision_keeps_delivered_replies() {
-        let decision = remote_muc_join_decision(Some(
-            crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(vec![
-                Stanza::Presence(xmpp_parsers::presence::Presence::new(
-                    xmpp_parsers::presence::Type::None,
-                )),
-            ]),
-        ));
-        let Some(RemoteMucJoinDecision::Delivered(replies)) = decision else {
+            ),
+        );
+        let RemoteMucJoinDecision::Delivered(replies) = decision else {
             panic!("expected delivered replies");
         };
         assert_eq!(replies.len(), 1);
@@ -902,14 +1051,17 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         Some(RoomRegistry::wrap(
                             state.deps.protocol.room_registry.clone(),
                         )),
+                        Some(&state.deps.room_serving),
                         room_jid,
                         // Room affiliations are keyed by the joiner's
                         // bare JID (`JoinWithAffiliation` uses
                         // `sender_jid.to_bare()`), so the sync must use
                         // the same key.
                         sender_jid.to_bare(),
-                        Affiliation::Outcast,
-                        admission_revision,
+                        crate::server::routes::websocket::ResolverAffiliationSyncWork {
+                            affiliation: Affiliation::Outcast,
+                            expected_admission_revision: admission_revision,
+                        },
                     );
                     return deny_join_admission(
                         room_jid,
@@ -939,12 +1091,15 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                             Some(RoomRegistry::wrap(
                                 state.deps.protocol.room_registry.clone(),
                             )),
+                            Some(&state.deps.room_serving),
                             room_jid,
                             // Same key as `JoinWithAffiliation`:
                             // `sender_jid.to_bare()`.
                             sender_jid.to_bare(),
-                            Affiliation::None,
-                            admission_revision,
+                            crate::server::routes::websocket::ResolverAffiliationSyncWork {
+                                affiliation: Affiliation::None,
+                                expected_admission_revision: admission_revision,
+                            },
                         );
                         return deny_join_admission(
                             room_jid,
@@ -988,6 +1143,51 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
         let (room_actor, created_instant_room) = match existing_room_actor {
             Some(actor) => (actor, false),
             None => {
+                // A missing local actor does not imply a new room: it can be
+                // an unmanaged room whose live actor is owned by another
+                // cluster node. Ask the authoritative claim-backed relay
+                // path before applying the local room-creation permission.
+                // The typed route decision allows only `LocalRoom` and
+                // `RoomUnclaimed` to reach the normal creation guard below;
+                // ambiguous claim/origin failures return a retryable stanza
+                // error without creating a competing local actor.
+                #[cfg(feature = "clustering")]
+                if let Some(origin) = ordered_relay_origin.as_ref() {
+                    match try_proxy_remote_muc_join(
+                        state,
+                        room_jid,
+                        sender_jid,
+                        &nick,
+                        presence_show,
+                        origin,
+                    )
+                    .await
+                    {
+                        RemoteMucJoinDecision::Delivered(replies) => {
+                            return replies
+                                .into_iter()
+                                .map(|reply| stanza_to_xml(&reply))
+                                .collect();
+                        }
+                        RemoteMucJoinDecision::MaybeCommitted => return Vec::new(),
+                        RemoteMucJoinDecision::RetryableNoEffect => {
+                            return vec![build_muc_presence_error_xml(
+                                room_jid,
+                                &nick,
+                                sender_jid,
+                                StanzaError::new(
+                                    ErrorType::Wait,
+                                    DefinedCondition::ResourceConstraint,
+                                    "en",
+                                    "This room's remote owner is temporarily unavailable; \
+                                     please retry.",
+                                ),
+                            )];
+                        }
+                        RemoteMucJoinDecision::LocalRoomOrUnclaimed => {}
+                    }
+                }
+
                 if managed_channel.is_none()
                     && !room_preparation_pending
                     && !server_permission_allowed(
@@ -1054,91 +1254,53 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 .await
                 {
                     Ok(acquisition) => acquisition,
-                    // ADR-0017 Phase 3 Slice 7 FIX 6 (council-adjudicated):
-                    // another node genuinely, currently owns this room's
-                    // claim. Phase 4 first tries the ordered relay MUC proxy
-                    // so the owning RoomActor remains the single writer.
-                    Err(waddle_xmpp::muc::room_registry_actor::RoomRegistryError::ClaimHeldByAnotherNode(_)) => {
+                    // The local registry cannot currently serve this room:
+                    // either a fresh foreign owner is already known or an
+                    // exact local generation is still reconciling. Phase 4
+                    // first asks the ordered-relay bridge, whose authoritative
+                    // claim read proxies only to a fresh foreign owner, so the
+                    // owning RoomActor remains the single writer. If the room
+                    // is local, unclaimed, or unavailable, preserve the
+                    // variant-specific retryable fallback below.
+                    Err(
+                        ownership_error @ (
+                            waddle_xmpp::muc::room_registry_actor::RoomRegistryError::ClaimHeldByAnotherNode(_)
+                            | waddle_xmpp::muc::room_registry_actor::RoomRegistryError::OwnershipReconciliationPending(_)
+                        ),
+                    ) => {
                         #[cfg(feature = "clustering")]
                         if let Some(origin) = ordered_relay_origin.as_ref() {
-                            if let Some(bridge) = state
-                                .deps
-                                .app_state
-                                .clustering_claims
-                                .ordered_relay_delivery_bridge
-                                .as_ref()
+                            match try_proxy_remote_muc_join(
+                                state,
+                                room_jid,
+                                sender_jid,
+                                &nick,
+                                presence_show,
+                                origin,
+                            )
+                            .await
                             {
-                                let mut presence = xmpp_parsers::presence::Presence::new(
-                                    xmpp_parsers::presence::Type::None,
-                                );
-                                presence.from = Some(jid::Jid::from(sender_jid.clone()));
-                                presence.to = room_jid
-                                    .clone()
-                                    .with_resource_str(&nick)
-                                    .ok()
-                                    .map(jid::Jid::from);
-                                if let Some(show) = presence_show {
-                                    presence.show = Some(show.to_xep0045());
+                                RemoteMucJoinDecision::Delivered(replies) => {
+                                    return replies
+                                        .into_iter()
+                                        .map(|reply| stanza_to_xml(&reply))
+                                        .collect();
                                 }
-                                let stanza = Stanza::Presence(presence);
-                                let _remote_muc_membership_guard = state
-                                    .deps
-                                    .protocol
-                                    .remote_muc_memberships
-                                    .lock_membership(sender_jid, room_jid)
-                                    .await;
-                                match remote_muc_join_decision(
-                                    bridge
-                                        .try_proxy_muc_remote(
-                                            room_jid,
-                                            &stanza,
-                                            crate::clustering::ordered_relay::OrderedRelayMucProxyKind::JoinPresence,
-                                            origin,
-                                        )
-                                        .await,
-                                ) {
-                                    Some(RemoteMucJoinDecision::Delivered(replies)) => {
-                                        state
-                                            .deps
-                                            .protocol
-                                            .remote_muc_memberships
-                                            .record_join(sender_jid, room_jid, &nick);
-                                        return replies
-                                            .into_iter()
-                                            .map(|reply| stanza_to_xml(&reply))
-                                            .collect();
-                                    }
-                                    Some(RemoteMucJoinDecision::MaybeCommitted) => {
-                                        // The remote owner may already have mutated room state; a
-                                        // local presence error would lie. Keep cleanup state and let
-                                        // the client retry/resynchronize instead.
-                                        state
-                                            .deps
-                                            .protocol
-                                            .remote_muc_memberships
-                                            .record_join(sender_jid, room_jid, &nick);
-                                        return Vec::new();
-                                    }
-                                    None => {}
-                                }
+                                RemoteMucJoinDecision::MaybeCommitted => return Vec::new(),
+                                RemoteMucJoinDecision::RetryableNoEffect
+                                | RemoteMucJoinDecision::LocalRoomOrUnclaimed => {}
                             }
                         }
-                        return vec![build_muc_presence_error_xml(
-                            room_jid,
-                            &nick,
-                            sender_jid,
-                            StanzaError::new(
-                                ErrorType::Wait,
-                                DefinedCondition::ResourceConstraint,
-                                "en",
+                        let message = match ownership_error {
+                            waddle_xmpp::muc::room_registry_actor::RoomRegistryError::ClaimHeldByAnotherNode(_) => {
                                 "This room's ownership is currently held by another node; \
-                                 please retry.",
-                            ),
-                        )];
-                    }
-                    Err(
-                        waddle_xmpp::muc::room_registry_actor::RoomRegistryError::OwnershipReconciliationPending(_),
-                    ) => {
+                                 please retry."
+                            }
+                            waddle_xmpp::muc::room_registry_actor::RoomRegistryError::OwnershipReconciliationPending(_) => {
+                                "This room's ownership is being reconciled; please retry."
+                            }
+                            _ => unreachable!("match arm accepts only remote-proxyable ownership errors"),
+                        };
                         return vec![build_muc_presence_error_xml(
                             room_jid,
                             &nick,
@@ -1147,7 +1309,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                                 ErrorType::Wait,
                                 DefinedCondition::ResourceConstraint,
                                 "en",
-                                "This room's ownership is being reconciled; please retry.",
+                                message,
                             ),
                         )];
                     }
@@ -2126,13 +2288,17 @@ mod resolver_sync_retry_tests {
         else {
             panic!("new scheduler starts one worker");
         };
-        tokio::spawn(run_resolver_affiliation_sync_worker(
-            actor,
-            room_registry,
-            room_jid,
-            member,
-            *worker,
-        ))
+        tokio::spawn(async move {
+            let _ = run_resolver_affiliation_sync_worker(
+                actor,
+                room_registry,
+                None,
+                room_jid,
+                member,
+                *worker,
+            )
+            .await;
+        })
     }
 
     #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -130,6 +130,33 @@ pub(super) async fn register_bound_connection_after_frame(
         blocklist,
     );
 
+    // Graceful UserActor retirement disables this same publication authority
+    // before it verifies both registries empty and releases the durable claim.
+    // Hold the read side from the first ConnectionRegistry insertion through
+    // the authoritative UserActor mirror (or its rollback), so shutdown's
+    // exclusive disable cannot complete while a bind is between those two
+    // views. A bind that reaches this point after disable fails before
+    // publishing anything.
+    let claim_publication = if let Some(node_identity) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .node_identity
+        .as_ref()
+    {
+        let expected = node_identity.current();
+        let Some(guard) = node_identity.guard_if_current(&expected).await else {
+            warn!(
+                jid = %jid,
+                "connection registration rejected after node publication authority was disabled"
+            );
+            return RegistrationAfterFrame::SessionInitializationFailed;
+        };
+        Some(guard)
+    } else {
+        None
+    };
+
     let owner = state
         .deps
         .protocol
@@ -196,12 +223,22 @@ pub(super) async fn register_bound_connection_after_frame(
         .connection_registry
         .entry_if_owner(&jid, &owner)
     {
-        let mirror_outcome = crate::server::dual_registration::mirror_register_outcome(
-            &state.deps.protocol.user_registry,
-            jid.clone(),
-            entry.clone(),
-        )
-        .await;
+        let mirror_outcome = if let Some(publication_guard) = claim_publication.as_ref() {
+            crate::server::dual_registration::mirror_register_outcome_under_authority(
+                &state.deps.protocol.user_registry,
+                jid.clone(),
+                entry.clone(),
+                publication_guard.permit(),
+            )
+            .await
+        } else {
+            crate::server::dual_registration::mirror_register_outcome(
+                &state.deps.protocol.user_registry,
+                jid.clone(),
+                entry.clone(),
+            )
+            .await
+        };
         let registered = match mirror_outcome {
             crate::server::dual_registration::MirrorRegisterOutcome::Registered => true,
             crate::server::dual_registration::MirrorRegisterOutcome::ForeignOwner => {
@@ -232,6 +269,12 @@ pub(super) async fn register_bound_connection_after_frame(
             return RegistrationAfterFrame::SessionInitializationFailed;
         }
     }
+
+    // The two authoritative registration views are now coherent. Dropping
+    // this guard allows shutdown to disable publication and retire them
+    // together; later owner-gated stream-state finalization cannot create a
+    // new registry entry.
+    drop(claim_publication);
 
     let sm_finalization = finalize_sm_after_registry_registration(state, conn, &jid, &owner).await;
     info!(

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1190,6 +1190,9 @@ impl TransportSecurity {
 pub struct WebSocketDeps {
     /// Core app state for accessing the global and per-waddle databases.
     pub app_state: Arc<AppState>,
+    /// Process-wide root-scope admission for room-capable connection and
+    /// background work.
+    pub(crate) room_serving: crate::server::room_serving_quiescence::RoomServingHandle,
     /// Authentication state for session validation.
     pub auth_state: Arc<AuthState>,
     /// Trusted deployment-level transport security used to enforce the

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -440,6 +440,7 @@ async fn create_test_websocket_state_with_extension_manager(
     Arc::new(WebSocketState {
             deps: WebSocketDeps {
                 app_state: Arc::clone(&app_state),
+                room_serving: app_state.room_serving.clone(),
                 auth_state,
                 transport_security:
                     super::state::TransportSecurity::from_public_websocket_url(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1,3 +1,8 @@
+//! Dedicated XEP-0045 websocket-adapter evidence, including clustered join
+//! routing decisions. The foreign-owner reconciliation tests assert that
+//! owner-built self-presence (status 110) is preserved, while unavailable
+//! room ownership and relay origins produce retryable stanza errors.
+
 use super::*;
 use crate::permissions::CheckPermission;
 use std::io;
@@ -79,6 +84,104 @@ fn validate_local_room_fence(
     }
 }
 
+#[cfg(feature = "clustering")]
+async fn ordinary_join_with_remote_preflight_decision(
+    room_jid: &BareJid,
+    decision: crate::clustering::route_bridge::MucProxyRouteDecision,
+) -> (Vec<String>, usize) {
+    use crate::clustering::route_bridge::OrderedRelayDeliveryBridge;
+    use crate::server::routes::interpret::{OrderedRelayRouteOrigin, OrderedRelayRouteOriginKind};
+    use crate::server::routes::websocket::handlers::presence::{
+        handle_muc_join_with_ordered_relay, MucJoinRequest,
+    };
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
+    use waddle_xmpp::muc::room_registry_actor::RoomCount;
+    use waddle_xmpp::ownership::{Entity, EntityType};
+
+    let joiner_jid: FullJid = "ordinary@example.com/web".parse().expect("joiner JID");
+    let bridge = OrderedRelayDeliveryBridge::new(
+        tokio_util::sync::CancellationToken::new(),
+        &crate::config::ClusteringMessagingConfig::default(),
+    );
+    bridge.set_test_muc_proxy_route_decision(decision).await;
+    let state = create_test_websocket_state_with_clustering(
+        crate::clustering::ClusteringHandles {
+            ordered_relay_delivery_bridge: Some(bridge),
+            ..Default::default()
+        },
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+    )
+    .await;
+    let ordinary_session = create_test_session(state.as_ref(), "ordinary").await;
+    let sender_entity = Entity::new(EntityType::UserActor, joiner_jid.to_bare().to_string());
+    let responses = handle_muc_join_with_ordered_relay(
+        state.as_ref(),
+        MucJoinRequest {
+            domain: "example.com",
+            room_jid,
+            sender_jid: &joiner_jid,
+            nick: "ordinary",
+            presence_show: None,
+            authenticated_session: &Some(ordinary_session),
+            ordered_relay_origin: Some(OrderedRelayRouteOrigin {
+                kind: OrderedRelayRouteOriginKind::Entity(sender_entity.clone()),
+                sender_entity,
+                inbound_sequence: 0,
+                handoff: None,
+            }),
+        },
+    )
+    .await;
+    let room_count = state
+        .deps
+        .protocol
+        .room_registry
+        .ask(RoomCount)
+        .await
+        .expect("room count");
+    (responses, room_count)
+}
+
+#[cfg(feature = "clustering")]
+fn assert_remote_owner_retryable_join_error(
+    responses: &[String],
+    room_jid: &BareJid,
+    expected_diagnostic: &str,
+) {
+    assert_eq!(responses.len(), 1, "one retryable error presence");
+    let presence = Element::from_str(&responses[0]).expect("error presence XML");
+    let expected_from = format!("{room_jid}/ordinary");
+    let expected_by = room_jid.to_string();
+    assert_eq!(presence.name(), "presence");
+    assert_eq!(presence.attr("type"), Some("error"));
+    assert_eq!(presence.attr("from"), Some(expected_from.as_str()));
+    assert_eq!(presence.attr("to"), Some("ordinary@example.com/web"));
+    assert!(
+        presence
+            .get_child("x", waddle_xmpp::muc::presence::NS_MUC)
+            .is_some(),
+        "XEP-0045 join errors must echo the MUC marker: {responses:?}"
+    );
+    let error = presence
+        .get_child("error", waddle_xmpp::parser::ns::JABBER_CLIENT)
+        .expect("typed stanza error");
+    assert_eq!(error.attr("type"), Some("wait"));
+    assert_eq!(error.attr("by"), Some(expected_by.as_str()));
+    assert!(
+        error
+            .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas",)
+            .is_some(),
+        "temporary routing failures must be retryable resource constraints: {responses:?}"
+    );
+    assert_eq!(
+        error
+            .get_child("text", "urn:ietf:params:xml:ns:xmpp-stanzas")
+            .expect("human-readable stanza error")
+            .text(),
+        expected_diagnostic
+    );
+}
+
 #[tokio::test]
 async fn muc_stale_leave_does_not_remove_current_resource() {
     let state = create_test_websocket_state().await;
@@ -118,7 +221,9 @@ async fn muc_stale_leave_does_not_remove_current_resource() {
 #[tokio::test]
 async fn muc_join_after_guarded_dormancy_eviction_respawns_room() {
     use waddle_xmpp::muc::room_actor::{IsDormant, SealGuard};
-    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoomIfInactive, RoomCount};
+    use waddle_xmpp::muc::room_registry_actor::{
+        CreateRoom, DestroyRoomIfInactive, DestroyRoomIfInactiveOutcome, RoomCount,
+    };
 
     let state = create_test_websocket_state().await;
     let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
@@ -143,7 +248,7 @@ async fn muc_join_after_guarded_dormancy_eviction_respawns_room() {
         .expect("create room");
     let probe = actor.ask(IsDormant).await.expect("probe");
     assert!(probe.dormant);
-    let destroyed: bool = state
+    let destroyed = state
         .deps
         .protocol
         .room_registry
@@ -154,7 +259,11 @@ async fn muc_join_after_guarded_dormancy_eviction_respawns_room() {
         })
         .await
         .expect("guarded destroy");
-    assert!(destroyed, "dormant room evicted");
+    assert_eq!(
+        destroyed,
+        DestroyRoomIfInactiveOutcome::Destroyed,
+        "dormant room evicted"
+    );
 
     // The join after eviction must succeed against a respawned room.
     let responses = handle_muc_join(
@@ -233,6 +342,297 @@ async fn muc_join_maps_registry_ownership_deferral_to_retryable_resource_constra
             .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas",)
             .is_some(),
         "ownership reconciliation must remain retryable: {responses:?}"
+    );
+    assert_eq!(
+        error
+            .get_child("text", "urn:ietf:params:xml:ns:xmpp-stanzas")
+            .expect("human-readable stanza error")
+            .text(),
+        "This room's ownership is being reconciled; please retry.",
+        "the no-relay fallback must preserve the reconciliation-specific diagnostic"
+    );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn muc_reconciliation_pending_proxies_owner_built_join_replies() {
+    use crate::clustering::route_bridge::{
+        OrderedRelayDeliveryBridge, OrderedRelayMucProxyOutcome,
+    };
+    use crate::server::routes::interpret::{OrderedRelayRouteOrigin, OrderedRelayRouteOriginKind};
+    use crate::server::routes::websocket::handlers::presence::{
+        handle_muc_join_with_ordered_relay, MucJoinRequest,
+    };
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
+    use waddle_xmpp::muc::room_actor::SetSubject;
+    use waddle_xmpp::muc::room_registry_actor::ReservePendingReclaimedRoom;
+    use waddle_xmpp::ownership::{Entity, EntityType};
+
+    let room_jid: BareJid = "pending-remote-owner@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let owner_jid: FullJid = "owner@example.com/web".parse().expect("owner JID");
+    let joiner_jid: FullJid = "joiner@example.com/web".parse().expect("joiner JID");
+
+    // Build the exact frames on a real authoritative RoomActor first. The
+    // injected relay result below is typed `Stanza` data, not hand-written
+    // XML, and carries a unique subject proving the pending node returns the
+    // owner's roster/self-presence/subject sequence.
+    let owner_state = create_test_websocket_state().await;
+    let owner_session =
+        create_test_server_owner_session(owner_state.as_ref(), "owner-session").await;
+    handle_muc_join(
+        owner_state.as_ref(),
+        "example.com",
+        &room_jid,
+        &owner_jid,
+        "owner",
+        None,
+        &Some(owner_session),
+    )
+    .await;
+    let room_actor = get_room_actor(owner_state.as_ref(), &room_jid)
+        .await
+        .expect("owner RoomActor");
+    room_actor
+        .ask(SetSubject {
+            texts: waddle_xmpp::muc::RoomSubjectTexts::from_iter([(
+                String::new(),
+                "remote owner subject".to_string(),
+            )]),
+            setter: owner_jid.to_bare(),
+            setter_nick: "owner".to_string(),
+            set_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("owner sets subject");
+    let joiner_session = create_test_session(owner_state.as_ref(), "joiner-session").await;
+    let owner_frames = handle_muc_join(
+        owner_state.as_ref(),
+        "example.com",
+        &room_jid,
+        &joiner_jid,
+        "joiner",
+        None,
+        &Some(joiner_session),
+    )
+    .await;
+    assert!(
+        owner_frames
+            .iter()
+            .any(|frame| frame.contains("remote owner subject")),
+        "authoritative join replies carry the owner subject: {owner_frames:?}"
+    );
+    let owner_stanzas = owner_frames
+        .iter()
+        .map(|frame| {
+            let element = Element::from_str(frame).expect("owner-built stanza XML");
+            match element.name() {
+                "presence" => waddle_xmpp::Stanza::Presence(
+                    xmpp_parsers::presence::Presence::try_from(element)
+                        .expect("owner presence stanza"),
+                ),
+                "message" => waddle_xmpp::Stanza::Message(
+                    xmpp_parsers::message::Message::try_from(element)
+                        .expect("owner subject stanza"),
+                ),
+                name => panic!("unexpected owner-built join stanza: {name}"),
+            }
+        })
+        .collect();
+
+    let bridge = OrderedRelayDeliveryBridge::new(
+        tokio_util::sync::CancellationToken::new(),
+        &crate::config::ClusteringMessagingConfig::default(),
+    );
+    bridge
+        .set_test_muc_proxy_outcome(OrderedRelayMucProxyOutcome::Delivered(owner_stanzas))
+        .await;
+    let pending_state = create_test_websocket_state_with_clustering(
+        crate::clustering::ClusteringHandles {
+            ordered_relay_delivery_bridge: Some(bridge),
+            ..Default::default()
+        },
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+    )
+    .await;
+    pending_state
+        .deps
+        .protocol
+        .room_registry
+        .ask(ReservePendingReclaimedRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+        .expect("reserve pending ownership reconciliation");
+    let pending_session =
+        create_test_server_owner_session(pending_state.as_ref(), "pending-session").await;
+    let sender_entity = Entity::new(EntityType::UserActor, joiner_jid.to_bare().to_string());
+
+    let responses = handle_muc_join_with_ordered_relay(
+        pending_state.as_ref(),
+        MucJoinRequest {
+            domain: "example.com",
+            room_jid: &room_jid,
+            sender_jid: &joiner_jid,
+            nick: "joiner",
+            presence_show: None,
+            authenticated_session: &Some(pending_session),
+            ordered_relay_origin: Some(OrderedRelayRouteOrigin {
+                kind: OrderedRelayRouteOriginKind::Entity(sender_entity.clone()),
+                sender_entity,
+                inbound_sequence: 0,
+                handoff: None,
+            }),
+        },
+    )
+    .await;
+
+    assert!(
+        responses
+            .iter()
+            .all(|frame| !frame.contains("type='error'") && !frame.contains("type=\"error\"")),
+        "pending reconciliation must not fall back to a local wait error: {responses:?}"
+    );
+    assert!(
+        responses
+            .iter()
+            .any(|frame| frame.contains("remote owner subject")),
+        "pending reconciliation must return the owner-built subject: {responses:?}"
+    );
+    assert!(
+        responses.iter().any(|frame| {
+            (frame.contains("status code='110'") || frame.contains("status code=\"110\""))
+                && frame.contains("/joiner")
+        }),
+        "pending reconciliation must return owner-built XEP-0045 self-presence: {responses:?}"
+    );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn ordinary_join_proxies_foreign_room_before_local_creation_permission() {
+    use crate::clustering::route_bridge::{MucProxyRouteDecision, OrderedRelayMucProxyOutcome};
+
+    let room_jid: BareJid = "foreign-owned-unmanaged@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let joiner_jid: FullJid = "ordinary@example.com/web".parse().expect("joiner JID");
+    let mut owner_reply = xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None);
+    owner_reply.from = room_jid
+        .clone()
+        .with_resource_str("ordinary")
+        .ok()
+        .map(jid::Jid::from);
+    owner_reply.to = Some(jid::Jid::from(joiner_jid.clone()));
+
+    let (responses, room_count) = ordinary_join_with_remote_preflight_decision(
+        &room_jid,
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(vec![
+            waddle_xmpp::Stanza::Presence(owner_reply),
+        ])),
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1, "foreign owner reply must be returned");
+    assert!(
+        !responses[0].contains("not-allowed"),
+        "local create permission must not reject a foreign-owned room: {responses:?}"
+    );
+    assert!(
+        responses[0].contains("foreign-owned-unmanaged@muc.example.com/ordinary"),
+        "the typed owner reply must survive proxying: {responses:?}"
+    );
+    assert_eq!(
+        room_count, 0,
+        "proxying a foreign-owned room must not create a local RoomActor"
+    );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn ordinary_join_cannot_create_unclaimed_room_via_remote_preflight() {
+    use crate::clustering::route_bridge::MucProxyRouteDecision;
+
+    let room_jid: BareJid = "unclaimed-unmanaged@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let (responses, room_count) = ordinary_join_with_remote_preflight_decision(
+        &room_jid,
+        MucProxyRouteDecision::RoomUnclaimed,
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1, "one creation denial presence");
+    assert!(
+        responses[0].contains("not-allowed"),
+        "an unclaimed room must still require CreateMuc: {responses:?}"
+    );
+    assert_eq!(
+        room_count, 0,
+        "a denied unclaimed join must not create a RoomActor"
+    );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn ordinary_join_gets_retryable_error_when_room_claim_is_temporarily_unavailable() {
+    use crate::clustering::route_bridge::MucProxyRouteDecision;
+
+    let room_jid: BareJid = "claim-unavailable@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let (responses, room_count) = ordinary_join_with_remote_preflight_decision(
+        &room_jid,
+        MucProxyRouteDecision::RoomClaimUnavailable,
+    )
+    .await;
+
+    assert_remote_owner_retryable_join_error(
+        &responses,
+        &room_jid,
+        "This room's remote owner is temporarily unavailable; please retry.",
+    );
+    assert_eq!(
+        room_count, 0,
+        "claim lookup failure must not create a local RoomActor"
+    );
+    assert!(
+        responses
+            .iter()
+            .all(|response| !response.contains("not-allowed")),
+        "a transient claim failure must not masquerade as a creation denial: {responses:?}"
+    );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn ordinary_join_gets_retryable_error_when_relay_origin_is_temporarily_unavailable() {
+    use crate::clustering::route_bridge::MucProxyRouteDecision;
+
+    let room_jid: BareJid = "origin-unavailable@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let (responses, room_count) = ordinary_join_with_remote_preflight_decision(
+        &room_jid,
+        MucProxyRouteDecision::OriginUnavailable,
+    )
+    .await;
+
+    assert_remote_owner_retryable_join_error(
+        &responses,
+        &room_jid,
+        "This room's remote owner is temporarily unavailable; please retry.",
+    );
+    assert_eq!(
+        room_count, 0,
+        "origin failure must not create a local RoomActor"
+    );
+    assert!(
+        responses
+            .iter()
+            .all(|response| !response.contains("not-allowed")),
+        "a transient origin failure must not masquerade as a creation denial: {responses:?}"
     );
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -22,6 +22,26 @@ use waddle_xmpp::{
 use xmpp_parsers::message::MessageType as XmppMessageType;
 use xmpp_parsers::minidom::Element;
 
+#[cfg(feature = "clustering")]
+struct HoldUserRegistry {
+    entered: tokio::sync::oneshot::Sender<()>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[cfg(feature = "clustering")]
+impl kameo::message::Message<HoldUserRegistry> for waddle_xmpp::registry::UserRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: HoldUserRegistry,
+        _ctx: &mut kameo::message::Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let _ = msg.entered.send(());
+        msg.release.notified().await;
+    }
+}
+
 #[tokio::test]
 async fn ensure_state_machine_initializes_sm_in_ready_phase() {
     let state = create_test_websocket_state().await;
@@ -124,6 +144,150 @@ async fn register_bound_connection_after_frame_registers_ready_connection_once()
     assert_eq!(
         state.deps.protocol.connection_registry.connection_count(),
         1
+    );
+}
+
+/// User-claim shutdown takes the exclusive side of the shared identity gate
+/// before checking both registries and releasing claims. A live bind must hold
+/// the read side across its DashMap publication and authoritative actor mirror,
+/// otherwise shutdown could observe the temporary half-registration as empty,
+/// release the claim, and let the actor mirror land afterward.
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn user_claim_disable_waits_for_connection_registration_mirror() {
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
+    use kameo::actor::ActorRef;
+    use waddle_xmpp::ownership::{
+        ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+    use waddle_xmpp::registry::{
+        GetUserForLocalClaim, UserRegistryActor, WireUserClusteringClaims,
+    };
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    let node_identity =
+        SharedNodeIdentity::new(NodeIdentity::new("registering-node", "registering-epoch"));
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let state = create_test_websocket_state_with_clustering(
+        crate::clustering::ClusteringHandles {
+            claim_store: Some(Arc::clone(&claim_store)),
+            node_identity: Some(node_identity.clone()),
+            ..Default::default()
+        },
+        Arc::new(InMemorySmSessionRegistry::new()),
+    )
+    .await;
+    state
+        .deps
+        .protocol
+        .user_registry
+        .ask(WireUserClusteringClaims {
+            claim_store,
+            node_identity: node_identity.clone(),
+        })
+        .await
+        .expect("wire the production-shared identity source");
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+
+    // Occupy the UserRegistry mailbox so the bind can publish into the
+    // ConnectionRegistry but cannot yet complete its authoritative mirror.
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let release = Arc::new(tokio::sync::Notify::new());
+    let user_registry: ActorRef<UserRegistryActor> = state.deps.protocol.user_registry.clone();
+    let blocker_release = Arc::clone(&release);
+    let blocker = tokio::spawn(async move {
+        user_registry
+            .ask(HoldUserRegistry {
+                entered: entered_tx,
+                release: blocker_release,
+            })
+            .await
+            .expect("registry blocker");
+    });
+    entered_rx.await.expect("registry blocker entered");
+
+    let registering_state = Arc::clone(&state);
+    let registering_jid = jid.clone();
+    let registration = tokio::spawn(async move {
+        let mut conn = WsConnState::new();
+        conn.phase = ConnectionPhase::ready(registering_jid, false);
+        let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+        let mut pending_tx = Some(tx);
+        register_bound_connection_after_frame(
+            registering_state.as_ref(),
+            "example.com",
+            &mut conn,
+            &mut pending_tx,
+        )
+        .await
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        while state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .is_none()
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("bind should reach ConnectionRegistry publication");
+
+    let disabling_identity = node_identity.clone();
+    let disable = tokio::spawn(async move { disabling_identity.disable().await });
+    tokio::task::yield_now().await;
+    assert!(
+        !disable.is_finished(),
+        "disable must wait while the connection is between registry publication and actor mirror"
+    );
+
+    release.notify_one();
+    blocker.await.expect("blocker task");
+    let result = registration.await.expect("registration task");
+    assert!(matches!(result, RegistrationAfterFrame::Registered(_)));
+    disable.await.expect("disable task");
+
+    assert!(
+        state
+            .deps
+            .protocol
+            .user_registry
+            .ask(GetUserForLocalClaim {
+                bare_jid: jid.to_bare(),
+            })
+            .await
+            .expect("user lookup")
+            .is_some(),
+        "disable returned only after the actor mirror completed"
+    );
+
+    let rejected_jid: FullJid = "bob@example.com/web".parse().expect("jid");
+    let mut rejected_conn = WsConnState::new();
+    rejected_conn.phase = ConnectionPhase::ready(rejected_jid.clone(), false);
+    let (rejected_tx, _rejected_rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut rejected_pending_tx = Some(rejected_tx);
+    let rejected = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut rejected_conn,
+        &mut rejected_pending_tx,
+    )
+    .await;
+    assert!(matches!(
+        rejected,
+        RegistrationAfterFrame::SessionInitializationFailed
+    ));
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&rejected_jid)
+            .is_none(),
+        "a bind starting after terminal disable must not publish into ConnectionRegistry"
     );
 }
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -107,7 +107,7 @@ fn max_promotion_attempts_from_env() -> u32 {
         .unwrap_or(DEFAULT_ATTEMPTS)
 }
 
-fn max_drain_duration_from_env() -> std::time::Duration {
+pub(crate) fn max_drain_duration_from_env() -> std::time::Duration {
     const DEFAULT_SECS: u64 = 30;
     const MIN_SECS: u64 = 1;
     const MAX_SECS: u64 = 600;
@@ -146,16 +146,25 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
     // whose resume window elapses leave MUC occupants in their rooms forever
     // and the `resumable_sessions` sidecar grows unbounded.
     let weak_state = Arc::downgrade(websocket_state);
+    let producer_cancel = websocket_state.deps.room_serving.producer_cancellation();
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
         // Skip the first tick (immediate) so we don't sweep before the
         // server has accepted any connections.
         ticker.tick().await;
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                biased;
+                _ = producer_cancel.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            let Ok(mut room_scope) = state.deps.room_serving.try_scope() else {
+                break;
+            };
+            room_scope.arm();
             let mut sweep_failed = false;
             let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
                 .deps
@@ -562,6 +571,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     SweepOutcome::Completed
                 },
             );
+            room_scope.complete_clean();
         }
     });
 }
@@ -673,7 +683,10 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             return;
         };
         let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
-        tokio::spawn(async move {
+        let room_serving = websocket_state.deps.room_serving.clone();
+        let producer_cancel = room_serving.producer_cancellation();
+        if let Err(error) = room_serving.spawn(move |room_scope| async move {
+            let mut release_safe = true;
             let terminal_room_registry =
                 waddle_xmpp::muc::RoomRegistry::wrap(room_registry_actor.clone());
             let registry_lifetime_watch = spawn_room_registry_lifetime_watch(
@@ -693,11 +706,17 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             ticker.tick().await;
             loop {
                 tokio::select! {
+                    biased;
+                    _ = producer_cancel.cancelled() => break,
                     _ = stop.cancelled() => break,
-                    _ = supervisor.workers.fatal_fence.cancelled() => break,
+                    _ = supervisor.workers.fatal_fence.cancelled() => {
+                        release_safe = false;
+                        break;
+                    },
                     _ = ticker.tick() => {}
                 }
                 if !supervisor.is_healthy() {
+                    release_safe = false;
                     error!("orphan reaper worker exited; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                     if supervisor.workers.fatal_fence.is_cancelled() {
@@ -721,11 +740,18 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                 let mut workers_healthy = supervisor.is_healthy();
                 let mut stop_after_sweep = false;
                 match sweep_outcome {
-                    OrphanSweepOutcome::Completed | OrphanSweepOutcome::Failed => {}
+                    OrphanSweepOutcome::Completed => {}
+                    OrphanSweepOutcome::Failed => {
+                        release_safe = false;
+                    }
                     OrphanSweepOutcome::Cancelled => {
+                        if supervisor.workers.fatal_fence.is_cancelled() {
+                            release_safe = false;
+                        }
                         stop_after_sweep = true;
                     }
                     OrphanSweepOutcome::TimedOut => {
+                        release_safe = false;
                         error!(
                             timeout = ?ORPHAN_REAPER_SWEEP_TIMEOUT,
                             "orphan reaper sweep timed out; self-fencing node because claim handoff state may be uncertain"
@@ -734,6 +760,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     }
                 }
                 if !stop_after_sweep && !workers_healthy {
+                    release_safe = false;
                     error!("orphan reaper worker exited during sweep; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                     if supervisor.workers.fatal_fence.is_cancelled() {
@@ -774,11 +801,25 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     );
                 }
                 Err(error) => {
+                    release_safe = false;
                     error!(%error, "orphan reaper: terminal RoomRegistry claim drain failed; node-expiry recovery remains authoritative");
                 }
             }
-            let _ = registry_lifetime_watch.await;
-        });
+            if let Err(error) = registry_lifetime_watch.await {
+                release_safe = false;
+                error!(%error, "orphan reaper: RoomRegistry lifetime watcher failed");
+            }
+            if release_safe {
+                room_scope.complete_clean();
+            } else {
+                room_scope.poison();
+            }
+        }) {
+            warn!(
+                ?error,
+                "orphan reaper: room-serving admission closed before the producer started"
+            );
+        }
     }
     #[cfg(not(feature = "clustering"))]
     {
@@ -2058,7 +2099,7 @@ async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn terminal_shutdown_transfers_a_post_cas_room_handoff_into_registry_drain() {
+async fn terminal_shutdown_prepares_a_post_cas_room_handoff_for_final_batch_release() {
     use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
 
     let registry = waddle_xmpp::muc::RoomRegistry::spawn(
@@ -2110,15 +2151,24 @@ async fn terminal_shutdown_transfers_a_post_cas_room_handoff_into_registry_drain
     let outcome = registry
         .drain_room_ownership_for_shutdown(handoffs)
         .await
-        .expect("drain transferred handoff");
+        .expect("prepare transferred handoff");
 
-    assert_eq!(outcome.released, 1);
+    assert_eq!(outcome.released, 0);
+    assert_eq!(outcome.preserved_live, 0);
     assert_eq!(outcome.retained, 0);
     assert!(claim_store
         .current_claim(&entity)
         .await
         .expect("claim")
-        .is_none());
+        .is_some());
+    assert_eq!(
+        registry
+            .list_pending_room_release_jids()
+            .await
+            .expect("prepared room release inventory"),
+        vec![room_jid],
+        "prepare-only shutdown must retain the exact claim for the authorized final batch"
+    );
 
     registry.actor_ref().kill();
     registry.actor_ref().wait_for_shutdown().await;
@@ -2690,15 +2740,26 @@ async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
         )
         .await
         .expect("wire room registry");
-    room_registry
+    let outcome = room_registry
         .drain_room_ownership_for_shutdown(room_handoffs)
         .await
-        .expect("drain handoff after failed restart");
+        .expect("prepare handoff after failed restart");
+    assert_eq!(outcome.released, 0);
+    assert_eq!(outcome.preserved_live, 0);
+    assert_eq!(outcome.retained, 0);
     assert!(room_claim_store
         .current_claim(&room_entity)
         .await
         .expect("room claim after drain")
-        .is_none());
+        .is_some());
+    assert_eq!(
+        room_registry
+            .list_pending_room_release_jids()
+            .await
+            .expect("prepared handoff inventory after failed restart"),
+        vec![room_jid],
+        "prepare-only shutdown must retain the exact handoff for final batch authorization"
+    );
     room_registry.actor_ref().kill();
     room_registry.actor_ref().wait_for_shutdown().await;
 }
@@ -5128,21 +5189,24 @@ fn record_sm_drain_outcome(released: bool) {
 pub(crate) fn spawn_graceful_shutdown_drain(
     websocket_state: Arc<WebSocketState>,
     drain_token: tokio_util::sync::CancellationToken,
-    drain_notify: Arc<tokio::sync::Notify>,
+    drain_complete: tokio_util::sync::CancellationToken,
+    room_serving_close: crate::server::room_serving_quiescence::RoomServingCloseHandle,
 ) {
     tokio::spawn(async move {
-        // Always notify_one on exit (success or early-return) so
-        // the runtime's awaiting code never blocks indefinitely
-        // on drain completion.
-        struct NotifyOnDrop(Arc<tokio::sync::Notify>);
-        impl Drop for NotifyOnDrop {
+        // Level-triggered completion cannot be lost when the observer starts
+        // waiting after this task exits.
+        struct CompleteOnDrop(tokio_util::sync::CancellationToken);
+        impl Drop for CompleteOnDrop {
             fn drop(&mut self) {
-                self.0.notify_one();
+                self.0.cancel();
             }
         }
-        let _notify_guard = NotifyOnDrop(drain_notify);
+        let _complete_guard = CompleteOnDrop(drain_complete);
 
         drain_token.cancelled().await;
+        // The first shutdown action closes room admission and cancels
+        // periodic room-capable producers.
+        room_serving_close.close();
         // ADR-0017 Phase 3 Slice 10: this task's own start-of-drain
         // timestamp, fed into the SAME `drain_duration_ms` histogram the
         // generic per-entity room drain records into (below, once the Q6
@@ -5530,6 +5594,33 @@ pub(crate) struct DormancySweepCounts {
     pub examined: usize,
     pub remaining: usize,
     failed: bool,
+    ambiguous: bool,
+}
+
+fn record_dormancy_destroy_outcome(
+    websocket_state: &WebSocketState,
+    room_jid: &jid::BareJid,
+    counts: &mut DormancySweepCounts,
+    outcome: waddle_xmpp::muc::room_registry_actor::DestroyRoomIfInactiveOutcome,
+) {
+    use waddle_xmpp::muc::room_registry_actor::DestroyRoomIfInactiveOutcome;
+
+    match outcome {
+        DestroyRoomIfInactiveOutcome::Destroyed => {
+            counts.evicted += 1;
+            debug!(room = %room_jid, "room dormancy janitor: evicted dormant room");
+        }
+        DestroyRoomIfInactiveOutcome::Retained => {}
+        DestroyRoomIfInactiveOutcome::MaybeSealed => {
+            counts.failed = true;
+            counts.ambiguous = true;
+            websocket_state.deps.room_serving.mark_unsafe_to_release();
+            warn!(
+                room = %room_jid,
+                "room dormancy janitor: guarded destroy may have sealed without a reply"
+            );
+        }
+    }
 }
 
 /// Walk every registered MUC room and destroy the ones that report
@@ -5614,13 +5705,15 @@ pub(crate) async fn sweep_dormant_rooms_once(
             })
             .await
         {
-            Ok(true) => {
-                counts.evicted += 1;
-                debug!(room = %room_jid, "room dormancy janitor: evicted dormant room");
+            Ok(outcome) => {
+                record_dormancy_destroy_outcome(websocket_state, &room_jid, &mut counts, outcome);
             }
-            Ok(false) => {}
             Err(error) => {
                 counts.failed = true;
+                if crate::server::routes::interpret::actor_send_maybe_enqueued(&error) {
+                    counts.ambiguous = true;
+                    websocket_state.deps.room_serving.mark_unsafe_to_release();
+                }
                 warn!(
                     room = %room_jid,
                     error = ?error,
@@ -5662,20 +5755,34 @@ pub(crate) async fn sweep_dormant_rooms_once(
 /// process doesn't sweep before any room has been touched.
 pub(crate) fn spawn_room_dormancy_janitor(websocket_state: &Arc<WebSocketState>) {
     let weak_state = Arc::downgrade(websocket_state);
+    let producer_cancel = websocket_state.deps.room_serving.producer_cancellation();
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(ROOM_DORMANCY_JANITOR_INTERVAL);
         ticker.tick().await;
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                biased;
+                _ = producer_cancel.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            run_room_dormancy_sweep(&state).await;
+            let Ok(mut room_scope) = state.deps.room_serving.try_scope() else {
+                break;
+            };
+            room_scope.arm();
+            let sweep_ambiguous = run_room_dormancy_sweep(&state).await;
+            if sweep_ambiguous {
+                room_scope.poison();
+            } else {
+                room_scope.complete_clean();
+            }
         }
     });
 }
 
-async fn run_room_dormancy_sweep(state: &WebSocketState) {
+async fn run_room_dormancy_sweep(state: &WebSocketState) -> bool {
     let counts = sweep_dormant_rooms_once(state).await;
     if counts.evicted > 0 {
         info!(
@@ -5699,6 +5806,7 @@ async fn run_room_dormancy_sweep(state: &WebSocketState) {
             SweepOutcome::Completed
         },
     );
+    counts.ambiguous
 }
 
 /// Per-sweep counts returned by [`sweep_empty_user_actors_once`].
@@ -5843,14 +5951,19 @@ pub(crate) fn spawn_user_actor_reaper(websocket_state: &Arc<WebSocketState>) {
 
 #[cfg(test)]
 mod room_dormancy_tests {
-    use super::{run_room_dormancy_sweep, sweep_dormant_rooms_once};
+    use super::{
+        record_dormancy_destroy_outcome, run_room_dormancy_sweep, sweep_dormant_rooms_once,
+        DormancySweepCounts,
+    };
     use crate::server::routes::websocket::tests::create_test_websocket_state;
     use waddle_xmpp::muc::{
         room_actor::{
             ChangeAffiliation, GetOccupantByJid, Join, JoinAffiliationGrant, JoinWithAffiliation,
             LeaveByRealJid,
         },
-        room_registry_actor::{CreateRoom, GetOrCreateRoom, RoomCount},
+        room_registry_actor::{
+            CreateRoom, DestroyRoomIfInactiveOutcome, GetOrCreateRoom, RoomCount,
+        },
         RoomConfig,
     };
     use waddle_xmpp_core::{Affiliation, Role};
@@ -5865,10 +5978,31 @@ mod room_dormancy_tests {
     }
 
     #[tokio::test]
+    async fn maybe_sealed_dormancy_result_poisons_terminal_room_release() {
+        let state = create_test_websocket_state().await;
+        let room_jid = room_bare_jid("ambiguous-seal");
+        let mut counts = DormancySweepCounts::default();
+
+        record_dormancy_destroy_outcome(
+            &state,
+            &room_jid,
+            &mut counts,
+            DestroyRoomIfInactiveOutcome::MaybeSealed,
+        );
+
+        assert!(counts.failed);
+        assert!(counts.ambiguous);
+        assert!(
+            state.deps.room_serving.status().unsafe_to_release,
+            "a lost seal reply must permanently forbid graceful room-claim release"
+        );
+    }
+
+    #[tokio::test]
     async fn zero_work_room_dormancy_sweep_records_completed_heartbeat() {
         let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
         let state = create_test_websocket_state().await;
-        run_room_dormancy_sweep(&state).await;
+        let _ = run_room_dormancy_sweep(&state).await;
 
         assert_eq!(
             metrics.counter_sum(
@@ -6326,6 +6460,7 @@ async fn collect_remote_muc_reconcile_candidates(
 #[cfg(feature = "clustering")]
 pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSocketState>) {
     let weak_state = Arc::downgrade(websocket_state);
+    let producer_cancel = websocket_state.deps.room_serving.producer_cancellation();
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(REMOTE_MUC_MEMBERSHIP_RECONCILE_INTERVAL);
         // A sweep slower than the interval (serial relays against an
@@ -6334,16 +6469,25 @@ pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSo
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         ticker.tick().await;
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                biased;
+                _ = producer_cancel.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            let Ok(mut room_scope) = state.deps.room_serving.try_scope() else {
+                break;
+            };
+            room_scope.arm();
             let candidates = collect_remote_muc_reconcile_candidates(&state).await;
             if candidates.occupants.is_empty() {
                 waddle_xmpp::telemetry::reliability::record_janitor_sweep(
                     Janitor::RemoteMucMembership,
                     remote_muc_sweep_outcome(candidates.had_failure),
                 );
+                room_scope.complete_clean();
                 continue;
             }
             info!(
@@ -6379,6 +6523,7 @@ pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSo
                 Janitor::RemoteMucMembership,
                 remote_muc_sweep_outcome(sweep_failed),
             );
+            room_scope.complete_clean();
         }
     });
 }

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -75,6 +75,9 @@ pub struct AppState {
     /// clustering is disabled or not compiled in — see
     /// [`crate::clustering::ClusteringHandles`].
     pub clustering_claims: crate::clustering::ClusteringHandles,
+    /// Process-wide admission fence for every operation that can touch a MUC
+    /// room or enqueue room-capable background work.
+    pub(crate) room_serving: crate::server::room_serving_quiescence::RoomServingHandle,
 }
 
 impl AppState {
@@ -106,6 +109,8 @@ impl AppState {
         let spaces_jid: BareJid = "spaces.localhost"
             .parse()
             .expect("test spaces JID 'spaces.localhost' parses as BareJid");
+        let (room_serving, _room_serving_closer) =
+            crate::server::room_serving_quiescence::RoomServingQuiescence::create();
         Self::new_with_deps(AppStateDeps {
             db_pool,
             blob_storage,
@@ -125,6 +130,7 @@ impl AppState {
             server_owner_jids: Arc::from(Vec::<BareJid>::new()),
             clustering_readiness: crate::clustering::ClusteringReadiness::new(),
             clustering_claims: crate::clustering::ClusteringHandles::default(),
+            room_serving,
         })
     }
 
@@ -147,6 +153,7 @@ impl AppState {
             server_owner_jids,
             clustering_readiness,
             clustering_claims,
+            room_serving,
         } = deps;
         Self {
             db_pool,
@@ -163,6 +170,7 @@ impl AppState {
             server_owner_jids,
             clustering_readiness,
             clustering_claims,
+            room_serving,
         }
     }
 }
@@ -185,6 +193,7 @@ pub struct AppStateDeps {
     pub server_owner_jids: Arc<[BareJid]>,
     pub clustering_readiness: crate::clustering::ClusteringReadiness,
     pub clustering_claims: crate::clustering::ClusteringHandles,
+    pub(crate) room_serving: crate::server::room_serving_quiescence::RoomServingHandle,
 }
 
 /// Resolve `WADDLE_SERVER_OWNER_LOCALPARTS` localparts into bare JIDs against

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -754,7 +754,12 @@ async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
         acme_http01_challenge_service: None,
         shutdown_handle: waddle_ecdysis::GracefulShutdown::new(std::time::Duration::from_secs(1))
             .handle(),
-        drain_complete: std::sync::Arc::new(tokio::sync::Notify::new()),
+        drain_complete: tokio_util::sync::CancellationToken::new(),
+        room_serving_close: {
+            let (_handle, closer) =
+                crate::server::room_serving_quiescence::RoomServingQuiescence::create();
+            closer.close_handle()
+        },
     })
     .await
     .unwrap();
@@ -1007,7 +1012,12 @@ async fn test_app() -> Router {
         acme_http01_challenge_service: None,
         shutdown_handle: waddle_ecdysis::GracefulShutdown::new(std::time::Duration::from_secs(1))
             .handle(),
-        drain_complete: std::sync::Arc::new(tokio::sync::Notify::new()),
+        drain_complete: tokio_util::sync::CancellationToken::new(),
+        room_serving_close: {
+            let (_handle, closer) =
+                crate::server::room_serving_quiescence::RoomServingQuiescence::create();
+            closer.close_handle()
+        },
     })
     .await
     .unwrap()

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -8,6 +8,8 @@
 //!
 //! - cross-node relay ask round-trip (ping) and the bounded XML codec on the
 //!   wire (thread-preserving stanza echo);
+//! - simultaneous full-mesh bootstrap dialing retains A→B and B→A relay
+//!   reachability across repeated dial ticks;
 //! - integrity under concurrent large + small payloads (libp2p per-substream
 //!   flow control interleaves them; per-pair *sequencing* is Phase 4);
 //! - the receiver-applied ask budgets fail a slow handler with the typed
@@ -41,8 +43,9 @@
 //! claim-scoped hydration capstone
 //! (`orphan_reaper_kills_one_node_and_hydrates_only_its_orphaned_sessions`,
 //! upgraded in Phase 4 Slice 1a to exercise the real stale-node watchdog);
-//! and the Phase 4 MUC foreign-owned-room proxy wire shape
-//! (`muc_join_routes_to_foreign_room_owner`).
+//! and the Phase 4 XEP-0045 foreign-owned-room proxy wire shape
+//! (`muc_join_routes_to_foreign_room_owner`), including the owner-built
+//! self-presence status 110 returned through the non-owner node.
 //!
 //! Deferred as a manual go/no-go measurement (dominated by kademlia's
 //! hardcoded 1h record TTL): the dead publisher's record-visibility window.
@@ -63,7 +66,9 @@ use waddle_server::clustering::ordered_relay::{
     OrderedRelayReply, OrderedRelaySenderState, OrderedRelaySequence, OriginInboundSequence,
     RemoteStanzaEnvelope,
 };
-use waddle_server::clustering::relay::{RelayAskError, RelayHandle, RelaySendFailure};
+use waddle_server::clustering::relay::{
+    RelayAskError, RelayHandle, RelayProbePeerReply, RelaySendFailure,
+};
 use waddle_server::clustering::swarm;
 use waddle_server::clustering::NodeId;
 use waddle_server::config::{ClusteringBootstrapConfig, ClusteringConfig, ClusteringLeaseConfig};
@@ -75,6 +80,9 @@ use waddle_xmpp::Stanza;
 const POOL_SIZE: usize = 4;
 const CLUSTER_PEER_USERNAME: &str = "cluster-peer";
 const CLUSTER_PEER_PASSWORD: &str = "cluster-peer-password";
+const CLUSTER_MEMBER_USERNAME: &str = "cluster-member";
+const CLUSTER_MEMBER_PASSWORD: &str = "cluster-member-password";
+const CLUSTER_ADMIN_PASSWORD: &str = "cluster-admin-password";
 
 struct EnrolledPool {
     /// base64-encoded 32-byte ed25519 seeds (the WADDLE_CLUSTERING_KEYPAIR_POOL value).
@@ -140,6 +148,28 @@ async fn open_control_db(url: &str) -> Database {
     )
     .await
     .expect("open harness postgres")
+}
+
+/// Run global migrations and provision the shared fixed accounts once before
+/// a test deliberately starts multiple server processes concurrently.
+async fn provision_cluster_test_accounts(postgres_url: &str) {
+    let postgres_url = postgres_url.to_string();
+    tokio::task::spawn_blocking(move || {
+        let provisioner = TestServer::start_with_extra_envs(
+            &[
+                (CLUSTER_PEER_USERNAME, CLUSTER_PEER_PASSWORD),
+                (CLUSTER_MEMBER_USERNAME, CLUSTER_MEMBER_PASSWORD),
+            ],
+            &[
+                ("WADDLE_DB_DRIVER", "postgres"),
+                ("WADDLE_DATABASE_URL", &postgres_url),
+                ("WADDLE_TEST_FIXED_ACCOUNT_PASSWORD", CLUSTER_ADMIN_PASSWORD),
+            ],
+        );
+        drop(provisioner);
+    })
+    .await
+    .expect("fixed-account provisioner task");
 }
 
 /// Reset the clustering control-plane tables and enroll every pool PeerId.
@@ -316,9 +346,67 @@ async fn spawn_cluster_server(
     swarm_port: u16,
     bootstrap_ports: &[u16],
 ) -> (TestServer, String, String) {
+    spawn_cluster_server_with_account_seeding(
+        postgres_url,
+        pool_env,
+        swarm_port,
+        bootstrap_ports,
+        true,
+        None,
+    )
+    .await
+}
+
+/// Spawn against fixed accounts provisioned by
+/// [`provision_cluster_test_accounts`] without racing their destructive
+/// delete-and-recreate setup.
+async fn spawn_cluster_server_preserving_accounts(
+    postgres_url: &str,
+    pool_env: &str,
+    swarm_port: u16,
+    bootstrap_ports: &[u16],
+) -> (TestServer, String, String) {
+    spawn_cluster_server_with_account_seeding(
+        postgres_url,
+        pool_env,
+        swarm_port,
+        bootstrap_ports,
+        false,
+        None,
+    )
+    .await
+}
+
+async fn spawn_cluster_server_preserving_accounts_with_dial_barrier(
+    postgres_url: &str,
+    pool_env: &str,
+    swarm_port: u16,
+    bootstrap_ports: &[u16],
+    fault_dial_barrier_dir: &std::path::Path,
+) -> (TestServer, String, String) {
+    spawn_cluster_server_with_account_seeding(
+        postgres_url,
+        pool_env,
+        swarm_port,
+        bootstrap_ports,
+        false,
+        Some(fault_dial_barrier_dir),
+    )
+    .await
+}
+
+async fn spawn_cluster_server_with_account_seeding(
+    postgres_url: &str,
+    pool_env: &str,
+    swarm_port: u16,
+    bootstrap_ports: &[u16],
+    seed_fixed_accounts: bool,
+    fault_dial_barrier_dir: Option<&std::path::Path>,
+) -> (TestServer, String, String) {
     let postgres_url = postgres_url.to_string();
     let pool_env = pool_env.to_string();
     let bootstrap_ports = bootstrap_ports.to_vec();
+    let fault_dial_barrier_dir = fault_dial_barrier_dir.map(|path| path.display().to_string());
     tokio::task::spawn_blocking(move || {
         let node_id_file = std::env::temp_dir().join(format!(
             "waddle-clustering-e2e-node-{}",
@@ -350,9 +438,10 @@ async fn spawn_cluster_server(
             // disabling it flips the permission backend onto the SpiceDB path and
             // fails startup. Its seeding is delete-then-recreate, safe for the
             // sequential startups this harness performs.
-            // The secondary fixed account is also owner-capable so foreign-owned
-            // MUC join tests reach the RoomRegistry ownership check instead of
-            // being denied by the local instant-room creation guard first.
+            // `cluster-peer` remains owner-capable for tests that deliberately
+            // create rooms. `cluster-member` is intentionally absent: the
+            // foreign-room join test proves routing happens before the local
+            // instant-room creation permission guard.
             ("WADDLE_SERVER_OWNER_LOCALPARTS", "admin,cluster-peer"),
             ("WADDLE_CLUSTERING_ENABLED", "true"),
             ("WADDLE_CLUSTERING_LISTEN_ADDRS", &listen),
@@ -399,9 +488,22 @@ async fn spawn_cluster_server(
         if !bootstrap_peers.is_empty() {
             envs.push(("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", &bootstrap_peers));
         }
+        if let Some(fault_dial_barrier_dir) = fault_dial_barrier_dir.as_deref() {
+            envs.push((
+                "WADDLE_CLUSTERING_FAULT_DIAL_BARRIER_DIR",
+                fault_dial_barrier_dir,
+            ));
+        }
+        if !seed_fixed_accounts {
+            envs.push(("WADDLE_TEST_FIXED_ACCOUNT_PASSWORD", CLUSTER_ADMIN_PASSWORD));
+            envs.push(("WADDLE_TEST_FIXED_ACCOUNT_SEED", "false"));
+        }
 
         let server = TestServer::start_with_extra_envs(
-            &[(CLUSTER_PEER_USERNAME, CLUSTER_PEER_PASSWORD)],
+            &[
+                (CLUSTER_PEER_USERNAME, CLUSTER_PEER_PASSWORD),
+                (CLUSTER_MEMBER_USERNAME, CLUSTER_MEMBER_PASSWORD),
+            ],
             &envs,
         );
 
@@ -535,6 +637,66 @@ fn cluster_e2e_serial_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
+struct FaultDialBarrierDirectory {
+    path: std::path::PathBuf,
+}
+
+impl FaultDialBarrierDirectory {
+    fn create() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "waddle-clustering-cross-dial-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir(&path).expect("create cross-dial barrier directory");
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    fn marker_count(&self) -> usize {
+        std::fs::read_dir(&self.path)
+            .expect("read cross-dial barrier directory")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with("dialed-"))
+            .count()
+    }
+
+    async fn release_and_drive_after_two_markers(&self) {
+        tokio::fs::write(self.path.join("release"), b"released\n")
+            .await
+            .expect("release subprocess first dials");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if self.marker_count() == 2 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "both subprocesses did not queue their bootstrap dial"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        tokio::fs::write(self.path.join("drive"), b"drive\n")
+            .await
+            .expect("drive both queued cross-dials");
+    }
+
+    fn assert_marker(&self, peer_id: &str) {
+        assert!(
+            self.path.join(format!("dialed-{peer_id}")).is_file(),
+            "subprocess {peer_id} did not publish its queued-dial marker"
+        );
+    }
+}
+
+impl Drop for FaultDialBarrierDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 /// The whole Phase 2 exit-criteria suite runs as ONE test: the test process
 /// hosts a single swarm (kameo `init_global` is a process singleton), and the
 /// scenario steps build on each other.
@@ -557,17 +719,41 @@ async fn cluster_exit_criteria_end_to_end() {
     let db = open_control_db(&postgres_url).await;
     reset_and_enroll(&db, &pool).await;
 
-    // --- Bring up the mesh: A (seed), B (bootstraps to A). Sequential so
-    // concurrent first-boot migrations cannot race on the shared database.
-    // Production shape: the headless Service resolves to every pod, so every
-    // node dials every peer directly. The harness expresses that as one
-    // loopback seed per node.
+    // --- Bring up the mesh with both bootstrap peers starting concurrently.
+    // This is the production rolling-surge shape: the headless Service
+    // resolves to every pod, so A and B dial each other at the same time.
+    // Pre-provision the shared migrations/accounts, then preserve them during
+    // the concurrent starts so this test isolates swarm convergence instead
+    // of racing the harness's destructive fixed-account reset.
+    provision_cluster_test_accounts(&postgres_url).await;
     let port_a = free_tcp_port();
     let port_b = free_tcp_port();
-    let (mut server_a, node_a, peer_a) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]).await;
-    let (server_b, node_b, _peer_b) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
+    let bootstrap_a = [port_b];
+    let bootstrap_b = [port_a];
+    let dial_barrier = FaultDialBarrierDirectory::create();
+    let (server_a_result, server_b_result, ()) = tokio::join!(
+        spawn_cluster_server_preserving_accounts_with_dial_barrier(
+            &postgres_url,
+            &pool.pool_env,
+            port_a,
+            &bootstrap_a,
+            dial_barrier.path(),
+        ),
+        spawn_cluster_server_preserving_accounts_with_dial_barrier(
+            &postgres_url,
+            &pool.pool_env,
+            port_b,
+            &bootstrap_b,
+            dial_barrier.path(),
+        ),
+        dial_barrier.release_and_drive_after_two_markers(),
+    );
+    let (mut server_a, node_a, peer_a) = server_a_result;
+    let (server_b, node_b, peer_b) = server_b_result;
+    dial_barrier.assert_marker(&peer_a);
+    dial_barrier.assert_marker(&peer_b);
+    let peer_a_id: libp2p::PeerId = peer_a.parse().expect("node A peer id");
+    let peer_b_id: libp2p::PeerId = peer_b.parse().expect("node B peer id");
 
     // --- The test process joins as node C.
     let stop = CancellationToken::new();
@@ -608,6 +794,7 @@ async fn cluster_exit_criteria_end_to_end() {
         },
         fault_injection: false,
         node_id_file: None,
+        fault_dial_barrier_dir: None,
         node_lease: waddle_server::config::ClusteringNodeLeaseConfig {
             heartbeat_interval: Duration::from_secs(1),
             lease_ttl: Duration::from_secs(10),
@@ -655,6 +842,45 @@ async fn cluster_exit_criteria_end_to_end() {
     ping_until(&mut relay_b, &node_b, Duration::from_secs(30))
         .await
         .expect("cross-node ping to B");
+
+    // Regression: simultaneous A↔B cross-dials used to let each endpoint
+    // close a different locally second connection, tearing down both links.
+    // Ask each subprocess relay to ping the other subprocess relay
+    // concurrently, then repeat across several 1s bootstrap-dial ticks so a
+    // reconnect/close oscillation cannot pass on one lucky instant. Each
+    // reply snapshots its source's peer count *before* the nested ping: with
+    // exactly A/B/C in this mesh it must already be 2, proving the assertion
+    // observes an existing A↔B link rather than letting the probe's on-demand
+    // resolution repair a missing one.
+    let mut relay_a_probe = RelayHandle::new(NodeId::new(node_a.clone()), stop.clone());
+    let mut relay_b_probe = RelayHandle::new(NodeId::new(node_b.clone()), stop.clone());
+    for dial_tick in 1..=4 {
+        let (a_to_b, b_to_a) = tokio::join!(
+            relay_a_probe.probe_peer(NodeId::new(node_b.clone()), peer_b_id),
+            relay_b_probe.probe_peer(NodeId::new(node_a.clone()), peer_a_id),
+        );
+        assert_eq!(
+            a_to_b.expect("ask A to probe B"),
+            RelayProbePeerReply::Reachable {
+                node_id: NodeId::new(node_b.clone()),
+                source_connected_peers_before: 2,
+                source_connections_to_target_before: 2,
+            },
+            "A must already have B connected, then reach it after simultaneous \
+             startup (dial tick {dial_tick})"
+        );
+        assert_eq!(
+            b_to_a.expect("ask B to probe A"),
+            RelayProbePeerReply::Reachable {
+                node_id: NodeId::new(node_a.clone()),
+                source_connected_peers_before: 2,
+                source_connections_to_target_before: 2,
+            },
+            "B must already have A connected, then reach it after simultaneous \
+             startup (dial tick {dial_tick})"
+        );
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+    }
 
     // --- Exit criterion: the bounded XML codec on the wire — a
     // thread-carrying stanza survives the round-trip to another process.
@@ -1695,8 +1921,8 @@ async fn orphan_reaper_kills_one_node_and_hydrates_only_its_orphaned_sessions() 
     let mut client_b = WsXmppClient::connect_and_auth(
         &server_b.ws_url(),
         DOMAIN,
-        CLUSTER_PEER_USERNAME,
-        CLUSTER_PEER_PASSWORD,
+        CLUSTER_MEMBER_USERNAME,
+        CLUSTER_MEMBER_PASSWORD,
         &resource_b,
     )
     .await
@@ -1840,12 +2066,13 @@ async fn orphan_reaper_kills_one_node_and_hydrates_only_its_orphaned_sessions() 
 /// via `NodeLeaseStore::report_steal_intent` rather than faking a
 /// production reporter call site that does not exist yet.
 ///
-/// Runs the REAL `self_fence::run_node_lease` loop (not a reimplementation)
-/// against real Postgres, with a short heartbeat interval, and asserts the
-/// wedged `RoomActor` is hard-killed within one heartbeat interval of the
-/// intent being seeded — "reconciliation conflict-closes within one
-/// heartbeat interval," the exact bound element 4's veto-scan text
-/// promises.
+/// Runs the REAL fail-closed node-lease loop (not a reimplementation) against
+/// real Postgres, with a short heartbeat interval, and asserts the wedged
+/// `RoomActor` is hard-killed within one heartbeat interval of the intent being
+/// seeded — "reconciliation conflict-closes within one heartbeat interval,"
+/// the exact bound element 4's veto-scan text promises. The harness cannot
+/// possess the process-wide room-serving fence, so shutdown deliberately
+/// abandons claims for node-expiry recovery.
 #[tokio::test]
 async fn deposed_owner_with_live_socket_room_actor_scenario() {
     use std::future::pending;
@@ -2063,7 +2290,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     let stop_token = CancellationToken::new();
     let local_claims: std::sync::Arc<dyn LocallyClaimedEntities> = room_local_claims;
     let live_identity = SharedNodeIdentity::new(identity.clone());
-    tokio::spawn(self_fence::run_node_lease(
+    tokio::spawn(self_fence::run_node_lease_fail_closed(
         node_lease_store,
         identity,
         stop_token.clone(),
@@ -2124,7 +2351,9 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
 /// never contested. Client B then joins the SAME room JID against node B:
 /// node B's own `RoomRegistryActor` sees a fresh foreign owner, proxies the
 /// join, and must return the owner node's roster/self-presence/subject
-/// sequence instead of a local retry error.
+/// sequence instead of a local retry error. Both nodes start simultaneously
+/// and dial each other, matching the production rolling-surge shape and
+/// proving the MUC proxy survives the cross-dial connection race.
 #[tokio::test]
 async fn muc_join_routes_to_foreign_room_owner() {
     let Ok(postgres_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
@@ -2140,6 +2369,7 @@ async fn muc_join_routes_to_foreign_room_owner() {
     let pool = generate_pool();
     reset_and_enroll(&db, &pool).await;
     reset_node_lease_tables(&db).await;
+    provision_cluster_test_accounts(&postgres_url).await;
 
     const DOMAIN: &str = "localhost";
     const OWNER_USERNAME: &str = "admin";
@@ -2147,10 +2377,24 @@ async fn muc_join_routes_to_foreign_room_owner() {
 
     let port_a = free_tcp_port();
     let port_b = free_tcp_port();
-    let (server_a, _node_a, _peer_a) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]).await;
-    let (server_b, _node_b, _peer_b) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
+    let bootstrap_a = [port_b];
+    let bootstrap_b = [port_a];
+    let (server_a_result, server_b_result) = tokio::join!(
+        spawn_cluster_server_preserving_accounts(
+            &postgres_url,
+            &pool.pool_env,
+            port_a,
+            &bootstrap_a,
+        ),
+        spawn_cluster_server_preserving_accounts(
+            &postgres_url,
+            &pool.pool_env,
+            port_b,
+            &bootstrap_b,
+        ),
+    );
+    let (server_a, _node_a, _peer_a) = server_a_result;
+    let (server_b, _node_b, _peer_b) = server_b_result;
 
     wait_for_readiness(&server_a, true, Duration::from_secs(15)).await;
     wait_for_readiness(&server_b, true, Duration::from_secs(15)).await;

--- a/server/crates/waddle-server/tests/xep0045_join_lifecycle_ws.rs
+++ b/server/crates/waddle-server/tests/xep0045_join_lifecycle_ws.rs
@@ -27,6 +27,12 @@
 //!    unavailable, and the fresh (never-joined) stream must not inherit
 //!    room fan-out.
 //!
+//! 4. Portable startup in a cluster-capable binary: when the
+//!    `clustering` feature is compiled but clustering is disabled at
+//!    runtime, a first join stays on the local XEP-0045 path. It must
+//!    not be rejected with a retryable `<resource-constraint/>`, and
+//!    readiness is confirmed by self-presence status code 110.
+//!
 //! Wire shapes are parsed via `minidom::Element` and asserted
 //! structurally so child ordering and attribute quoting cannot flake
 //! the tests.
@@ -475,6 +481,87 @@ fn groupchat_message_xml(to: &str, id: &str, body: &str) -> String {
             )
             .build(),
     )
+}
+
+/// XEP-0045 §7.2.2: a binary compiled with cluster support must
+/// retain portable single-node semantics when clustering is disabled at
+/// runtime. In that mode there is no ordered-relay bridge, so the first
+/// join must be handled locally rather than bounced with the
+/// `<resource-constraint/>` that tells the client to retry a genuinely
+/// unavailable remote owner. A completed join is proven by the
+/// room-authored self-presence carrying status code 110, followed by the
+/// room subject.
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn xep_0045_cluster_capable_binary_with_runtime_clustering_disabled_joins_locally() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_envs(&[], &[("WADDLE_CLUSTERING_ENABLED", "false")]);
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ADMIN, &admin_pass, "runtime-clustering-disabled").await;
+    let room = format!(
+        "runtime-clustering-disabled-{}@muc.{DOMAIN}",
+        uuid::Uuid::new_v4()
+    );
+    let room_nick = format!("{room}/{ADMIN}");
+    let join = element_to_xml(
+        Element::builder("presence", "jabber:client")
+            .attr(
+                xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
+                room_nick.as_str(),
+            )
+            .append(Element::builder("x", NS_MUC).build())
+            .build(),
+    );
+
+    admin.send(&join).await.expect("send first local MUC join");
+    let join_frames = admin
+        .recv_until(|frame| {
+            frame.parse::<Element>().is_ok_and(|element| {
+                find_descendant(&element, "subject", "jabber:client").is_some()
+                    || (element.name() == "presence" && element.attr("type") == Some("error"))
+            })
+        })
+        .await
+        .expect("first join must complete or return a typed presence error");
+
+    let parsed = join_frames
+        .iter()
+        .map(|frame| {
+            frame
+                .parse::<Element>()
+                .unwrap_or_else(|error| panic!("join frame must parse as XML: {error}; {frame}"))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        parsed
+            .iter()
+            .all(|frame| find_descendant(frame, "resource-constraint", NS_XMPP_STANZAS).is_none()),
+        "runtime-disabled clustering must not turn a local first join into a retryable \
+         resource-constraint: {join_frames:?}"
+    );
+    assert!(
+        parsed.iter().any(|frame| {
+            frame.name() == "presence"
+                && frame.attr("from") == Some(room_nick.as_str())
+                && frame
+                    .children()
+                    .find(|child| child.name() == "x" && child.ns() == NS_MUC_USER)
+                    .is_some_and(|muc_user| {
+                        muc_user.children().any(|child| {
+                            child.name() == "status" && child.attr("code") == Some("110")
+                        })
+                    })
+        }),
+        "XEP-0045 self-presence status 110 must confirm local join readiness: {join_frames:?}"
+    );
+    assert!(
+        parsed
+            .iter()
+            .any(|frame| find_descendant(frame, "subject", "jabber:client").is_some()),
+        "a successful first join must finish with the room subject: {join_frames:?}"
+    );
+
+    let _ = admin.close().await;
 }
 
 /// XEP-0045 §7.4 stable-id (#1265 item 14): the service and rooms

--- a/server/crates/waddle-ws-test-support/src/lib.rs
+++ b/server/crates/waddle-ws-test-support/src/lib.rs
@@ -145,7 +145,17 @@ impl TestServer {
         extra_envs: &[(&str, &str)],
     ) -> Self {
         let bin = waddle_server_bin();
-        let fixed_account_password = format!("ws-test-password-{}", uuid::Uuid::new_v4());
+        let generated_fixed_account_password = format!("ws-test-password-{}", uuid::Uuid::new_v4());
+        // Extra envs are applied after the harness defaults below, so the
+        // accessor must report the same overridden password the subprocess
+        // actually receives.
+        let fixed_account_password = extra_envs
+            .iter()
+            .rev()
+            .find_map(|(key, value)| {
+                (*key == "WADDLE_TEST_FIXED_ACCOUNT_PASSWORD").then(|| (*value).to_string())
+            })
+            .unwrap_or(generated_fixed_account_password);
         let test_profile_publish_token = uuid::Uuid::new_v4().to_string();
         let extra_accounts_env = extra_accounts
             .iter()

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -405,6 +405,12 @@ pub struct RoomActor {
     /// ownership-loss seal, whose non-serving local actor must be evicted even
     /// when that backlog is full.
     seal_state: RoomSealState,
+    /// Whether the graceful-shutdown mailbox barrier has run for this actor.
+    ///
+    /// Kept separately from `seal_state` so an actor can retain definitive
+    /// `OwnershipLost` provenance while still rejecting the cache-only
+    /// recovery replays that ownership loss ordinarily permits.
+    shutdown_seal_installed: bool,
     occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
     /// Durable membership hydrated from the deployment's membership
     /// source at spawn (#1135). Kept separate from
@@ -487,6 +493,13 @@ pub enum RoomSealState {
     Open,
     /// The registry sealed an inactive actor before a terminal local removal.
     Inactive,
+    /// Graceful shutdown placed a terminal mailbox seal after every message
+    /// already queued ahead of it. No later serving action may start while the
+    /// actor remains alive awaiting retirement and claim release: admissions,
+    /// occupancy/presence/call updates, room/admin/invite mutations,
+    /// restore/hydration work, destruction, and traffic-producing dispatch
+    /// snapshots are all refused.
+    Shutdown,
     /// The durable ownership gate proved this incarnation is non-serving.
     OwnershipLost,
 }
@@ -523,9 +536,10 @@ pub enum RoomActorError {
     StaleAdmissionRevision,
     #[error("join is blocked pending invite membership rollback acknowledgement")]
     InviteRollbackPending,
-    /// #1108: this room actor was sealed by the registry's guarded
-    /// destroy and is about to be dropped. Retryable — the caller must
-    /// re-run the registry lookup, which respawns the room.
+    /// This room actor was sealed by guarded destruction, ownership loss, or
+    /// graceful shutdown and is no longer allowed to perform serving work.
+    /// Retryable during ordinary inactivity eviction; during shutdown the
+    /// caller must stop dispatching new room work.
     #[error("room actor is sealed pending destruction")]
     RoomSealed,
     /// #1107: the joining FULL JID already occupies this room under a
@@ -606,6 +620,7 @@ impl RoomActor {
             invite_operation_by_invitee: HashMap::new(),
             occupancy_revision: 0,
             seal_state: RoomSealState::Open,
+            shutdown_seal_installed: false,
             occupant_id_secret,
             durable_member_recipients: Vec::new(),
             membership_source: None,
@@ -679,6 +694,36 @@ impl RoomActor {
             && revision >= member_revision
     }
 
+    /// Reject any serving operation once an actor seal is visible.
+    ///
+    /// Read-only diagnostics intentionally do not call this helper, so the
+    /// drain can still inspect the actor until retirement. Every operation
+    /// that mutates room state or prepares externally emitted room traffic
+    /// must call it before reading data that could drive that work.
+    fn gate_serving_activity(&self) -> Result<(), RoomActorError> {
+        if self.seal_state.is_sealed() {
+            Err(RoomActorError::RoomSealed)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Whether even exact, read-only recovery replays are forbidden.
+    ///
+    /// Bare ownership loss permits callers to recover already-recorded
+    /// idempotency outcomes, while every state transition remains fenced by
+    /// the mutation gate. Inactivity and shutdown are actor-lifecycle
+    /// terminals. The separate shutdown bit also covers an OwnershipLost
+    /// actor after the drain's ordered mailbox barrier without erasing that
+    /// stronger ownership provenance.
+    fn blocks_recovery_replay(&self) -> bool {
+        self.shutdown_seal_installed
+            || matches!(
+                self.seal_state,
+                RoomSealState::Inactive | RoomSealState::Shutdown
+            )
+    }
+
     /// ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): the
     /// pre-mutation ownership gate every durable-relevant mutation handler
     /// runs BEFORE touching in-memory state. `Ok(())` when unfenced (no
@@ -695,7 +740,7 @@ impl RoomActor {
         // actor incarnation. Do not let a later transient store failure
         // override that proof through a later uncertain probe while the
         // registry is still converging the non-serving actor's removal.
-        if self.seal_state == RoomSealState::OwnershipLost {
+        if self.seal_state.is_sealed() {
             return Err(PreMutationOwnershipError::NotOwner);
         }
         let Some(store) = self.durable_store.clone() else {
@@ -849,7 +894,9 @@ impl RoomActor {
     async fn reject_sealed_join(&mut self) -> Result<(), RoomActorError> {
         match self.seal_state {
             RoomSealState::Open => Ok(()),
-            RoomSealState::OwnershipLost => Err(RoomActorError::RoomSealed),
+            RoomSealState::Shutdown | RoomSealState::OwnershipLost => {
+                Err(RoomActorError::RoomSealed)
+            }
             RoomSealState::Inactive => {
                 let _ = self.gate_join_ownership().await;
                 Err(RoomActorError::RoomSealed)
@@ -1134,13 +1181,14 @@ pub struct HydrateDurableRecipients {
 }
 
 impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
-    type Reply = ();
+    type Reply = Result<(), RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: HydrateDurableRecipients,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         // Retain the source so affiliation changes to `None` can
         // re-run hydration later (round-2 review R1) instead of
         // guessing whether the member is still space-entitled.
@@ -1164,6 +1212,7 @@ impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
                 );
             }
         }
+        Ok(())
     }
 }
 
@@ -1233,15 +1282,21 @@ impl kameo::message::Message<GetDurableRestoreReadiness> for RoomActor {
 }
 
 impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
-    type Reply = ();
+    type Reply = Result<(), RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: RestoreDurableRoomState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.restore_state == DurableRestoreState::OwnershipLost {
-            return;
+        if self.blocks_recovery_replay() {
+            return Err(RoomActorError::RoomSealed);
+        }
+        if self.seal_state == RoomSealState::OwnershipLost {
+            // Ownership loss is terminal for this incarnation. A duplicate
+            // restore is an idempotent convergence message: do not retry the
+            // stale fence or replace the retained store/fence identity.
+            return Ok(());
         }
         if let Some(retained) = self.durable_claim_fence.as_ref() {
             if retained != &msg.claim_fence {
@@ -1256,7 +1311,7 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
                 // tuple must not read, install, or retain successor state.
                 self.restore_state = DurableRestoreState::OwnershipLost;
                 self.seal_state = RoomSealState::OwnershipLost;
-                return;
+                return Ok(());
             }
         }
         // Retain this incarnation's exact authority before awaiting the
@@ -1304,6 +1359,7 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
                 self.restore_state = DurableRestoreState::Pending;
             }
         }
+        Ok(())
     }
 }
 
@@ -1366,6 +1422,7 @@ impl kameo::message::Message<Leave> for RoomActor {
     type Reply = Result<(), RoomActorError>;
 
     async fn handle(&mut self, msg: Leave, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.gate_serving_activity()?;
         self.room
             .remove_occupant(&msg.nick)
             .map(|_| ())
@@ -1379,16 +1436,18 @@ pub struct GetOccupantByJid {
 }
 
 impl kameo::message::Message<GetOccupantByJid> for RoomActor {
-    type Reply = Option<OccupantInfo>;
+    type Reply = Result<Option<OccupantInfo>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetOccupantByJid,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room
+        self.gate_serving_activity()?;
+        Ok(self
+            .room
             .find_occupant_by_real_jid(&msg.jid)
-            .map(OccupantInfo::from_occupant)
+            .map(OccupantInfo::from_occupant))
     }
 }
 
@@ -1398,16 +1457,18 @@ pub struct GetOccupantByNick {
 }
 
 impl kameo::message::Message<GetOccupantByNick> for RoomActor {
-    type Reply = Option<OccupantInfo>;
+    type Reply = Result<Option<OccupantInfo>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetOccupantByNick,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room
+        self.gate_serving_activity()?;
+        Ok(self
+            .room
             .get_occupant(&msg.nick)
-            .map(OccupantInfo::from_occupant)
+            .map(OccupantInfo::from_occupant))
     }
 }
 
@@ -1426,13 +1487,14 @@ pub struct RoomInfo {
 pub struct GetInfo;
 
 impl kameo::message::Message<GetInfo> for RoomActor {
-    type Reply = Result<RoomInfo, Infallible>;
+    type Reply = Result<RoomInfo, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: GetInfo,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         Ok(RoomInfo {
             room_jid: self.room.room_jid.clone(),
             occupant_count: self.room.occupant_count(),
@@ -1445,13 +1507,14 @@ impl kameo::message::Message<GetInfo> for RoomActor {
 pub struct GetConfig;
 
 impl kameo::message::Message<GetConfig> for RoomActor {
-    type Reply = Result<RoomConfig, Infallible>;
+    type Reply = Result<RoomConfig, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: GetConfig,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         Ok(self.room.config.clone())
     }
 }
@@ -1668,13 +1731,14 @@ pub struct ApplyPin {
 }
 
 impl kameo::message::Message<ApplyPin> for RoomActor {
-    type Reply = ();
+    type Reply = Result<(), RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: ApplyPin,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         match msg.change {
             PinStateChange::Pin(entry) => {
                 self.room.upsert_pin(entry);
@@ -1683,6 +1747,7 @@ impl kameo::message::Message<ApplyPin> for RoomActor {
                 self.room.remove_pin_by_target(&target_stanza_id);
             }
         }
+        Ok(())
     }
 }
 
@@ -1693,14 +1758,15 @@ impl kameo::message::Message<ApplyPin> for RoomActor {
 pub struct GetPinList;
 
 impl kameo::message::Message<GetPinList> for RoomActor {
-    type Reply = Vec<PinnedEntry>;
+    type Reply = Result<Vec<PinnedEntry>, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: GetPinList,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room.pinned_entries().to_vec()
+        self.gate_serving_activity()?;
+        Ok(self.room.pinned_entries().to_vec())
     }
 }
 
@@ -1745,13 +1811,14 @@ pub struct GetAffiliation {
 }
 
 impl kameo::message::Message<GetAffiliation> for RoomActor {
-    type Reply = Result<Affiliation, Infallible>;
+    type Reply = Result<Affiliation, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         Ok(self.room.get_affiliation(&msg.jid))
     }
 }
@@ -1779,13 +1846,14 @@ pub struct ListAffiliations {
 }
 
 impl kameo::message::Message<ListAffiliations> for RoomActor {
-    type Reply = Vec<AffiliationEntry>;
+    type Reply = Result<Vec<AffiliationEntry>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: ListAffiliations,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         let mut entries: Vec<AffiliationEntry> = self
             .room
             .get_all_affiliations()
@@ -1796,7 +1864,7 @@ impl kameo::message::Message<ListAffiliations> for RoomActor {
             })
             .collect();
         entries.sort_by(|a, b| a.jid.cmp(&b.jid));
-        entries
+        Ok(entries)
     }
 }
 
@@ -1804,18 +1872,20 @@ impl kameo::message::Message<ListAffiliations> for RoomActor {
 pub struct ListOccupants;
 
 impl kameo::message::Message<ListOccupants> for RoomActor {
-    type Reply = Vec<OccupantInfo>;
+    type Reply = Result<Vec<OccupantInfo>, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: ListOccupants,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room
+        self.gate_serving_activity()?;
+        Ok(self
+            .room
             .occupants
             .values()
             .map(OccupantInfo::from_occupant)
-            .collect()
+            .collect())
     }
 }
 
@@ -1823,14 +1893,15 @@ impl kameo::message::Message<ListOccupants> for RoomActor {
 pub struct OccupantCount;
 
 impl kameo::message::Message<OccupantCount> for RoomActor {
-    type Reply = usize;
+    type Reply = Result<usize, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: OccupantCount,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room.occupant_count()
+        self.gate_serving_activity()?;
+        Ok(self.room.occupant_count())
     }
 }
 
@@ -1918,6 +1989,25 @@ impl kameo::message::Message<GetRoomSealState> for RoomActor {
     }
 }
 
+/// Read the exact durable claim retained by this actor incarnation.
+///
+/// This is a typed, read-only diagnostic for ownership convergence. It must
+/// never be used as dispatch authorization: [`GetRoomSnapshot`] remains the
+/// serving boundary and rejects every sealed actor.
+pub struct GetRetainedRoomClaimFence;
+
+impl kameo::message::Message<GetRetainedRoomClaimFence> for RoomActor {
+    type Reply = Option<super::durable::RoomClaimFenceContext>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetRetainedRoomClaimFence,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.durable_claim_fence.clone()
+    }
+}
+
 /// The inactivity predicate a guarded destroy checks before sealing
 /// the room actor (#1108).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1972,6 +2062,10 @@ impl kameo::message::Message<SealIfInactive> for RoomActor {
         match self.seal_state {
             RoomSealState::OwnershipLost => return SealIfInactiveOutcome::OwnershipLost,
             RoomSealState::Inactive => return SealIfInactiveOutcome::Inactive,
+            // Graceful shutdown owns this actor's terminal retirement and
+            // exact claim release. The inactivity reaper must leave it in
+            // place rather than racing that ordered sequence.
+            RoomSealState::Shutdown => return SealIfInactiveOutcome::Refused,
             RoomSealState::Open => {}
         }
         if self.occupancy_revision != msg.expected_occupancy_revision {
@@ -1997,14 +2091,16 @@ impl kameo::message::Message<SealIfInactive> for RoomActor {
 pub struct Destroy;
 
 impl kameo::message::Message<Destroy> for RoomActor {
-    type Reply = ();
+    type Reply = Result<(), RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: Destroy,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         self.room.occupants.clear();
+        Ok(())
     }
 }
 
@@ -2026,18 +2122,53 @@ impl kameo::message::Message<GetRoomJid> for RoomActor {
 pub struct GetSnapshot;
 
 impl kameo::message::Message<GetSnapshot> for RoomActor {
-    type Reply = Result<RoomSnapshot, Infallible>;
+    type Reply = Result<RoomSnapshot, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: GetSnapshot,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // The full snapshot drives roster/config responses, external archive
+        // authorization, and fan-out. Keep it behind the serving seal; narrow
+        // typed diagnostics have dedicated messages.
+        self.gate_serving_activity()?;
         Ok(RoomSnapshot {
             room: self.room.clone(),
             config_revision: self.config_revision,
             admission_revision: self.admission_revision,
         })
+    }
+}
+
+/// Install the terminal graceful-shutdown seal at this exact mailbox
+/// position.
+///
+/// A successful reply proves every message queued before this one finished,
+/// including any awaited fenced durable write. Messages queued later still
+/// reach the live actor until the drain retires it, but the central serving
+/// gate and typed handler outcomes refuse admissions, occupancy/presence/call
+/// updates, self-ping and occupant authorization reads, pin/config/admin/
+/// affiliation/invite mutations, restore/hydration, destruction, and
+/// broadcast/dispatch preparation. Harmless diagnostic reads remain available
+/// to the drain. The transition is idempotent. A separate shutdown overlay
+/// blocks ownership-loss recovery replays without erasing that definitive
+/// provenance from [`GetRoomSealState`].
+pub struct SealForShutdown;
+
+impl kameo::message::Message<SealForShutdown> for RoomActor {
+    type Reply = RoomSealState;
+
+    async fn handle(
+        &mut self,
+        _msg: SealForShutdown,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.shutdown_seal_installed = true;
+        if self.seal_state != RoomSealState::OwnershipLost {
+            self.seal_state = RoomSealState::Shutdown;
+        }
+        self.seal_state
     }
 }
 
@@ -2047,9 +2178,9 @@ impl kameo::message::Message<GetSnapshot> for RoomActor {
 /// actor's mailbox loop is live and responsive right now, since kameo
 /// processes a mailbox strictly in order. Production callers:
 /// `RoomLocalClaims::health_check` (the Slice 7 owner-veto/reconciliation
-/// path) and `RoomLocalClaims::seal_before_release` (the Slice 10 drain
-/// barrier — a reply after the drain's `owned()` snapshot proves every
-/// mutation queued ahead of it already committed its fenced durable write).
+/// path). Graceful drain uses [`SealForShutdown`] instead so the same mailbox
+/// barrier also prevents any later mutation from starting before retirement
+/// and claim release.
 pub struct HealthCheck;
 
 impl kameo::message::Message<HealthCheck> for RoomActor {

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeMap, convert::Infallible};
+use std::collections::BTreeMap;
 
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
 use xmpp_parsers::presence::Presence;
 
-use super::{AdminApplyError, AdminContext, RoomActor};
+use super::{AdminApplyError, AdminContext, RoomActor, RoomActorError};
 use crate::muc::admin::{is_role_change_query, AdminItem};
 use crate::muc::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
@@ -305,13 +305,16 @@ pub struct GetAdminContext {
 }
 
 impl kameo::message::Message<GetAdminContext> for RoomActor {
-    type Reply = Result<AdminContext, Infallible>;
+    type Reply = Result<AdminContext, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetAdminContext,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // This context authorizes externally visible admin/moderation work;
+        // it is not a diagnostic read from a retired actor.
+        self.gate_serving_activity()?;
         let sender_affiliation = self.room.get_affiliation(&msg.sender_jid.to_bare());
         let sender_occupant = self.room.find_occupant_by_real_jid(&msg.sender_jid);
         let sender_role = sender_occupant.map(|o| o.role).unwrap_or(Role::None);
@@ -678,14 +681,18 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
 pub struct EnforceMembersOnly;
 
 impl kameo::message::Message<EnforceMembersOnly> for RoomActor {
-    type Reply = Vec<(FullJid, Presence)>;
+    type Reply = Result<Vec<(FullJid, Presence)>, RoomActorError>;
 
     async fn handle(
         &mut self,
         _msg: EnforceMembersOnly,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        enforce_members_only(&mut self.room, &self.occupant_id_secret)
+        self.gate_serving_activity()?;
+        Ok(enforce_members_only(
+            &mut self.room,
+            &self.occupant_id_secret,
+        ))
     }
 }
 
@@ -757,9 +764,10 @@ pub struct IsOwner {
 }
 
 impl kameo::message::Message<IsOwner> for RoomActor {
-    type Reply = bool;
+    type Reply = Result<bool, RoomActorError>;
 
     async fn handle(&mut self, msg: IsOwner, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-        self.room.get_affiliation(&msg.jid) == Affiliation::Owner
+        self.gate_serving_activity()?;
+        Ok(self.room.get_affiliation(&msg.jid) == Affiliation::Owner)
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
@@ -128,6 +128,7 @@ pub enum MediatedInviteRollbackError {
 pub enum MediatedInviteRollbackAbort {
     Aborted,
     NotPrepared,
+    RoomSealed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
@@ -135,6 +136,7 @@ pub enum MediatedInviteGrantFinalization {
     Finalized,
     RollbackPending,
     Superseded,
+    RoomSealed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
@@ -142,6 +144,7 @@ pub enum MediatedInviteOperationAcknowledgement {
     Acknowledged,
     Pending,
     Unknown,
+    RoomSealed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -14,6 +14,13 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
         msg: AuthorizeMediatedInvite,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Inactivity/shutdown retire the actor, so even cached replies are
+        // blocked. Ownership loss still permits inspection of an exact
+        // pre-existing operation so recovery can obtain its opaque rollback
+        // authority without applying another room mutation.
+        if self.blocks_recovery_replay() {
+            return Err(MediatedInviteGrantError::RoomSealed);
+        }
         if let Some(record) = self.invite_operations.get(&msg.operation_id) {
             return if record.inviter == msg.inviter && record.invitee == msg.invitee {
                 Ok(record.authorization.clone())
@@ -21,7 +28,7 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
                 Err(MediatedInviteGrantError::OperationMismatch)
             };
         }
-        if self.seal_state.is_sealed() {
+        if self.seal_state == RoomSealState::OwnershipLost {
             return Err(MediatedInviteGrantError::RoomSealed);
         }
         self.gate_mutation().await?;

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/completion.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/completion.rs
@@ -12,6 +12,9 @@ impl kameo::message::Message<FinalizeMediatedInviteGrant> for RoomActor {
         msg: FinalizeMediatedInviteGrant,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.seal_state.is_sealed() {
+            return MediatedInviteGrantFinalization::RoomSealed;
+        }
         let Some(record) = self.invite_operations.get_mut(&msg.operation_id) else {
             return MediatedInviteGrantFinalization::Superseded;
         };
@@ -60,6 +63,9 @@ impl kameo::message::Message<AcknowledgeMediatedInviteOperation> for RoomActor {
         msg: AcknowledgeMediatedInviteOperation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.seal_state.is_sealed() {
+            return MediatedInviteOperationAcknowledgement::RoomSealed;
+        }
         let Some(record) = self.invite_operations.get(&msg.operation_id) else {
             return MediatedInviteOperationAcknowledgement::Unknown;
         };

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
@@ -25,6 +25,9 @@ impl kameo::message::Message<PrepareMediatedInviteGrantRollback> for RoomActor {
         msg: PrepareMediatedInviteGrantRollback,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.blocks_recovery_replay() {
+            return Err(RoomMutationError::NotOwner);
+        }
         if self
             .invite_operations
             .get(&msg.grant.operation_id)
@@ -67,6 +70,9 @@ impl kameo::message::Message<CommitMediatedInviteGrantRollback> for RoomActor {
         msg: CommitMediatedInviteGrantRollback,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.blocks_recovery_replay() {
+            return Err(MediatedInviteRollbackError::NotOwner);
+        }
         let Some(record) = self.invite_operations.get(&msg.grant.operation_id) else {
             return Ok(MediatedInviteRollbackCommit::Superseded);
         };
@@ -151,6 +157,9 @@ impl kameo::message::Message<AbortMediatedInviteGrantRollback> for RoomActor {
         msg: AbortMediatedInviteGrantRollback,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.seal_state.is_sealed() {
+            return MediatedInviteRollbackAbort::RoomSealed;
+        }
         if self.invite_rollback_is_prepared(&msg.grant) {
             self.invite_operations
                 .get_mut(&msg.grant.operation_id)

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
 
@@ -234,13 +232,14 @@ pub struct LeaveByRealJid {
 }
 
 impl kameo::message::Message<LeaveByRealJid> for RoomActor {
-    type Reply = Result<Option<LeaveOutcome>, Infallible>;
+    type Reply = Result<Option<LeaveOutcome>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: LeaveByRealJid,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         // #1107: collect EVERY nick this full JID occupies. Post-#1107
         // the join path refuses a second nick for the same full JID, so
         // this is normally a single entry — but pre-existing ghost
@@ -350,13 +349,17 @@ pub struct PresenceUpdateData {
 }
 
 impl kameo::message::Message<PresenceUpdateData> for RoomActor {
-    type Reply = Result<Option<PresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<PresenceUpdateOutcome>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: PresenceUpdateData,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Although this message does not mutate memory, its result directly
+        // authorizes a presence broadcast, so it is serving work rather than
+        // a harmless diagnostic snapshot.
+        self.gate_serving_activity()?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -421,13 +424,14 @@ pub struct MujiPresenceUpdateOutcome {
 }
 
 impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
-    type Reply = Result<Option<MujiPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<MujiPresenceUpdateOutcome>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: UpsertMujiPresence,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -467,13 +471,14 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
 }
 
 impl kameo::message::Message<ClearMujiPresence> for RoomActor {
-    type Reply = Result<Option<MujiPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<MujiPresenceUpdateOutcome>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: ClearMujiPresence,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -530,13 +535,14 @@ pub struct InCallPresenceUpdateOutcome {
 }
 
 impl kameo::message::Message<UpsertInCallState> for RoomActor {
-    type Reply = Result<Option<InCallPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<InCallPresenceUpdateOutcome>, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: UpsertInCallState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -564,6 +570,7 @@ impl kameo::message::Message<PingSelfCheck> for RoomActor {
         msg: PingSelfCheck,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         if self.room.get_occupant(&msg.nick).is_none() {
             return Err(RoomActorError::OccupantNotFound(msg.nick.clone()));
         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
 use xmpp_parsers::message::Message;
@@ -90,13 +88,16 @@ pub struct GetRoomSnapshot {
 }
 
 impl kameo::message::Message<GetRoomSnapshot> for RoomActor {
-    type Reply = Result<RoomChainSnapshot, Infallible>;
+    type Reply = Result<RoomChainSnapshot, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetRoomSnapshot,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // This is the dispatch-chain admission snapshot, not a diagnostic
+        // read: returning it authorizes archive writes and room fan-out.
+        self.gate_serving_activity()?;
         let occupants: Vec<RoomChainOccupant> = self
             .room
             .occupants
@@ -174,6 +175,7 @@ impl kameo::message::Message<BuildGroupchatBroadcast> for RoomActor {
         msg: BuildGroupchatBroadcast,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_serving_activity()?;
         let sender_occupant = self
             .room
             .find_occupant_by_real_jid(&msg.sender_jid)
@@ -226,15 +228,17 @@ pub struct GetNicknameGeneration {
 }
 
 impl kameo::message::Message<GetNicknameGeneration> for RoomActor {
-    type Reply = u64;
+    type Reply = Result<u64, RoomActorError>;
 
     async fn handle(
         &mut self,
         msg: GetNicknameGeneration,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.room
+        self.gate_serving_activity()?;
+        Ok(self
+            .room
             .current_nickname_generation(&msg.nick)
-            .unwrap_or(0)
+            .unwrap_or(0))
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -3495,6 +3495,340 @@ async fn health_check_replies_when_the_room_actor_is_idle() {
     actor.ask(HealthCheck).await.expect("health check replies");
 }
 
+#[tokio::test]
+async fn shutdown_seal_rejects_later_serving_activity_before_actor_retirement() {
+    use crate::muc::pin::PinStateChange;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let original = actor.ask(GetConfig).await.expect("initial config");
+    let alice = test_full_jid("alice");
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("seed occupant before shutdown");
+    actor
+        .ask(ChangeAffiliation {
+            jid: alice.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("authorize seeded inviter");
+    let invite_operation_id = MediatedInviteOperationId::generate();
+    let invitee: BareJid = "invitee@example.com".parse().expect("invitee jid");
+    let invite_authorization = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id,
+            inviter: alice.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("seed mediated invite operation");
+    let invite_grant = invite_authorization
+        .grant
+        .expect("members-only room creates a temporary grant");
+
+    assert_eq!(
+        actor
+            .ask(SealForShutdown)
+            .await
+            .expect("shutdown seal replies"),
+        RoomSealState::Shutdown
+    );
+    assert!(
+        actor.is_alive(),
+        "the seal must close admission and mutation before the drain kills the actor"
+    );
+    assert_eq!(
+        actor
+            .ask(SealForShutdown)
+            .await
+            .expect("shutdown seal is idempotent"),
+        RoomSealState::Shutdown
+    );
+
+    let self_ping = actor
+        .ask(PingSelfCheck {
+            nick: "alice".to_string(),
+            sender_jid: alice.clone(),
+        })
+        .await;
+    assert!(matches!(
+        self_ping,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let occupant_lookup = actor.ask(GetOccupantByJid { jid: alice.clone() }).await;
+    assert!(matches!(
+        occupant_lookup,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor
+            .ask(GetOccupantByNick {
+                nick: "alice".to_string(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(GetInfo).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(GetPinList).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor
+            .ask(GetAffiliation {
+                jid: alice.to_bare(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(ListAffiliations { filter: None }).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(ListOccupants).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(OccupantCount).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor
+            .ask(GetNicknameGeneration {
+                nick: "alice".to_string(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor
+            .ask(IsOwner {
+                jid: alice.to_bare(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor
+            .ask(GetAdminContext {
+                sender_jid: alice.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(matches!(
+        actor.ask(GetSnapshot).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    let join = actor
+        .ask(Join {
+            nick: "late".to_string(),
+            real_jid: test_full_jid("late"),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await;
+    assert!(matches!(
+        join,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    let mut changed = original.clone();
+    changed.members_only = !changed.members_only;
+    let update = actor.ask(UpdateConfig { config: changed }).await;
+    assert!(matches!(
+        update,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+
+    let leave = actor
+        .ask(LeaveByRealJid {
+            sender_jid: alice.clone(),
+        })
+        .await;
+    assert!(matches!(
+        leave,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    let presence_broadcast = actor
+        .ask(PresenceUpdateData {
+            sender_jid: alice.clone(),
+        })
+        .await;
+    assert!(matches!(
+        presence_broadcast,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let room_dispatch = actor
+        .ask(GetRoomSnapshot {
+            sender_jid: alice.clone(),
+        })
+        .await;
+    assert!(matches!(
+        room_dispatch,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let legacy_broadcast = actor
+        .ask(BuildGroupchatBroadcast {
+            sender_jid: alice.clone(),
+            message: xmpp_parsers::message::Message::new(None::<jid::Jid>),
+        })
+        .await;
+    assert!(matches!(
+        legacy_broadcast,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let in_call_update = actor
+        .ask(UpsertInCallState {
+            sender_jid: alice.clone(),
+            state: crate::xep::InCallPresenceState {
+                hand_raised: true,
+                muted: false,
+            },
+        })
+        .await;
+    assert!(matches!(
+        in_call_update,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    let target = StanzaId::new(
+        "late-unpin".to_string(),
+        jid::Jid::from(test_room().room_jid),
+    );
+    let pin_update = actor
+        .ask(ApplyPin {
+            change: PinStateChange::Unpin {
+                target_stanza_id: target,
+            },
+        })
+        .await;
+    assert!(matches!(
+        pin_update,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let members_only_eviction = actor.ask(EnforceMembersOnly).await;
+    assert!(matches!(
+        members_only_eviction,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    let destroy = actor.ask(Destroy).await;
+    assert!(matches!(
+        destroy,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    let restore_store = FakeDurableStore::owned();
+    let late_restore = actor
+        .ask(RestoreDurableRoomState {
+            store: restore_store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
+        })
+        .await;
+    assert!(matches!(
+        late_restore,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        restore_store
+            .load_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "a post-seal restore must not start an external durable read"
+    );
+
+    let invite_replay = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id,
+            inviter: test_full_jid("alice"),
+            invitee,
+        })
+        .await;
+    assert!(matches!(
+        invite_replay,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::RoomSealed
+        ))
+    ));
+    let invite_prepare = actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: invite_grant.clone(),
+        })
+        .await;
+    assert!(matches!(
+        invite_prepare,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    let invite_commit = actor
+        .ask(CommitMediatedInviteGrantRollback {
+            grant: invite_grant.clone(),
+        })
+        .await;
+    assert!(matches!(
+        invite_commit,
+        Err(SendError::HandlerError(
+            MediatedInviteRollbackError::NotOwner
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback {
+                grant: invite_grant,
+            })
+            .await
+            .expect("typed invite abort refusal"),
+        MediatedInviteRollbackAbort::RoomSealed
+    );
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant {
+                operation_id: invite_operation_id,
+            })
+            .await
+            .expect("typed invite finalization refusal"),
+        MediatedInviteGrantFinalization::RoomSealed
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: invite_operation_id,
+            })
+            .await
+            .expect("typed invite acknowledgement refusal"),
+        MediatedInviteOperationAcknowledgement::RoomSealed
+    );
+
+    let probe = actor.ask(IsDormant).await.expect("dormancy probe");
+    assert_eq!(
+        actor
+            .ask(SealIfInactive {
+                expected_occupancy_revision: probe.occupancy_revision,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("stale inactivity reaper probe"),
+        SealIfInactiveOutcome::Refused,
+        "the inactivity reaper must not take ownership of shutdown retirement"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): the pre-mutation
 // fencing gate every durable-relevant mutation handler now runs.
@@ -4061,10 +4395,10 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
 async fn update_config_gate_blocks_the_mutation_when_deposed() {
     let store = FakeDurableStore::deposed();
     let actor = spawn_room_actor_with_store(store.clone()).await;
-    let original = actor.ask(GetConfig).await.expect("ask").members_only;
+    let original = actor.ask(GetConfig).await.expect("ask");
 
-    let mut new_config = actor.ask(GetConfig).await.expect("ask");
-    new_config.members_only = !original;
+    let mut new_config = original.clone();
+    new_config.members_only = !original.members_only;
     let result = actor.ask(UpdateConfig { config: new_config }).await;
     assert!(
         matches!(
@@ -4074,15 +4408,19 @@ async fn update_config_gate_blocks_the_mutation_when_deposed() {
         "expected NotOwner, got: {result:?}"
     );
 
-    let after = actor.ask(GetConfig).await.expect("ask").members_only;
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert_eq!(
-        after, original,
-        "a gated-out mutation must never have applied in-memory"
+        store.save_call_count(),
+        0,
+        "a gated-out mutation must never reach durable persistence"
     );
 
     store.set_fenced(None);
-    let mut retry_config = actor.ask(GetConfig).await.expect("retry config");
-    retry_config.members_only = !original;
+    let mut retry_config = original;
+    retry_config.members_only = !retry_config.members_only;
     let retry = actor
         .ask(UpdateConfig {
             config: retry_config,
@@ -4195,15 +4533,10 @@ async fn ownership_lost_seal_blocks_a_later_mutation() {
         update,
         Err(SendError::HandlerError(RoomMutationError::NotOwner))
     ));
-    assert_eq!(
-        actor
-            .ask(GetConfig)
-            .await
-            .expect("unchanged config")
-            .members_only,
-        original.members_only,
-        "a definitive ownership-loss seal must dominate later uncertainty"
-    );
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert_eq!(
         store.save_call_count(),
         0,
@@ -4244,11 +4577,7 @@ async fn update_config_seals_the_actor_when_the_fenced_write_loses_ownership() {
 
     let mut changed = original.clone();
     changed.members_only = !changed.members_only;
-    let result = actor
-        .ask(UpdateConfig {
-            config: changed.clone(),
-        })
-        .await;
+    let result = actor.ask(UpdateConfig { config: changed }).await;
     assert!(
         matches!(
             result,
@@ -4259,11 +4588,10 @@ async fn update_config_seals_the_actor_when_the_fenced_write_loses_ownership() {
         "expected OwnershipLostAfterApply, got: {result:?}"
     );
     assert_eq!(store.save_call_count(), 1, "the fenced write was attempted");
-    assert_eq!(
-        actor.ask(GetConfig).await.expect("mutated config"),
-        changed,
-        "the local config mutation remains applied after the durable ownership loss"
-    );
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert_eq!(
         actor.ask(GetRoomSealState).await.expect("typed seal state"),
         RoomSealState::OwnershipLost,
@@ -4287,7 +4615,8 @@ async fn update_config_seals_the_actor_when_the_fenced_write_loses_ownership() {
 
 #[tokio::test]
 async fn change_affiliation_gate_blocks_the_mutation_when_deposed() {
-    let actor = spawn_room_actor_with_store(FakeDurableStore::deposed()).await;
+    let store = FakeDurableStore::deposed();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
     let jid: BareJid = "carol@example.com".parse().expect("valid jid");
 
     let result = actor
@@ -4304,11 +4633,14 @@ async fn change_affiliation_gate_blocks_the_mutation_when_deposed() {
         "expected NotOwner, got: {result:?}"
     );
 
-    let affiliation = actor.ask(GetAffiliation { jid }).await.expect("ask");
+    assert!(matches!(
+        actor.ask(GetAffiliation { jid }).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert_eq!(
-        affiliation,
-        Affiliation::None,
-        "a gated-out affiliation change must never have applied"
+        store.save_call_count(),
+        0,
+        "a gated-out affiliation change must never reach durable persistence"
     );
 }
 
@@ -4915,6 +5247,7 @@ async fn sync_resolver_affiliation_refuses_sealed_actor() {
         })
         .await
         .expect("seed resolver-derived member");
+    let sealed_admission_revision = current_admission_revision(&actor).await;
 
     let probe = actor
         .ask(crate::muc::room_actor::IsDormant)
@@ -4937,7 +5270,7 @@ async fn sync_resolver_affiliation_refuses_sealed_actor() {
         .ask(SyncResolverAffiliation {
             jid: alice.clone(),
             affiliation: Affiliation::None,
-            expected_admission_revision: current_admission_revision(&actor).await,
+            expected_admission_revision: sealed_admission_revision,
         })
         .await
         .expect("ask");
@@ -4946,15 +5279,10 @@ async fn sync_resolver_affiliation_refuses_sealed_actor() {
         ResolverAffiliationSyncOutcome::RoomSealed,
         "a sealed actor must refuse the sync"
     );
-    let affiliation = actor
-        .ask(GetAffiliation { jid: alice })
-        .await
-        .expect("affiliation query");
-    assert_eq!(
-        affiliation,
-        Affiliation::Member,
-        "the refused sync must leave the sealed actor's state untouched"
-    );
+    assert!(matches!(
+        actor.ask(GetAffiliation { jid: alice }).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 /// A resolver write with a different value must not downgrade an

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -385,6 +385,7 @@ async fn rollback_persist_failure_retains_the_exact_token_and_reservation_for_re
 #[tokio::test]
 async fn rollback_ownership_loss_is_typed_and_keeps_the_operation_prepared() {
     let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let replay_inviter = inviter.clone();
     let store = FakeDurableStore::owned();
     actor
         .ask(RestoreDurableRoomState {
@@ -417,20 +418,173 @@ async fn rollback_ownership_loss_is_typed_and_keeps_the_operation_prepared() {
         1,
         "ownership rejection must happen before rollback persistence",
     );
-    assert_eq!(
+    assert!(matches!(
         actor
             .ask(GetAffiliation {
                 jid: invitee.clone(),
             })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: grant.operation_id(),
+                inviter: replay_inviter.clone(),
+                invitee: invitee.clone(),
+            })
             .await
-            .expect("unchanged temporary membership"),
-        Affiliation::Member,
+            .expect("exact cached authorization remains inspectable")
+            .grant,
+        Some(grant.clone()),
     );
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: replay_inviter,
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::RoomSealed
+        ))
+    ));
     assert_eq!(
         actor
             .ask(PrepareMediatedInviteGrantRollback { grant })
             .await
             .expect("prepared state remains replayable"),
         MediatedInviteRollbackPreparation::Prepared,
+    );
+}
+
+#[tokio::test]
+async fn ownership_loss_preserves_cached_rollback_output_without_reopening_lifecycle_mutations() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let replay_inviter = inviter.clone();
+    let replay_invitee = invitee.clone();
+    let store = FakeDurableStore::owned();
+    let retained_fence = test_claim_fence(&test_room().room_jid);
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+            claim_fence: retained_fence.clone(),
+        })
+        .await
+        .expect("attach owned durable store");
+    let grant = authorize_invite_grant(&actor, inviter, invitee).await;
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare while the actor owns the room");
+    let applied = actor
+        .ask(CommitMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("commit while the actor owns the room");
+
+    *store.fenced.lock().expect("fence lock") = Some(false);
+    let mut attempted_config = actor.ask(GetConfig).await.expect("current config");
+    attempted_config.name = "must not mutate".to_string();
+    assert!(matches!(
+        actor
+            .ask(UpdateConfig {
+                config: attempted_config,
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await
+            .expect("cached rollback output remains inspectable"),
+        applied,
+    );
+    assert_eq!(
+        actor
+            .ask(SealForShutdown)
+            .await
+            .expect("ordered shutdown seal"),
+        RoomSealState::OwnershipLost,
+        "shutdown must retain definitive ownership-loss provenance",
+    );
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: grant.operation_id(),
+                inviter: replay_inviter.clone(),
+                invitee: replay_invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::RoomSealed
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteRollbackError::NotOwner
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await
+            .expect("typed lifecycle refusal"),
+        MediatedInviteRollbackAbort::RoomSealed,
+    );
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant {
+                operation_id: grant.operation_id(),
+            })
+            .await
+            .expect("typed lifecycle refusal"),
+        MediatedInviteGrantFinalization::RoomSealed,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: grant.operation_id(),
+            })
+            .await
+            .expect("typed lifecycle refusal"),
+        MediatedInviteOperationAcknowledgement::RoomSealed,
+    );
+    assert!(matches!(
+        actor
+            .ask(GetRoomSnapshot {
+                sender_jid: replay_inviter,
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetRetainedRoomClaimFence)
+            .await
+            .expect("retained claim-fence diagnostic"),
+        Some(retained_fence),
     );
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -14,6 +14,8 @@ use kameo::message::{BoxReply, Context};
 use kameo::reply::{DelegatedReply, ReplySender};
 use kameo::{Actor, Reply};
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tracing::{debug, info, warn};
 
 use super::affiliation::DurableMembershipSource;
@@ -175,6 +177,13 @@ struct CompleteDetachedRoomRelease {
     outcome: DetachedRoomReleaseOutcome,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoomOwnershipShutdownMode {
+    Serving,
+    Prepared,
+    Abandoned,
+}
+
 #[derive(Clone)]
 struct PendingReclaimedState {
     claim_fence: super::RoomClaimFenceContext,
@@ -247,9 +256,17 @@ pub struct RoomRegistryActor {
     pending_retry_order: u64,
     pending_retry_timer_generation: u64,
     scheduled_pending_retry_generation: Option<u64>,
-    /// Terminal shutdown has begun. Once set inside the actor mailbox, no
-    /// later demand or orphan-reaper message may acquire fresh room authority.
-    terminal_claim_acquisition_disabled: bool,
+    /// Terminal shutdown state. Once this leaves
+    /// [`RoomOwnershipShutdownMode::Serving`] inside the actor mailbox, no
+    /// later demand/orphan message may acquire fresh room authority and no
+    /// registry path may release a room claim. Only the server's process-wide
+    /// quiescence fence can authorize the separate clustering batch release.
+    room_ownership_shutdown_mode: RoomOwnershipShutdownMode,
+    /// Every detached preparation, operational release, and best-effort
+    /// demotion notification spawned by this registry. Terminal shutdown
+    /// cancels and joins this inventory before reporting its barrier.
+    background_room_tasks: TaskTracker,
+    background_room_tasks_cancel: CancellationToken,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -341,7 +358,9 @@ impl RoomRegistryActor {
             pending_retry_order: 0,
             pending_retry_timer_generation: 0,
             scheduled_pending_retry_generation: None,
-            terminal_claim_acquisition_disabled: false,
+            room_ownership_shutdown_mode: RoomOwnershipShutdownMode::Serving,
+            background_room_tasks: TaskTracker::new(),
+            background_room_tasks_cancel: CancellationToken::new(),
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -350,6 +369,10 @@ impl RoomRegistryActor {
             durable_store: None,
             rollout_backoff: None,
         }
+    }
+
+    fn room_ownership_terminal(&self) -> bool {
+        self.room_ownership_shutdown_mode != RoomOwnershipShutdownMode::Serving
     }
 
     fn has_pending_release_capacity(
@@ -699,7 +722,7 @@ impl RoomRegistryActor {
     }
 
     fn schedule_pending_room_retry(&mut self, actor_ref: &ActorRef<Self>) {
-        if self.scheduled_pending_retry_generation.is_some() {
+        if self.room_ownership_terminal() || self.scheduled_pending_retry_generation.is_some() {
             return;
         }
         self.pending_retry_timer_generation = self.pending_retry_timer_generation.wrapping_add(1);
@@ -721,26 +744,44 @@ impl RoomRegistryActor {
         claim_fence: super::RoomClaimFenceContext,
         registry_ref: ActorRef<Self>,
     ) {
+        if self.room_ownership_terminal() {
+            return;
+        }
         let claim_store = Arc::clone(&self.claim_store);
-        tokio::spawn(async move {
-            let owner = claim_fence.owner();
-            let outcome = match tokio::time::timeout(
-                ROOM_OWNERSHIP_CALL_TIMEOUT,
-                claim_store.release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
-            )
-            .await
-            {
-                Ok(Ok(ExactReleaseOutcome::Released)) => DetachedRoomReleaseOutcome::Released,
-                Ok(Ok(ExactReleaseOutcome::NotOwned)) => DetachedRoomReleaseOutcome::NotOwned,
-                Ok(Err(_)) | Err(_) => DetachedRoomReleaseOutcome::Retry,
-            };
-            let _ = registry_ref
-                .tell(CompleteDetachedRoomRelease {
-                    room_jid,
-                    claim_fence,
-                    outcome,
-                })
-                .await;
+        let cancel = self.background_room_tasks_cancel.clone();
+        self.background_room_tasks.spawn(async move {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {}
+                _ = async move {
+                    let owner = claim_fence.owner();
+                    let outcome = match tokio::time::timeout(
+                        ROOM_OWNERSHIP_CALL_TIMEOUT,
+                        claim_store.release_exact(
+                            &claim_fence.entity,
+                            &owner,
+                            claim_fence.epoch,
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(Ok(ExactReleaseOutcome::Released)) => {
+                            DetachedRoomReleaseOutcome::Released
+                        }
+                        Ok(Ok(ExactReleaseOutcome::NotOwned)) => {
+                            DetachedRoomReleaseOutcome::NotOwned
+                        }
+                        Ok(Err(_)) | Err(_) => DetachedRoomReleaseOutcome::Retry,
+                    };
+                    let _ = registry_ref
+                        .tell(CompleteDetachedRoomRelease {
+                            room_jid,
+                            claim_fence,
+                            outcome,
+                        })
+                        .await;
+                } => {}
+            }
         });
     }
 
@@ -1025,7 +1066,7 @@ impl RoomRegistryActor {
         room_jid: &BareJid,
         actor_ref: &ActorRef<Self>,
     ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
-        if self.terminal_claim_acquisition_disabled {
+        if self.room_ownership_terminal() {
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
         }
         let convergence_deadline = tokio::time::Instant::now() + PRE_ACQUIRE_CONVERGENCE_BUDGET;
@@ -1234,27 +1275,47 @@ impl RoomRegistryActor {
         previous_owner: &NodeIdentity,
         new_epoch: ClaimEpoch,
     ) {
+        if self.room_ownership_terminal() {
+            return;
+        }
         let Some(store) = self.durable_store.clone() else {
             return;
         };
         let room_jid = room_jid.clone();
         let previous_owner = previous_owner.clone();
-        tokio::spawn(async move {
-            if let Err(error) = store
-                .notify_previous_owner_demoted(
-                    &room_jid,
-                    &previous_owner.node_id,
-                    &previous_owner.node_epoch,
-                    new_epoch,
-                )
-                .await
-            {
-                warn!(
-                    room = %room_jid,
-                    %error,
-                    "best-effort Demote notification to the previous owner failed \
-                     (the guaranteed fenced pre-fan-out backstop is unaffected)"
-                );
+        let cancel = self.background_room_tasks_cancel.clone();
+        self.background_room_tasks.spawn(async move {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {}
+                result = tokio::time::timeout(
+                    ROOM_OWNERSHIP_CALL_TIMEOUT,
+                    store.notify_previous_owner_demoted(
+                        &room_jid,
+                        &previous_owner.node_id,
+                        &previous_owner.node_epoch,
+                        new_epoch,
+                    ),
+                ) => {
+                    match result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => {
+                            warn!(
+                                room = %room_jid,
+                                %error,
+                                "best-effort Demote notification to the previous owner failed \
+                                 (the guaranteed fenced pre-fan-out backstop is unaffected)"
+                            );
+                        }
+                        Err(_) => {
+                            warn!(
+                                room = %room_jid,
+                                "best-effort Demote notification to the previous owner timed out \
+                                 (the guaranteed fenced pre-fan-out backstop is unaffected)"
+                            );
+                        }
+                    }
+                }
             }
         });
     }
@@ -1533,7 +1594,12 @@ impl RoomRegistryActor {
             },
         );
         debug_assert!(replaced.is_none(), "same-room preparation must coalesce");
-        tokio::spawn(async move {
+        let cancel = self.background_room_tasks_cancel.clone();
+        self.background_room_tasks.spawn(async move {
+            tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {}
+                _ = async move {
             let first_readiness = actor_ref
                 .ask(GetDurableRestoreReadiness)
                 .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
@@ -1601,6 +1667,8 @@ impl RoomRegistryActor {
                     readiness,
                 })
                 .await;
+                } => {}
+            }
         });
     }
 
@@ -1765,18 +1833,21 @@ impl RoomRegistryActor {
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 3 (council-adjudicated): `async` (not
-    /// sync) so the dead-actor branch can release the Postgres claim
-    /// before returning. Previously this removed the dead entry from
+    /// sync) so an operational dead-actor lookup can release the Postgres
+    /// claim before returning. Previously this removed the dead entry from
     /// `self.rooms` WITHOUT releasing its Postgres claim at all — an
     /// orphaned claim: Postgres kept attributing the room to this node
     /// (which no longer has a live actor for it, or any record of the
     /// epoch needed to release it, once `self.rooms.remove` ran) until
     /// this node's own liveness lease eventually looked stale to another
     /// node's `OwnerStale` steal. This capture-then-release closes that
-    /// gap: the claim epoch is read BEFORE the entry is removed, and
-    /// [`Self::release_room_claim`] runs on it — the exact same
-    /// best-effort, epoch-gated release [`DestroyRoom`]'s handler already
-    /// uses for the graceful-destroy path.
+    /// operational gap.
+    ///
+    /// Terminal shutdown is intentionally different: it retains the entry
+    /// and exact claim so `RoomLocalClaims::owned()` inventories it, then
+    /// fails the unavailable actor's seal barrier and abandons the claim for
+    /// node-expiry recovery. Releasing from this lookup would bypass the
+    /// shutdown seal-before-release ordering proof.
     async fn live_room(
         &mut self,
         room_jid: &BareJid,
@@ -1792,6 +1863,19 @@ impl RoomRegistryActor {
         if let Some(entry) = self.rooms.get(room_jid) {
             if entry.actor_ref.is_alive() {
                 return Ok(Some(entry.actor_ref.clone()));
+            }
+            if self.room_ownership_terminal() {
+                // Terminal drain must inventory this exact claim and then
+                // abandon it because there is no live actor that can answer
+                // the shutdown seal. Removing the entry here would erase that
+                // inventory; releasing here would skip the required
+                // seal-before-release proof.
+                warn!(
+                    room = %room_jid,
+                    "Retaining dead RoomActor entry during terminal shutdown; \
+                     exact claim will be abandoned for node-expiry recovery"
+                );
+                return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
             }
             let claim_fence = entry.claim_fence.clone();
             if !self.has_pending_release_capacity(room_jid, &claim_fence) {
@@ -1851,6 +1935,13 @@ impl RoomRegistryActor {
         timeout: std::time::Duration,
         context: ClaimReleaseContext,
     ) {
+        if self.room_ownership_terminal() {
+            self.transfer_exact_responsibility_to_pending_release(
+                room_jid.clone(),
+                claim_fence.clone(),
+            );
+            return;
+        }
         let owner = claim_fence.owner();
         match tokio::time::timeout(
             timeout,
@@ -1923,6 +2014,14 @@ impl RoomRegistryActor {
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         if claim_fence.entity != entity {
             return ReclaimedRoomOutcome::LostRace;
+        }
+        if self.room_ownership_terminal() {
+            self.remember_pending_reclaimed_room(
+                room_jid.clone(),
+                claim_fence.clone(),
+                previous_owner.clone(),
+            );
+            return ReclaimedRoomOutcome::PendingRetry;
         }
         match tokio::time::timeout(
             timeout,
@@ -2111,7 +2210,7 @@ impl kameo::message::Message<CompleteRoomPreparation> for RoomRegistryActor {
         if !is_current {
             return;
         }
-        if self.terminal_claim_acquisition_disabled {
+        if self.room_ownership_terminal() {
             let pending = self
                 .pending_room_preparations
                 .remove(&msg.room_jid)
@@ -2183,7 +2282,7 @@ impl kameo::message::Message<PublishNextReadyRoom> for RoomRegistryActor {
                 .pending_room_preparations
                 .remove(&ready.room_jid)
                 .expect("generation was checked in the same mailbox turn");
-            if self.terminal_claim_acquisition_disabled {
+            if self.room_ownership_terminal() {
                 self.abandon_preparation_for_terminal(
                     ready.room_jid,
                     pending,
@@ -2297,6 +2396,11 @@ impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
             .keys()
             .map(|(room_jid, _)| room_jid.clone())
             .collect::<Vec<_>>();
+        room_jids.extend(
+            self.pending_reclaimed_rooms
+                .keys()
+                .map(|(room_jid, _)| room_jid.clone()),
+        );
         room_jids.sort();
         room_jids.dedup();
         room_jids
@@ -2333,6 +2437,7 @@ impl kameo::message::Message<IsPendingRoomReleaseOnly> for RoomRegistryActor {
             && self
                 .pending_room_releases
                 .keys()
+                .chain(self.pending_reclaimed_rooms.keys())
                 .any(|(room_jid, _)| room_jid == &msg.room_jid)
     }
 }
@@ -2356,6 +2461,7 @@ impl kameo::message::Message<IsCurrentIdentityPendingRoomReleaseOnly> for RoomRe
         let mut pending = self
             .pending_room_releases
             .keys()
+            .chain(self.pending_reclaimed_rooms.keys())
             .filter(|(room_jid, _)| room_jid == &msg.room_jid)
             .peekable();
         pending.peek().is_some()
@@ -2399,6 +2505,9 @@ impl kameo::message::Message<RetryPendingRoomReleases> for RoomRegistryActor {
         msg: RetryPendingRoomReleases,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.room_ownership_terminal() {
+            return 0;
+        }
         let attempted = self.retry_pending_room_work(msg.limit).await;
         if self.has_pending_room_retry_work() {
             self.schedule_pending_room_retry(ctx.actor_ref());
@@ -2415,6 +2524,9 @@ impl kameo::message::Message<RetryPendingRoomWork> for RoomRegistryActor {
         msg: RetryPendingRoomWork,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.room_ownership_terminal() {
+            return 0;
+        }
         if self.scheduled_pending_retry_generation != Some(msg.generation) {
             return 0;
         }
@@ -2593,13 +2705,24 @@ pub struct PendingReclaimedRoomBacklog {
 
 pub struct GetPendingReclaimedRoomBacklog;
 
-/// Terminally release every won-but-unserved room epoch currently registered
-/// in this actor, including exact post-CAS handoffs retained by the orphan
-/// reaper supervisor when its sweep was cancelled before mailbox delivery.
-/// The handler imports those handoffs and disables future room-claim
-/// acquisition in the same mailbox turn, so queued demand cannot race an
-/// out-of-actor release.
+/// Establish the terminal registry barrier and inventory every won-but-
+/// unserved room epoch, including exact post-CAS handoffs retained by the
+/// orphan-reaper supervisor when its sweep was cancelled before mailbox
+/// delivery.
+///
+/// Despite its historical name, this message no longer releases claims. The
+/// only shutdown release is the server-side all-or-none batch authorized by a
+/// process-wide `RoomServingFence`.
 pub struct DrainRoomOwnershipForShutdown {
+    pub pending_handoffs: Vec<PendingReclaimedRoom>,
+}
+
+/// Irreversibly select the terminal no-release outcome.
+///
+/// This establishes the same admission/background-task barrier as
+/// [`DrainRoomOwnershipForShutdown`] and additionally records that this
+/// registry lifetime must abandon every room claim for node-expiry recovery.
+pub struct AbandonRoomOwnershipForShutdown {
     pub pending_handoffs: Vec<PendingReclaimedRoom>,
 }
 
@@ -2613,12 +2736,26 @@ pub struct RoomOwnershipDrainOutcome {
 struct RoomOwnershipShutdownReconciliation {
     preserved_live: usize,
     retained: usize,
-    reservation_owned: Vec<(BareJid, super::RoomClaimFenceContext)>,
 }
 
 impl RoomRegistryActor {
-    fn begin_room_ownership_shutdown(&mut self, pending_handoffs: Vec<PendingReclaimedRoom>) {
-        self.terminal_claim_acquisition_disabled = true;
+    async fn begin_room_ownership_shutdown(
+        &mut self,
+        pending_handoffs: Vec<PendingReclaimedRoom>,
+        abandon: bool,
+    ) {
+        self.room_ownership_shutdown_mode = match (self.room_ownership_shutdown_mode, abandon) {
+            (RoomOwnershipShutdownMode::Abandoned, _) | (_, true) => {
+                RoomOwnershipShutdownMode::Abandoned
+            }
+            (RoomOwnershipShutdownMode::Serving, false) => RoomOwnershipShutdownMode::Prepared,
+            (RoomOwnershipShutdownMode::Prepared, false) => RoomOwnershipShutdownMode::Prepared,
+        };
+        // Invalidate both the queued timer message and the actor-side
+        // generation before any await. A retry already in the mailbox after
+        // this barrier can no longer issue a release or acquisition call.
+        self.pending_retry_timer_generation = self.pending_retry_timer_generation.wrapping_add(1);
+        self.scheduled_pending_retry_generation = None;
         self.ready_room_publications.clear();
         self.ready_room_publication_scheduled = false;
         let pending_preparations = std::mem::take(&mut self.pending_room_preparations);
@@ -2633,6 +2770,13 @@ impl RoomRegistryActor {
             self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
             self.transfer_exact_responsibility_to_pending_release(room_jid, claim_fence);
         }
+        // Every raw background future is both inventoried above (where it can
+        // own a claim) and cancellation-aware. Join after cancellation so no
+        // preparation publication, detached exact release, or demotion
+        // notification can outlive the terminal barrier.
+        self.background_room_tasks_cancel.cancel();
+        self.background_room_tasks.close();
+        self.background_room_tasks.wait().await;
         for pending in pending_handoffs {
             self.remember_pending_reclaimed_room(
                 pending.room_jid,
@@ -2708,7 +2852,6 @@ impl RoomRegistryActor {
         RoomOwnershipShutdownReconciliation {
             preserved_live,
             retained,
-            reservation_owned: Vec::new(),
         }
     }
 
@@ -2743,7 +2886,6 @@ impl RoomRegistryActor {
 
         let mut preserved_live = 0usize;
         let mut retained = 0usize;
-        let mut reservation_owned = Vec::new();
         for (room_jid, entity, current) in reservation_claims {
             match current {
                 Ok(Ok(Some(snapshot))) if snapshot.owner.same_incarnation(&owner) => {
@@ -2757,10 +2899,9 @@ impl RoomRegistryActor {
                         preserved_live += 1;
                     } else {
                         self.transfer_reclaimed_reservation_to_pending_release(
-                            room_jid.clone(),
-                            claim_fence.clone(),
+                            room_jid,
+                            claim_fence,
                         );
-                        reservation_owned.push((room_jid, claim_fence));
                     }
                 }
                 Ok(Ok(_)) => {
@@ -2778,77 +2919,6 @@ impl RoomRegistryActor {
             }
         }
         RoomOwnershipShutdownReconciliation {
-            preserved_live,
-            retained,
-            reservation_owned,
-        }
-    }
-
-    /// Drain every exact ordinary/reclaimed release responsibility in one
-    /// concurrent terminal batch after ambiguous state has been reconciled.
-    async fn release_exact_room_ownership_for_shutdown(
-        &mut self,
-        reservation_owned: Vec<(BareJid, super::RoomClaimFenceContext)>,
-    ) -> RoomOwnershipDrainOutcome {
-        let duplicate_live = self
-            .pending_reclaimed_rooms
-            .keys()
-            .filter(|(room_jid, claim_fence)| self.has_live_room_with_fence(room_jid, claim_fence))
-            .cloned()
-            .collect::<Vec<_>>();
-        for (room_jid, claim_fence) in &duplicate_live {
-            self.clear_pending_reclaimed_room(room_jid, claim_fence);
-        }
-        let preserved_live = duplicate_live.len();
-
-        let mut pending = self
-            .pending_room_releases
-            .keys()
-            .cloned()
-            .collect::<HashSet<_>>();
-        pending.extend(self.pending_reclaimed_rooms.keys().cloned());
-        pending.extend(reservation_owned);
-        let claim_store = Arc::clone(&self.claim_store);
-        let outcomes =
-            futures::future::join_all(pending.into_iter().map(|(room_jid, claim_fence)| {
-                let claim_store = Arc::clone(&claim_store);
-                async move {
-                    let owner = claim_fence.owner();
-                    let outcome = tokio::time::timeout(
-                        RECLAIMED_ROOM_RELEASE_TIMEOUT,
-                        claim_store.release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
-                    )
-                    .await;
-                    (room_jid, claim_fence, outcome)
-                }
-            }))
-            .await;
-
-        let mut released = 0usize;
-        let mut retained = 0usize;
-        for (room_jid, claim_fence, outcome) in outcomes {
-            match outcome {
-                Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
-                    self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
-                    self.clear_pending_room_release(&room_jid, &claim_fence);
-                    self.pending_reclaimed_reservations.remove(&room_jid);
-                    if let Some(store) = &self.durable_store {
-                        store.forget_claim_fence(&room_jid, &claim_fence);
-                    }
-                    released += 1;
-                }
-                Ok(Err(error)) => {
-                    warn!(room = %room_jid, %error, "terminal room-ownership release failed; retaining exact fence until node expiry");
-                    retained += 1;
-                }
-                Err(_) => {
-                    warn!(room = %room_jid, "terminal room-ownership release timed out; retaining exact fence until node expiry");
-                    retained += 1;
-                }
-            }
-        }
-        RoomOwnershipDrainOutcome {
-            released,
             preserved_live,
             retained,
         }
@@ -2884,19 +2954,43 @@ impl kameo::message::Message<DrainRoomOwnershipForShutdown> for RoomRegistryActo
         msg: DrainRoomOwnershipForShutdown,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.begin_room_ownership_shutdown(msg.pending_handoffs);
+        self.begin_room_ownership_shutdown(msg.pending_handoffs, false)
+            .await;
         let acquisition = self
             .reconcile_uncertain_room_acquisitions_for_shutdown()
             .await;
         let reservations = self
             .reconcile_reclaimed_room_reservations_for_shutdown()
             .await;
-        let mut outcome = self
-            .release_exact_room_ownership_for_shutdown(reservations.reservation_owned)
+        RoomOwnershipDrainOutcome {
+            released: 0,
+            preserved_live: acquisition.preserved_live + reservations.preserved_live,
+            retained: acquisition.retained + reservations.retained,
+        }
+    }
+}
+
+impl kameo::message::Message<AbandonRoomOwnershipForShutdown> for RoomRegistryActor {
+    type Reply = RoomOwnershipDrainOutcome;
+
+    async fn handle(
+        &mut self,
+        msg: AbandonRoomOwnershipForShutdown,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.begin_room_ownership_shutdown(msg.pending_handoffs, true)
             .await;
-        outcome.preserved_live += acquisition.preserved_live + reservations.preserved_live;
-        outcome.retained += acquisition.retained + reservations.retained;
-        outcome
+        let acquisition = self
+            .reconcile_uncertain_room_acquisitions_for_shutdown()
+            .await;
+        let reservations = self
+            .reconcile_reclaimed_room_reservations_for_shutdown()
+            .await;
+        RoomOwnershipDrainOutcome {
+            released: 0,
+            preserved_live: acquisition.preserved_live + reservations.preserved_live,
+            retained: acquisition.retained + reservations.retained,
+        }
     }
 }
 
@@ -2924,7 +3018,7 @@ impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor 
         msg: ReservePendingReclaimedRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.terminal_claim_acquisition_disabled {
+        if self.room_ownership_terminal() {
             return false;
         }
         if self.pending_reclaimed_reservations.contains(&msg.room_jid)
@@ -3040,7 +3134,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
             return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
         }
-        if self.terminal_claim_acquisition_disabled {
+        if self.room_ownership_terminal() {
             if self.has_live_room_with_fence(&msg.room_jid, &claim_fence) {
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                 return ctx.reply(ReclaimedRoomOutcome::AlreadyLive);
@@ -3487,7 +3581,7 @@ pub enum DestroyRoomReason {
     DeposedEviction,
 }
 
-/// Outcome of a [`DestroyRoom`] ask. Split four ways because callers
+/// Outcome of a [`DestroyRoom`] ask. Split five ways because callers
 /// must distinguish "the room simply was not registered" (fine for
 /// admin deletion of a dormant room) from "the fenced durable wipe
 /// failed and the room was deliberately kept alive for a retry"
@@ -3506,6 +3600,9 @@ pub enum DestroyRoomOutcome {
     /// The bounded exact-release retry set is full, so the registry kept the
     /// actor and claim intact rather than losing responsibility for the fence.
     ReleaseBacklogFull,
+    /// Graceful shutdown owns the room's terminal seal, actor retirement, and
+    /// claim release sequence. Ordinary/admin destruction must not race it.
+    ShutdownInProgress,
 }
 
 /// Destroy a room, removing it from the registry.
@@ -3522,6 +3619,9 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         msg: DestroyRoom,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.room_ownership_terminal() && msg.reason != DestroyRoomReason::DeposedEviction {
+            return DestroyRoomOutcome::ShutdownInProgress;
+        }
         if msg.reason != DestroyRoomReason::DeposedEviction {
             let claim_fence = self
                 .rooms
@@ -3658,7 +3758,33 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
 /// [`RoomActorError::RoomSealed`](super::room_actor::RoomActorError::RoomSealed)
 /// refusal, which the join path retries through the registry.
 ///
-/// Returns `true` when the room was sealed and removed.
+/// Typed result of a guarded inactive-room destroy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum DestroyRoomIfInactiveOutcome {
+    Destroyed,
+    Retained,
+    /// The seal request was enqueued but its reply was lost. The room may
+    /// already be sealed even though the registry deliberately retained it.
+    MaybeSealed,
+}
+
+fn classify_inactive_seal_failure<M, E>(
+    error: &kameo::error::SendError<M, E>,
+) -> DestroyRoomIfInactiveOutcome {
+    match error {
+        // The message was returned to the caller, so the actor could not have
+        // applied the seal.
+        kameo::error::SendError::ActorNotRunning(_)
+        | kameo::error::SendError::MailboxFull(_)
+        | kameo::error::SendError::Timeout(Some(_)) => DestroyRoomIfInactiveOutcome::Retained,
+        // No message was returned. The handler may have applied the seal
+        // before its reply was lost, so terminal release must fail closed.
+        kameo::error::SendError::ActorStopped
+        | kameo::error::SendError::Timeout(None)
+        | kameo::error::SendError::HandlerError(_) => DestroyRoomIfInactiveOutcome::MaybeSealed,
+    }
+}
+
 pub struct DestroyRoomIfInactive {
     pub room_jid: BareJid,
     pub expected_occupancy_revision: u64,
@@ -3672,7 +3798,7 @@ pub struct DestroyRoomIfInactive {
 const SEAL_ASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
-    type Reply = bool;
+    type Reply = DestroyRoomIfInactiveOutcome;
 
     async fn handle(
         &mut self,
@@ -3682,11 +3808,31 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         // Preparation is not yet published and therefore cannot have been
         // observed inactive at the supplied occupancy revision.
         if self.pending_room_preparations.contains_key(&msg.room_jid) {
-            return false;
+            return DestroyRoomIfInactiveOutcome::Retained;
         }
         let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
-            return false;
+            return DestroyRoomIfInactiveOutcome::Retained;
         };
+        if self.room_ownership_terminal() {
+            // Only a definitive non-serving fence may bypass graceful
+            // shutdown's seal -> retire -> release sequence. Ordinary
+            // inactivity cleanup must leave the live entry and exact claim
+            // for the drain.
+            let seal_state = entry
+                .actor_ref
+                .ask(GetRoomSealState)
+                .mailbox_timeout(SEAL_ASK_TIMEOUT)
+                .reply_timeout(SEAL_ASK_TIMEOUT)
+                .await;
+            return match seal_state {
+                Ok(RoomSealState::OwnershipLost) => {
+                    self.evict_ownership_lost_room(&msg.room_jid, entry).await;
+                    DestroyRoomIfInactiveOutcome::Destroyed
+                }
+                Ok(RoomSealState::Open | RoomSealState::Inactive | RoomSealState::Shutdown)
+                | Err(_) => DestroyRoomIfInactiveOutcome::Retained,
+            };
+        }
         if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
             // Ordinary inactivity must remain open when there is nowhere to
             // retain an uncertain release. A terminally non-serving actor is
@@ -3703,15 +3849,15 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                 Ok(RoomSealState::OwnershipLost) => {
                     self.evict_ownership_lost_room(&msg.room_jid, entry).await;
                     info!(room = %msg.room_jid, "Evicted non-serving room during inactive-room cleanup");
-                    true
+                    DestroyRoomIfInactiveOutcome::Destroyed
                 }
-                Ok(RoomSealState::Open | RoomSealState::Inactive) => {
+                Ok(RoomSealState::Open | RoomSealState::Inactive | RoomSealState::Shutdown) => {
                     warn!(room = %msg.room_jid, "Skipping inactive-room seal because exact-release retry backlog is full");
-                    false
+                    DestroyRoomIfInactiveOutcome::Retained
                 }
                 Err(error) => {
                     warn!(room = %msg.room_jid, error = ?error, "Could not classify room seal while exact-release retry backlog is full");
-                    false
+                    DestroyRoomIfInactiveOutcome::Retained
                 }
             };
         }
@@ -3728,7 +3874,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
             Ok(SealIfInactiveOutcome::OwnershipLost) => {
                 self.evict_ownership_lost_room(&msg.room_jid, entry).await;
                 info!(room = %msg.room_jid, "Evicted non-serving room during inactive-room cleanup");
-                true
+                DestroyRoomIfInactiveOutcome::Destroyed
             }
             Ok(SealIfInactiveOutcome::Inactive) => {
                 self.rooms.remove(&msg.room_jid);
@@ -3741,14 +3887,14 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                 self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                     .await;
                 info!(room = %msg.room_jid, "Destroyed inactive room (guarded)");
-                true
+                DestroyRoomIfInactiveOutcome::Destroyed
             }
             Ok(SealIfInactiveOutcome::Refused) => {
                 debug!(
                     room = %msg.room_jid,
                     "Guarded destroy refused: room no longer inactive at expected revision"
                 );
-                false
+                DestroyRoomIfInactiveOutcome::Retained
             }
             Err(error) => {
                 // Never remove on uncertainty. If the seal actually
@@ -3760,7 +3906,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                     error = ?error,
                     "Guarded destroy seal ask failed; keeping the room"
                 );
-                false
+                classify_inactive_seal_failure(&error)
             }
         }
     }
@@ -3797,6 +3943,13 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             return false;
         };
         if !entry.actor_ref.is_alive() {
+            if self.room_ownership_terminal() {
+                // The terminal drain needs this exact entry in its owned
+                // inventory. With no live actor, it cannot prove the
+                // seal-before-release barrier and must abandon the claim
+                // until node-expiry recovery instead of releasing it here.
+                return false;
+            }
             if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
                 return false;
             }
@@ -3831,6 +3984,9 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
                 true
             }
             Ok(RoomSealState::Inactive) => {
+                if self.room_ownership_terminal() {
+                    return false;
+                }
                 if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
                     return false;
                 }
@@ -3846,7 +4002,10 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
                 );
                 true
             }
-            Ok(RoomSealState::Open) => false,
+            // Graceful drain owns the shutdown-sealed actor's ordered
+            // retirement and release. A concurrent stale reaper must not
+            // remove the registry entry or release the claim early.
+            Ok(RoomSealState::Open | RoomSealState::Shutdown) => false,
             Err(error) => {
                 warn!(
                     room = %msg.room_jid,
@@ -3909,6 +4068,13 @@ impl kameo::message::Message<ListRooms> for RoomRegistryActor {
         for room_jid in room_ids {
             match self.live_room(&room_jid).await {
                 Ok(Some(_)) => live_rooms.push(room_jid),
+                Err(RoomRegistryError::RoomActorStateLost(_)) if self.room_ownership_terminal() => {
+                    // Shutdown ownership inventory must retain dead entries:
+                    // their actor cannot answer the seal barrier, so the
+                    // caller abandons the exact claim for node-expiry
+                    // recovery rather than releasing it.
+                    live_rooms.push(room_jid);
+                }
                 Ok(None) | Err(RoomRegistryError::RoomActorStateLost(_)) => {
                     // Ignore stale/dead rooms in discovery listing; per-room
                     // operations still fail fast with RoomActorStateLost.

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -346,7 +346,7 @@ async fn guarded_destroy_refuses_when_join_landed_after_dormancy_probe() {
         .expect("interleaved join");
 
     // Janitor half 2: guarded destroy with the stale revision → refused.
-    let destroyed: bool = registry
+    let destroyed = registry
         .ask(DestroyRoomIfInactive {
             room_jid: jid.clone(),
             expected_occupancy_revision: probe.occupancy_revision,
@@ -354,8 +354,9 @@ async fn guarded_destroy_refuses_when_join_landed_after_dormancy_probe() {
         })
         .await
         .expect("guarded destroy ask");
-    assert!(
-        !destroyed,
+    assert_eq!(
+        destroyed,
+        DestroyRoomIfInactiveOutcome::Retained,
         "a join after the dormancy probe must refuse the guarded destroy \
          — destroying here orphans the freshly-admitted occupant (#1108)"
     );
@@ -383,7 +384,7 @@ async fn guarded_destroy_refuses_when_join_landed_after_dormancy_probe() {
         .expect("outcome");
     let probe = actor.ask(IsDormant).await.expect("second probe");
     assert!(probe.dormant, "room is dormant again after the leave");
-    let destroyed: bool = registry
+    let destroyed = registry
         .ask(DestroyRoomIfInactive {
             room_jid: jid.clone(),
             expected_occupancy_revision: probe.occupancy_revision,
@@ -391,7 +392,11 @@ async fn guarded_destroy_refuses_when_join_landed_after_dormancy_probe() {
         })
         .await
         .expect("guarded destroy ask");
-    assert!(destroyed, "an actually-dormant room is destroyed");
+    assert_eq!(
+        destroyed,
+        DestroyRoomIfInactiveOutcome::Destroyed,
+        "an actually-dormant room is destroyed"
+    );
     assert!(
         !registry
             .ask(RoomExists { room_jid: jid })
@@ -428,7 +433,7 @@ async fn sealed_room_refuses_late_join_with_retryable_error() {
     let probe = stale_ref.ask(IsDormant).await.expect("probe");
     assert!(probe.dormant);
 
-    let destroyed: bool = registry
+    let destroyed = registry
         .ask(DestroyRoomIfInactive {
             room_jid: jid.clone(),
             expected_occupancy_revision: probe.occupancy_revision,
@@ -436,7 +441,7 @@ async fn sealed_room_refuses_late_join_with_retryable_error() {
         })
         .await
         .expect("guarded destroy ask");
-    assert!(destroyed);
+    assert_eq!(destroyed, DestroyRoomIfInactiveOutcome::Destroyed);
 
     let alice: jid::FullJid = "alice@example.com/web".parse().expect("full jid");
     let result = stale_ref
@@ -3596,7 +3601,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn terminal_drain_cancels_pending_publication_and_releases_claim() {
+    async fn terminal_drain_cancels_pending_publication_without_releasing_claim() {
         let registry = spawn_registry().await;
         let room_jid = test_room_jid("terminal-drain-pending-restore");
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
@@ -3617,7 +3622,7 @@ mod ownership_claims_tests {
             })
             .await
             .expect("terminal drain");
-        assert_eq!(drained.released, 1);
+        assert_eq!(drained.released, 0);
         assert_eq!(drained.retained, 0);
         assert!(matches!(
             create.await.expect("create task"),
@@ -3637,7 +3642,15 @@ mod ownership_claims_tests {
             .current_claim(&entity)
             .await
             .expect("claim lookup")
-            .is_none());
+            .is_some());
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("terminal exact inventory")
+                .depth,
+            1
+        );
     }
 
     #[tokio::test]
@@ -5321,7 +5334,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn terminal_drain_reconciles_a_fresh_acquire_committed_before_timeout() {
+    async fn terminal_drain_inventories_a_fresh_acquire_committed_before_timeout() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(DeadOwnerClaimStore::empty());
         claim_store.set_ensure_post_commit_delay(std::time::Duration::from_secs(60));
@@ -5374,7 +5387,7 @@ mod ownership_claims_tests {
         assert_eq!(
             outcome,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -5383,14 +5396,14 @@ mod ownership_claims_tests {
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
             .await
             .expect("claim lookup")
-            .is_none());
+            .is_some());
         assert_eq!(
             registry
                 .ask(GetPendingRoomReleaseBacklog)
                 .await
-                .expect("drained ownership backlog")
+                .expect("terminal ownership inventory")
                 .depth,
-            0
+            1
         );
     }
 
@@ -5767,14 +5780,17 @@ mod ownership_claims_tests {
                 .await
                 .expect("fill backlog");
         }
-        assert!(!registry
-            .ask(DestroyRoomIfInactive {
-                room_jid: jid,
-                expected_occupancy_revision: 0,
-                guard: SealGuard::Dormant,
-            })
-            .await
-            .expect("capacity refusal"));
+        assert_eq!(
+            registry
+                .ask(DestroyRoomIfInactive {
+                    room_jid: jid,
+                    expected_occupancy_revision: 0,
+                    guard: SealGuard::Dormant,
+                })
+                .await
+                .expect("capacity refusal"),
+            DestroyRoomIfInactiveOutcome::Retained
+        );
         assert!(!acquisition
             .actor_ref
             .ask(IsSealed)
@@ -6103,7 +6119,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn terminal_drain_resolves_a_won_reservation_without_an_exact_handoff() {
+    async fn terminal_drain_inventories_a_won_reservation_without_an_exact_handoff() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let owner = this_identity();
@@ -6139,7 +6155,7 @@ mod ownership_claims_tests {
         assert_eq!(
             outcome,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -6147,22 +6163,20 @@ mod ownership_claims_tests {
         assert!(claim_store
             .current_claim(&entity)
             .await
-            .expect("read drained claim")
-            .is_none());
+            .expect("read retained claim")
+            .is_some());
         assert_eq!(
             registry
-                .ask(GetPendingReclaimedRoomBacklog)
+                .ask(GetPendingRoomReleaseBacklog)
                 .await
-                .expect("terminal backlog"),
-            PendingReclaimedRoomBacklog {
-                depth: 0,
-                oldest_age_ms: 0,
-            }
+                .expect("terminal exact inventory")
+                .depth,
+            1
         );
     }
 
     #[tokio::test]
-    async fn terminal_drain_releases_an_already_pending_exact_release() {
+    async fn terminal_drain_retains_an_already_pending_exact_release() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let owner = this_identity();
@@ -6199,7 +6213,7 @@ mod ownership_claims_tests {
         assert_eq!(
             outcome,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -6207,16 +6221,88 @@ mod ownership_claims_tests {
         assert!(claim_store
             .current_claim(&entity)
             .await
-            .expect("read drained claim")
-            .is_none());
+            .expect("read retained claim")
+            .is_some());
         assert_eq!(
             registry
                 .ask(GetPendingRoomReleaseBacklog)
                 .await
                 .expect("pending release backlog")
                 .depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_abandon_permanently_disables_release_retries() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-explicit-abandon");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("seed exact claim");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(entity.clone(), owner.clone(), epoch),
+            })
+            .await
+            .expect("remember pending exact release"));
+
+        let outcome = registry
+            .ask(AbandonRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal abandon");
+
+        assert_eq!(
+            outcome,
+            RoomOwnershipDrainOutcome {
+                released: 0,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("terminal retry refusal"),
             0
         );
+        assert!(
+            claim_store
+                .fence(&entity, &owner, epoch)
+                .await
+                .expect("retained exact claim"),
+            "explicit abandon must never release a room claim"
+        );
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(room)
+            )) if room == jid
+        ));
     }
 
     #[tokio::test]
@@ -6279,7 +6365,7 @@ mod ownership_claims_tests {
         assert_eq!(
             after_commit,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -6287,15 +6373,23 @@ mod ownership_claims_tests {
         assert!(claim_store
             .current_claim(&entity)
             .await
-            .expect("read drained late claim")
-            .is_none());
+            .expect("read retained late claim")
+            .is_some());
         assert_eq!(
             registry
                 .ask(GetPendingReclaimedRoomBacklog)
                 .await
-                .expect("resolved reservation backlog")
+                .expect("reservation transferred to exact inventory")
                 .depth,
             0
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("terminal exact inventory")
+                .depth,
+            1
         );
     }
 
@@ -6334,7 +6428,7 @@ mod ownership_claims_tests {
             RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 0,
-                retained: 1,
+                retained: 0,
             }
         );
         assert!(registry
@@ -6356,16 +6450,16 @@ mod ownership_claims_tests {
                 .ask(RetryPendingRoomReleases { limit: 1 })
                 .await
                 .expect("retry exact release"),
-            1
+            0
         );
-        assert!(!registry
+        assert!(registry
             .ask(IsPendingRoomReleaseOnly { room_jid: jid })
             .await
-            .expect("exact fence cleared after successful retry"));
+            .expect("terminal exact fence remains inventoried"));
     }
 
     #[tokio::test]
-    async fn terminal_drain_releases_the_active_snapshot_after_local_authority_is_disabled() {
+    async fn terminal_drain_retains_the_active_snapshot_after_local_authority_is_disabled() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let owner = this_identity();
@@ -6402,7 +6496,7 @@ mod ownership_claims_tests {
         assert_eq!(
             outcome,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -6410,16 +6504,16 @@ mod ownership_claims_tests {
         assert!(claim_store
             .current_claim(&entity)
             .await
-            .expect("read drained claim")
-            .is_none());
-        assert!(!registry
+            .expect("read retained claim")
+            .is_some());
+        assert!(registry
             .ask(IsPendingRoomReleaseOnly { room_jid: jid })
             .await
-            .expect("typed release cleared"));
+            .expect("typed release retained"));
     }
 
     #[tokio::test]
-    async fn terminal_drain_releases_registered_reclaimed_epochs_and_disables_acquisition() {
+    async fn terminal_drain_retains_registered_reclaimed_epochs_and_disables_acquisition() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let owner = this_identity();
@@ -6462,7 +6556,7 @@ mod ownership_claims_tests {
         assert_eq!(
             outcome,
             RoomOwnershipDrainOutcome {
-                released: 1,
+                released: 0,
                 preserved_live: 0,
                 retained: 0,
             }
@@ -6470,12 +6564,12 @@ mod ownership_claims_tests {
         assert!(claim_store
             .current_claim(&entity)
             .await
-            .expect("read drained claim")
-            .is_none());
-        assert!(registry
+            .expect("read retained claim")
+            .is_some());
+        assert!(!registry
             .ask(ListPendingReclaimedRooms { limit: 8 })
             .await
-            .expect("pending after drain")
+            .expect("pending after terminal barrier")
             .is_empty());
         assert!(!registry
             .ask(ReservePendingReclaimedRoom {
@@ -6538,7 +6632,7 @@ mod ownership_claims_tests {
             RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 0,
-                retained: 1,
+                retained: 0,
             }
         );
         assert_eq!(
@@ -6621,6 +6715,218 @@ mod ownership_claims_tests {
             .await
             .expect("pending after live duplicate cleanup")
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_shutdown_inventories_a_dead_actor_without_releasing_its_exact_claim() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let room_jid = test_room_jid("terminal-dead-inventory");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "w-terminal".to_string(),
+                channel_id: "c-terminal".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish room")
+            .actor_ref;
+        let claim = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read live claim")
+            .expect("room has an exact claim");
+
+        actor.kill();
+        actor.wait_for_shutdown().await;
+        assert!(!actor.is_alive(), "test precondition: actor is dead");
+
+        assert_eq!(
+            registry
+                .ask(DrainRoomOwnershipForShutdown {
+                    pending_handoffs: Vec::new(),
+                })
+                .await
+                .expect("begin terminal room shutdown"),
+            RoomOwnershipDrainOutcome {
+                released: 0,
+                preserved_live: 0,
+                retained: 0,
+            },
+            "the registry drain phase must not release a dead entry before \
+             the actor seal inventory classifies it"
+        );
+
+        assert_eq!(
+            registry.ask(ListRooms).await.expect("terminal inventory"),
+            vec![room_jid.clone()],
+            "terminal inventory must retain a dead entry so the outer drain \
+             abandons its unsealable exact claim"
+        );
+        assert!(matches!(
+            registry
+                .ask(GetRoom {
+                    room_jid: room_jid.clone(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::RoomActorStateLost(ref room)))
+                if *room == room_jid
+        ));
+        assert!(
+            !registry
+                .ask(ReapSealedRoom {
+                    room_jid: room_jid.clone(),
+                })
+                .await
+                .expect("terminal dead-actor reap refusal"),
+            "the sealed-room reaper must not consume terminal drain inventory"
+        );
+
+        assert_eq!(
+            registry.ask(RoomCount).await.expect("retained room count"),
+            1
+        );
+        assert_eq!(
+            registry
+                .ask(ListRoomsOwnedBy {
+                    owner: owner.clone(),
+                })
+                .await
+                .expect("exact-owner inventory"),
+            vec![room_jid.clone()]
+        );
+        assert!(
+            registry
+                .ask(ListPendingRoomReleaseJids)
+                .await
+                .expect("pending releases")
+                .is_empty(),
+            "the dead entry itself, not a release retry, retains responsibility"
+        );
+        assert!(
+            claim_store
+                .fence(&entity, &owner, claim.claim_epoch)
+                .await
+                .expect("check retained exact claim"),
+            "list/get/reap must never release the exact claim after terminal shutdown begins"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_shutdown_refuses_destroy_and_inactive_cleanup_until_retirement() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(owner.clone()),
+            Arc::clone(&durable_store),
+        )
+        .await;
+        let room_jid = test_room_jid("terminal-destroy-race");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "w-terminal".to_string(),
+                channel_id: "c-terminal".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish live room")
+            .actor_ref;
+        let claim = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read live claim")
+            .expect("live room is claimed");
+
+        registry
+            .ask(DrainRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("begin terminal room shutdown");
+        assert_eq!(
+            actor
+                .ask(crate::muc::room_actor::SealForShutdown)
+                .await
+                .expect("terminal actor seal"),
+            crate::muc::room_actor::RoomSealState::Shutdown
+        );
+
+        assert_eq!(
+            registry
+                .ask(DestroyRoom {
+                    room_jid: room_jid.clone(),
+                    reason: DestroyRoomReason::Destroy,
+                })
+                .await
+                .expect("typed destroy refusal"),
+            DestroyRoomOutcome::ShutdownInProgress
+        );
+        assert_eq!(
+            registry
+                .ask(DestroyRoomIfInactive {
+                    room_jid: room_jid.clone(),
+                    expected_occupancy_revision: 0,
+                    guard: SealGuard::Dormant,
+                })
+                .await
+                .expect("typed inactive-cleanup refusal"),
+            DestroyRoomIfInactiveOutcome::Retained
+        );
+        assert!(!registry
+            .ask(ReapSealedRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("typed sealed-reaper refusal"));
+
+        assert!(
+            actor.is_alive(),
+            "no registry cleanup path may retire the actor ahead of the shutdown drain"
+        );
+        assert_eq!(
+            registry
+                .ask(GetRoom {
+                    room_jid: room_jid.clone(),
+                })
+                .await
+                .expect("room remains registered")
+                .expect("live room remains")
+                .id(),
+            actor.id()
+        );
+        assert!(
+            claim_store
+                .fence(&entity, &owner, claim.claim_epoch)
+                .await
+                .expect("check exact claim"),
+            "no registry cleanup path may release the claim before actor retirement"
+        );
+        assert!(
+            durable_store
+                .deleted_rooms
+                .lock()
+                .expect("deleted-room log")
+                .is_empty(),
+            "ordinary destroy must not wipe durable room state during shutdown"
+        );
     }
 
     #[tokio::test]
@@ -7475,13 +7781,12 @@ mod ownership_claims_tests {
                 .expect("sync reply"),
             ResolverAffiliationSyncOutcome::RoomSealed,
         );
-        assert_eq!(
-            actor
-                .ask(GetAffiliation { jid })
-                .await
-                .expect("affiliation query"),
-            Affiliation::None,
-        );
+        assert!(matches!(
+            actor.ask(GetAffiliation { jid }).await,
+            Err(SendError::HandlerError(
+                crate::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
     }
 
     #[tokio::test]
@@ -7553,7 +7858,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn inactive_destroy_hard_kills_a_previously_deposed_actor() {
+    async fn terminal_inactive_cleanup_still_hard_kills_a_previously_deposed_actor() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
@@ -7608,14 +7913,23 @@ mod ownership_claims_tests {
             ))
         ));
 
-        assert!(registry
-            .ask(DestroyRoomIfInactive {
-                room_jid: room_jid.clone(),
-                expected_occupancy_revision: 0,
-                guard: SealGuard::Dormant,
+        registry
+            .ask(DrainRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
             })
             .await
-            .expect("typed inactive destroy"));
+            .expect("begin terminal room shutdown");
+        assert_eq!(
+            registry
+                .ask(DestroyRoomIfInactive {
+                    room_jid: room_jid.clone(),
+                    expected_occupancy_revision: 0,
+                    guard: SealGuard::Dormant,
+                })
+                .await
+                .expect("typed inactive destroy"),
+            DestroyRoomIfInactiveOutcome::Destroyed
+        );
         actor.wait_for_shutdown().await;
         assert!(
             !actor.is_alive(),
@@ -7915,4 +8229,25 @@ async fn reap_sealed_room_purges_a_sealed_but_registered_actor() {
         .await
         .expect("reap live");
     assert!(!not_reaped, "an unsealed room must never be reaped");
+}
+
+#[test]
+fn inactive_seal_reply_loss_is_typed_as_maybe_sealed() {
+    let lost_reply: SendError<SealIfInactive, std::convert::Infallible> = SendError::Timeout(None);
+    assert_eq!(
+        classify_inactive_seal_failure(&lost_reply),
+        DestroyRoomIfInactiveOutcome::MaybeSealed,
+        "a seal whose reply was lost may already have changed actor admission"
+    );
+
+    let returned_message: SendError<SealIfInactive, std::convert::Infallible> =
+        SendError::Timeout(Some(SealIfInactive {
+            expected_occupancy_revision: 0,
+            guard: SealGuard::Dormant,
+        }));
+    assert_eq!(
+        classify_inactive_seal_failure(&returned_message),
+        DestroyRoomIfInactiveOutcome::Retained,
+        "a returned mailbox message proves the seal was not applied"
+    );
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -36,8 +36,9 @@ use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
-    CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DemoteRoomIfOwner,
-    DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason,
+    AbandonRoomOwnershipForShutdown, CancelPendingReclaimedRoomReservation, CreateInstantRoom,
+    CreateRoom, DemoteRoomIfOwner, DestroyRoom, DestroyRoomIfInactive,
+    DestroyRoomIfInactiveOutcome, DestroyRoomOutcome, DestroyRoomReason,
     DrainRoomOwnershipForShutdown, GetOrCreateRoom, GetPendingReclaimedRoomBacklog,
     GetPendingRoomReleaseBacklog, GetRoom, IsCurrentIdentityPendingRoomReleaseOnly,
     IsCurrentRoomPendingRelease, IsMucJid, IsPendingRoomReleaseOnly, ListPendingReclaimedRooms,
@@ -306,6 +307,14 @@ impl RoomRegistry {
     );
 
     registry_method!(
+        abandon_room_ownership_for_shutdown(
+            pending_handoffs: Vec<PendingReclaimedRoom>
+        ) -> RoomOwnershipDrainOutcome,
+        "abandon_room_ownership_for_shutdown",
+        AbandonRoomOwnershipForShutdown { pending_handoffs }
+    );
+
+    registry_method!(
         pending_room_release_backlog() -> PendingRoomReleaseBacklog,
         "pending_room_release_backlog",
         GetPendingRoomReleaseBacklog
@@ -399,12 +408,13 @@ impl RoomRegistry {
 
     registry_method!(
         /// Destroy a room only if it is still inactive at the expected
-        /// occupancy revision (#1108). Returns whether it was destroyed.
+        /// occupancy revision (#1108). Preserves a distinct ambiguity result
+        /// when the inner room seal may have landed without a reply.
         destroy_room_if_inactive(
             room_jid: BareJid,
             expected_occupancy_revision: u64,
             guard: SealGuard
-        ) -> bool,
+        ) -> DestroyRoomIfInactiveOutcome,
         "destroy_room_if_inactive",
         DestroyRoomIfInactive { room_jid, expected_occupancy_revision, guard }
     );

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -291,12 +291,61 @@ pub struct SharedNodeIdentity {
 pub struct CurrentNodeIdentityGuard {
     identity: NodeIdentity,
     rotation_gate: std::sync::Arc<tokio::sync::RwLock<()>>,
-    _rotation_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+    _rotation_guard: std::sync::Arc<tokio::sync::OwnedRwLockReadGuard<()>>,
 }
 
 impl CurrentNodeIdentityGuard {
     pub fn identity(&self) -> &NodeIdentity {
         &self.identity
+    }
+
+    /// Mint a cloneable, source-bound permit for an actor message without
+    /// transferring ownership of this guard's read lock into that message.
+    ///
+    /// The caller must retain this guard across the complete publication and
+    /// rollback-enqueue boundary. A queued actor message only holds the weak
+    /// permit, so a timed-out ask cannot keep terminal identity disable
+    /// blocked forever.
+    pub fn permit(&self) -> CurrentNodeIdentityPermit {
+        CurrentNodeIdentityPermit {
+            identity: self.identity.clone(),
+            rotation_gate: self.rotation_gate.clone(),
+            rotation_guard: std::sync::Arc::downgrade(&self._rotation_guard),
+        }
+    }
+}
+
+/// Cloneable proof that a caller currently owns a publication guard.
+///
+/// Unlike [`CurrentNodeIdentityGuard`], this value does not keep the
+/// publication read lock alive. Consumers upgrade it only around a short,
+/// synchronous publication boundary; upgrade fails after the caller drops the
+/// original guard.
+#[derive(Clone)]
+pub struct CurrentNodeIdentityPermit {
+    identity: NodeIdentity,
+    rotation_gate: std::sync::Arc<tokio::sync::RwLock<()>>,
+    rotation_guard: std::sync::Weak<tokio::sync::OwnedRwLockReadGuard<()>>,
+}
+
+/// Source-bound proof that [`SharedNodeIdentity::disable`] has drained every
+/// publication guard and terminally revoked this process incarnation's
+/// authority.
+///
+/// Graceful shutdown passes this value into local actor retirement before
+/// releasing actor claims. Consumers must verify it with
+/// [`SharedNodeIdentity::owns_disabled`]; the prior active identity is only a
+/// cleanup selector and does not itself carry publication authority.
+#[derive(Clone, Debug)]
+pub struct DisabledNodeIdentity {
+    prior_identity: NodeIdentity,
+    source_gate: std::sync::Arc<tokio::sync::RwLock<()>>,
+}
+
+impl DisabledNodeIdentity {
+    /// The active identity whose publication authority was revoked.
+    pub fn prior_identity(&self) -> &NodeIdentity {
+        &self.prior_identity
     }
 }
 
@@ -348,7 +397,7 @@ impl SharedNodeIdentity {
         (identity.is_active() && identity == *expected).then_some(CurrentNodeIdentityGuard {
             identity,
             rotation_gate: self.rotation_gate.clone(),
-            _rotation_guard: rotation_guard,
+            _rotation_guard: std::sync::Arc::new(rotation_guard),
         })
     }
 
@@ -367,26 +416,80 @@ impl SharedNodeIdentity {
         std::sync::Arc::ptr_eq(&self.rotation_gate, &guard.rotation_gate)
     }
 
+    /// Upgrade a source-bound weak permit while its caller still owns the
+    /// corresponding publication guard.
+    ///
+    /// The returned guard is intended for a short, non-async publication
+    /// transition. It prevents rotation for that transition without allowing
+    /// a queued or wedged actor message to retain publication authority after
+    /// its caller has timed out and begun rollback.
+    pub fn upgrade_permit(
+        &self,
+        permit: &CurrentNodeIdentityPermit,
+    ) -> Option<CurrentNodeIdentityGuard> {
+        if !std::sync::Arc::ptr_eq(&self.rotation_gate, &permit.rotation_gate) {
+            return None;
+        }
+        let rotation_guard = permit.rotation_guard.upgrade()?;
+        let identity = self.current();
+        (identity.is_active() && identity == permit.identity).then_some(CurrentNodeIdentityGuard {
+            identity,
+            rotation_gate: self.rotation_gate.clone(),
+            _rotation_guard: rotation_guard,
+        })
+    }
+
+    /// Verify that `proof` came from this exact identity source and that the
+    /// source is still terminally disabled for the same process incarnation.
+    ///
+    /// Node-id/epoch equality alone is insufficient: a separately-created
+    /// identity source can carry identical text while this source remains
+    /// active. Pointer-binding the proof to the rotation gate closes that
+    /// substitution.
+    pub fn owns_disabled(&self, proof: &DisabledNodeIdentity) -> bool {
+        std::sync::Arc::ptr_eq(&self.rotation_gate, &proof.source_gate)
+            && self.with_current(|current| {
+                !current.is_active() && current.same_incarnation(&proof.prior_identity)
+            })
+    }
+
     /// Replace the current identity only after every in-flight guarded
     /// publication or transaction has completed.
+    ///
+    /// Terminal disable is irreversible for this shared identity source.
+    /// Once [`Self::disable`] has returned, a late node-lease task cannot
+    /// reactivate publication authority by rotating in a fresh active
+    /// identity. A terminally-disabled replacement is likewise rejected:
+    /// only [`Self::disable`] may perform that transition and mint its proof.
     pub async fn rotate(&self, identity: NodeIdentity) {
         let _rotation_guard = self.rotation_gate.write().await;
-        *self
+        let mut current = self
             .identity
             .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = identity;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !current.is_active() || !identity.is_active() {
+            return;
+        }
+        *current = identity;
     }
 
     /// Permanently revoke publication authority for this clustering
     /// lifetime after every in-flight guarded publication has drained.
     /// The last identity remains inspectable for diagnostics, but compares
     /// unequal to its former active value and cannot pass a claim acquire.
-    pub async fn disable(&self) {
+    pub async fn disable(&self) -> DisabledNodeIdentity {
         let _rotation_guard = self.rotation_gate.write().await;
-        self.identity
+        let mut identity = self
+            .identity
             .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .authority = NodeAuthority::TerminallyDisabled;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let prior_identity =
+            NodeIdentity::new(identity.node_id.clone(), identity.node_epoch.clone());
+        identity.authority = NodeAuthority::TerminallyDisabled;
+        DisabledNodeIdentity {
+            prior_identity,
+            source_gate: self.rotation_gate.clone(),
+        }
     }
 }
 
@@ -594,15 +697,17 @@ pub trait ClaimStore: Send + Sync {
     /// call.
     async fn current_claim(&self, entity: &Entity) -> Result<Option<ClaimSnapshot>, ClaimError>;
 
-    /// Observe a claim only after any detached write already mutating that
-    /// claim row has committed or rolled back. Terminal recovery uses this
-    /// as an ordering barrier after cancellation may have dropped a steal
-    /// future while its backend statement remained in flight.
+    /// Observe a claim only after any detached write already mutating or
+    /// creating that entity's claim has committed or rolled back. Terminal
+    /// recovery uses this as an ordering barrier after cancellation may have
+    /// dropped an acquire or steal future while its backend statement
+    /// remained in flight.
     ///
     /// In-process stores execute claim mutations synchronously and therefore
     /// need no stronger operation than [`Self::current_claim`]. Stores that
-    /// can outlive a dropped future must override this method with a row-lock
-    /// or equivalent serialization barrier.
+    /// can outlive a dropped future must override this method with a
+    /// serialization barrier that also covers an absent-row INSERT; a row
+    /// lock alone is insufficient.
     async fn current_claim_after_pending_writes(
         &self,
         entity: &Entity,
@@ -769,9 +874,11 @@ mod tests {
     async fn terminally_disabled_identity_rejects_guards_and_claim_acquisition() {
         let active = NodeIdentity::new("node-a", "epoch-0");
         let shared = SharedNodeIdentity::new(active.clone());
-        shared.disable().await;
+        let proof = shared.disable().await;
 
         let disabled = shared.current();
+        assert_eq!(proof.prior_identity(), &active);
+        assert!(shared.owns_disabled(&proof));
         assert!(!disabled.is_active());
         assert_ne!(disabled, active);
         assert!(disabled.same_incarnation(&active));
@@ -784,6 +891,41 @@ mod tests {
             store.acquire(&entity, &disabled).await,
             Err(ClaimError::AuthorityDisabled)
         ));
+    }
+
+    #[tokio::test]
+    async fn terminally_disabled_identity_cannot_be_reactivated_by_rotation() {
+        let active = NodeIdentity::new("node-a", "epoch-0");
+        let shared = SharedNodeIdentity::new(active.clone());
+        shared.disable().await;
+
+        shared
+            .rotate(NodeIdentity::new("node-a", "epoch-after-disable"))
+            .await;
+
+        let disabled = shared.current();
+        assert!(!disabled.is_active());
+        assert!(disabled.same_incarnation(&active));
+        assert!(
+            !disabled.same_incarnation(&NodeIdentity::new("node-a", "epoch-after-disable")),
+            "a late rotate must not reopen terminal publication authority"
+        );
+        assert!(shared.guard_if_current(&disabled).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn disabled_identity_proof_is_bound_to_its_exact_source() {
+        let identity = NodeIdentity::new("node-a", "epoch-0");
+        let active_source = SharedNodeIdentity::new(identity.clone());
+        let separate_source = SharedNodeIdentity::new(identity);
+        let foreign_proof = separate_source.disable().await;
+
+        assert!(
+            !active_source.owns_disabled(&foreign_proof),
+            "identical node/epoch text from another source is not terminal-disable proof"
+        );
+        assert!(active_source.current().is_active());
+        assert!(separate_source.owns_disabled(&foreign_proof));
     }
 
     #[tokio::test]
@@ -811,5 +953,31 @@ mod tests {
         rotation.await.expect("rotation task");
         assert_eq!(shared.current(), NodeIdentity::new("node-a", "epoch-1"));
         assert!(shared.guard_if_current(&old).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn weak_publication_permit_cannot_outlive_its_callers_guard() {
+        let active = NodeIdentity::new("node-a", "epoch-0");
+        let shared = SharedNodeIdentity::new(active.clone());
+        let guard = shared
+            .guard_if_current(&active)
+            .await
+            .expect("active identity starts current");
+        let permit = guard.permit();
+
+        assert!(
+            shared.upgrade_permit(&permit).is_some(),
+            "the permit is usable while its caller retains the publication guard"
+        );
+        drop(guard);
+
+        let proof = tokio::time::timeout(Duration::from_millis(100), shared.disable())
+            .await
+            .expect("a weak permit must not keep terminal disable blocked");
+        assert!(shared.owns_disabled(&proof));
+        assert!(
+            shared.upgrade_permit(&permit).is_none(),
+            "a queued message cannot recover publication authority after caller rollback"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
@@ -168,6 +168,15 @@ pub enum ForceDetachOutcome {
     /// `LocalForcedDetachOutcome::NotLiveLocally` (re-check persistence and
     /// retry).
     NotPersisted,
+    /// No authoritative result was received, so the asker has no proof that
+    /// the connection closed.
+    ///
+    /// This is deliberately distinct from [`Self::NotPersisted`], which
+    /// proves that identity matched and teardown completed even though no
+    /// resumable snapshot was written. Relay cancellation, timeout, or an
+    /// unavailable remote socket must report `Unavailable`; callers must
+    /// preserve the owning claim and retry or let fenced reclaim resolve it.
+    Unavailable,
 }
 
 /// Connection state stored in the registry.

--- a/server/crates/waddle-xmpp/src/registry/mod.rs
+++ b/server/crates/waddle-xmpp/src/registry/mod.rs
@@ -35,6 +35,8 @@ pub use user_actor::GetResources;
 pub use user_registry::{
     DemoteUserActor, DemoteUserActorIfOwner, DemotedUserActor, DemotedUserResource,
     GetOrCreateUser, GetUser, GetUserForLocalClaim, ListUsers, ListUsersOwnedBy, ReapUserIfEmpty,
-    RegisterUserResource, RegisterUserResourceIfOwnerOrAbsent, RemoveUser, UnregisterUserResource,
-    UserCount, UserRegistryActor, UserRegistryError, WireUserClusteringClaims,
+    RegisterUserResource, RegisterUserResourceIfOwnerOrAbsentUnderAuthority,
+    RegisterUserResourceUnderAuthority, RemoveUser, RetireUserActorAfterAuthorityDisabled,
+    RetireUserActorAfterAuthorityDisabledOutcome, UnregisterUserResource, UserCount,
+    UserRegistryActor, UserRegistryError, WireUserClusteringClaims,
 };

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -27,8 +27,8 @@ use super::user_actor::{
 };
 use crate::metrics;
 use crate::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
-    SharedNodeIdentity, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimStore, CurrentNodeIdentityPermit, DisabledNodeIdentity, Entity,
+    EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity, StalePredicate,
 };
 
 const CHILD_ACTOR_TIMEOUT: Duration = Duration::from_secs(2);
@@ -181,6 +181,44 @@ impl UserRegistryActor {
         actor_ref
     }
 
+    async fn discard_new_user_actor(
+        &mut self,
+        bare_jid: &BareJid,
+        actor_ref: &ActorRef<UserActor>,
+    ) {
+        let Some(entry) = self.users.get(bare_jid) else {
+            return;
+        };
+        if entry.actor_ref.id() != actor_ref.id() || !entry.resources.is_empty() {
+            return;
+        }
+        let Some(entry) = self.users.remove(bare_jid) else {
+            return;
+        };
+        entry.actor_ref.kill();
+        self.release_user_claim(bare_jid, &entry.claim).await;
+    }
+
+    fn demote_user_actor_if_owner(
+        &mut self,
+        bare_jid: &BareJid,
+        owner: &NodeIdentity,
+    ) -> Option<DemotedUserActor> {
+        let entry = self.users.get(bare_jid)?.clone();
+        if entry.claim.owner != *owner {
+            return None;
+        }
+        let removed = self.users.remove(bare_jid)?;
+        removed.actor_ref.kill();
+        Some(DemotedUserActor {
+            resources: removed
+                .resources
+                .into_iter()
+                .map(|(jid, entry)| DemotedUserResource { jid, entry })
+                .collect(),
+        })
+    }
+
     async fn acquire_and_publish_user(
         &mut self,
         bare_jid: BareJid,
@@ -192,6 +230,99 @@ impl UserRegistryActor {
             return Err(UserRegistryError::ClaimUnavailable(bare_jid));
         };
         Ok(self.spawn_user_actor(bare_jid, claim))
+    }
+
+    async fn acquire_and_publish_user_under_permit(
+        &mut self,
+        bare_jid: BareJid,
+        publication_permit: &CurrentNodeIdentityPermit,
+    ) -> Result<ActorRef<UserActor>, UserRegistryError> {
+        let claim = self.acquire_user_claim(&bare_jid).await?;
+        let Some(publication_guard) = self.node_identity.upgrade_permit(publication_permit) else {
+            self.release_user_claim(&bare_jid, &claim).await;
+            return Err(UserRegistryError::ClaimUnavailable(bare_jid));
+        };
+        if claim.owner != *publication_guard.identity() {
+            drop(publication_guard);
+            self.release_user_claim(&bare_jid, &claim).await;
+            return Err(UserRegistryError::ClaimUnavailable(bare_jid));
+        }
+        // `spawn_user_actor` is synchronous: hold upgraded authority only
+        // across the exact local publication, never an actor or backend await.
+        Ok(self.spawn_user_actor(bare_jid, claim))
+    }
+
+    async fn register_user_resource(
+        &mut self,
+        jid: FullJid,
+        entry: ConnectionEntry,
+        publication_permit: Option<&CurrentNodeIdentityPermit>,
+    ) -> Result<(), UserRegistryError> {
+        let bare_jid = jid.to_bare();
+        let mirrored_entry = entry.clone();
+        if self.poisoned_users.contains(&bare_jid) {
+            return Err(UserRegistryError::UserActorStateLost(bare_jid));
+        }
+
+        let (user_actor, new_actor) = if let Some(actor_ref) = self
+            .existing_user_actor_for_current_claim(&bare_jid)
+            .await?
+        {
+            (actor_ref, false)
+        } else if let Some(publication_permit) = publication_permit {
+            (
+                self.acquire_and_publish_user_under_permit(bare_jid.clone(), publication_permit)
+                    .await?,
+                true,
+            )
+        } else {
+            (self.acquire_and_publish_user(bare_jid.clone()).await?, true)
+        };
+
+        // Existing-actor registration and new-actor resource publication are
+        // both publication boundaries. Upgrade only after all potentially
+        // unbounded claim-store validation/acquisition work, then retain this
+        // short-lived guard across the bounded child ask and synchronous
+        // resource-map insertion. A queued message never owns this guard.
+        let publication_guard = if let Some(publication_permit) = publication_permit {
+            match self.node_identity.upgrade_permit(publication_permit) {
+                Some(publication_guard) => Some(publication_guard),
+                None => {
+                    if new_actor {
+                        self.discard_new_user_actor(&bare_jid, &user_actor).await;
+                    }
+                    return Err(UserRegistryError::ClaimUnavailable(bare_jid));
+                }
+            }
+        } else {
+            None
+        };
+
+        match user_actor
+            .ask(RegisterConnection {
+                jid: jid.clone(),
+                entry,
+            })
+            .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
+            .reply_timeout(CHILD_ACTOR_TIMEOUT)
+            .await
+        {
+            Ok(()) => {
+                if let Some(user) = self.users.get_mut(&bare_jid) {
+                    user.resources.insert(jid, mirrored_entry);
+                }
+                drop(publication_guard);
+            }
+            Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
+                return Err(UserRegistryError::UserActorBusy(bare_jid));
+            }
+            Err(_) => {
+                drop(publication_guard);
+                return Err(self.mark_actor_state_lost(&bare_jid).await);
+            }
+        }
+
+        Ok(())
     }
 
     async fn release_user_claim(&self, bare_jid: &BareJid, claim: &UserClaimLease) {
@@ -353,6 +484,13 @@ impl UserRegistryActor {
                         jid = %jid,
                         requester = %bare_jid,
                         "stale UserActor resource force-detach identity mismatch; refusing claim reuse"
+                    );
+                    return false;
+                }
+                Ok(Ok(ForceDetachOutcome::Unavailable)) => {
+                    warn!(
+                        jid = %jid,
+                        "stale UserActor resource force-detach was unavailable; refusing claim reuse"
                     );
                     return false;
                 }
@@ -531,78 +669,106 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
         msg: RegisterUserResource,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        let bare_jid = msg.jid.to_bare();
-        let mirrored_entry = msg.entry.clone();
-        if self.poisoned_users.contains(&bare_jid) {
-            return Err(UserRegistryError::UserActorStateLost(bare_jid));
-        }
-
-        let user_actor = if let Some(actor_ref) = self
-            .existing_user_actor_for_current_claim(&bare_jid)
-            .await?
-        {
-            actor_ref
-        } else {
-            self.acquire_and_publish_user(bare_jid.clone()).await?
-        };
-
-        match user_actor
-            .ask(RegisterConnection {
-                jid: msg.jid.clone(),
-                entry: msg.entry,
-            })
-            .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
-            .reply_timeout(CHILD_ACTOR_TIMEOUT)
-            .await
-        {
-            Ok(()) => {
-                if let Some(user) = self.users.get_mut(&bare_jid) {
-                    user.resources.insert(msg.jid.clone(), mirrored_entry);
-                }
-            }
-            Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
-                return Err(UserRegistryError::UserActorBusy(bare_jid));
-            }
-            Err(_) => return Err(self.mark_actor_state_lost(&bare_jid).await),
-        }
-
-        Ok(())
+        self.register_user_resource(msg.jid, msg.entry, None).await
     }
 }
 
-/// Register a user resource without replacing a different owner token.
+/// Register a local WebSocket resource while reusing the publication guard
+/// already acquired before its ConnectionRegistry insertion.
+///
+/// The caller retains the real guard through rollback enqueue. This message
+/// carries only a weak permit, so a timed-out ask cannot retain the identity
+/// read lock and deadlock a queued terminal-disable writer.
+pub struct RegisterUserResourceUnderAuthority {
+    pub jid: FullJid,
+    pub entry: ConnectionEntry,
+    pub publication_permit: CurrentNodeIdentityPermit,
+}
+
+impl kameo::message::Message<RegisterUserResourceUnderAuthority> for UserRegistryActor {
+    type Reply = Result<(), UserRegistryError>;
+
+    async fn handle(
+        &mut self,
+        msg: RegisterUserResourceUnderAuthority,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        // Prove the caller still owns live authority when this mailbox handler
+        // begins, but never retain the upgraded guard across an await.
+        let Some(publication_guard) = self.node_identity.upgrade_permit(&msg.publication_permit)
+        else {
+            return Err(UserRegistryError::ClaimUnavailable(msg.jid.to_bare()));
+        };
+        drop(publication_guard);
+        self.register_user_resource(msg.jid, msg.entry, Some(&msg.publication_permit))
+            .await
+    }
+}
+
+/// Register a user resource without replacing a different owner token while
+/// reusing the publication guard held by the clustered remote-owner caller.
 ///
 /// This keeps clustered remote-resource mirrors from deleting a live local
 /// same-full-JID resource that won the slot while the remote register was in
-/// flight. It otherwise follows [`RegisterUserResource`] so user lifecycle and
-/// claim acquisition remain serialized by this actor.
-pub struct RegisterUserResourceIfOwnerOrAbsent {
+/// flight. The weak permit also prevents an already-queued relay registration
+/// from publishing a resource after terminal node-identity disable.
+pub struct RegisterUserResourceIfOwnerOrAbsentUnderAuthority {
     pub jid: FullJid,
     pub entry: ConnectionEntry,
     pub owner: Arc<AtomicBool>,
+    pub publication_permit: CurrentNodeIdentityPermit,
 }
 
-impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegistryActor {
+impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsentUnderAuthority>
+    for UserRegistryActor
+{
     type Reply = Result<bool, UserRegistryError>;
 
     async fn handle(
         &mut self,
-        msg: RegisterUserResourceIfOwnerOrAbsent,
+        msg: RegisterUserResourceIfOwnerOrAbsentUnderAuthority,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Reject a message that only begins running after its caller has
+        // dropped publication authority. Never retain this first upgrade
+        // across claim-store I/O.
+        let Some(publication_guard) = self.node_identity.upgrade_permit(&msg.publication_permit)
+        else {
+            return Err(UserRegistryError::ClaimUnavailable(msg.jid.to_bare()));
+        };
+        drop(publication_guard);
+
         let bare_jid = msg.jid.to_bare();
         let mirrored_entry = msg.entry.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
 
-        let user_actor = if let Some(actor_ref) = self
+        let (user_actor, new_actor) = if let Some(actor_ref) = self
             .existing_user_actor_for_current_claim(&bare_jid)
             .await?
         {
-            actor_ref
+            (actor_ref, false)
         } else {
-            self.acquire_and_publish_user(bare_jid.clone()).await?
+            (
+                self.acquire_and_publish_user_under_permit(
+                    bare_jid.clone(),
+                    &msg.publication_permit,
+                )
+                .await?,
+                true,
+            )
+        };
+
+        // Claim validation/acquisition above may await. Re-upgrade at the
+        // exact resource-publication boundary and retain the short guard
+        // through the bounded child ask plus synchronous registry mirror.
+        let Some(publication_guard) = self.node_identity.upgrade_permit(&msg.publication_permit)
+        else {
+            if new_actor {
+                self.discard_new_user_actor(&bare_jid, &user_actor).await;
+            }
+            return Err(UserRegistryError::ClaimUnavailable(bare_jid));
         };
 
         match user_actor
@@ -621,12 +787,16 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
                         user.resources.insert(msg.jid.clone(), mirrored_entry);
                     }
                 }
+                drop(publication_guard);
                 Ok(registered)
             }
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 Err(UserRegistryError::UserActorBusy(bare_jid))
             }
-            Err(_) => Err(self.mark_actor_state_lost(&bare_jid).await),
+            Err(_) => {
+                drop(publication_guard);
+                Err(self.mark_actor_state_lost(&bare_jid).await)
+            }
         }
     }
 }
@@ -779,19 +949,52 @@ impl kameo::message::Message<DemoteUserActorIfOwner> for UserRegistryActor {
         msg: DemoteUserActorIfOwner,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        let entry = self.users.get(&msg.bare_jid)?.clone();
-        if entry.claim.owner != msg.owner {
-            return None;
+        self.demote_user_actor_if_owner(&msg.bare_jid, &msg.owner)
+    }
+}
+
+/// Result of graceful-shutdown retirement after publication authority was
+/// terminally disabled.
+#[derive(kameo::Reply)]
+pub enum RetireUserActorAfterAuthorityDisabledOutcome {
+    /// The proof did not originate from this registry's exact identity source,
+    /// or that source is not terminally disabled.
+    AuthorityNotDisabled,
+    /// The proof is valid and no exact local UserActor remains.
+    AlreadyAbsent,
+    /// The proof is valid and the exact former owner's actor was removed.
+    Retired(DemotedUserActor),
+}
+
+/// Gracefully retire one exact-owner UserActor only after verifying a
+/// source-bound terminal-disable proof against this registry's own shared
+/// identity handle.
+pub struct RetireUserActorAfterAuthorityDisabled {
+    pub bare_jid: BareJid,
+    pub disabled_identity: DisabledNodeIdentity,
+}
+
+impl kameo::message::Message<RetireUserActorAfterAuthorityDisabled> for UserRegistryActor {
+    type Reply = RetireUserActorAfterAuthorityDisabledOutcome;
+
+    async fn handle(
+        &mut self,
+        msg: RetireUserActorAfterAuthorityDisabled,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if !self.node_identity.owns_disabled(&msg.disabled_identity) {
+            warn!(
+                jid = %msg.bare_jid,
+                "refusing graceful UserActor retirement without this registry's \
+                 terminal-disable proof"
+            );
+            return RetireUserActorAfterAuthorityDisabledOutcome::AuthorityNotDisabled;
         }
-        let removed = self.users.remove(&msg.bare_jid)?;
-        removed.actor_ref.kill();
-        Some(DemotedUserActor {
-            resources: removed
-                .resources
-                .into_iter()
-                .map(|(jid, entry)| DemotedUserResource { jid, entry })
-                .collect(),
-        })
+        match self.demote_user_actor_if_owner(&msg.bare_jid, msg.disabled_identity.prior_identity())
+        {
+            Some(demoted) => RetireUserActorAfterAuthorityDisabledOutcome::Retired(demoted),
+            None => RetireUserActorAfterAuthorityDisabledOutcome::AlreadyAbsent,
+        }
     }
 }
 

--- a/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
@@ -16,6 +16,24 @@ struct WedgeUserActor {
     entered: Arc<tokio::sync::Notify>,
 }
 
+struct HoldUserRegistry {
+    entered: tokio::sync::oneshot::Sender<()>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+impl kameo::message::Message<HoldUserRegistry> for UserRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: HoldUserRegistry,
+        _ctx: &mut kameo::message::Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let _ = msg.entered.send(());
+        msg.release.notified().await;
+    }
+}
+
 impl kameo::message::Message<WedgeUserActor> for UserActor {
     type Reply = ();
 
@@ -400,6 +418,88 @@ async fn get_or_create_releases_a_claim_if_identity_rotates_after_the_cas() {
         .await
         .expect("claim lookup")
         .is_none());
+}
+
+#[tokio::test]
+async fn queued_authority_registration_cannot_block_terminal_identity_disable() {
+    let registry = spawn_registry().await;
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let identity = this_identity();
+    let shared_identity = SharedNodeIdentity::new(identity.clone());
+    wire_shared_claims(&registry, Arc::clone(&claim_store), shared_identity.clone()).await;
+
+    let publication_guard = shared_identity
+        .guard_if_current(&identity)
+        .await
+        .expect("active identity guard");
+    let publication_permit = publication_guard.permit();
+
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let release = Arc::new(tokio::sync::Notify::new());
+    let blocker = tokio::spawn({
+        let registry = registry.clone();
+        let release = Arc::clone(&release);
+        async move {
+            registry
+                .ask(HoldUserRegistry {
+                    entered: entered_tx,
+                    release,
+                })
+                .await
+        }
+    });
+    entered_rx.await.expect("registry blocker entered");
+
+    let jid = full("queued-permit", "phone");
+    let bare_jid = jid.to_bare();
+    let (tx, _rx) = outbound_channel();
+    let registering = tokio::spawn({
+        let registry = registry.clone();
+        async move {
+            registry
+                .ask(RegisterUserResourceUnderAuthority {
+                    jid,
+                    entry: ConnectionEntry::new(tx),
+                    publication_permit,
+                })
+                .await
+        }
+    });
+    tokio::task::yield_now().await;
+    drop(publication_guard);
+
+    let disabled = tokio::time::timeout(Duration::from_millis(100), shared_identity.disable())
+        .await
+        .expect("a queued actor message must not retain the publication read lock");
+    assert!(shared_identity.owns_disabled(&disabled));
+
+    release.notify_one();
+    blocker
+        .await
+        .expect("blocker task")
+        .expect("blocker message");
+    let result = registering.await.expect("registration task");
+    assert!(
+        matches!(
+            result,
+            Err(SendError::HandlerError(UserRegistryError::ClaimUnavailable(ref jid)))
+                if *jid == bare_jid
+        ),
+        "the late queued registration must fail after terminal disable: {result:?}"
+    );
+    assert!(registry
+        .ask(ListUsers)
+        .await
+        .expect("list users")
+        .is_empty());
+    assert!(
+        claim_store
+            .current_claim(&user_entity(&bare_jid))
+            .await
+            .expect("claim lookup")
+            .is_none(),
+        "a rejected late registration must not leak a UserActor claim"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -16,9 +16,10 @@ use waddle_xmpp::muc::durable::{
 };
 use waddle_xmpp::muc::room_actor::{
     DurableRestoreReadiness, GetAffiliation, GetConfig, GetDurableRestoreReadiness,
-    GetRoomSealState, GetRoomSnapshot, Join, JoinAffiliationGrant, JoinWithAffiliation,
-    OccupantCount, ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor,
-    RoomActorError, RoomMutationError, RoomSealState, SyncResolverAffiliation, UpdateConfig,
+    GetRetainedRoomClaimFence, GetRoomSealState, GetRoomSnapshot, Join, JoinAffiliationGrant,
+    JoinWithAffiliation, OccupantCount, ResolverAffiliationSyncOutcome, RestoreDurableRoomState,
+    RoomActor, RoomActorError, RoomMutationError, RoomSealState, SyncResolverAffiliation,
+    UpdateConfig,
 };
 use waddle_xmpp::muc::room_registry_actor::{
     CreateRoom, GetOrCreateRoom, RoomCreation, RoomRegistryActor, RoomRegistryError,
@@ -261,7 +262,10 @@ async fn deposed_room_refuses_xep0045_resolver_join() {
         actor.ask(resolver_join()).await,
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
-    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+    assert!(matches!(
+        actor.ask(OccupantCount).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 #[tokio::test]
@@ -384,7 +388,10 @@ async fn deposed_room_refuses_legacy_xep0045_join() {
         actor.ask(legacy_join()).await,
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
-    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+    assert!(matches!(
+        actor.ask(OccupantCount).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 #[tokio::test]
@@ -418,13 +425,10 @@ async fn deposed_room_refuses_resolver_affiliation_sync() {
             .expect("sync outcome"),
         ResolverAffiliationSyncOutcome::RoomSealed,
     );
-    assert_eq!(
-        actor
-            .ask(GetAffiliation { jid })
-            .await
-            .expect("affiliation"),
-        Affiliation::None,
-    );
+    assert!(matches!(
+        actor.ask(GetAffiliation { jid }).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 #[tokio::test]
@@ -471,6 +475,7 @@ async fn assert_invalid_restore_fence_fails_closed(invalid_fence: RoomClaimFence
         expected_epoch,
         None,
     ));
+    let original_config = actor.ask(GetConfig).await.expect("original config");
 
     actor
         .ask(RestoreDurableRoomState {
@@ -492,22 +497,24 @@ async fn assert_invalid_restore_fence_fails_closed(invalid_fence: RoomClaimFence
         actor.ask(GetRoomSealState).await.expect("room seal state"),
         RoomSealState::OwnershipLost,
     );
-    let original_config = actor.ask(GetConfig).await.expect("original config");
     let mut attempted = original_config.clone();
     attempted.name = "must not mutate".to_string();
     assert!(matches!(
         actor.ask(UpdateConfig { config: attempted }).await,
         Err(SendError::HandlerError(RoomMutationError::NotOwner))
     ));
-    assert_eq!(
-        actor.ask(GetConfig).await.expect("config after rejection"),
-        original_config,
-    );
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert!(matches!(
         actor.ask(resolver_join()).await,
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
-    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+    assert!(matches!(
+        actor.ask(OccupantCount).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 #[tokio::test]
@@ -598,16 +605,21 @@ async fn second_restore_cannot_transplant_an_actor_to_a_successor_fence() {
         "the successor store must not receive a load from the old actor incarnation"
     );
     assert_eq!(original_store.take_observed_load_count(), 0);
-    assert_eq!(
+    assert!(matches!(
         actor
             .ask(GetRoomSnapshot {
                 sender_jid: snapshot_sender,
             })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetRetainedRoomClaimFence)
             .await
-            .expect("snapshot after transplant attempt")
-            .claim_fence,
+            .expect("retained claim-fence diagnostic"),
         Some(original_fence.clone()),
-        "a rejected successor restore must not replace the fence carried by old snapshots",
+        "a rejected successor restore must not replace the old incarnation's retained fence",
     );
 
     let mut attempted = original_config.clone();
@@ -616,15 +628,18 @@ async fn second_restore_cannot_transplant_an_actor_to_a_successor_fence() {
         actor.ask(UpdateConfig { config: attempted }).await,
         Err(SendError::HandlerError(RoomMutationError::NotOwner))
     ));
-    assert_eq!(
-        actor.ask(GetConfig).await.expect("config after rejection"),
-        original_config,
-    );
+    assert!(matches!(
+        actor.ask(GetConfig).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
     assert!(matches!(
         actor.ask(resolver_join()).await,
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
-    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+    assert!(matches!(
+        actor.ask(OccupantCount).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
 }
 
 fn durable_existing_room() -> DurableRoomState {

--- a/server/docs/adrs/0017-horizontal-scaling-remote-actors.md
+++ b/server/docs/adrs/0017-horizontal-scaling-remote-actors.md
@@ -165,8 +165,10 @@ Key elements:
      slot-lease TTL. The CAS guarantees at most one
      live leaseholder per slot, so no two concurrent swarm members ever
      share a PeerId — including the old+new pod overlap of a
-     RollingUpdate with surge; as defense in depth, the swarm behaviour
-     layer rejects a second live session for an already-connected PeerId.
+     RollingUpdate with surge. The swarm permits multiple authenticated
+     transport connections to that one PeerId and tracks connectivity on
+     the first established / last closed connection; this is required for
+     safe convergence when both endpoints dial each other concurrently.
      **Scale-up beyond the enrolled pool requires a pipeline enrollment
      run first** — a documented operational constraint — and the Phase 4
      chart ships the pool-Secret templating plus the enrollment Helm hook
@@ -990,9 +992,19 @@ Key elements:
      never double-promote the same unacked queue into `pending_delivery`.
      The same janitor performs the `pending_delivery` sweep-flush for owned
      bare JIDs (element 5).
-   - Graceful shutdown drain **releases claims per entity, after that
-     entity's final fenced writes** (Phase 3 drain sequence) rather than
-     assuming exclusive table ownership.
+   - Graceful shutdown closes process-wide room admission, drains every root
+     room-serving scope, terminally inventories/seals/hard-retires every
+     locally-owned `RoomActor`, and then releases the **complete room batch
+     or none of it**. Any uncertain seal or retirement, timeout, poisoned
+     fence, or fatal fence leaves every room claim held for normal
+     TTL-fenced reclaim; a partially clean room set is never released.
+     `UserActor` has no final durable write, so its handoff barrier is
+     deliberately separate: terminally disable new same-incarnation
+     publication, retire the exact actor and every local resource, verify
+     both actor and connection registries are quiescent, then release only
+     those independently verified user claims. The SM-session Q6 drain
+     remains a third, independent owner of its promote/delete/release
+     sequence.
    - An **orphan reaper** handles rows claimed by nodes whose liveness
      expired: any node may steal such claims (fenced CAS) and then expire or
      promote them, after first committing the expire CAS on the owner's
@@ -1205,7 +1217,7 @@ convention alone.
   All fan-out paths use `try_send` + typed drop outcome.
 - **Phase 2 — remote subsystem spike:** build the swarm subsystem (event
   loop; **keypair-pool Secret management with the Postgres CAS slot lease
-  and duplicate-PeerId rejection** per element 3; peer-ID allowlist
+  and safe multi-connection convergence** per element 3; peer-ID allowlist
   enforcement with read-only runtime grants and **live-connection
   revocation on refresh** per element 3; headless-DNS peer dialing
   with re-dial on pod churn; swarm-level configuration — listen addrs,
@@ -1288,26 +1300,39 @@ convention alone.
   Demote/fenced-broadcast backstop, and the re-election
   protocol (element 7); steal-intent/owner-veto unwedge path for RoomActor
   and UserActor claims (element 4); Postgres-backed ISR token store with the
-  two-case failure handling (element 10). Graceful drain sequence,
-  **per-entity, not phase-ordered** (phase ordering would self-fence the
-  draining node's own final writes): (1) mark the node draining in `nodes`
+  two-case failure handling (element 10). Graceful drain sequence preserves
+  the **writes-before-release invariant** without allowing a partially
+  retired room set to transfer: (1) mark the node draining in `nodes`
   so it stops acquiring claims **for entities it is not already serving
   locally** — a draining node continues to hold and write under the SM
   claims of its own draining sessions, which exist since `<enable/>`;
-  (2) for each owned entity, complete all final fenced writes (detach
-  snapshot, Q6 promotion or explicit durable-queue handoff, occupant-roster
-  flush) **while still holding the claim**, and only then release that
-  entity's claim — triggering immediate re-election, not TTL wait — in
-  parallel with connection drain but completing before process exit. There
-  is no global "promote what remains" step after release: releasing first
-  and promoting second is a fencing violation by this ADR's own rules.
-  **Claim release is batched**: the ordering constraint is
-  writes-before-release *per entity*, which batching preserves — entities
-  whose final fenced writes have committed are released in fenced
-  multi-row statements (or the release piggybacks on the entity's final
-  fenced write's transaction), because a per-entity release tail of ~18k
-  claims (the modeled 50k users + 5k rooms over ~3 replicas) through a
-  small pool cannot fit a seconds-scale budget one statement at a time.
+  (2) stop HTTP/root room admission, cancel every producer that can open a
+  room-serving scope, and wait for the process-wide scope count to reach
+  zero; (3) close `RoomRegistryActor` creation, take a terminal inventory,
+  reconciling every timed-out claim acquisition behind a transaction-scoped
+  entity-key lock that also exists before a claim row is inserted,
+  and seal plus hard-retire **every** locally-owned room while its exact
+  claim is still held; (4) revalidate and consume the clean room-serving
+  fence, then release the deduplicated complete room set in one
+  `release_many`. Any failed, retained, timed-out, or reply-ambiguous room,
+  any poisoned/fatal fence, or any ambiguous batch result selects terminal
+  no-release for the entire room set. There is no partial room release and
+  no global "promote what remains" step after release: releasing first and
+  completing work second is a fencing violation by this ADR's own rules.
+  `UserActor` is the explicit no-durable-final-write refinement: cap the
+  all-or-none `RoomActor` work at half of `claimReleaseBudget`, then
+  terminally disable same-incarnation publication, retire and verify each
+  exact local user actor/resource set, and use all remaining budget for the
+  verified user-claim release batch. Unused room time is donated to users;
+  a wedged room cannot consume the user handoff opportunity. A timeout,
+  identity mismatch, full detach channel, unverifiable registry, or
+  ambiguous release never authorizes a user claim release.
+  SM sessions retain their independent Q6 promote/delete/release sequence.
+  **Claim release is batched**: rooms use one all-or-none statement; users
+  use a batch containing only exact identities whose local retirement was
+  verified. This avoids a per-claim release tail of ~18k claims (the modeled
+  50k users + 5k rooms over ~3 replicas) through a small pool that cannot fit
+  a seconds-scale budget one statement at a time.
   If the budget still overruns, the kubelet SIGKILLs with claims
   unreleased — fencing keeps that safe, but the affected entities stall
   until lease-TTL expiry, silently degrading the "~1 move per entity per
@@ -1461,10 +1486,11 @@ convention alone.
   outage; a node genuinely isolated from all of two-or-more live peers
   still fences, while partial link failures degrade to durable-queue
   routing instead of amputating healthy nodes (element 4).
-- Rolling deploys re-elect ownership immediately via proactive per-entity
-  claim release instead of stalling every owned room/user for a heartbeat
-  TTL, and rollout-aware placement moves each entity approximately once per
-  deploy.
+- Clean rolling drains re-elect ownership immediately via the all-or-none
+  room batch plus the separately verified user batch. An ambiguous room
+  drain deliberately transfers no room claims and waits for heartbeat-TTL
+  recovery; rollout-aware placement still moves every cleanly released
+  entity approximately once per deploy.
 - Phase 1 is a self-funding refactor (retires dead-code-in-waiting and
   external locking) even if clustering never ships — but it is a delivery-
   path rebuild with preserved invariants, not a pure move.
@@ -1553,10 +1579,12 @@ convention alone.
   so any pod with code execution holds the private-key bytes for the *whole
   pool*, not just its CAS-leased slot. A compromised process can therefore
   present any allowlisted PeerId directly from the pool bytes without
-  leasing a slot (the swarm-layer duplicate-PeerId rejection only blocks a
-  *currently-connected* PeerId, not an unused pool slot), so revoking a
-  single key does not contain a compromised pod — it reconnects under
-  another pool key. **The practical unit of revocation under key-material
+  leasing a slot. Transport authentication and connection counting cannot
+  prove that the remote process owns the corresponding Postgres lease, and
+  permitting multiple transport connections per PeerId is necessary for
+  safe simultaneous-dial convergence, so revoking a single key does not
+  contain a compromised pod — it reconnects under another pool key.
+  **The practical unit of revocation under key-material
   compromise is thus the entire pool** (rotate the pool, roll every
   replica); per-key revocation contains cleanly-decommissioned/rotated
   peers, not an actively-compromised pod. The recorded StatefulSet /

--- a/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
+++ b/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
@@ -117,7 +117,8 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
   counter) via the OTel `metrics.rs` + periodic-task pattern.
   *Exit:* single-node swarm boots, listens, reports PeerId, bootstraps.
 
-- **Slice 2 — keypair-slot Postgres CAS lease + duplicate-PeerId rejection.**
+- **Slice 2 — keypair-slot Postgres CAS lease + safe multi-connection
+  convergence.**
   `keypair_slots` lease (Postgres-only CAS: Acquire `INSERT … ON CONFLICT DO
   NOTHING` + `rows_affected==1`; Heartbeat renewal CAS on freshness; Expire CAS
   (committed `expired` flag); Release on drain — all on Postgres `now()`),
@@ -130,10 +131,14 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
   can no longer prove it still holds the slot. Self-fencing cancels a
   clustering-scoped child token, tearing down only the clustering subsystem
   (swarm, relay, janitors) — never the whole server.
-  Duplicate-PeerId rejection at the swarm behaviour layer (reject a second live
-  session for an already-connected PeerId) as defence in depth. Runs on the
-  shared global pool in Phase 2; the **dedicated small control-plane
-  pool/handle** is a Phase 3 deliverable (see the implementation notes).
+  Multiple authenticated transport connections to the same PeerId remain
+  valid: simultaneous full-mesh dialing can establish an inbound and outbound
+  connection at both endpoints, and independently closing each endpoint's
+  locally second connection can make the peers close opposite links and lose
+  connectivity entirely. Peer-level bookkeeping therefore changes only on
+  the first established and last closed connection. Runs on the shared global
+  pool in Phase 2; the **dedicated small control-plane pool/handle** is a
+  Phase 3 deliverable (see the implementation notes).
   Postgres-gated CAS tests (acquire, renew, expire-steal, at-most-one
   leaseholder per slot).
 


### PR DESCRIPTION
## Problem

Production Grafana/Faro showed that `/r/chat` was blanking after transient clustered MUC ownership failures:

- 185 `room-join-resource-constraint` events in the inspected 24-hour window
- 44 downstream room-member `item-not-found` failures
- 65 `registration-required` denials, with the `no-stefan` room confirmed as expected ACL behavior

The WASM change was not the cause. The generated source package, installed package, and production bundle remain byte-identical. The failure path was a temporary XMPP `wait/resource-constraint` during clustered room-ownership transitions; the web client cached that one rejection as terminal for the session and left the chat view empty.

## Implementation

### Chat

- Preserve typed MUC stanza errors across the WASM boundary.
- Retry only RFC 6120 `wait` failures and ambiguous self-presence timeouts with bounded backoff.
- Require validated XEP-0045 status-110 self-presence before room-dependent work proceeds.
- Use one generation-aware join flight and cancellation path across navigation, reconnect, disconnect, readiness flushes, and MAM hydration.
- Keep ACL, authentication, conflict, policy, and other terminal failures immediate and non-retryable.
- Use the validated XMPP/room snapshot for MAM so stale navigation cannot hydrate the wrong room.

### Server

- Add process-wide room-serving admission and quiescence across websocket, relay, admin, janitor, and background producers.
- Keep ownership heartbeats alive through terminal shutdown fencing.
- Release room claims only after clean, all-or-none quiescence; abandon claims after cancellation, panic, or uncertain delivery.
- Reconcile timed-out claim acquisition behind a transaction-scoped entity advisory lock, including the absent-row `INSERT` case.
- Keep all-feature builds with clustering disabled on the local single-node path.
- Downgrade the expected `ClaimHeldByAnotherNode` remote-cleanup race while retaining warnings for unexpected failures.
- Leave SFU behavior and APIs unchanged.

## XEP review

Reviewed against XEP-0045 room-entry and self-presence behavior. The client waits for status code 110, preserves typed presence-error semantics, and retries only temporary `wait` conditions. Official namespaces and stanza shapes are unchanged. Dedicated Rust websocket coverage verifies successful room entry, status 110, and room subject delivery.

## Validation

- `chat`: 3,510 tests passed
- focused room-send/readiness suite: 106 tests passed
- `bun run lint`
- `bun run build` / Astro check
- generated, installed, and bundled WASM SHA-256 match
- `cargo fmt --all --check`
- workspace/all-target/all-feature Clippy with `-D warnings`
- all-feature compile check and CI-profile server build
- 7,608 Rust nextest tests passed
- Rust documentation tests passed
- `git diff --check`
- adversarial client, server, XEP/integration, WASM-freshness, and regression reviews completed with all actionable findings resolved

The new live-Postgres absent-row serialization test is present in the all-feature test inventory and compiles locally. Its database body requires `WADDLE_TEST_POSTGRES_URL`; the repository's Nix CI test boots PostgreSQL and supplies that URL, so CI is the operational execution gate.

## Delivery plan

1. Run the complete PR checks, including the Nix/PostgreSQL server suite.
2. Resolve any failures and repeat until green.
3. Merge through the repository workflow.
4. Verify the deployed release and re-query Grafana Faro/Loki for transient join failures, blank-view signals, member-query errors, and clustered cleanup warnings, excluding expected `no-stefan` ACL denials.
