### PR TITLE
fix(chat): stop unsafe retries after terminal MUC denials

### DIFF
--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -55,6 +55,7 @@ type UseChannelMamPagingDeps = {
   pendingEchoClientIds: Set<string>;
   appendQueuedMessages: (timeline: TimelineMessage[], roomJid: string) => TimelineMessage[];
   roomJidForChannel: (channelId: string) => string | null;
+  isRoomAccessRequired: (roomJid: string) => boolean;
   scrollToPinnedEdgeAndPin: () => Promise<boolean>;
   persistLastSeen: (channelId: string, messageId: string) => void;
 };
@@ -77,6 +78,7 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     pendingEchoClientIds,
     appendQueuedMessages,
     roomJidForChannel,
+    isRoomAccessRequired,
     scrollToPinnedEdgeAndPin,
     persistLastSeen,
   } = deps;
@@ -114,6 +116,7 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     channelId: string,
     unreadAtLoad = 0,
     metadataSeed: TimelineMessage[] = [],
+    options: { allowAccessRetry?: boolean } = {},
   ): Promise<TimelineLoadResult> {
     if (!session.value) return "aborted";
 
@@ -137,7 +140,22 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     pendingEchoClientIds.clear();
     messages.value = appendQueuedMessages([], roomJid);
 
+    if (options.allowAccessRetry === false && isRoomAccessRequired(roomJid)) {
+      isLoadingMessages.value = false;
+      hasOlderMessages.value = false;
+      hydratePinnedRoom(roomJid, []);
+      return "loaded";
+    }
+
     try {
+      if (
+        options.allowAccessRetry === true
+        && xmppClient.value
+        && "retryRoomAccess" in xmppClient.value
+      ) {
+        await xmppClient.value.retryRoomAccess(spaceId, channelId);
+      }
+
       // #414: hydrate the pin store for this room. Fire-and-forget — the
       // panel + badge tolerate an empty store and the live pin-event
       // handler will mutate it from now on. Capture the epoch at request

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -35,6 +35,7 @@ import {
   threadCursorFromLatestPage,
 } from "@/lib/xmpp/mam";
 import { hydratePinnedRoom, pinnedRoomsEpoch } from "@/stores/pinned-messages";
+import type { ChannelLoadIntent } from "@/channels/room-access";
 
 const PAGE_SIZE = 100;
 
@@ -116,7 +117,7 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     channelId: string,
     unreadAtLoad = 0,
     metadataSeed: TimelineMessage[] = [],
-    options: { allowAccessRetry?: boolean } = {},
+    options: { intent?: ChannelLoadIntent } = {},
   ): Promise<TimelineLoadResult> {
     if (!session.value) return "aborted";
 
@@ -140,7 +141,10 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     pendingEchoClientIds.clear();
     messages.value = appendQueuedMessages([], roomJid);
 
-    if (options.allowAccessRetry === false && isRoomAccessRequired(roomJid)) {
+    if (
+      options.intent !== "explicit-navigation"
+      && isRoomAccessRequired(roomJid)
+    ) {
       isLoadingMessages.value = false;
       hasOlderMessages.value = false;
       hydratePinnedRoom(roomJid, []);
@@ -149,7 +153,7 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
 
     try {
       if (
-        options.allowAccessRetry === true
+        options.intent === "explicit-navigation"
         && xmppClient.value
         && "retryRoomAccess" in xmppClient.value
       ) {

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -9,7 +9,6 @@ import {
   type CatchupConversationFailure,
   type LiveRoomMessage,
   type RoomActivityEvent,
-  type RoomAccessChangedEvent,
   type SessionLifecycleEvent,
   type RoomAuthority,
   type RoomHats,
@@ -55,6 +54,10 @@ import { useChannelLiveMerge } from "@/channels/live-merge";
 import { useChannelChatStates } from "@/channels/chat-states";
 import { useChannelReadMarkers } from "@/channels/read-markers";
 import { useChannelMessageSearch } from "@/channels/message-search";
+import {
+  type ChannelLoadIntent,
+  useRoomAccessRequirements,
+} from "@/channels/room-access";
 import { useChatWindowVisibility } from "@/shell/window-visibility";
 
 export function useChannelMessages(
@@ -153,32 +156,10 @@ export function useChannelMessages(
   const activeTimelineRoomJid = computed(() =>
     isChannelTimelineActive.value ? currentRoomJid.value : null
   );
-  type RequiredRoomAccess = Pick<
-    Extract<RoomAccessChangedEvent, { state: "required" }>,
-    "roomJid" | "condition"
-  >;
-  const roomAccessRequirements = ref<Record<string, RequiredRoomAccess>>({});
-  const currentRoomAccessRequirement = computed(() => {
-    const roomJid = currentRoomJid.value;
-    return roomJid ? roomAccessRequirements.value[bareJidKey(roomJid)] ?? null : null;
-  });
-
-  function applyRoomAccessEvent(event: RoomAccessChangedEvent) {
-    const key = bareJidKey(event.roomJid);
-    if (event.state === "required") {
-      roomAccessRequirements.value = {
-        ...roomAccessRequirements.value,
-        [key]: {
-          roomJid: event.roomJid,
-          condition: event.condition,
-        },
-      };
-      return;
-    }
-    const next = { ...roomAccessRequirements.value };
-    delete next[key];
-    roomAccessRequirements.value = next;
-  }
+  const {
+    currentRoomAccessRequirement,
+    isRoomAccessRequired,
+  } = useRoomAccessRequirements(xmppClient, currentRoomJid);
 
   function roomJidForChannel(channelId: string): string | null {
     const currentSession = session.value;
@@ -211,7 +192,7 @@ export function useChannelMessages(
     return mergeQueuedIntoTimeline(timeline, queuedMessagesForRoom(roomJid), applyForumContext);
   }
 
-  watch(xmppClient, (client, _previousClient, onCleanup) => {
+  watch(xmppClient, (client) => {
     if (client) {
       client.setMessageHandler((msg) => {
         // Out-of-room body-bearing message: record cross-room activity
@@ -381,17 +362,10 @@ export function useChannelMessages(
       client.setRoomAvatarHandler((roomJid, hash) => {
         roomAvatarHashes.value = { ...roomAvatarHashes.value, [roomJid]: hash };
       });
-      const unsubscribeRoomAccess = client.onRoomAccessChanged?.(applyRoomAccessEvent) ?? (() => {});
-      onCleanup(unsubscribeRoomAccess);
-      roomAccessRequirements.value = {};
-      for (const requirement of client.listRoomAccessRequirements?.() ?? []) {
-        applyRoomAccessEvent(requirement);
-      }
     } else {
       // $xmppStatus is reset by XmppProvider on logout/unmount.
       clearTypingState();
       clearLiveActivityState();
-      roomAccessRequirements.value = {};
     }
   }, { immediate: true });
 
@@ -614,8 +588,7 @@ export function useChannelMessages(
     pendingEchoClientIds,
     appendQueuedMessages,
     roomJidForChannel,
-    isRoomAccessRequired: (roomJid) =>
-      !!roomAccessRequirements.value[bareJidKey(roomJid)],
+    isRoomAccessRequired,
     scrollToPinnedEdgeAndPin,
     persistLastSeen,
   });
@@ -640,7 +613,7 @@ export function useChannelMessages(
     channelId: string,
     unreadAtLoad = 0,
     metadataSeed: TimelineMessage[] = [],
-    options: { allowAccessRetry?: boolean } = {},
+    options: { intent?: ChannelLoadIntent } = {},
   ) {
     messageSearch.reset();
     return withSpan(
@@ -661,7 +634,7 @@ export function useChannelMessages(
     messages.value = [];
     clearTypingState();
     await loadMessages(activeSpaceId.value ?? "", channelId, 0, [], {
-      allowAccessRetry: true,
+      intent: "explicit-navigation",
     });
   }
 

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -9,6 +9,7 @@ import {
   type CatchupConversationFailure,
   type LiveRoomMessage,
   type RoomActivityEvent,
+  type RoomAccessChangedEvent,
   type SessionLifecycleEvent,
   type RoomAuthority,
   type RoomHats,
@@ -152,6 +153,32 @@ export function useChannelMessages(
   const activeTimelineRoomJid = computed(() =>
     isChannelTimelineActive.value ? currentRoomJid.value : null
   );
+  type RequiredRoomAccess = Pick<
+    Extract<RoomAccessChangedEvent, { state: "required" }>,
+    "roomJid" | "condition"
+  >;
+  const roomAccessRequirements = ref<Record<string, RequiredRoomAccess>>({});
+  const currentRoomAccessRequirement = computed(() => {
+    const roomJid = currentRoomJid.value;
+    return roomJid ? roomAccessRequirements.value[bareJidKey(roomJid)] ?? null : null;
+  });
+
+  function applyRoomAccessEvent(event: RoomAccessChangedEvent) {
+    const key = bareJidKey(event.roomJid);
+    if (event.state === "required") {
+      roomAccessRequirements.value = {
+        ...roomAccessRequirements.value,
+        [key]: {
+          roomJid: event.roomJid,
+          condition: event.condition,
+        },
+      };
+      return;
+    }
+    const next = { ...roomAccessRequirements.value };
+    delete next[key];
+    roomAccessRequirements.value = next;
+  }
 
   function roomJidForChannel(channelId: string): string | null {
     const currentSession = session.value;
@@ -184,7 +211,7 @@ export function useChannelMessages(
     return mergeQueuedIntoTimeline(timeline, queuedMessagesForRoom(roomJid), applyForumContext);
   }
 
-  watch(xmppClient, (client) => {
+  watch(xmppClient, (client, _previousClient, onCleanup) => {
     if (client) {
       client.setMessageHandler((msg) => {
         // Out-of-room body-bearing message: record cross-room activity
@@ -354,10 +381,17 @@ export function useChannelMessages(
       client.setRoomAvatarHandler((roomJid, hash) => {
         roomAvatarHashes.value = { ...roomAvatarHashes.value, [roomJid]: hash };
       });
+      const unsubscribeRoomAccess = client.onRoomAccessChanged?.(applyRoomAccessEvent) ?? (() => {});
+      onCleanup(unsubscribeRoomAccess);
+      roomAccessRequirements.value = {};
+      for (const requirement of client.listRoomAccessRequirements?.() ?? []) {
+        applyRoomAccessEvent(requirement);
+      }
     } else {
       // $xmppStatus is reset by XmppProvider on logout/unmount.
       clearTypingState();
       clearLiveActivityState();
+      roomAccessRequirements.value = {};
     }
   }, { immediate: true });
 
@@ -810,6 +844,7 @@ export function useChannelMessages(
     timelineEl,
     timelineEdgeScroller,
     currentRoomJid,
+    currentRoomAccessRequirement,
     typingUsers,
     roomHats,
     roomAuthority,

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -614,6 +614,8 @@ export function useChannelMessages(
     pendingEchoClientIds,
     appendQueuedMessages,
     roomJidForChannel,
+    isRoomAccessRequired: (roomJid) =>
+      !!roomAccessRequirements.value[bareJidKey(roomJid)],
     scrollToPinnedEdgeAndPin,
     persistLastSeen,
   });
@@ -638,19 +640,29 @@ export function useChannelMessages(
     channelId: string,
     unreadAtLoad = 0,
     metadataSeed: TimelineMessage[] = [],
+    options: { allowAccessRetry?: boolean } = {},
   ) {
     messageSearch.reset();
     return withSpan(
       "xmpp.initial_render",
       { "conversation.kind": "room" },
-      () => paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed),
+      () =>
+        paging.loadMessages(
+          spaceId,
+          channelId,
+          unreadAtLoad,
+          metadataSeed,
+          options,
+        ),
     );
   }
 
   async function selectChannel(channelId: string) {
     messages.value = [];
     clearTypingState();
-    await loadMessages(activeSpaceId.value ?? "", channelId);
+    await loadMessages(activeSpaceId.value ?? "", channelId, 0, [], {
+      allowAccessRetry: true,
+    });
   }
 
   function disconnect() {

--- a/chat/src/channels/room-access.ts
+++ b/chat/src/channels/room-access.ts
@@ -1,0 +1,61 @@
+import { computed, ref, watch, type ComputedRef, type Ref } from "vue";
+import {
+  bareJidKey,
+  type BrowserXmppClient,
+  type RoomAccessChangedEvent,
+} from "@/lib/xmpp-client";
+
+export type ChannelLoadIntent = "automatic" | "explicit-navigation";
+
+type RequiredRoomAccess = Pick<
+  Extract<RoomAccessChangedEvent, { state: "required" }>,
+  "roomJid" | "condition"
+>;
+
+export function useRoomAccessRequirements(
+  xmppClient: Ref<BrowserXmppClient | null>,
+  currentRoomJid: ComputedRef<string | null>,
+) {
+  const requirements = ref<Record<string, RequiredRoomAccess>>({});
+  const currentRoomAccessRequirement = computed(() => {
+    const roomJid = currentRoomJid.value;
+    return roomJid ? requirements.value[bareJidKey(roomJid)] ?? null : null;
+  });
+
+  function applyEvent(event: RoomAccessChangedEvent) {
+    const key = bareJidKey(event.roomJid);
+    if (event.state === "required") {
+      requirements.value = {
+        ...requirements.value,
+        [key]: {
+          roomJid: event.roomJid,
+          condition: event.condition,
+        },
+      };
+      return;
+    }
+    const next = { ...requirements.value };
+    delete next[key];
+    requirements.value = next;
+  }
+
+  function isRoomAccessRequired(roomJid: string): boolean {
+    return !!requirements.value[bareJidKey(roomJid)];
+  }
+
+  watch(xmppClient, (client, _previousClient, onCleanup) => {
+    requirements.value = {};
+    if (!client) return;
+
+    const unsubscribe = client.onRoomAccessChanged?.(applyEvent) ?? (() => {});
+    onCleanup(unsubscribe);
+    for (const requirement of client.listRoomAccessRequirements?.() ?? []) {
+      applyEvent(requirement);
+    }
+  }, { immediate: true });
+
+  return {
+    currentRoomAccessRequirement,
+    isRoomAccessRequired,
+  };
+}

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -126,6 +126,7 @@ const {
   authorHatsByNick,
   authorAuthorityByNick,
   activeActionError,
+  activeRoomAccessRequirement,
   activeErrorActionLabel,
   activeUploadProgress,
   setContentAreaRef,
@@ -872,6 +873,7 @@ onUnmounted(() => {
               :first-unseen-id="activeFirstUnseenId"
               :xmpp-status="messaging.xmppStatus.value"
               :action-error="activeActionError"
+              :channel-access-required="!!activeRoomAccessRequirement"
               :error-action-label="activeErrorActionLabel"
               :update-available="appUpdate.updateAvailable.value"
               :is-applying-update="appUpdate.isApplyingUpdate.value"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -78,6 +78,7 @@ const props = defineProps<{
   firstUnseenId: string | null;
   xmppStatus: XmppStatusSnapshot;
   actionError: string;
+  channelAccessRequired?: boolean;
   errorActionLabel?: string | null;
   updateAvailable: boolean;
   isApplyingUpdate: boolean;
@@ -470,7 +471,9 @@ const currentUserCanPin = computed(() => {
   const myAffiliation = props.roomAuthority[me]?.affiliation ?? "none";
   return myAffiliation === "owner" || myAffiliation === "admin";
 });
-const canShowComposer = computed(() => !!(props.channel || props.dmPeer));
+const canShowComposer = computed(() =>
+  !!(props.channel || props.dmPeer) && !props.channelAccessRequired,
+);
 const queuedMessageCount = computed(() =>
   props.messages.filter((message) =>
     message.isSelf && (message.deliveryStatus === "sending" || message.deliveryStatus === "failed")
@@ -816,7 +819,7 @@ function dayDividerLabel(createdAt: string): string {
 
     <!-- Error banner -->
     <div
-      v-if="actionError"
+      v-if="actionError && !channelAccessRequired"
       class="type-control bg-destructive/10 border-b border-destructive/20 text-destructive animate-fade-in"
       role="alert"
       aria-live="assertive"
@@ -929,12 +932,19 @@ function dayDividerLabel(createdAt: string): string {
 
     <!-- Messages -->
     <div
-      v-if="isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
+      v-if="channelAccessRequired || isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
       :ref="setMessagesContainer"
       class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 px-[var(--chat-content-inline)]"
       @scroll="onMessagesScroll"
     >
-      <MessageListSkeleton v-if="isLoadingMessages" />
+      <TimelineEmptyState
+        v-if="channelAccessRequired"
+        variant="access-required"
+        :is-forum-channel="isForumChannel"
+        :channel-name="channel?.name ?? null"
+      />
+
+      <MessageListSkeleton v-else-if="isLoadingMessages" />
 
       <TimelineEmptyState
         v-else-if="!channel && !dmPeer"

--- a/chat/src/components/chat/TimelineEmptyState.vue
+++ b/chat/src/components/chat/TimelineEmptyState.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { Hash, MessageCircle, MessagesSquare } from "lucide-vue-next";
+import { Hash, LockKeyhole, MessageCircle, MessagesSquare } from "lucide-vue-next";
 
 defineProps<{
   /**
    * pick  → no conversation selected yet.
    * quiet → conversation selected but its timeline is empty.
+   * access-required → the server denied this account access to the channel.
    */
-  variant: "pick" | "quiet";
+  variant: "pick" | "quiet" | "access-required";
   sidebarMode?: "channels" | "dms";
   isForumChannel: boolean;
   dmPeerUsername?: string | null;
@@ -15,7 +16,29 @@ defineProps<{
 </script>
 
 <template>
-  <div v-if="variant === 'pick'" class="chat-empty-state">
+  <div
+    v-if="variant === 'access-required'"
+    class="chat-empty-state"
+    role="status"
+    aria-live="polite"
+  >
+    <div class="chat-empty-state__halo">
+      <span class="chat-empty-state__halo-glow" aria-hidden="true" />
+      <span class="chat-empty-state__halo-ring chat-empty-state__halo-ring--muted">
+        <LockKeyhole class="w-6 h-6 text-primary/70" aria-hidden="true" />
+      </span>
+    </div>
+    <div class="chat-field-stack">
+      <p class="type-empty-title">
+        You need access to this channel
+      </p>
+      <p class="type-field text-muted-foreground chat-copy-measure">
+        Ask a space admin for access, then open the channel again to retry.
+      </p>
+    </div>
+  </div>
+
+  <div v-else-if="variant === 'pick'" class="chat-empty-state">
     <div class="chat-empty-state__halo">
       <span class="chat-empty-state__halo-glow" aria-hidden="true" />
       <span class="chat-empty-state__halo-ring chat-empty-state__halo-ring--muted">

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -311,6 +311,7 @@ export class ResumeStateStore {
     this.setHandle(null);
     this.persistence.clearSm();
     this.persistence.clearJoinedRooms();
+    this.persistence.clearAutoJoinBlocks?.();
   }
 
   /**

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -36,6 +36,7 @@ import type {
   XmppStatusSnapshot,
 } from "./types";
 import type { InboxEntry } from "./inbox-types";
+import type { TerminalMucJoinCondition } from "./room-auto-join-policy";
 import type { WasmPinEvent, WasmPubsubEvent } from "./wasm-types";
 
 /** Event name → payload tuple. */
@@ -79,6 +80,17 @@ export type CatchupHookInfo = {
   outcome: CatchupOutcome;
 };
 
+export type RoomAccessChangedEvent =
+  | {
+      roomJid: string;
+      state: "required";
+      condition: TerminalMucJoinCondition;
+    }
+  | {
+      roomJid: string;
+      state: "available";
+    };
+
 /**
  * Event map for `BrowserXmppClient`'s internal bus.
  *
@@ -116,6 +128,7 @@ export type ClientEvents = {
   queuedMessageStatus: [messageId: string, status: "queued" | "sending"];
   sessionLifecycle: [event: SessionLifecycleEvent];
   catchupFailure: [failure: CatchupConversationFailure];
+  roomAccessChanged: [event: RoomAccessChangedEvent];
   // Observe-only telemetry hooks (multi-listener, error-isolated via
   // `emitSafe`). Includes the background-tab RESULT_CODE_HUNG health
   // hooks (see docs/planning/hung-tab-investigation.md); the client

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2336,12 +2336,13 @@ export class BrowserXmppClient {
         ({ roomKey, fields }) => [roomKey, new Set(fields)] as const,
       ),
     );
+    const absentRoomKeysAuthoritative = topology.roomCatalogComplete
+      && topology.roomReconciliationAuthority.absentRoomKeysAuthoritative;
     const reconciliation = reconcileAutoJoinBlocks(
       this.terminallyDeniedAutoJoinRooms,
       topology.rooms,
       {
-        absentRoomKeysAuthoritative:
-          topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+        absentRoomKeysAuthoritative,
         authoritativeFingerprintFields,
       },
     );
@@ -2354,7 +2355,11 @@ export class BrowserXmppClient {
       });
     }
     if (reconciliation.changed) this.persistAutoJoinBlocks();
-    this.updateRoomDiscoveryCaches(topology, authoritativeFingerprintFields);
+    this.updateRoomDiscoveryCaches(
+      topology,
+      authoritativeFingerprintFields,
+      absentRoomKeysAuthoritative,
+    );
     if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
     const autoJoinRoomJids = topology.rooms
       .filter((room) => {
@@ -2374,6 +2379,7 @@ export class BrowserXmppClient {
       string,
       ReadonlySet<RoomCatalogFingerprintField>
     >,
+    absentRoomKeysAuthoritative: boolean,
   ): void {
     const discoveredRoomEntries = topology.rooms.flatMap((room) =>
       room.jid ? [[room.id, room.jid] as const] : []
@@ -2396,7 +2402,7 @@ export class BrowserXmppClient {
       this.hasDiscoveredRoomCatalog = true;
     } else {
       const fingerprints = new Map(this.roomCatalogFingerprints);
-      if (topology.roomReconciliationAuthority.absentRoomKeysAuthoritative) {
+      if (absentRoomKeysAuthoritative) {
         for (const key of fingerprints.keys()) {
           if (!freshRoomKeys.has(key)) fingerprints.delete(key);
         }
@@ -2411,7 +2417,7 @@ export class BrowserXmppClient {
       this.roomCatalogFingerprints = fingerprints;
     }
 
-    if (topology.roomReconciliationAuthority.absentRoomKeysAuthoritative) {
+    if (absentRoomKeysAuthoritative) {
       this.discoveredRoomJids = new Map(discoveredRoomEntries);
       this.autoJoinRoomJids = topology.rooms
         .filter((room) => room.autojoin !== false && !!room.jid)

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -91,6 +91,7 @@ import type {
   ReactionEvent,
   RoomActivityEvent,
   RoomAuthority,
+  RoomCatalogFingerprintField,
   RoomHats,
   RoomPresence,
   RosterContact,
@@ -119,6 +120,7 @@ import {
   type ResumePersistence,
 } from "./resume-persistence";
 import {
+  hasCompleteRoomCatalogFingerprintAuthority,
   reconcileAutoJoinBlocks,
   roomCatalogFingerprint,
   terminalMucJoinCondition,
@@ -2329,8 +2331,10 @@ export class BrowserXmppClient {
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
-    const authoritativeRoomKeys = new Set(
-      topology.roomReconciliationAuthority.fingerprintRoomKeys,
+    const authoritativeFingerprintFields = new Map(
+      topology.roomReconciliationAuthority.roomFingerprints.map(
+        ({ roomKey, fields }) => [roomKey, new Set(fields)] as const,
+      ),
     );
     const reconciliation = reconcileAutoJoinBlocks(
       this.terminallyDeniedAutoJoinRooms,
@@ -2338,7 +2342,7 @@ export class BrowserXmppClient {
       {
         absentRoomKeysAuthoritative:
           topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
-        authoritativeRoomKeys,
+        authoritativeFingerprintFields,
       },
     );
     this.terminallyDeniedAutoJoinRooms = reconciliation.blocks;
@@ -2350,10 +2354,15 @@ export class BrowserXmppClient {
       });
     }
     if (reconciliation.changed) this.persistAutoJoinBlocks();
-    this.updateRoomDiscoveryCaches(topology, authoritativeRoomKeys);
+    this.updateRoomDiscoveryCaches(topology, authoritativeFingerprintFields);
     if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
     const autoJoinRoomJids = topology.rooms
-      .filter((room) => room.autojoin !== false && !!room.jid)
+      .filter((room) => {
+        if (room.autojoin === false || !room.jid) return false;
+        const key = this.roomJoinKey(room.jid);
+        return topology.roomCatalogComplete
+          || authoritativeFingerprintFields.get(key)?.has("autojoin");
+      })
       .map((room) => room.jid!);
     if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
     return topology;
@@ -2361,7 +2370,10 @@ export class BrowserXmppClient {
 
   private updateRoomDiscoveryCaches(
     topology: DiscoveredTopology,
-    authoritativeRoomKeys: ReadonlySet<string>,
+    authoritativeFingerprintFields: ReadonlyMap<
+      string,
+      ReadonlySet<RoomCatalogFingerprintField>
+    >,
   ): void {
     const discoveredRoomEntries = topology.rooms.flatMap((room) =>
       room.jid ? [[room.id, room.jid] as const] : []
@@ -2371,7 +2383,7 @@ export class BrowserXmppClient {
     );
     const authoritativeRooms = topology.rooms.filter((room) => {
       const key = room.jid ? this.roomJoinKey(room.jid) : "";
-      return !!key && authoritativeRoomKeys.has(key);
+      return !!key && !!authoritativeFingerprintFields.get(key)?.size;
     });
 
     if (topology.roomCatalogComplete) {
@@ -2390,7 +2402,11 @@ export class BrowserXmppClient {
         }
       }
       for (const room of authoritativeRooms) {
-        fingerprints.set(this.roomJoinKey(room.jid!), roomCatalogFingerprint(room));
+        const key = this.roomJoinKey(room.jid!);
+        const fields = authoritativeFingerprintFields.get(key)!;
+        if (hasCompleteRoomCatalogFingerprintAuthority(fields)) {
+          fingerprints.set(key, roomCatalogFingerprint(room));
+        }
       }
       this.roomCatalogFingerprints = fingerprints;
     }
@@ -2414,8 +2430,10 @@ export class BrowserXmppClient {
       const roomJid = room.jid!;
       const key = this.roomJoinKey(roomJid);
       discoveredRoomJids.set(room.id, roomJid);
-      autoJoinRooms.delete(key);
-      if (room.autojoin !== false) autoJoinRooms.set(key, roomJid);
+      if (authoritativeFingerprintFields.get(key)?.has("autojoin")) {
+        autoJoinRooms.delete(key);
+        if (room.autojoin !== false) autoJoinRooms.set(key, roomJid);
+      }
     }
     this.discoveredRoomJids = discoveredRoomJids;
     this.autoJoinRoomJids = [...autoJoinRooms.values()];

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1389,9 +1389,27 @@ export class BrowserXmppClient {
     await Promise.allSettled(workers);
   }
 
-  async switchRoom(_spaceId: string, channelId: string) {
+  async retryRoomAccess(spaceId: string, channelId: string): Promise<void> {
+    const roomJid = this.roomJidForChannel(channelId);
+    if (!this.terminallyDeniedAutoJoinRooms.has(this.roomJoinKey(roomJid))) return;
+    await this.switchRoom(spaceId, channelId, { allowAccessRetry: true });
+  }
+
+  async switchRoom(
+    _spaceId: string,
+    channelId: string,
+    options: { allowAccessRetry?: boolean } = {},
+  ) {
     await this.connect();
     const nextRoom = this.roomJidForChannel(channelId);
+    if (
+      options.allowAccessRetry !== true
+      && this.terminallyDeniedAutoJoinRooms.has(this.roomJoinKey(nextRoom))
+    ) {
+      this.currentRoom = nextRoom;
+      this.dispatchFocusedRoomHandlers();
+      throw new Error("You need access to this channel.");
+    }
     if (this.roomSwitchPromise) {
       if (this.roomSwitchTarget === nextRoom) return this.roomSwitchPromise;
       await this.roomSwitchPromise.catch(() => undefined);
@@ -2306,6 +2324,7 @@ export class BrowserXmppClient {
     const reconciliation = reconcileAutoJoinBlocks(
       this.terminallyDeniedAutoJoinRooms,
       topology.rooms,
+      { catalogComplete: topology.roomCatalogComplete },
     );
     this.terminallyDeniedAutoJoinRooms = reconciliation.blocks;
     for (const key of reconciliation.unblockedRoomKeys) {
@@ -2316,19 +2335,27 @@ export class BrowserXmppClient {
       });
     }
     if (reconciliation.changed) this.persistAutoJoinBlocks();
-    this.roomCatalogFingerprints = new Map(
-      topology.rooms.flatMap((room) => {
-        const key = room.jid ? this.roomJoinKey(room.jid) : "";
-        return key ? [[key, roomCatalogFingerprint(room)] as const] : [];
-      }),
-    );
-    this.hasDiscoveredRoomCatalog = true;
+    if (topology.roomCatalogComplete) {
+      this.roomCatalogFingerprints = new Map(
+        topology.rooms.flatMap((room) => {
+          const key = room.jid ? this.roomJoinKey(room.jid) : "";
+          return key ? [[key, roomCatalogFingerprint(room)] as const] : [];
+        }),
+      );
+      this.hasDiscoveredRoomCatalog = true;
+    }
     if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
-    this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : []));
     const autoJoinRoomJids = topology.rooms
       .filter((room) => room.autojoin !== false && !!room.jid)
       .map((room) => room.jid!);
-    this.autoJoinRoomJids = autoJoinRoomJids;
+    if (topology.roomCatalogComplete) {
+      this.discoveredRoomJids = new Map(
+        topology.rooms.flatMap((room) =>
+          room.jid ? [[room.id, room.jid] as const] : []
+        ),
+      );
+      this.autoJoinRoomJids = autoJoinRoomJids;
+    }
     if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
     return topology;
   }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -710,6 +710,10 @@ export class BrowserXmppClient {
     return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
   }
 
+  private roomIsTerminallyDenied(roomJid: string): boolean {
+    return this.terminallyDeniedAutoJoinRooms.has(this.roomJoinKey(roomJid));
+  }
+
   private markMucReadyFromSelfPresence(roomJid: string): void {
     const key = this.roomJoinKey(roomJid);
     if (!key) return;
@@ -1365,7 +1369,7 @@ export class BrowserXmppClient {
       const key = this.roomJoinKey(roomJid);
       if (!key || seenThisCall.has(key)) continue;
       seenThisCall.add(key);
-      if (this.terminallyDeniedAutoJoinRooms.has(key)) continue;
+      if (this.roomIsTerminallyDenied(roomJid)) continue;
       if (this.autoJoinAttemptedRoomKeys.has(key)) continue;
       this.autoJoinAttemptedRoomKeys.add(key);
       queue.push(roomJid);
@@ -1391,20 +1395,24 @@ export class BrowserXmppClient {
 
   async retryRoomAccess(spaceId: string, channelId: string): Promise<void> {
     const roomJid = this.roomJidForChannel(channelId);
-    if (!this.terminallyDeniedAutoJoinRooms.has(this.roomJoinKey(roomJid))) return;
-    await this.switchRoom(spaceId, channelId, { allowAccessRetry: true });
+    if (!this.roomIsTerminallyDenied(roomJid)) return;
+    await this.switchRoomForIntent(spaceId, channelId, "explicit-navigation");
   }
 
-  async switchRoom(
+  async switchRoom(spaceId: string, channelId: string) {
+    await this.switchRoomForIntent(spaceId, channelId, "automatic");
+  }
+
+  private async switchRoomForIntent(
     _spaceId: string,
     channelId: string,
-    options: { allowAccessRetry?: boolean } = {},
+    intent: "automatic" | "explicit-navigation",
   ) {
     await this.connect();
     const nextRoom = this.roomJidForChannel(channelId);
     if (
-      options.allowAccessRetry !== true
-      && this.terminallyDeniedAutoJoinRooms.has(this.roomJoinKey(nextRoom))
+      intent !== "explicit-navigation"
+      && this.roomIsTerminallyDenied(nextRoom)
     ) {
       this.currentRoom = nextRoom;
       this.dispatchFocusedRoomHandlers();
@@ -2570,6 +2578,7 @@ export class BrowserXmppClient {
   }
 
   private async flushQueuedRoomAfterJoin(xmpp: XmppClientInstance, roomJid: string): Promise<void> {
+    if (this.roomIsTerminallyDenied(roomJid)) return;
     try {
       await this.ensureJoined(roomJid);
       if (this.xmpp !== xmpp) return;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -122,6 +122,7 @@ import {
 import {
   hasCompleteRoomCatalogFingerprintAuthority,
   reconcileAutoJoinBlocks,
+  ROOM_CATALOG_FINGERPRINT_FIELDS,
   roomCatalogFingerprint,
   terminalMucJoinCondition,
   type RoomAutoJoinBlock,
@@ -465,8 +466,11 @@ export class BrowserXmppClient {
   // out of automatic fan-out while still allowing `switchRoom` to retry
   // explicitly when the user navigates back.
   private terminallyDeniedAutoJoinRooms = new Map<string, RoomAutoJoinBlock>();
-  private roomCatalogFingerprints = new Map<string, string>();
-  private hasDiscoveredRoomCatalog = false;
+  private currentRoomCatalogFingerprintEvidence = new Map<
+    string,
+    Pick<RoomAutoJoinBlock, "catalogFingerprint" | "catalogFingerprintFields">
+  >();
+  private roomDiscoveryGeneration = 0;
   private uploadServiceJid: string | null = null;
   private mucServiceJid = "";
   private discoveredRoomJids = new Map<string, string>();
@@ -784,12 +788,12 @@ export class BrowserXmppClient {
     // microtasks later and its token guard makes this early delete safe).
     this.revokeMucReadiness(room);
     if (terminalAuthorizationCondition) {
+      const catalogFingerprintEvidence =
+        this.currentRoomCatalogFingerprintEvidence.get(key);
       this.terminallyDeniedAutoJoinRooms.set(key, {
         roomJid: key,
         condition: terminalAuthorizationCondition,
-        ...(this.hasDiscoveredRoomCatalog
-          ? { catalogFingerprint: this.roomCatalogFingerprints.get(key) ?? null }
-          : {}),
+        ...catalogFingerprintEvidence,
       });
       this.persistAutoJoinBlocks();
       this.events.emit("roomAccessChanged", {
@@ -1130,6 +1134,8 @@ export class BrowserXmppClient {
 
   async disconnect() {
     this.destroying = true;
+    this.roomDiscoveryGeneration += 1;
+    this.currentRoomCatalogFingerprintEvidence.clear();
     this.disarmOnlineRecovery();
     this.clearReconnectTimer();
     // F3: cancel the pending connect attempt outright. Bump the epoch
@@ -2330,7 +2336,20 @@ export class BrowserXmppClient {
   }
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
+    const discoveryGeneration = ++this.roomDiscoveryGeneration;
+    // A new refresh invalidates the previous observation until this run
+    // proves each room's complete fingerprint again. A terminal denial
+    // arriving while discovery is degraded or in flight must not inherit
+    // an older pre-denial membership snapshot.
+    this.currentRoomCatalogFingerprintEvidence.clear();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    if (
+      this.destroying
+      || this.xmpp !== xmpp
+      || discoveryGeneration !== this.roomDiscoveryGeneration
+    ) {
+      return topology;
+    }
     const authoritativeFingerprintFields = new Map(
       topology.roomReconciliationAuthority.roomFingerprints.map(
         ({ roomKey, fields }) => [roomKey, new Set(fields)] as const,
@@ -2384,38 +2403,28 @@ export class BrowserXmppClient {
     const discoveredRoomEntries = topology.rooms.flatMap((room) =>
       room.jid ? [[room.id, room.jid] as const] : []
     );
-    const freshRoomKeys = new Set(
-      discoveredRoomEntries.map(([, roomJid]) => this.roomJoinKey(roomJid)),
-    );
     const authoritativeRooms = topology.rooms.filter((room) => {
       const key = room.jid ? this.roomJoinKey(room.jid) : "";
       return !!key && !!authoritativeFingerprintFields.get(key)?.size;
     });
 
-    if (topology.roomCatalogComplete) {
-      this.roomCatalogFingerprints = new Map(
-        topology.rooms.flatMap((room) => {
-          const key = room.jid ? this.roomJoinKey(room.jid) : "";
-          return key ? [[key, roomCatalogFingerprint(room)] as const] : [];
-        }),
-      );
-      this.hasDiscoveredRoomCatalog = true;
-    } else {
-      const fingerprints = new Map(this.roomCatalogFingerprints);
-      if (absentRoomKeysAuthoritative) {
-        for (const key of fingerprints.keys()) {
-          if (!freshRoomKeys.has(key)) fingerprints.delete(key);
-        }
-      }
-      for (const room of authoritativeRooms) {
+    this.currentRoomCatalogFingerprintEvidence = new Map(
+      authoritativeRooms.flatMap((room) => {
         const key = this.roomJoinKey(room.jid!);
         const fields = authoritativeFingerprintFields.get(key)!;
-        if (hasCompleteRoomCatalogFingerprintAuthority(fields)) {
-          fingerprints.set(key, roomCatalogFingerprint(room));
-        }
-      }
-      this.roomCatalogFingerprints = fingerprints;
-    }
+        return [[key, {
+          catalogFingerprint: roomCatalogFingerprint(room),
+          ...(hasCompleteRoomCatalogFingerprintAuthority(fields)
+            ? {}
+            : {
+              catalogFingerprintFields:
+                ROOM_CATALOG_FINGERPRINT_FIELDS.filter((field) =>
+                  fields.has(field)
+                ),
+            }),
+        }] as const];
+      }),
+    );
 
     if (absentRoomKeysAuthoritative) {
       this.discoveredRoomJids = new Map(discoveredRoomEntries);
@@ -2732,6 +2741,8 @@ export class BrowserXmppClient {
     // New epoch: a genuine fresh cycle must be free to rejoin (#1221),
     // and the next handle must run its own session-ready setup.
     this.autoJoinAttemptedRoomKeys.clear();
+    this.roomDiscoveryGeneration += 1;
+    this.currentRoomCatalogFingerprintEvidence.clear();
     this.sessionReadyHandledXmpp = null;
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2329,10 +2329,17 @@ export class BrowserXmppClient {
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    const authoritativeRoomKeys = new Set(
+      topology.roomReconciliationAuthority.fingerprintRoomKeys,
+    );
     const reconciliation = reconcileAutoJoinBlocks(
       this.terminallyDeniedAutoJoinRooms,
       topology.rooms,
-      { catalogComplete: topology.roomCatalogComplete },
+      {
+        absentRoomKeysAuthoritative:
+          topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+        authoritativeRoomKeys,
+      },
     );
     this.terminallyDeniedAutoJoinRooms = reconciliation.blocks;
     for (const key of reconciliation.unblockedRoomKeys) {
@@ -2343,6 +2350,30 @@ export class BrowserXmppClient {
       });
     }
     if (reconciliation.changed) this.persistAutoJoinBlocks();
+    this.updateRoomDiscoveryCaches(topology, authoritativeRoomKeys);
+    if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
+    const autoJoinRoomJids = topology.rooms
+      .filter((room) => room.autojoin !== false && !!room.jid)
+      .map((room) => room.jid!);
+    if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
+    return topology;
+  }
+
+  private updateRoomDiscoveryCaches(
+    topology: DiscoveredTopology,
+    authoritativeRoomKeys: ReadonlySet<string>,
+  ): void {
+    const discoveredRoomEntries = topology.rooms.flatMap((room) =>
+      room.jid ? [[room.id, room.jid] as const] : []
+    );
+    const freshRoomKeys = new Set(
+      discoveredRoomEntries.map(([, roomJid]) => this.roomJoinKey(roomJid)),
+    );
+    const authoritativeRooms = topology.rooms.filter((room) => {
+      const key = room.jid ? this.roomJoinKey(room.jid) : "";
+      return !!key && authoritativeRoomKeys.has(key);
+    });
+
     if (topology.roomCatalogComplete) {
       this.roomCatalogFingerprints = new Map(
         topology.rooms.flatMap((room) => {
@@ -2351,21 +2382,43 @@ export class BrowserXmppClient {
         }),
       );
       this.hasDiscoveredRoomCatalog = true;
+    } else {
+      const fingerprints = new Map(this.roomCatalogFingerprints);
+      if (topology.roomReconciliationAuthority.absentRoomKeysAuthoritative) {
+        for (const key of fingerprints.keys()) {
+          if (!freshRoomKeys.has(key)) fingerprints.delete(key);
+        }
+      }
+      for (const room of authoritativeRooms) {
+        fingerprints.set(this.roomJoinKey(room.jid!), roomCatalogFingerprint(room));
+      }
+      this.roomCatalogFingerprints = fingerprints;
     }
-    if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
-    const autoJoinRoomJids = topology.rooms
-      .filter((room) => room.autojoin !== false && !!room.jid)
-      .map((room) => room.jid!);
-    if (topology.roomCatalogComplete) {
-      this.discoveredRoomJids = new Map(
-        topology.rooms.flatMap((room) =>
-          room.jid ? [[room.id, room.jid] as const] : []
-        ),
-      );
-      this.autoJoinRoomJids = autoJoinRoomJids;
+
+    if (topology.roomReconciliationAuthority.absentRoomKeysAuthoritative) {
+      this.discoveredRoomJids = new Map(discoveredRoomEntries);
+      this.autoJoinRoomJids = topology.rooms
+        .filter((room) => room.autojoin !== false && !!room.jid)
+        .map((room) => room.jid!);
+      return;
     }
-    if (autoJoinRoomJids.length > 0) void this.fanOutAutoJoin(autoJoinRoomJids);
-    return topology;
+
+    const discoveredRoomJids = new Map(this.discoveredRoomJids);
+    const autoJoinRooms = new Map(
+      this.autoJoinRoomJids.flatMap((roomJid) => {
+        const key = this.roomJoinKey(roomJid);
+        return key ? [[key, roomJid] as const] : [];
+      }),
+    );
+    for (const room of authoritativeRooms) {
+      const roomJid = room.jid!;
+      const key = this.roomJoinKey(roomJid);
+      discoveredRoomJids.set(room.id, roomJid);
+      autoJoinRooms.delete(key);
+      if (room.autojoin !== false) autoJoinRooms.set(key, roomJid);
+    }
+    this.discoveredRoomJids = discoveredRoomJids;
+    this.autoJoinRoomJids = [...autoJoinRooms.values()];
   }
   async listRoomMembers(channelId: string, options?: ListRoomMembersOptions): Promise<MemberSummary[]> { return this.mucAdmin.listRoomMembers(channelId, options); }
   async setRoomAffiliation(channelId: string, jid: string, affiliation: MemberSummary["affiliation"]): Promise<void> { return this.mucAdmin.setRoomAffiliation(channelId, jid, affiliation); }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -41,6 +41,7 @@ import type {
   ClientEvents,
   MdsDisplayedEntry,
   PubsubEvent,
+  RoomAccessChangedEvent,
 } from "./client-events";
 import {
   OfflineSendQueue,
@@ -117,6 +118,12 @@ import {
   createLocalStorageResumePersistence,
   type ResumePersistence,
 } from "./resume-persistence";
+import {
+  reconcileAutoJoinBlocks,
+  roomCatalogFingerprint,
+  terminalMucJoinCondition,
+  type RoomAutoJoinBlock,
+} from "./room-auto-join-policy";
 import { clearDmCallJoinCacheForAccount } from "@/lib/calls/dm-call-join-cache";
 import {
   discoverExtensionCommands,
@@ -451,6 +458,13 @@ export class BrowserXmppClient {
   // later trigger, and the three fan-out triggers per session coalesce.
   // Cleared on disconnect so a genuine fresh cycle rejoins.
   private readonly autoJoinAttemptedRoomKeys = new Set<string>();
+  // XEP-0045 terminal room-entry denials are not transient join failures:
+  // reconnecting cannot grant membership or undo a ban. Keep those rooms
+  // out of automatic fan-out while still allowing `switchRoom` to retry
+  // explicitly when the user navigates back.
+  private terminallyDeniedAutoJoinRooms = new Map<string, RoomAutoJoinBlock>();
+  private roomCatalogFingerprints = new Map<string, string>();
+  private hasDiscoveredRoomCatalog = false;
   private uploadServiceJid: string | null = null;
   private mucServiceJid = "";
   private discoveredRoomJids = new Map<string, string>();
@@ -648,6 +662,10 @@ export class BrowserXmppClient {
       },
     });
     this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
+    for (const block of this.resumePersistence.loadAutoJoinBlocks?.() ?? []) {
+      const key = this.roomJoinKey(block.roomJid);
+      if (key) this.terminallyDeniedAutoJoinRooms.set(key, { ...block, roomJid: key });
+    }
   }
 
   private trustedLinkPreviewMediaOrigin(): string | null {
@@ -744,16 +762,41 @@ export class BrowserXmppClient {
     if (!waiter) return false;
     if (errorNick !== waiter.requestedNick) return false;
 
-    waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
+    const terminalAuthorizationCondition = terminalMucJoinCondition(
+      presence.error_type,
+      presence.error_condition,
+    );
+    waiter?.reject(new Error(
+      terminalAuthorizationCondition
+        ? "You need access to this channel."
+        : "Channel presence was rejected. Try again in a moment.",
+    ));
     // Fully revoke — including the pending joinedMucs promise and its
     // token — BEFORE emitting, so an error listener that synchronously
     // retries the join starts a fresh one instead of awaiting the doomed
     // rejected entry (ensureJoined's own catch cleanup only lands several
     // microtasks later and its token guard makes this early delete safe).
     this.revokeMucReadiness(room);
+    if (terminalAuthorizationCondition) {
+      this.terminallyDeniedAutoJoinRooms.set(key, {
+        roomJid: key,
+        condition: terminalAuthorizationCondition,
+        ...(this.hasDiscoveredRoomCatalog
+          ? { catalogFingerprint: this.roomCatalogFingerprints.get(key) ?? null }
+          : {}),
+      });
+      this.persistAutoJoinBlocks();
+      this.events.emit("roomAccessChanged", {
+        roomJid: key,
+        state: "required",
+        condition: terminalAuthorizationCondition,
+      });
+      this.resumedSessionRoomKeys.delete(key);
+      if (this.retainedJoinedRoomJids.delete(key)) this.persistRetainedJoinedRooms();
+    }
     this.emitError({
       kind: "muc-join",
-      recoverable: true,
+      recoverable: !terminalAuthorizationCondition,
       detail: `room join rejected — ${room}`,
       roomLocalpart: jidLocalpart(room),
       ...stanzaErrorContext({
@@ -809,6 +852,14 @@ export class BrowserXmppClient {
   onSendEnqueued(hook: (info: { kind: "room" | "dm"; reason: string }) => void) { this.events.on("sendEnqueued", hook); }
   onQueueDepthChange(hook: (depth: { kind: "room" | "dm"; persisted: number; inflight: number }) => void) { this.events.on("queueDepthChange", hook); }
   onError(hook: (event: XmppErrorEvent) => void) { this.events.on("error", hook); }
+  listRoomAccessRequirements(): ReadonlyArray<Extract<RoomAccessChangedEvent, { state: "required" }>> {
+    return [...this.terminallyDeniedAutoJoinRooms.values()].map((block) => ({
+      roomJid: block.roomJid,
+      state: "required",
+      condition: block.condition,
+    }));
+  }
+  onRoomAccessChanged(hook: (event: RoomAccessChangedEvent) => void) { return this.events.on("roomAccessChanged", hook); }
   onReconnectScheduled(hook: (info: { attempt: number; delayMs: number }) => void) { this.events.on("reconnectScheduled", hook); }
   onCatchup(hook: (info: CatchupHookInfo) => void) { this.events.on("catchup", hook); }
   onResumeDrain(hook: (info: { buffered: number; durationMs: number }) => void) { this.events.on("resumeDrain", hook); }
@@ -1219,6 +1270,7 @@ export class BrowserXmppClient {
       }
       if (!existingToken && !this.joinedMucs.has(key)) return;
       this.joinedMucReady.add(key);
+      this.clearAutoJoinBlock(key);
       this.rememberJoinedRoom(roomJid);
       return;
     }
@@ -1230,6 +1282,7 @@ export class BrowserXmppClient {
       await promise;
       if (this.joinedMucJoinTokens.get(key) === joinToken) {
         this.joinedMucReady.add(key);
+        this.clearAutoJoinBlock(key);
         this.rememberJoinedRoom(roomJid);
       }
     } catch (err) {
@@ -1252,6 +1305,21 @@ export class BrowserXmppClient {
 
   private persistRetainedJoinedRooms(): void {
     this.resumePersistence.saveJoinedRooms([...this.retainedJoinedRoomJids]);
+  }
+
+  private persistAutoJoinBlocks(): void {
+    this.resumePersistence.saveAutoJoinBlocks?.([...this.terminallyDeniedAutoJoinRooms.values()]);
+  }
+
+  private clearAutoJoinBlock(roomJid: string): void {
+    const key = this.roomJoinKey(roomJid);
+    if (!key || !this.terminallyDeniedAutoJoinRooms.delete(key)) return;
+    this.autoJoinAttemptedRoomKeys.delete(key);
+    this.persistAutoJoinBlocks();
+    this.events.emit("roomAccessChanged", {
+      roomJid: key,
+      state: "available",
+    });
   }
 
   private async performMucJoin(roomJid: string): Promise<void> {
@@ -1297,6 +1365,7 @@ export class BrowserXmppClient {
       const key = this.roomJoinKey(roomJid);
       if (!key || seenThisCall.has(key)) continue;
       seenThisCall.add(key);
+      if (this.terminallyDeniedAutoJoinRooms.has(key)) continue;
       if (this.autoJoinAttemptedRoomKeys.has(key)) continue;
       this.autoJoinAttemptedRoomKeys.add(key);
       queue.push(roomJid);
@@ -2234,6 +2303,26 @@ export class BrowserXmppClient {
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    const reconciliation = reconcileAutoJoinBlocks(
+      this.terminallyDeniedAutoJoinRooms,
+      topology.rooms,
+    );
+    this.terminallyDeniedAutoJoinRooms = reconciliation.blocks;
+    for (const key of reconciliation.unblockedRoomKeys) {
+      this.autoJoinAttemptedRoomKeys.delete(key);
+      this.events.emit("roomAccessChanged", {
+        roomJid: key,
+        state: "available",
+      });
+    }
+    if (reconciliation.changed) this.persistAutoJoinBlocks();
+    this.roomCatalogFingerprints = new Map(
+      topology.rooms.flatMap((room) => {
+        const key = room.jid ? this.roomJoinKey(room.jid) : "";
+        return key ? [[key, roomCatalogFingerprint(room)] as const] : [];
+      }),
+    );
+    this.hasDiscoveredRoomCatalog = true;
     if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
     this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : []));
     const autoJoinRoomJids = topology.rooms

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -2,7 +2,12 @@ import type { WaddleClient } from "@waddle/xmpp-client-wasm";
 import { normalizeChannelType } from "@/lib/channel-types";
 import { reportError } from "@/lib/telemetry";
 import { XMPP_ERROR_CONDITIONS } from "./types";
-import type { DiscoveredChannel, DiscoveredSpace, DiscoveredTopology } from "./types";
+import type {
+  DiscoveredChannel,
+  DiscoveredSpace,
+  DiscoveredTopology,
+  RoomCatalogFingerprintField,
+} from "./types";
 import { bareJidKey, barePeerJid, jidDomain, jidLocalpart } from "./jid";
 import { FIELD_PIN_PERMISSION } from "./protocol-helpers";
 import { stanzaErrorContext } from "./stanza-error-context";
@@ -472,7 +477,10 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   let roomCatalogComplete = true;
   let bookmarkCatalogComplete = true;
   let mucCatalogComplete = true;
+  let userBookmarksComplete = true;
   const bookmarkedRooms = new Map<string, { spaceId?: string; autojoin: boolean; name?: string }>();
+  const spaceBookmarkedRoomJids = new Set<string>();
+  const userBookmarkedRoomJids = new Set<string>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
 
@@ -500,7 +508,9 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
         const bookmarks = await sendPubsubItems(xmpp, services.spaces, item.node);
         for (const bookmark of bookmarks) {
           if (bookmark.jid) {
-            bookmarkedRooms.set(barePeerJid(bookmark.jid), {
+            const roomJid = barePeerJid(bookmark.jid);
+            spaceBookmarkedRoomJids.add(roomJid);
+            bookmarkedRooms.set(roomJid, {
               spaceId,
               autojoin: bookmark.autojoin ?? false,
               name: bookmark.name,
@@ -523,6 +533,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     for (const bookmark of userBookmarks) {
       if (!bookmark.jid) continue;
       const roomJid = barePeerJid(bookmark.jid);
+      userBookmarkedRoomJids.add(roomJid);
       const existing = bookmarkedRooms.get(roomJid);
       bookmarkedRooms.set(roomJid, {
         ...existing,
@@ -533,6 +544,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   } catch {
     roomCatalogComplete = false;
     bookmarkCatalogComplete = false;
+    userBookmarksComplete = false;
   }
 
   // Narrow try/catch JUST around `sendDiscoItems`: a wedged muc service
@@ -621,14 +633,33 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   });
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
-  const authoritativeRoomFingerprintKeys = bookmarkCatalogComplete
-    ? rooms.flatMap((room) => {
-        const roomJid = room.jid ? barePeerJid(room.jid) : "";
-        return roomJid && fingerprintCompleteRoomJids.has(roomJid)
-          ? [bareJidKey(roomJid)]
-          : [];
-      })
-    : [];
+  const authoritativeRoomFingerprints = rooms.flatMap((room) => {
+    const roomJid = room.jid ? barePeerJid(room.jid) : "";
+    if (!roomJid || !fingerprintCompleteRoomJids.has(roomJid)) return [];
+    if (bookmarkCatalogComplete) {
+      return [{
+        roomKey: bareJidKey(roomJid),
+        fields: [
+          "spaceId",
+          "autojoin",
+          "isGroupDm",
+          "isBookmarked",
+        ] satisfies RoomCatalogFingerprintField[],
+      }];
+    }
+    const hasSpaceBookmark = spaceBookmarkedRoomJids.has(roomJid);
+    const hasUserBookmark = userBookmarkedRoomJids.has(roomJid);
+    if (!hasSpaceBookmark && !hasUserBookmark) return [];
+    const fields: RoomCatalogFingerprintField[] = [
+      "isGroupDm",
+      "isBookmarked",
+    ];
+    if (hasSpaceBookmark) fields.push("spaceId");
+    if (hasUserBookmark || (hasSpaceBookmark && userBookmarksComplete)) {
+      fields.push("autojoin");
+    }
+    return [{ roomKey: bareJidKey(roomJid), fields }];
+  });
   return {
     spaces,
     rooms: rooms.map((room, position) => ({ ...room, position, ...(room.jid && roomSpaceIds.get(barePeerJid(room.jid)) ? { standalone: false } : { standalone: room.standalone ?? true }) })),
@@ -636,7 +667,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     roomReconciliationAuthority: {
       absentRoomKeysAuthoritative:
         bookmarkCatalogComplete && mucCatalogComplete,
-      fingerprintRoomKeys: authoritativeRoomFingerprintKeys,
+      roomFingerprints: authoritativeRoomFingerprints,
     },
     serverRole,
     services,

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -568,6 +568,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     return {
       ...roomWithoutSpace,
       position,
+      isBookmarked: !!bookmark,
       ...(bookmark?.spaceId
         ? { spaceId: bookmark.spaceId, standalone: false, autojoin: bookmark.autojoin }
         : parentSpaceId

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -482,6 +482,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
         if (!isSpacesNodeInfo(info)) continue;
         if (info) role = parseDiscoveryRole(info.fields.get("pubsub#affiliation") ?? null) ?? serverRole;
       } catch {
+        roomCatalogComplete = false;
         continue;
       }
       try {
@@ -495,10 +496,14 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
             });
           }
         }
-      } catch {}
+      } catch {
+        roomCatalogComplete = false;
+      }
       spaces.push({ id: spaceId, name: item.name ?? spaceId, role });
     }
-  } catch {}
+  } catch {
+    roomCatalogComplete = false;
+  }
 
   try {
     const userBookmarks = await sendPubsubItems(xmpp, barePeerJid(jid), NS_BOOKMARKS_1);
@@ -512,7 +517,9 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
         name: bookmark.name ?? existing?.name,
       });
     }
-  } catch {}
+  } catch {
+    roomCatalogComplete = false;
+  }
 
   // Narrow try/catch JUST around `sendDiscoItems`: a wedged muc service
   // (which now times out via `withIqTimeout` instead of hanging forever)

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -461,6 +461,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const domain = jidDomain(jid);
   const services = await discoverComponentServices(xmpp, domain, jid);
   let rooms: DiscoveredChannel[] = [];
+  let roomCatalogComplete = true;
   const bookmarkedRooms = new Map<string, { spaceId?: string; autojoin: boolean; name?: string }>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
@@ -530,6 +531,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     // sendDiscoItems already logged via logDiscoFailure; here we just
     // continue with an empty room list. The cause is observable in the
     // console for diagnostics.
+    roomCatalogComplete = false;
     void err;
   }
   const roomItems: Array<{ jid?: string; name?: string; bookmarkOnly?: boolean }> =
@@ -549,6 +551,9 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
     ),
   );
+  if (hydratedSettled.some((entry) => entry.status === "rejected")) {
+    roomCatalogComplete = false;
+  }
   const hydrated = hydratedSettled.flatMap((entry, index) => {
     const source = roomItems[index]!;
     if (entry.status === "fulfilled") {
@@ -583,6 +588,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   return {
     spaces,
     rooms: rooms.map((room, position) => ({ ...room, position, ...(room.jid && roomSpaceIds.get(barePeerJid(room.jid)) ? { standalone: false } : { standalone: room.standalone ?? true }) })),
+    roomCatalogComplete,
     serverRole,
     services,
   };

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -3,7 +3,7 @@ import { normalizeChannelType } from "@/lib/channel-types";
 import { reportError } from "@/lib/telemetry";
 import { XMPP_ERROR_CONDITIONS } from "./types";
 import type { DiscoveredChannel, DiscoveredSpace, DiscoveredTopology } from "./types";
-import { barePeerJid, jidDomain, jidLocalpart } from "./jid";
+import { bareJidKey, barePeerJid, jidDomain, jidLocalpart } from "./jid";
 import { FIELD_PIN_PERMISSION } from "./protocol-helpers";
 import { stanzaErrorContext } from "./stanza-error-context";
 
@@ -424,16 +424,24 @@ export function applyDiscoInfoToChannel(room: DiscoveredChannel, info: DiscoInfo
   };
 }
 
-async function hydrateRoomInfo(xmpp: HybridClient, room: DiscoveredChannel): Promise<DiscoveredChannel> {
-  if (!room.jid) return room;
+type RoomInfoHydration = {
+  room: DiscoveredChannel;
+  fingerprintComplete: boolean;
+};
+
+async function hydrateRoomInfo(xmpp: HybridClient, room: DiscoveredChannel): Promise<RoomInfoHydration> {
+  if (!room.jid) return { room, fingerprintComplete: false };
   // No internal try/catch: callers wrap this in `Promise.allSettled` and
   // map rejected entries to the unhydrated `channelFromRoom` record, so a
   // local catch here would make the outer rejection branch unreachable
   // dead code. Single resilience layer (one site to reason about), not
   // two redundant ones.
   const info = await sendDiscoInfo(xmpp, room.jid);
-  if (!info) return room;
-  return applyDiscoInfoToChannel(room, info);
+  if (!info) return { room, fingerprintComplete: false };
+  return {
+    room: applyDiscoInfoToChannel(room, info),
+    fingerprintComplete: true,
+  };
 }
 
 export async function discoverChannels(xmpp: HybridClient, jid: string): Promise<DiscoveredChannel[]> {
@@ -451,7 +459,7 @@ export async function discoverChannels(xmpp: HybridClient, jid: string): Promise
   );
   const hydrated = settled.map((entry, index) =>
     entry.status === "fulfilled"
-      ? entry.value
+      ? entry.value.room
       : channelFromRoom({ jid: items[index]!.jid ?? "", name: items[index]!.name }, index),
   );
   return hydrated.map((room, position) => ({ id: room.id, name: room.name, channelType: room.channelType, position }));
@@ -462,6 +470,8 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const services = await discoverComponentServices(xmpp, domain, jid);
   let rooms: DiscoveredChannel[] = [];
   let roomCatalogComplete = true;
+  let bookmarkCatalogComplete = true;
+  let mucCatalogComplete = true;
   const bookmarkedRooms = new Map<string, { spaceId?: string; autojoin: boolean; name?: string }>();
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
@@ -483,6 +493,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
         if (info) role = parseDiscoveryRole(info.fields.get("pubsub#affiliation") ?? null) ?? serverRole;
       } catch {
         roomCatalogComplete = false;
+        bookmarkCatalogComplete = false;
         continue;
       }
       try {
@@ -498,11 +509,13 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
         }
       } catch {
         roomCatalogComplete = false;
+        bookmarkCatalogComplete = false;
       }
       spaces.push({ id: spaceId, name: item.name ?? spaceId, role });
     }
   } catch {
     roomCatalogComplete = false;
+    bookmarkCatalogComplete = false;
   }
 
   try {
@@ -519,6 +532,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     }
   } catch {
     roomCatalogComplete = false;
+    bookmarkCatalogComplete = false;
   }
 
   // Narrow try/catch JUST around `sendDiscoItems`: a wedged muc service
@@ -539,6 +553,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     // continue with an empty room list. The cause is observable in the
     // console for diagnostics.
     roomCatalogComplete = false;
+    mucCatalogComplete = false;
     void err;
   }
   const roomItems: Array<{ jid?: string; name?: string; bookmarkOnly?: boolean }> =
@@ -558,16 +573,30 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
       hydrateRoomInfo(xmpp, channelFromRoom({ jid: room.jid ?? "", name: room.name }, position)),
     ),
   );
-  if (hydratedSettled.some((entry) => entry.status === "rejected")) {
+  if (hydratedSettled.some(
+    (entry) =>
+      entry.status === "rejected"
+      || !entry.value.fingerprintComplete
+  )) {
     roomCatalogComplete = false;
   }
+  const fingerprintCompleteRoomJids = new Set(
+    hydratedSettled.flatMap((entry) => {
+      if (entry.status !== "fulfilled" || !entry.value.fingerprintComplete) return [];
+      const roomJid = entry.value.room.jid ? barePeerJid(entry.value.room.jid) : "";
+      return roomJid ? [roomJid] : [];
+    }),
+  );
   const hydrated = hydratedSettled.flatMap((entry, index) => {
     const source = roomItems[index]!;
     if (entry.status === "fulfilled") {
-      if (source.bookmarkOnly && !entry.value.features?.some((feature) => feature === NS_MUC)) {
+      if (
+        source.bookmarkOnly
+        && !entry.value.room.features?.some((feature) => feature === NS_MUC)
+      ) {
         return [];
       }
-      return [entry.value];
+      return [entry.value.room];
     }
     if (source.bookmarkOnly) return [];
     return [channelFromRoom({ jid: source.jid ?? "", name: source.name }, index)];
@@ -592,10 +621,23 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   });
 
   const roomSpaceIds = new Map(rooms.flatMap((room) => room.jid ? [[barePeerJid(room.jid), room.spaceId]] as const : []));
+  const authoritativeRoomFingerprintKeys = bookmarkCatalogComplete
+    ? rooms.flatMap((room) => {
+        const roomJid = room.jid ? barePeerJid(room.jid) : "";
+        return roomJid && fingerprintCompleteRoomJids.has(roomJid)
+          ? [bareJidKey(roomJid)]
+          : [];
+      })
+    : [];
   return {
     spaces,
     rooms: rooms.map((room, position) => ({ ...room, position, ...(room.jid && roomSpaceIds.get(barePeerJid(room.jid)) ? { standalone: false } : { standalone: room.standalone ?? true }) })),
     roomCatalogComplete,
+    roomReconciliationAuthority: {
+      absentRoomKeysAuthoritative:
+        bookmarkCatalogComplete && mucCatalogComplete,
+      fingerprintRoomKeys: authoritativeRoomFingerprintKeys,
+    },
     serverRole,
     services,
   };

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -666,7 +666,7 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
     roomCatalogComplete,
     roomReconciliationAuthority: {
       absentRoomKeysAuthoritative:
-        bookmarkCatalogComplete && mucCatalogComplete,
+        roomCatalogComplete && bookmarkCatalogComplete && mucCatalogComplete,
       roomFingerprints: authoritativeRoomFingerprints,
     },
     serverRole,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -1,5 +1,9 @@
 export { BrowserXmppClient } from "./client";
-export type { CatchupConversationFailure, PubsubEvent } from "./client-events";
+export type {
+  CatchupConversationFailure,
+  PubsubEvent,
+  RoomAccessChangedEvent,
+} from "./client-events";
 export type {
   DmBookmarkItem,
   NotifyMode,

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -29,10 +29,13 @@
  */
 
 import { reportError } from "@/lib/telemetry";
+import { bareJidKey } from "./jid";
+import type { RoomAutoJoinBlock } from "./room-auto-join-policy";
 
 const CATCHUP_PREFIX = "waddle.chat.resume-cursors";
 const SM_PREFIX = "waddle.chat.sm-resume";
 const JOINED_ROOMS_PREFIX = "waddle.chat.joined-rooms";
+const AUTO_JOIN_BLOCKS_PREFIX = "waddle.chat.auto-join-blocks";
 const OWNER_LEASE_PREFIX = `${SM_PREFIX}.owner-lease`;
 const OWNER_HANDOFF_PREFIX = `${SM_PREFIX}.owner-handoff`;
 
@@ -64,6 +67,8 @@ export type PersistedSmResumeState = {
   unhandledOutboundStanzas?: string[];
   resource?: string;
 };
+
+type PersistedAutoJoinBlock = RoomAutoJoinBlock;
 
 interface PersistedSmEnvelope extends PersistedSmResumeState {
   savedAt: number;
@@ -114,6 +119,9 @@ export interface ResumePersistence {
   loadJoinedRooms(): string[];
   saveJoinedRooms(roomJids: readonly string[]): void;
   clearJoinedRooms(): void;
+  loadAutoJoinBlocks?(): PersistedAutoJoinBlock[];
+  saveAutoJoinBlocks?(blocks: readonly PersistedAutoJoinBlock[]): void;
+  clearAutoJoinBlocks?(): void;
 }
 
 /** No-op persistence — used in tests / non-browser contexts. */
@@ -129,6 +137,9 @@ export const nullResumePersistence: ResumePersistence = {
   loadJoinedRooms: () => [],
   saveJoinedRooms: () => undefined,
   clearJoinedRooms: () => undefined,
+  loadAutoJoinBlocks: () => [],
+  saveAutoJoinBlocks: () => undefined,
+  clearAutoJoinBlocks: () => undefined,
 };
 
 export function createLocalStorageResumePersistence(accountKey: string, ownerId?: string): ResumePersistence {
@@ -139,6 +150,7 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
   const catchupKey = `${catchupKeyPrefix}.${owner.ownerId}`;
   const smKey = `${SM_PREFIX}.${accountKey}`;
   const joinedRoomsKey = `${JOINED_ROOMS_PREFIX}.${accountKey}.${owner.ownerId}`;
+  const autoJoinBlocksKey = `${AUTO_JOIN_BLOCKS_PREFIX}.${accountKey}.${owner.ownerId}`;
 
   return {
     loadCatchup() {
@@ -201,6 +213,42 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
     },
     clearJoinedRooms() {
       removeKey(joinedRoomsKey, "joined-rooms");
+    },
+    loadAutoJoinBlocks() {
+      const stored = readJson<PersistedAutoJoinBlock[]>(
+        autoJoinBlocksKey,
+        isPersistedAutoJoinBlockArray,
+        "auto-join-blocks",
+      ) ?? [];
+      const normalized = new Map<string, PersistedAutoJoinBlock>();
+      for (const block of stored) {
+        const roomJid = normalizeRoomJid(block.roomJid);
+        if (!roomJid) continue;
+        normalized.set(roomJid, {
+          roomJid,
+          condition: block.condition,
+          ...(block.catalogFingerprint !== undefined
+            ? { catalogFingerprint: block.catalogFingerprint }
+            : {}),
+        });
+      }
+      return [...normalized.values()];
+    },
+    saveAutoJoinBlocks(blocks) {
+      writeJson(
+        autoJoinBlocksKey,
+        blocks.map((block) => ({
+          roomJid: normalizeRoomJid(block.roomJid),
+          condition: block.condition,
+          ...(block.catalogFingerprint !== undefined
+            ? { catalogFingerprint: block.catalogFingerprint }
+            : {}),
+        })).filter((block) => !!block.roomJid),
+        "auto-join-blocks",
+      );
+    },
+    clearAutoJoinBlocks() {
+      removeKey(autoJoinBlocksKey, "auto-join-blocks");
     },
   };
 }
@@ -510,6 +558,23 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
+function isPersistedAutoJoinBlockArray(value: unknown): value is PersistedAutoJoinBlock[] {
+  return Array.isArray(value) && value.every((item) => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as Record<string, unknown>;
+    return typeof candidate.roomJid === "string"
+      && (
+        candidate.condition === "registration-required"
+        || candidate.condition === "forbidden"
+      )
+      && (
+        candidate.catalogFingerprint === undefined
+        || candidate.catalogFingerprint === null
+        || typeof candidate.catalogFingerprint === "string"
+      );
+  });
+}
+
 function isOwnerLease(value: unknown): value is OwnerLease {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
@@ -539,7 +604,7 @@ function isPositiveU32(value: unknown): value is number {
 }
 
 function normalizeRoomJid(roomJid: string): string {
-  return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
+  return bareJidKey(roomJid);
 }
 
 function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -30,7 +30,11 @@
 
 import { reportError } from "@/lib/telemetry";
 import { bareJidKey } from "./jid";
-import type { RoomAutoJoinBlock } from "./room-auto-join-policy";
+import {
+  ROOM_CATALOG_FINGERPRINT_FIELDS,
+  type RoomAutoJoinBlock,
+} from "./room-auto-join-policy";
+import type { RoomCatalogFingerprintField } from "./types";
 
 const CATCHUP_PREFIX = "waddle.chat.resume-cursors";
 const SM_PREFIX = "waddle.chat.sm-resume";
@@ -230,6 +234,12 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
           ...(block.catalogFingerprint !== undefined
             ? { catalogFingerprint: block.catalogFingerprint }
             : {}),
+          ...(block.catalogFingerprintFields
+            ? {
+              catalogFingerprintFields:
+                [...block.catalogFingerprintFields],
+            }
+            : {}),
         });
       }
       return [...normalized.values()];
@@ -242,6 +252,12 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
           condition: block.condition,
           ...(block.catalogFingerprint !== undefined
             ? { catalogFingerprint: block.catalogFingerprint }
+            : {}),
+          ...(block.catalogFingerprintFields
+            ? {
+              catalogFingerprintFields:
+                [...block.catalogFingerprintFields],
+            }
             : {}),
         })).filter((block) => !!block.roomJid),
         "auto-join-blocks",
@@ -571,8 +587,30 @@ function isPersistedAutoJoinBlockArray(value: unknown): value is PersistedAutoJo
         candidate.catalogFingerprint === undefined
         || candidate.catalogFingerprint === null
         || typeof candidate.catalogFingerprint === "string"
+      )
+      && (
+        candidate.catalogFingerprintFields === undefined
+        || (
+          typeof candidate.catalogFingerprint === "string"
+          && isRoomCatalogFingerprintFieldArray(
+            candidate.catalogFingerprintFields,
+          )
+        )
       );
   });
+}
+
+function isRoomCatalogFingerprintFieldArray(
+  value: unknown,
+): value is RoomCatalogFingerprintField[] {
+  return Array.isArray(value)
+    && value.every(
+      (field) =>
+        typeof field === "string"
+        && ROOM_CATALOG_FINGERPRINT_FIELDS.includes(
+          field as RoomCatalogFingerprintField,
+        ),
+    );
 }
 
 function isOwnerLease(value: unknown): value is OwnerLease {

--- a/chat/src/lib/xmpp/room-auto-join-policy.ts
+++ b/chat/src/lib/xmpp/room-auto-join-policy.ts
@@ -4,7 +4,7 @@ import type {
 } from "./types";
 import { bareJidKey } from "./jid";
 
-const ROOM_CATALOG_FINGERPRINT_FIELDS = [
+export const ROOM_CATALOG_FINGERPRINT_FIELDS = [
   "spaceId",
   "autojoin",
   "isGroupDm",
@@ -24,6 +24,11 @@ export type RoomAutoJoinBlock = {
    * room was absent from the discovered catalog.
    */
   catalogFingerprint?: string | null;
+  /**
+   * Fields proven by a partial first observation. Missing means every
+   * fingerprint field is authoritative.
+   */
+  catalogFingerprintFields?: RoomCatalogFingerprintField[];
 };
 
 export function terminalMucJoinCondition(
@@ -82,29 +87,79 @@ export function reconcileAutoJoinBlocks(
     }
     const currentFingerprint = roomIsPresent ? catalog.get(key)! : null;
     if (block.catalogFingerprint === undefined) {
-      if (
-        roomIsPresent
-        && !hasCompleteRoomCatalogFingerprintAuthority(authoritativeFields!)
-      ) {
-        blocks.set(key, block);
-        continue;
-      }
-      blocks.set(key, { ...block, catalogFingerprint: currentFingerprint });
+      const observedFields = roomIsPresent
+        ? orderedRoomCatalogFingerprintFields(authoritativeFields!)
+        : [];
+      blocks.set(key, {
+        ...block,
+        catalogFingerprint: currentFingerprint,
+        ...(roomIsPresent
+            && !hasCompleteRoomCatalogFingerprintAuthority(authoritativeFields!)
+          ? { catalogFingerprintFields: observedFields }
+          : {}),
+      });
       changed = true;
       continue;
     }
+    const baselineFields = roomIsPresent
+      ? new Set(
+        block.catalogFingerprintFields
+          ?? ROOM_CATALOG_FINGERPRINT_FIELDS,
+      )
+      : undefined;
+    const comparableFields = roomIsPresent
+      ? intersectRoomCatalogFingerprintFields(
+          authoritativeFields!,
+          baselineFields!,
+        )
+      : undefined;
     if (
       roomIsPresent
         ? roomCatalogFingerprintChanged(
             block.catalogFingerprint,
             roomsByKey.get(key)!,
-            authoritativeFields!,
+            comparableFields!,
           )
         : block.catalogFingerprint !== currentFingerprint
     ) {
       unblockedRoomKeys.push(key);
       changed = true;
       continue;
+    }
+    if (roomIsPresent && block.catalogFingerprintFields) {
+      const expandedFields = new Set([
+        ...baselineFields!,
+        ...authoritativeFields!,
+      ]);
+      if (expandedFields.size > baselineFields!.size) {
+        const expandedFingerprint = mergeRoomCatalogFingerprint(
+          block.catalogFingerprint,
+          roomsByKey.get(key)!,
+          authoritativeFields!,
+        );
+        if (expandedFingerprint) {
+          const {
+            catalogFingerprintFields: _discardPartialFields,
+            ...blockWithoutPartialFields
+          } = block;
+          blocks.set(
+            key,
+            hasCompleteRoomCatalogFingerprintAuthority(expandedFields)
+              ? {
+                ...blockWithoutPartialFields,
+                catalogFingerprint: expandedFingerprint,
+              }
+              : {
+                ...block,
+                catalogFingerprint: expandedFingerprint,
+                catalogFingerprintFields:
+                  orderedRoomCatalogFingerprintFields(expandedFields),
+              },
+          );
+          changed = true;
+          continue;
+        }
+      }
     }
     blocks.set(key, block);
   }
@@ -120,6 +175,41 @@ export function hasCompleteRoomCatalogFingerprintAuthority(
   fields: ReadonlySet<RoomCatalogFingerprintField>,
 ): boolean {
   return ROOM_CATALOG_FINGERPRINT_FIELDS.every((field) => fields.has(field));
+}
+
+function orderedRoomCatalogFingerprintFields(
+  fields: ReadonlySet<RoomCatalogFingerprintField>,
+): RoomCatalogFingerprintField[] {
+  return ROOM_CATALOG_FINGERPRINT_FIELDS.filter((field) => fields.has(field));
+}
+
+function intersectRoomCatalogFingerprintFields(
+  left: ReadonlySet<RoomCatalogFingerprintField>,
+  right: ReadonlySet<RoomCatalogFingerprintField>,
+): Set<RoomCatalogFingerprintField> {
+  return new Set(
+    ROOM_CATALOG_FINGERPRINT_FIELDS.filter(
+      (field) => left.has(field) && right.has(field),
+    ),
+  );
+}
+
+function mergeRoomCatalogFingerprint(
+  baseline: string | null,
+  room: DiscoveredChannel,
+  fields: ReadonlySet<RoomCatalogFingerprintField>,
+): string | null {
+  if (baseline === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(baseline);
+  } catch {
+    return null;
+  }
+  if (!isRoomCatalogFingerprintData(parsed)) return null;
+  const current = roomCatalogFingerprintData(room);
+  for (const field of fields) parsed[field] = current[field];
+  return JSON.stringify(parsed);
 }
 
 function roomCatalogFingerprintChanged(

--- a/chat/src/lib/xmpp/room-auto-join-policy.ts
+++ b/chat/src/lib/xmpp/room-auto-join-policy.ts
@@ -29,20 +29,15 @@ export function terminalMucJoinCondition(
 export function reconcileAutoJoinBlocks(
   current: ReadonlyMap<string, RoomAutoJoinBlock>,
   rooms: readonly DiscoveredChannel[],
-  options: { catalogComplete?: boolean } = {},
+  options: {
+    absentRoomKeysAuthoritative?: boolean;
+    authoritativeRoomKeys?: ReadonlySet<string>;
+  } = {},
 ): {
   blocks: Map<string, RoomAutoJoinBlock>;
   unblockedRoomKeys: string[];
   changed: boolean;
 } {
-  if (options.catalogComplete === false) {
-    return {
-      blocks: new Map(current),
-      unblockedRoomKeys: [],
-      changed: false,
-    };
-  }
-
   const catalog = new Map<string, string>();
   for (const room of rooms) {
     const roomJid = room.jid ? bareJidKey(room.jid) : "";
@@ -54,7 +49,15 @@ export function reconcileAutoJoinBlocks(
   let changed = false;
 
   for (const [key, block] of current) {
-    const currentFingerprint = catalog.get(key) ?? null;
+    const roomIsPresent = catalog.has(key);
+    const fingerprintIsAuthoritative = roomIsPresent
+      ? options.authoritativeRoomKeys?.has(key) ?? options.absentRoomKeysAuthoritative !== false
+      : options.absentRoomKeysAuthoritative !== false;
+    if (!fingerprintIsAuthoritative) {
+      blocks.set(key, block);
+      continue;
+    }
+    const currentFingerprint = roomIsPresent ? catalog.get(key)! : null;
     if (block.catalogFingerprint === undefined) {
       blocks.set(key, { ...block, catalogFingerprint: currentFingerprint });
       changed = true;

--- a/chat/src/lib/xmpp/room-auto-join-policy.ts
+++ b/chat/src/lib/xmpp/room-auto-join-policy.ts
@@ -1,0 +1,81 @@
+import type { DiscoveredChannel } from "./types";
+import { bareJidKey } from "./jid";
+
+export type TerminalMucJoinCondition =
+  | "registration-required"
+  | "forbidden";
+
+export type RoomAutoJoinBlock = {
+  roomJid: string;
+  condition: TerminalMucJoinCondition;
+  /**
+   * Stable room-catalog fingerprint captured when access was denied.
+   * Missing means topology had not been discovered yet; `null` means the
+   * room was absent from the discovered catalog.
+   */
+  catalogFingerprint?: string | null;
+};
+
+export function terminalMucJoinCondition(
+  errorType: string | undefined,
+  condition: string | undefined,
+): TerminalMucJoinCondition | null {
+  if (errorType !== "auth") return null;
+  return condition === "registration-required" || condition === "forbidden"
+    ? condition
+    : null;
+}
+
+export function reconcileAutoJoinBlocks(
+  current: ReadonlyMap<string, RoomAutoJoinBlock>,
+  rooms: readonly DiscoveredChannel[],
+): {
+  blocks: Map<string, RoomAutoJoinBlock>;
+  unblockedRoomKeys: string[];
+  changed: boolean;
+} {
+  const catalog = new Map<string, string>();
+  const bookmarkedRoomKeys = new Set<string>();
+  for (const room of rooms) {
+    const roomJid = room.jid ? bareJidKey(room.jid) : "";
+    if (!roomJid) continue;
+    catalog.set(roomJid, roomCatalogFingerprint(room));
+    if (room.isBookmarked) bookmarkedRoomKeys.add(roomJid);
+  }
+  const blocks = new Map<string, RoomAutoJoinBlock>();
+  const unblockedRoomKeys: string[] = [];
+  let changed = false;
+
+  for (const [key, block] of current) {
+    const currentFingerprint = catalog.get(key) ?? null;
+    if (block.catalogFingerprint === undefined) {
+      if (bookmarkedRoomKeys.has(key)) {
+        unblockedRoomKeys.push(key);
+        changed = true;
+        continue;
+      }
+      blocks.set(key, { ...block, catalogFingerprint: currentFingerprint });
+      changed = true;
+      continue;
+    }
+    if (block.catalogFingerprint !== currentFingerprint) {
+      unblockedRoomKeys.push(key);
+      changed = true;
+      continue;
+    }
+    blocks.set(key, block);
+  }
+
+  return { blocks, unblockedRoomKeys, changed };
+}
+
+export function roomCatalogFingerprint(room: DiscoveredChannel): string {
+  return JSON.stringify([
+    room.jid ? bareJidKey(room.jid) : "",
+    room.id,
+    room.spaceId ?? null,
+    room.autojoin ?? null,
+    room.isGroupDm ?? false,
+    room.isBookmarked ?? false,
+  ]);
+}

--- a/chat/src/lib/xmpp/room-auto-join-policy.ts
+++ b/chat/src/lib/xmpp/room-auto-join-policy.ts
@@ -1,5 +1,15 @@
-import type { DiscoveredChannel } from "./types";
+import type {
+  DiscoveredChannel,
+  RoomCatalogFingerprintField,
+} from "./types";
 import { bareJidKey } from "./jid";
+
+const ROOM_CATALOG_FINGERPRINT_FIELDS = [
+  "spaceId",
+  "autojoin",
+  "isGroupDm",
+  "isBookmarked",
+] as const satisfies readonly RoomCatalogFingerprintField[];
 
 export type TerminalMucJoinCondition =
   | "registration-required"
@@ -31,7 +41,10 @@ export function reconcileAutoJoinBlocks(
   rooms: readonly DiscoveredChannel[],
   options: {
     absentRoomKeysAuthoritative?: boolean;
-    authoritativeRoomKeys?: ReadonlySet<string>;
+    authoritativeFingerprintFields?: ReadonlyMap<
+      string,
+      ReadonlySet<RoomCatalogFingerprintField>
+    >;
   } = {},
 ): {
   blocks: Map<string, RoomAutoJoinBlock>;
@@ -39,10 +52,12 @@ export function reconcileAutoJoinBlocks(
   changed: boolean;
 } {
   const catalog = new Map<string, string>();
+  const roomsByKey = new Map<string, DiscoveredChannel>();
   for (const room of rooms) {
     const roomJid = room.jid ? bareJidKey(room.jid) : "";
     if (!roomJid) continue;
     catalog.set(roomJid, roomCatalogFingerprint(room));
+    roomsByKey.set(roomJid, room);
   }
   const blocks = new Map<string, RoomAutoJoinBlock>();
   const unblockedRoomKeys: string[] = [];
@@ -50,8 +65,16 @@ export function reconcileAutoJoinBlocks(
 
   for (const [key, block] of current) {
     const roomIsPresent = catalog.has(key);
+    const authoritativeFields = roomIsPresent
+      ? options.authoritativeFingerprintFields?.get(key)
+        ?? (options.authoritativeFingerprintFields
+          ? undefined
+          : options.absentRoomKeysAuthoritative !== false
+            ? new Set(ROOM_CATALOG_FINGERPRINT_FIELDS)
+            : undefined)
+      : undefined;
     const fingerprintIsAuthoritative = roomIsPresent
-      ? options.authoritativeRoomKeys?.has(key) ?? options.absentRoomKeysAuthoritative !== false
+      ? !!authoritativeFields?.size
       : options.absentRoomKeysAuthoritative !== false;
     if (!fingerprintIsAuthoritative) {
       blocks.set(key, block);
@@ -59,11 +82,26 @@ export function reconcileAutoJoinBlocks(
     }
     const currentFingerprint = roomIsPresent ? catalog.get(key)! : null;
     if (block.catalogFingerprint === undefined) {
+      if (
+        roomIsPresent
+        && !hasCompleteRoomCatalogFingerprintAuthority(authoritativeFields!)
+      ) {
+        blocks.set(key, block);
+        continue;
+      }
       blocks.set(key, { ...block, catalogFingerprint: currentFingerprint });
       changed = true;
       continue;
     }
-    if (block.catalogFingerprint !== currentFingerprint) {
+    if (
+      roomIsPresent
+        ? roomCatalogFingerprintChanged(
+            block.catalogFingerprint,
+            roomsByKey.get(key)!,
+            authoritativeFields!,
+          )
+        : block.catalogFingerprint !== currentFingerprint
+    ) {
       unblockedRoomKeys.push(key);
       changed = true;
       continue;
@@ -75,12 +113,65 @@ export function reconcileAutoJoinBlocks(
 }
 
 export function roomCatalogFingerprint(room: DiscoveredChannel): string {
-  return JSON.stringify([
-    room.jid ? bareJidKey(room.jid) : "",
-    room.id,
-    room.spaceId ?? null,
-    room.autojoin ?? null,
-    room.isGroupDm ?? false,
-    room.isBookmarked ?? false,
-  ]);
+  return JSON.stringify(roomCatalogFingerprintData(room));
+}
+
+export function hasCompleteRoomCatalogFingerprintAuthority(
+  fields: ReadonlySet<RoomCatalogFingerprintField>,
+): boolean {
+  return ROOM_CATALOG_FINGERPRINT_FIELDS.every((field) => fields.has(field));
+}
+
+function roomCatalogFingerprintChanged(
+  baseline: string | null,
+  room: DiscoveredChannel,
+  fields: ReadonlySet<RoomCatalogFingerprintField>,
+): boolean {
+  if (baseline === null) return true;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(baseline);
+  } catch {
+    return hasCompleteRoomCatalogFingerprintAuthority(fields)
+      && baseline !== roomCatalogFingerprint(room);
+  }
+  if (!isRoomCatalogFingerprintData(parsed)) {
+    return hasCompleteRoomCatalogFingerprintAuthority(fields)
+      && baseline !== roomCatalogFingerprint(room);
+  }
+  const current = roomCatalogFingerprintData(room);
+  return [...fields].some(
+    (field) => !Object.is(parsed[field], current[field]),
+  );
+}
+
+type RoomCatalogFingerprintData = {
+  roomKey: string;
+  roomId: string;
+} & Record<RoomCatalogFingerprintField, string | boolean | null>;
+
+function roomCatalogFingerprintData(
+  room: DiscoveredChannel,
+): RoomCatalogFingerprintData {
+  return {
+    roomKey: room.jid ? bareJidKey(room.jid) : "",
+    roomId: room.id,
+    spaceId: room.spaceId ?? null,
+    autojoin: room.autojoin ?? null,
+    isGroupDm: room.isGroupDm ?? false,
+    isBookmarked: room.isBookmarked ?? false,
+  };
+}
+
+function isRoomCatalogFingerprintData(
+  value: unknown,
+): value is RoomCatalogFingerprintData {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<RoomCatalogFingerprintData>;
+  return typeof candidate.roomKey === "string"
+    && typeof candidate.roomId === "string"
+    && (typeof candidate.spaceId === "string" || candidate.spaceId === null)
+    && (typeof candidate.autojoin === "boolean" || candidate.autojoin === null)
+    && typeof candidate.isGroupDm === "boolean"
+    && typeof candidate.isBookmarked === "boolean";
 }

--- a/chat/src/lib/xmpp/room-auto-join-policy.ts
+++ b/chat/src/lib/xmpp/room-auto-join-policy.ts
@@ -29,18 +29,25 @@ export function terminalMucJoinCondition(
 export function reconcileAutoJoinBlocks(
   current: ReadonlyMap<string, RoomAutoJoinBlock>,
   rooms: readonly DiscoveredChannel[],
+  options: { catalogComplete?: boolean } = {},
 ): {
   blocks: Map<string, RoomAutoJoinBlock>;
   unblockedRoomKeys: string[];
   changed: boolean;
 } {
+  if (options.catalogComplete === false) {
+    return {
+      blocks: new Map(current),
+      unblockedRoomKeys: [],
+      changed: false,
+    };
+  }
+
   const catalog = new Map<string, string>();
-  const bookmarkedRoomKeys = new Set<string>();
   for (const room of rooms) {
     const roomJid = room.jid ? bareJidKey(room.jid) : "";
     if (!roomJid) continue;
     catalog.set(roomJid, roomCatalogFingerprint(room));
-    if (room.isBookmarked) bookmarkedRoomKeys.add(roomJid);
   }
   const blocks = new Map<string, RoomAutoJoinBlock>();
   const unblockedRoomKeys: string[] = [];
@@ -49,11 +56,6 @@ export function reconcileAutoJoinBlocks(
   for (const [key, block] of current) {
     const currentFingerprint = catalog.get(key) ?? null;
     if (block.catalogFingerprint === undefined) {
-      if (bookmarkedRoomKeys.has(key)) {
-        unblockedRoomKeys.push(key);
-        changed = true;
-        continue;
-      }
       blocks.set(key, { ...block, catalogFingerprint: currentFingerprint });
       changed = true;
       continue;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -554,6 +554,12 @@ export interface DiscoveredSpace {
   role?: "owner" | "admin" | "moderator" | "member" | null;
 }
 
+export type RoomCatalogFingerprintField =
+  | "spaceId"
+  | "autojoin"
+  | "isGroupDm"
+  | "isBookmarked";
+
 export interface DiscoveredTopology {
   spaces: DiscoveredSpace[];
   rooms: DiscoveredChannel[];
@@ -566,8 +572,15 @@ export interface DiscoveredTopology {
   roomReconciliationAuthority: {
     /** True when successful MUC and bookmark listings make absence authoritative. */
     absentRoomKeysAuthoritative: boolean;
-    /** Normalized room keys whose own hydration and all bookmark sources completed. */
-    fingerprintRoomKeys: string[];
+    /**
+     * Field-level evidence for present rooms. This lets a successful exact-room
+     * bookmark source remain useful without treating unrelated failed sources
+     * as authoritative for fields they could have overridden.
+     */
+    roomFingerprints: Array<{
+      roomKey: string;
+      fields: RoomCatalogFingerprintField[];
+    }>;
   };
   serverRole?: "owner" | "admin" | "moderator" | "member" | null;
   services?: {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -530,6 +530,10 @@ export interface DiscoveredChannel {
   standalone?: boolean;
   features?: string[];
   isGroupDm?: boolean;
+  /** Whether this room arrived through the account's XEP-0402 bookmark
+   * membership view. A change is a concrete membership-generation signal
+   * even when the room's disco metadata itself is unchanged. */
+  isBookmarked?: boolean;
   /**
    * XEP-0402 bookmark `autojoin` value. Bookmarked rooms with the
    * attribute omitted are `false` per spec; rooms discovered outside

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -557,6 +557,8 @@ export interface DiscoveredSpace {
 export interface DiscoveredTopology {
   spaces: DiscoveredSpace[];
   rooms: DiscoveredChannel[];
+  /** False when room discovery or hydration degraded and `rooms` may be incomplete. */
+  roomCatalogComplete: boolean;
   serverRole?: "owner" | "admin" | "moderator" | "member" | null;
   services?: {
     muc?: string;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -559,6 +559,16 @@ export interface DiscoveredTopology {
   rooms: DiscoveredChannel[];
   /** False when room discovery or hydration degraded and `rooms` may be incomplete. */
   roomCatalogComplete: boolean;
+  /**
+   * Exact authority available for terminal-denial reconciliation. Whole-cache
+   * replacement remains gated by `roomCatalogComplete`.
+   */
+  roomReconciliationAuthority: {
+    /** True when successful MUC and bookmark listings make absence authoritative. */
+    absentRoomKeysAuthoritative: boolean;
+    /** Normalized room keys whose own hydration and all bookmark sources completed. */
+    fingerprintRoomKeys: string[];
+  };
   serverRole?: "owner" | "admin" | "moderator" | "member" | null;
   services?: {
     muc?: string;

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -502,6 +502,7 @@ export function useChatAppController() {
     authorHatsByNick: memberDirectory.authorHatsByNick,
     authorAuthorityByNick: memberDirectory.authorAuthorityByNick,
     activeActionError: conversation.activeActionError,
+    activeRoomAccessRequirement: conversation.activeRoomAccessRequirement,
     activeErrorActionLabel: conversation.activeErrorActionLabel,
     activeUploadProgress: conversation.activeUploadProgress,
     setContentAreaRef: conversation.setContentAreaRef,

--- a/chat/src/shell/controllers/use-active-conversation.ts
+++ b/chat/src/shell/controllers/use-active-conversation.ts
@@ -129,7 +129,12 @@ export function useActiveConversation(deps: ActiveConversationDeps) {
     isActiveDirectDmSurface() ? dmMessaging : messaging,
   );
 
-  const activeActionError = computed(() => ui.actionError.value);
+  const activeRoomAccessRequirement = computed(() =>
+    isActiveDirectDmSurface() ? null : messaging.currentRoomAccessRequirement.value,
+  );
+  const activeActionError = computed(() =>
+    activeRoomAccessRequirement.value ? "" : ui.actionError.value,
+  );
   const activeErrorActionLabel = computed(() => {
     const peer = activeDmPeer.value;
     return isActiveDirectDmSurface() &&
@@ -158,6 +163,7 @@ export function useActiveConversation(deps: ActiveConversationDeps) {
     activeUploadProgress,
     activeDmPeer,
     activeTarget,
+    activeRoomAccessRequirement,
     activeActionError,
     activeErrorActionLabel,
   };

--- a/chat/src/shell/controllers/use-extension-routes.ts
+++ b/chat/src/shell/controllers/use-extension-routes.ts
@@ -82,7 +82,13 @@ export function useExtensionRoutes(deps: ExtensionRoutesDeps) {
     if (waddles.activeChannelId.value !== channelId) {
       waddles.activeChannelId.value = channelId;
       messaging.clearMessages();
-      await messaging.loadMessages(waddles.currentChannel.value?.spaceId ?? "", channelId);
+      await messaging.loadMessages(
+        waddles.currentChannel.value?.spaceId ?? "",
+        channelId,
+        0,
+        [],
+        { allowAccessRetry: true },
+      );
     }
     activeExtensionRouteKey.value = { channelId, pluginId: route.pluginId, routeId: route.routeId };
     activeRightPanel.value = "extension";

--- a/chat/src/shell/controllers/use-extension-routes.ts
+++ b/chat/src/shell/controllers/use-extension-routes.ts
@@ -87,7 +87,7 @@ export function useExtensionRoutes(deps: ExtensionRoutesDeps) {
         channelId,
         0,
         [],
-        { allowAccessRetry: true },
+        { intent: "explicit-navigation" },
       );
     }
     activeExtensionRouteKey.value = { channelId, pluginId: route.pluginId, routeId: route.routeId };

--- a/chat/src/shell/controllers/use-room-sync.ts
+++ b/chat/src/shell/controllers/use-room-sync.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/channel-room";
 import { navigate } from "@/router";
 import type { ExtensionRouteKey } from "@/shell/controllers/use-extension-routes";
+import type { ChannelLoadIntent } from "@/channels/room-access";
 
 interface RoomSyncDeps {
   ui: ChatShellState;
@@ -75,7 +76,7 @@ export function useRoomSync(deps: RoomSyncDeps) {
       if (!channel || channel.id === waddles.activeChannelId.value) return;
       void selectChannel(channel.id, {
         roomJid: normalizedRoomJid,
-        allowAccessRetry: false,
+        intent: "automatic",
       });
     },
   );
@@ -106,7 +107,7 @@ export function useRoomSync(deps: RoomSyncDeps) {
     options: {
       roomJid?: string;
       surface?: "channels" | "dms";
-      allowAccessRetry?: boolean;
+      intent?: ChannelLoadIntent;
     } = {},
   ) {
     clearPendingChannelRoomJidSelection();
@@ -138,7 +139,7 @@ export function useRoomSync(deps: RoomSyncDeps) {
       channelId,
       unreadAtLoad,
       [],
-      { allowAccessRetry: options.allowAccessRetry !== false },
+      { intent: options.intent ?? "explicit-navigation" },
     );
     ui.showMobileNav.value = false;
   }
@@ -170,7 +171,7 @@ export function useRoomSync(deps: RoomSyncDeps) {
 
   async function selectGroupDm(
     roomJid: string,
-    options: { updateUrl?: boolean; allowAccessRetry?: boolean } = {},
+    options: { updateUrl?: boolean; intent?: ChannelLoadIntent } = {},
   ) {
     const normalizedRoomJid = barePeerJid(roomJid);
     const group = waddles.groupDms.value.find((candidate) => barePeerJid(candidate.roomJid) === normalizedRoomJid);
@@ -193,7 +194,7 @@ export function useRoomSync(deps: RoomSyncDeps) {
     await selectChannel(channelId, {
       roomJid: normalizedRoomJid,
       surface: "dms",
-      allowAccessRetry: options.allowAccessRetry !== false,
+      intent: options.intent ?? "explicit-navigation",
     });
     if (options.updateUrl !== false) updateUrl();
     return true;

--- a/chat/src/shell/controllers/use-room-sync.ts
+++ b/chat/src/shell/controllers/use-room-sync.ts
@@ -73,7 +73,10 @@ export function useRoomSync(deps: RoomSyncDeps) {
         candidate.jid ? barePeerJid(candidate.jid) === normalizedRoomJid : false
       );
       if (!channel || channel.id === waddles.activeChannelId.value) return;
-      void selectChannel(channel.id, { roomJid: normalizedRoomJid });
+      void selectChannel(channel.id, {
+        roomJid: normalizedRoomJid,
+        allowAccessRetry: false,
+      });
     },
   );
   watch(
@@ -98,7 +101,14 @@ export function useRoomSync(deps: RoomSyncDeps) {
     return resolveRoomJidForChannelId(sess, waddles.channels.value, channelId);
   }
 
-  async function selectChannel(channelId: string, options: { roomJid?: string; surface?: "channels" | "dms" } = {}) {
+  async function selectChannel(
+    channelId: string,
+    options: {
+      roomJid?: string;
+      surface?: "channels" | "dms";
+      allowAccessRetry?: boolean;
+    } = {},
+  ) {
     clearPendingChannelRoomJidSelection();
     ui.activePage.value = "chat";
     ui.sidebarMode.value = options.surface ?? "channels";
@@ -127,6 +137,8 @@ export function useRoomSync(deps: RoomSyncDeps) {
       waddles.currentChannel.value?.spaceId ?? "",
       channelId,
       unreadAtLoad,
+      [],
+      { allowAccessRetry: options.allowAccessRetry !== false },
     );
     ui.showMobileNav.value = false;
   }
@@ -156,7 +168,10 @@ export function useRoomSync(deps: RoomSyncDeps) {
     await selectChannel(channelId, { roomJid: normalizedRoomJid });
   }
 
-  async function selectGroupDm(roomJid: string, options: { updateUrl?: boolean } = {}) {
+  async function selectGroupDm(
+    roomJid: string,
+    options: { updateUrl?: boolean; allowAccessRetry?: boolean } = {},
+  ) {
     const normalizedRoomJid = barePeerJid(roomJid);
     const group = waddles.groupDms.value.find((candidate) => barePeerJid(candidate.roomJid) === normalizedRoomJid);
     const channelId = group?.id ?? knownChannelIdForRoomJid(
@@ -175,7 +190,11 @@ export function useRoomSync(deps: RoomSyncDeps) {
       return false;
     }
     dmConversations.closeDm();
-    await selectChannel(channelId, { roomJid: normalizedRoomJid, surface: "dms" });
+    await selectChannel(channelId, {
+      roomJid: normalizedRoomJid,
+      surface: "dms",
+      allowAccessRetry: options.allowAccessRetry !== false,
+    });
     if (options.updateUrl !== false) updateUrl();
     return true;
   }

--- a/chat/src/shell/controllers/use-route-sync.ts
+++ b/chat/src/shell/controllers/use-route-sync.ts
@@ -81,7 +81,10 @@ interface RouteSyncDeps {
   activeExtensionRouteKey: Ref<ExtensionRouteKey | null>;
   clearPendingChannelRoomJidSelection: () => void;
   openDm: (peerJid: string) => Promise<void>;
-  selectGroupDm: (roomJid: string, options?: { updateUrl?: boolean }) => Promise<boolean>;
+  selectGroupDm: (
+    roomJid: string,
+    options?: { updateUrl?: boolean; allowAccessRetry?: boolean },
+  ) => Promise<boolean>;
   /** Owned by the connection lifecycle's structure-retry state: a user
    * navigation supersedes any channel route parked for a structure reload. */
   clearPendingChannelRoute: () => void;
@@ -216,14 +219,18 @@ export function useRouteSync(deps: RouteSyncDeps) {
     clearPendingChannelRoute();
     const requestId = ++routeRequestId;
     isApplyingRoute.value = true;
-    void applyRouteTarget(match, requestId).finally(() => {
+    void applyRouteTarget(match, requestId, { allowAccessRetry: true }).finally(() => {
       if (requestId === routeRequestId) {
         isApplyingRoute.value = false;
       }
     });
   }
 
-  async function applyRouteTarget(match: RouteMatch, requestId: number) {
+  async function applyRouteTarget(
+    match: RouteMatch,
+    requestId: number,
+    options: { allowAccessRetry?: boolean } = {},
+  ) {
     clearPendingChannelRoomJidSelection();
     applyMatchToShellState(ui, match);
     if (match.id === "stories") {
@@ -289,7 +296,10 @@ export function useRouteSync(deps: RouteSyncDeps) {
     if (match.id === "groupDmRoom") {
       activeExtensionRouteKey.value = null;
       dmConversations.closeDm();
-      await selectGroupDm(match.params.roomJid, { updateUrl: false });
+      await selectGroupDm(match.params.roomJid, {
+        updateUrl: false,
+        allowAccessRetry: options.allowAccessRetry === true,
+      });
       if (requestId !== routeRequestId) return;
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
@@ -325,7 +335,9 @@ export function useRouteSync(deps: RouteSyncDeps) {
         routeId: match.params.routeId,
       };
       messaging.clearMessages();
-      await messaging.loadMessages(ch.spaceId ?? "", ch.id);
+      await messaging.loadMessages(ch.spaceId ?? "", ch.id, 0, [], {
+        allowAccessRetry: options.allowAccessRetry === true,
+      });
       if (requestId !== routeRequestId) return;
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
@@ -352,7 +364,10 @@ export function useRouteSync(deps: RouteSyncDeps) {
         params: { roomJid: ch.jid },
         search: match.search,
       }, { replace: true });
-      await selectGroupDm(ch.jid, { updateUrl: false });
+      await selectGroupDm(ch.jid, {
+        updateUrl: false,
+        allowAccessRetry: options.allowAccessRetry === true,
+      });
       ui.showPinnedPanel.value = match.search.pinned;
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = match.search.thread;
@@ -369,7 +384,9 @@ export function useRouteSync(deps: RouteSyncDeps) {
     waddles.activeChannelId.value = ch.id;
     void waddles.reloadChannelMembers(ch.id);
     messaging.clearMessages();
-    await messaging.loadMessages(ch.spaceId ?? "", ch.id);
+    await messaging.loadMessages(ch.spaceId ?? "", ch.id, 0, [], {
+      allowAccessRetry: options.allowAccessRetry === true,
+    });
 
     // Restore the thread panel from the URL and initialize paging for every
     // visible thread pane. Dedupe in the messaging composable keeps already

--- a/chat/src/shell/controllers/use-route-sync.ts
+++ b/chat/src/shell/controllers/use-route-sync.ts
@@ -10,6 +10,7 @@ import { matchLocation, navigate, type RouteMatch } from "@/router";
 import { resolveChannelBySlug } from "@/shell/route-helpers";
 import type { ActiveRightPanel } from "@/shell/controllers/use-thread-panels";
 import type { ExtensionRouteKey } from "@/shell/controllers/use-extension-routes";
+import type { ChannelLoadIntent } from "@/channels/room-access";
 
 /**
  * Single mapping from the typed route match to the page-level shell
@@ -83,7 +84,7 @@ interface RouteSyncDeps {
   openDm: (peerJid: string) => Promise<void>;
   selectGroupDm: (
     roomJid: string,
-    options?: { updateUrl?: boolean; allowAccessRetry?: boolean },
+    options?: { updateUrl?: boolean; intent?: ChannelLoadIntent },
   ) => Promise<boolean>;
   /** Owned by the connection lifecycle's structure-retry state: a user
    * navigation supersedes any channel route parked for a structure reload. */
@@ -219,7 +220,9 @@ export function useRouteSync(deps: RouteSyncDeps) {
     clearPendingChannelRoute();
     const requestId = ++routeRequestId;
     isApplyingRoute.value = true;
-    void applyRouteTarget(match, requestId, { allowAccessRetry: true }).finally(() => {
+    void applyRouteTarget(match, requestId, {
+      intent: "explicit-navigation",
+    }).finally(() => {
       if (requestId === routeRequestId) {
         isApplyingRoute.value = false;
       }
@@ -229,7 +232,7 @@ export function useRouteSync(deps: RouteSyncDeps) {
   async function applyRouteTarget(
     match: RouteMatch,
     requestId: number,
-    options: { allowAccessRetry?: boolean } = {},
+    options: { intent?: ChannelLoadIntent } = {},
   ) {
     clearPendingChannelRoomJidSelection();
     applyMatchToShellState(ui, match);
@@ -298,7 +301,7 @@ export function useRouteSync(deps: RouteSyncDeps) {
       dmConversations.closeDm();
       await selectGroupDm(match.params.roomJid, {
         updateUrl: false,
-        allowAccessRetry: options.allowAccessRetry === true,
+        intent: options.intent ?? "automatic",
       });
       if (requestId !== routeRequestId) return;
       activeThreadTargetMessageId.value = null;
@@ -336,7 +339,7 @@ export function useRouteSync(deps: RouteSyncDeps) {
       };
       messaging.clearMessages();
       await messaging.loadMessages(ch.spaceId ?? "", ch.id, 0, [], {
-        allowAccessRetry: options.allowAccessRetry === true,
+        intent: options.intent ?? "automatic",
       });
       if (requestId !== routeRequestId) return;
       activeThreadTargetMessageId.value = null;
@@ -366,7 +369,7 @@ export function useRouteSync(deps: RouteSyncDeps) {
       }, { replace: true });
       await selectGroupDm(ch.jid, {
         updateUrl: false,
-        allowAccessRetry: options.allowAccessRetry === true,
+        intent: options.intent ?? "automatic",
       });
       ui.showPinnedPanel.value = match.search.pinned;
       activeThreadTargetMessageId.value = null;
@@ -385,7 +388,7 @@ export function useRouteSync(deps: RouteSyncDeps) {
     void waddles.reloadChannelMembers(ch.id);
     messaging.clearMessages();
     await messaging.loadMessages(ch.spaceId ?? "", ch.id, 0, [], {
-      allowAccessRetry: options.allowAccessRetry === true,
+      intent: options.intent ?? "automatic",
     });
 
     // Restore the thread panel from the URL and initialize paging for every

--- a/chat/tests/bootstrap-mam-race.test.ts
+++ b/chat/tests/bootstrap-mam-race.test.ts
@@ -118,6 +118,7 @@ describe("useChannelMamPaging.loadMessages — bootstrap race (#675)", () => {
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -187,6 +188,7 @@ describe("useChannelMamPaging.loadMessages — bootstrap race (#675)", () => {
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -242,6 +244,7 @@ describe("bootstrap failure keeps live arrivals (#675 review)", () => {
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -302,6 +305,7 @@ describe("bootstrap merge keeps the unread divider anchored (#675 review)", () =
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -366,6 +370,7 @@ describe("bootstrap merge keeps archive-applied retractions (#675 review)", () =
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -433,6 +438,7 @@ describe("bootstrap merge keeps archive-applied corrections (#675 review)", () =
       pendingEchoClientIds,
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });

--- a/chat/tests/client-connection.test.ts
+++ b/chat/tests/client-connection.test.ts
@@ -364,6 +364,7 @@ function createRecordingPersistence() {
     loadJoinedRooms: () => [],
     saveJoinedRooms: () => undefined,
     clearJoinedRooms: () => calls.push("clearJoinedRooms"),
+    clearAutoJoinBlocks: () => calls.push("clearAutoJoinBlocks"),
   };
   return { persistence, calls, getSaved: () => saved };
 }
@@ -433,5 +434,11 @@ describe("ResumeStateStore", () => {
     store.clearAll();
     expect(freed).toBe(1);
     expect(store.handle).toBeNull();
+    expect(calls).toEqual([
+      "clearSm",
+      "clearSm",
+      "clearJoinedRooms",
+      "clearAutoJoinBlocks",
+    ]);
   });
 });

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -25,77 +25,101 @@ function session(): WaddleSession {
   } as WaddleSession;
 }
 
+type DiscoveryFixtureState = {
+  mucCatalogAvailable: boolean;
+  roomJids: string[];
+  bookmarks: Array<{ id: string; name: string; autojoin: boolean }>;
+  rejectUserBookmarks?: boolean;
+  rejectRoomInfo?: string;
+};
+
+function createDiscoveryXmpp(
+  state: DiscoveryFixtureState,
+  joinRoom: ReturnType<typeof mock>,
+) {
+  return {
+    join_room: joinRoom,
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          return discoItemsXml([
+            { jid: "spaces.example.test", name: "Spaces" },
+            { jid: "muc.example.test", name: "Chatrooms" },
+          ]);
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoItemsXml([]);
+        }
+        if (xml.includes('to="muc.example.test"')) {
+          if (!state.mucCatalogAvailable) {
+            throw new Error("temporary MUC catalog failure");
+          }
+          return discoItemsXml(
+            state.roomJids.map((jid) => ({
+              jid,
+              name: jid === roomJid ? "Private" : "Broken",
+            })),
+          );
+        }
+        return discoItemsXml([]);
+      }
+
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (
+          state.rejectRoomInfo
+          && xml.includes(`to="${state.rejectRoomInfo}"`)
+        ) {
+          throw new Error("temporary room hydration failure");
+        }
+        if (
+          xml.includes('to="muc.example.test"')
+          || state.roomJids.some((jid) => xml.includes(`to="${jid}"`))
+          || state.bookmarks.some(({ id }) => xml.includes(`to="${id}"`))
+        ) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service" }],
+            features: ["http://jabber.org/protocol/pubsub", "urn:xmpp:spaces:0"],
+          });
+        }
+        return discoInfoXml({
+          identities: [{ category: "server", type: "im" }],
+        });
+      }
+
+      if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        if (
+          state.rejectUserBookmarks
+          && xml.includes('to="alice@example.test"')
+        ) {
+          throw new Error("temporary bookmark failure");
+        }
+        return pubsubItemsXml(state.bookmarks);
+      }
+
+      throw new Error(`Unexpected IQ: ${xml}`);
+    },
+  };
+}
+
 describe("BrowserXmppClient room discovery cache", () => {
   test("degraded refreshes preserve denial, room, and auto-join caches", async () => {
     await withFakeDomParser(async () => {
-      let mucCatalogAvailable = true;
-      let rejectUserBookmarks = false;
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [roomJid],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: true }],
+        rejectUserBookmarks: false,
+      };
       const joinRoom = mock(async () => {
         throw new Error("a degraded refresh must not attempt a join");
       });
-      const xmpp = {
-        join_room: joinRoom,
-        async send_raw_iq(xml: string): Promise<string> {
-          if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
-            if (xml.includes('to="example.test"')) {
-              return discoItemsXml([
-                { jid: "spaces.example.test", name: "Spaces" },
-                { jid: "muc.example.test", name: "Chatrooms" },
-              ]);
-            }
-            if (xml.includes('to="spaces.example.test"')) {
-              return discoItemsXml([]);
-            }
-            if (xml.includes('to="muc.example.test"')) {
-              if (!mucCatalogAvailable) {
-                throw new Error("temporary MUC catalog failure");
-              }
-              return discoItemsXml([{ jid: roomJid, name: "Private" }]);
-            }
-            return discoItemsXml([]);
-          }
-
-          if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
-            if (xml.includes('to="muc.example.test"')) {
-              return discoInfoXml({
-                identities: [{ category: "conference", type: "text" }],
-                features: ["http://jabber.org/protocol/muc"],
-              });
-            }
-            if (xml.includes(`to="${roomJid}"`)) {
-              return discoInfoXml({
-                identities: [{ category: "conference", type: "text" }],
-                features: ["http://jabber.org/protocol/muc"],
-              });
-            }
-            if (xml.includes('to="spaces.example.test"')) {
-              return discoInfoXml({
-                identities: [{ category: "pubsub", type: "service" }],
-                features: ["http://jabber.org/protocol/pubsub", "urn:xmpp:spaces:0"],
-              });
-            }
-            return discoInfoXml({
-              identities: [{ category: "server", type: "im" }],
-            });
-          }
-
-          if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
-            if (
-              rejectUserBookmarks
-              && xml.includes('to="alice@example.test"')
-            ) {
-              throw new Error("temporary bookmark failure");
-            }
-            return pubsubItemsXml(
-              mucCatalogAvailable
-                ? [{ id: roomJid, name: "Private", autojoin: true }]
-                : [],
-            );
-          }
-
-          throw new Error(`Unexpected IQ: ${xml}`);
-        },
-      };
+      const xmpp = createDiscoveryXmpp(fixture, joinRoom);
       const client = new BrowserXmppClient(session(), {
         ...nullResumePersistence,
         loadAutoJoinBlocks: () => [{
@@ -119,7 +143,7 @@ describe("BrowserXmppClient room discovery cache", () => {
       expect(state.roomJidForChannel("private")).toBe(roomJid);
       expect(state.autoJoinRoomJids).toEqual([roomJid]);
 
-      rejectUserBookmarks = true;
+      fixture.rejectUserBookmarks = true;
       const bookmarkDegraded = await client.discoverTopology();
 
       expect(bookmarkDegraded.roomCatalogComplete).toBe(false);
@@ -128,8 +152,9 @@ describe("BrowserXmppClient room discovery cache", () => {
       expect(state.autoJoinRoomJids).toEqual([roomJid]);
       expect(joinRoom).not.toHaveBeenCalled();
 
-      rejectUserBookmarks = false;
-      mucCatalogAvailable = false;
+      fixture.rejectUserBookmarks = false;
+      fixture.mucCatalogAvailable = false;
+      fixture.bookmarks = [];
       const degraded = await client.discoverTopology();
 
       expect(degraded.roomCatalogComplete).toBe(false);
@@ -139,4 +164,78 @@ describe("BrowserXmppClient room discovery cache", () => {
       expect(joinRoom).not.toHaveBeenCalled();
     });
   });
+
+  for (const {
+    degradedSource,
+    shouldUnblock,
+  } of [
+    { degradedSource: "sibling hydration", shouldUnblock: true },
+    { degradedSource: "MUC items", shouldUnblock: true },
+    { degradedSource: "blocked room hydration", shouldUnblock: false },
+  ] as const) {
+    test(`${shouldUnblock ? "an authoritative" : "an incomplete"} membership change ${
+      shouldUnblock ? "unblocks" : "stays blocked"
+    } through degraded ${degradedSource}`, async () => {
+      await withFakeDomParser(async () => {
+        const siblingRoomJid = "broken@rooms.example.test";
+        const fixture: DiscoveryFixtureState = {
+          mucCatalogAvailable: true,
+          roomJids: [roomJid, siblingRoomJid],
+          bookmarks: [],
+        };
+        const joinRoom = mock(async () => undefined);
+        const xmpp = createDiscoveryXmpp(fixture, joinRoom);
+        const client = new BrowserXmppClient(session(), {
+          ...nullResumePersistence,
+          loadAutoJoinBlocks: () => [{
+            roomJid,
+            condition: "forbidden",
+          }],
+        });
+        const state = client as unknown as {
+          xmpp: typeof xmpp;
+          connected: boolean;
+          autoJoinRoomJids: readonly string[];
+        };
+        state.xmpp = xmpp;
+        state.connected = true;
+
+        const baseline = await client.discoverTopology();
+        expect(baseline.roomCatalogComplete).toBe(true);
+        expect(client.listRoomAccessRequirements()).toHaveLength(1);
+        joinRoom.mockClear();
+
+        fixture.bookmarks = [{
+          id: roomJid,
+          name: "Private",
+          autojoin: false,
+        }];
+        if (degradedSource === "MUC items") {
+          fixture.mucCatalogAvailable = false;
+        } else {
+          fixture.rejectRoomInfo =
+            degradedSource === "sibling hydration"
+              ? siblingRoomJid
+              : roomJid;
+        }
+        const changed = await client.discoverTopology();
+
+        expect(changed.roomCatalogComplete).toBe(false);
+        expect(
+          changed.roomReconciliationAuthority.fingerprintRoomKeys.includes(
+            roomJid,
+          ),
+        ).toBe(shouldUnblock);
+        expect(client.listRoomAccessRequirements()).toHaveLength(
+          shouldUnblock ? 0 : 1,
+        );
+        expect(state.autoJoinRoomJids.includes(roomJid)).toBe(false);
+        expect(
+          joinRoom.mock.calls.some(([joinedRoomJid]) =>
+            joinedRoomJid === roomJid
+          ),
+        ).toBe(false);
+      });
+    });
+  }
 });

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, mock, test } from "bun:test";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { nullResumePersistence } from "../src/lib/xmpp/resume-persistence";
+import {
+  discoInfoXml,
+  discoItemsXml,
+  pubsubItemsXml,
+  withFakeDomParser,
+} from "./helpers/disco-xml";
+
+const roomJid = "private@rooms.example.test";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.test",
+    session_id: "s1",
+    user_id: "u1",
+    avatar_url: null,
+    xmpp_localpart: "alice",
+    xmpp_websocket_url: "wss://example.test/xmpp",
+    is_expired: false,
+    expires_at: null,
+  } as WaddleSession;
+}
+
+describe("BrowserXmppClient room discovery cache", () => {
+  test("a degraded refresh preserves the last complete room and auto-join caches", async () => {
+    await withFakeDomParser(async () => {
+      let catalogAvailable = true;
+      const joinRoom = mock(async () => undefined);
+      const xmpp = {
+        join_room: joinRoom,
+        async send_raw_iq(xml: string): Promise<string> {
+          if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+            if (xml.includes('to="example.test"')) {
+              return discoItemsXml([
+                { jid: "spaces.example.test", name: "Spaces" },
+                { jid: "muc.example.test", name: "Chatrooms" },
+              ]);
+            }
+            if (xml.includes('to="spaces.example.test"')) {
+              return discoItemsXml([]);
+            }
+            if (xml.includes('to="muc.example.test"')) {
+              if (!catalogAvailable) throw new Error("temporary MUC catalog failure");
+              return discoItemsXml([{ jid: roomJid, name: "Private" }]);
+            }
+            return discoItemsXml([]);
+          }
+
+          if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+            if (xml.includes('to="muc.example.test"')) {
+              return discoInfoXml({
+                identities: [{ category: "conference", type: "text" }],
+                features: ["http://jabber.org/protocol/muc"],
+              });
+            }
+            if (xml.includes(`to="${roomJid}"`)) {
+              return discoInfoXml({
+                identities: [{ category: "conference", type: "text" }],
+                features: ["http://jabber.org/protocol/muc"],
+              });
+            }
+            if (xml.includes('to="spaces.example.test"')) {
+              return discoInfoXml({
+                identities: [{ category: "pubsub", type: "service" }],
+                features: ["http://jabber.org/protocol/pubsub", "urn:xmpp:spaces:0"],
+              });
+            }
+            return discoInfoXml({
+              identities: [{ category: "server", type: "im" }],
+            });
+          }
+
+          if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+            return pubsubItemsXml(
+              catalogAvailable
+                ? [{ id: roomJid, name: "Private", autojoin: true }]
+                : [],
+            );
+          }
+
+          throw new Error(`Unexpected IQ: ${xml}`);
+        },
+      };
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        loadAutoJoinBlocks: () => [{
+          roomJid,
+          condition: "forbidden",
+        }],
+        saveAutoJoinBlocks: () => {},
+        clearAutoJoinBlocks: () => {},
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        roomJidForChannel: (channelId: string) => string;
+        autoJoinRoomJids: readonly string[];
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+
+      const complete = await client.discoverTopology();
+      expect(complete.roomCatalogComplete).toBe(true);
+      expect(state.roomJidForChannel("private")).toBe(roomJid);
+      expect(state.autoJoinRoomJids).toEqual([roomJid]);
+
+      catalogAvailable = false;
+      const degraded = await client.discoverTopology();
+
+      expect(degraded.roomCatalogComplete).toBe(false);
+      expect(degraded.rooms).toEqual([]);
+      expect(state.roomJidForChannel("private")).toBe(roomJid);
+      expect(state.autoJoinRoomJids).toEqual([roomJid]);
+      expect(joinRoom).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -29,6 +29,8 @@ type DiscoveryFixtureState = {
   mucCatalogAvailable: boolean;
   roomJids: string[];
   bookmarks: Array<{ id: string; name: string; autojoin: boolean }>;
+  spaceBookmarks?: Array<{ id: string; name: string; autojoin: boolean }>;
+  rejectSpaceBookmarks?: boolean;
   rejectUserBookmarks?: boolean;
   rejectRoomInfo?: string;
 };
@@ -48,7 +50,11 @@ function createDiscoveryXmpp(
           ]);
         }
         if (xml.includes('to="spaces.example.test"')) {
-          return discoItemsXml([]);
+          return state.spaceBookmarks || state.rejectSpaceBookmarks
+            ? discoItemsXml([
+                { name: "Engineering", node: "space-engineering" },
+              ])
+            : discoItemsXml([]);
         }
         if (xml.includes('to="muc.example.test"')) {
           if (!state.mucCatalogAvailable) {
@@ -82,6 +88,16 @@ function createDiscoveryXmpp(
           });
         }
         if (xml.includes('to="spaces.example.test"')) {
+          if (xml.includes(' node=')) {
+            return discoInfoXml({
+              identities: [{ category: "pubsub", type: "leaf" }],
+              features: ["http://jabber.org/protocol/pubsub", "urn:xmpp:spaces:0"],
+              fields: {
+                FORM_TYPE: "http://jabber.org/protocol/pubsub#meta-data",
+                "pubsub#type": "urn:xmpp:spaces:0",
+              },
+            });
+          }
           return discoInfoXml({
             identities: [{ category: "pubsub", type: "service" }],
             features: ["http://jabber.org/protocol/pubsub", "urn:xmpp:spaces:0"],
@@ -93,6 +109,12 @@ function createDiscoveryXmpp(
       }
 
       if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        if (xml.includes('to="spaces.example.test"')) {
+          if (state.rejectSpaceBookmarks) {
+            throw new Error("temporary space bookmark failure");
+          }
+          return pubsubItemsXml(state.spaceBookmarks ?? []);
+        }
         if (
           state.rejectUserBookmarks
           && xml.includes('to="alice@example.test"')
@@ -222,8 +244,8 @@ describe("BrowserXmppClient room discovery cache", () => {
 
         expect(changed.roomCatalogComplete).toBe(false);
         expect(
-          changed.roomReconciliationAuthority.fingerprintRoomKeys.includes(
-            roomJid,
+          changed.roomReconciliationAuthority.roomFingerprints.some(
+            ({ roomKey }) => roomKey === roomJid,
           ),
         ).toBe(shouldUnblock);
         expect(client.listRoomAccessRequirements()).toHaveLength(
@@ -238,4 +260,52 @@ describe("BrowserXmppClient room discovery cache", () => {
       });
     });
   }
+
+  test("an exact space-membership change unblocks despite failed user bookmarks", async () => {
+    await withFakeDomParser(async () => {
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [roomJid],
+        bookmarks: [],
+      };
+      const joinRoom = mock(async () => undefined);
+      const xmpp = createDiscoveryXmpp(fixture, joinRoom);
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        loadAutoJoinBlocks: () => [{
+          roomJid,
+          condition: "forbidden",
+        }],
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+
+      await client.discoverTopology();
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
+      const accessEvents: Array<{ roomJid: string; state: string }> = [];
+      client.onRoomAccessChanged((event) => accessEvents.push(event));
+      joinRoom.mockClear();
+
+      fixture.spaceBookmarks = [{
+        id: roomJid,
+        name: "Private",
+        autojoin: true,
+      }];
+      fixture.rejectUserBookmarks = true;
+      const changed = await client.discoverTopology();
+
+      expect(changed.roomCatalogComplete).toBe(false);
+      expect(changed.roomReconciliationAuthority.roomFingerprints).toEqual([{
+        roomKey: roomJid,
+        fields: ["isGroupDm", "isBookmarked", "spaceId"],
+      }]);
+      expect(client.listRoomAccessRequirements()).toEqual([]);
+      expect(accessEvents).toContainEqual({ roomJid, state: "available" });
+      expect(joinRoom).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -189,11 +189,24 @@ describe("BrowserXmppClient room discovery cache", () => {
 
   for (const {
     degradedSource,
+    expectedCachedAutoJoin,
     shouldUnblock,
   } of [
-    { degradedSource: "sibling hydration", shouldUnblock: true },
-    { degradedSource: "MUC items", shouldUnblock: true },
-    { degradedSource: "blocked room hydration", shouldUnblock: false },
+    {
+      degradedSource: "sibling hydration",
+      expectedCachedAutoJoin: false,
+      shouldUnblock: true,
+    },
+    {
+      degradedSource: "MUC items",
+      expectedCachedAutoJoin: false,
+      shouldUnblock: true,
+    },
+    {
+      degradedSource: "blocked room hydration",
+      expectedCachedAutoJoin: true,
+      shouldUnblock: false,
+    },
   ] as const) {
     test(`${shouldUnblock ? "an authoritative" : "an incomplete"} membership change ${
       shouldUnblock ? "unblocks" : "stays blocked"
@@ -251,7 +264,9 @@ describe("BrowserXmppClient room discovery cache", () => {
         expect(client.listRoomAccessRequirements()).toHaveLength(
           shouldUnblock ? 0 : 1,
         );
-        expect(state.autoJoinRoomJids.includes(roomJid)).toBe(false);
+        expect(state.autoJoinRoomJids.includes(roomJid)).toBe(
+          expectedCachedAutoJoin,
+        );
         expect(
           joinRoom.mock.calls.some(([joinedRoomJid]) =>
             joinedRoomJid === roomJid
@@ -305,6 +320,56 @@ describe("BrowserXmppClient room discovery cache", () => {
       }]);
       expect(client.listRoomAccessRequirements()).toEqual([]);
       expect(accessEvents).toContainEqual({ roomJid, state: "available" });
+      expect(joinRoom).not.toHaveBeenCalled();
+    });
+  });
+
+  test("an omitted bookmark-only room cannot clear denial or discovery caches", async () => {
+    await withFakeDomParser(async () => {
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [roomJid],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: true }],
+      };
+      const joinRoom = mock(async () => undefined);
+      const xmpp = createDiscoveryXmpp(fixture, joinRoom);
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        loadAutoJoinBlocks: () => [{
+          roomJid,
+          condition: "forbidden",
+        }],
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        roomJidForChannel: (channelId: string) => string;
+        autoJoinRoomJids: readonly string[];
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+
+      await client.discoverTopology();
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
+      expect(state.roomJidForChannel("private")).toBe(roomJid);
+      expect(state.autoJoinRoomJids).toEqual([roomJid]);
+      const accessEvents: Array<{ roomJid: string; state: string }> = [];
+      client.onRoomAccessChanged((event) => accessEvents.push(event));
+      joinRoom.mockClear();
+
+      fixture.roomJids = [];
+      fixture.rejectRoomInfo = roomJid;
+      const degraded = await client.discoverTopology();
+
+      expect(degraded.roomCatalogComplete).toBe(false);
+      expect(degraded.rooms).toEqual([]);
+      expect(
+        degraded.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(false);
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
+      expect(state.roomJidForChannel("private")).toBe(roomJid);
+      expect(state.autoJoinRoomJids).toEqual([roomJid]);
+      expect(accessEvents).toEqual([]);
       expect(joinRoom).not.toHaveBeenCalled();
     });
   });

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
+import type { RoomAutoJoinBlock } from "../src/lib/xmpp/room-auto-join-policy";
 import { nullResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import {
   discoInfoXml,
@@ -371,6 +372,330 @@ describe("BrowserXmppClient room discovery cache", () => {
       expect(state.autoJoinRoomJids).toEqual([roomJid]);
       expect(accessEvents).toEqual([]);
       expect(joinRoom).not.toHaveBeenCalled();
+    });
+  });
+
+  test("an omitted room cannot seed a fresh denial from a stale fingerprint", async () => {
+    await withFakeDomParser(async () => {
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: false }],
+      };
+      let onPresence: ((presence: {
+        from?: string;
+        presence_type: string;
+        error_condition?: string;
+        error_type?: string;
+      }) => void) | null = null;
+      const joinRoom = mock(async () => undefined);
+      const xmpp = {
+        ...createDiscoveryXmpp(fixture, joinRoom),
+        set_on_presence(callback: NonNullable<typeof onPresence>) {
+          onPresence = callback;
+        },
+      };
+      let savedBlocks: RoomAutoJoinBlock[] = [];
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        saveAutoJoinBlocks: (blocks) => {
+          savedBlocks = blocks.map((block) => ({ ...block }));
+        },
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        wireEvents: (xmpp: typeof xmpp) => void;
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+      state.wireEvents(xmpp);
+
+      const first = await client.discoverTopology();
+      expect(first.roomCatalogComplete).toBe(true);
+      expect(joinRoom).not.toHaveBeenCalled();
+
+      fixture.bookmarks = [{
+        id: roomJid,
+        name: "Private",
+        autojoin: true,
+      }];
+      fixture.rejectRoomInfo = roomJid;
+      const incomplete = await client.discoverTopology();
+      expect(incomplete.roomCatalogComplete).toBe(false);
+      expect(incomplete.rooms).toEqual([]);
+
+      const rejected = client.fanOutAutoJoin([roomJid]);
+      await Promise.resolve();
+      onPresence?.({
+        from: `${roomJid}/alice`,
+        presence_type: "error",
+        error_condition: "registration-required",
+        error_type: "auth",
+      });
+      await rejected;
+
+      expect(savedBlocks).toEqual([{
+        roomJid,
+        condition: "registration-required",
+      }]);
+
+      fixture.rejectRoomInfo = undefined;
+      const stable = await client.discoverTopology();
+      expect(stable.roomCatalogComplete).toBe(true);
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
+      expect(savedBlocks[0]?.catalogFingerprint).toBeString();
+
+      fixture.bookmarks = [{
+        id: roomJid,
+        name: "Private",
+        autojoin: false,
+      }];
+      await client.discoverTopology();
+      expect(client.listRoomAccessRequirements()).toEqual([]);
+    });
+  });
+
+  test("an older overlapping discovery cannot repopulate denial evidence", async () => {
+    await withFakeDomParser(async () => {
+      const firstFixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: false }],
+      };
+      const latestFixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: true }],
+      };
+      const joinRoom = mock(async () => undefined);
+      const firstXmpp = createDiscoveryXmpp(firstFixture, joinRoom);
+      const latestXmpp = createDiscoveryXmpp(latestFixture, joinRoom);
+      let releaseFirst!: () => void;
+      let releaseLatest!: () => void;
+      let markFirstStarted!: () => void;
+      let markLatestStarted!: () => void;
+      const firstGate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const latestGate = new Promise<void>((resolve) => {
+        releaseLatest = resolve;
+      });
+      const firstStarted = new Promise<void>((resolve) => {
+        markFirstStarted = resolve;
+      });
+      const latestStarted = new Promise<void>((resolve) => {
+        markLatestStarted = resolve;
+      });
+      let rootDiscoveryCalls = 0;
+      let activeFixture: "first" | "latest" | null = null;
+      let onPresence: ((presence: {
+        from?: string;
+        presence_type: string;
+        error_condition?: string;
+        error_type?: string;
+      }) => void) | null = null;
+      const xmpp = {
+        join_room: joinRoom,
+        set_on_presence(callback: NonNullable<typeof onPresence>) {
+          onPresence = callback;
+        },
+        async send_raw_iq(xml: string): Promise<string> {
+          if (
+            xml.includes('xmlns="http://jabber.org/protocol/disco#items"')
+            && xml.includes('to="example.test"')
+          ) {
+            rootDiscoveryCalls += 1;
+            if (rootDiscoveryCalls === 1) {
+              markFirstStarted();
+              await firstGate;
+              activeFixture = "first";
+              return firstXmpp.send_raw_iq(xml);
+            }
+            markLatestStarted();
+            await latestGate;
+            activeFixture = "latest";
+            return latestXmpp.send_raw_iq(xml);
+          }
+          if (activeFixture === "first") {
+            return firstXmpp.send_raw_iq(xml);
+          }
+          return latestXmpp.send_raw_iq(xml);
+        },
+      };
+      let savedBlocks: RoomAutoJoinBlock[] = [];
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        saveAutoJoinBlocks: (blocks) => {
+          savedBlocks = blocks.map((block) => ({ ...block }));
+        },
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        wireEvents: (xmpp: typeof xmpp) => void;
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+      state.wireEvents(xmpp);
+
+      const firstDiscovery = client.discoverTopology();
+      await firstStarted;
+      const latestDiscovery = client.discoverTopology();
+      await latestStarted;
+
+      releaseFirst();
+      await firstDiscovery;
+
+      const rejected = client.fanOutAutoJoin([roomJid]);
+      await Promise.resolve();
+      onPresence?.({
+        from: `${roomJid}/alice`,
+        presence_type: "error",
+        error_condition: "registration-required",
+        error_type: "auth",
+      });
+      await rejected;
+      expect(savedBlocks).toEqual([{
+        roomJid,
+        condition: "registration-required",
+      }]);
+
+      releaseLatest();
+      await latestDiscovery;
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
+      expect(savedBlocks[0]?.catalogFingerprint).toBeString();
+    });
+  });
+
+  test("an in-flight discovery cannot repopulate evidence after disconnect", async () => {
+    await withFakeDomParser(async () => {
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [],
+        bookmarks: [{ id: roomJid, name: "Private", autojoin: true }],
+      };
+      const joinRoom = mock(async () => undefined);
+      const discoveryXmpp = createDiscoveryXmpp(fixture, joinRoom);
+      let releaseDiscovery!: () => void;
+      let markDiscoveryStarted!: () => void;
+      const discoveryGate = new Promise<void>((resolve) => {
+        releaseDiscovery = resolve;
+      });
+      const discoveryStarted = new Promise<void>((resolve) => {
+        markDiscoveryStarted = resolve;
+      });
+      let rootDiscoveryBlocked = false;
+      const xmpp = {
+        join_room: joinRoom,
+        async send_raw_iq(xml: string): Promise<string> {
+          if (
+            !rootDiscoveryBlocked
+            && xml.includes('xmlns="http://jabber.org/protocol/disco#items"')
+            && xml.includes('to="example.test"')
+          ) {
+            rootDiscoveryBlocked = true;
+            markDiscoveryStarted();
+            await discoveryGate;
+          }
+          return discoveryXmpp.send_raw_iq(xml);
+        },
+      };
+      const client = new BrowserXmppClient(session(), nullResumePersistence);
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        autoJoinRoomJids: readonly string[];
+        currentRoomCatalogFingerprintEvidence: ReadonlyMap<string, unknown>;
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+
+      const discovery = client.discoverTopology();
+      await discoveryStarted;
+      await client.disconnect();
+      releaseDiscovery();
+      await discovery;
+
+      expect(state.currentRoomCatalogFingerprintEvidence.size).toBe(0);
+      expect(state.autoJoinRoomJids).toEqual([]);
+      expect(joinRoom).not.toHaveBeenCalled();
+    });
+  });
+
+  test("partial room authority seeds a field-scoped denial baseline", async () => {
+    await withFakeDomParser(async () => {
+      const fixture: DiscoveryFixtureState = {
+        mucCatalogAvailable: true,
+        roomJids: [roomJid],
+        bookmarks: [],
+        spaceBookmarks: [{
+          id: roomJid,
+          name: "Private",
+          autojoin: true,
+        }],
+        rejectUserBookmarks: true,
+      };
+      let onPresence: ((presence: {
+        from?: string;
+        presence_type: string;
+        error_condition?: string;
+        error_type?: string;
+      }) => void) | null = null;
+      const joinRoom = mock(async () => undefined);
+      const xmpp = {
+        ...createDiscoveryXmpp(fixture, joinRoom),
+        set_on_presence(callback: NonNullable<typeof onPresence>) {
+          onPresence = callback;
+        },
+      };
+      let savedBlocks: RoomAutoJoinBlock[] = [];
+      const client = new BrowserXmppClient(session(), {
+        ...nullResumePersistence,
+        saveAutoJoinBlocks: (blocks) => {
+          savedBlocks = blocks.map((block) => ({ ...block }));
+        },
+      });
+      const state = client as unknown as {
+        xmpp: typeof xmpp;
+        connected: boolean;
+        wireEvents: (xmpp: typeof xmpp) => void;
+      };
+      state.xmpp = xmpp;
+      state.connected = true;
+      state.wireEvents(xmpp);
+
+      const incomplete = await client.discoverTopology();
+      expect(incomplete.roomCatalogComplete).toBe(false);
+      expect(
+        incomplete.roomReconciliationAuthority.roomFingerprints.find(
+          ({ roomKey }) => roomKey === roomJid,
+        )?.fields,
+      ).toEqual(["isGroupDm", "isBookmarked", "spaceId"]);
+
+      const rejected = client.fanOutAutoJoin([roomJid]);
+      await Promise.resolve();
+      onPresence?.({
+        from: `${roomJid}/alice`,
+        presence_type: "error",
+        error_condition: "forbidden",
+        error_type: "auth",
+      });
+      await rejected;
+
+      expect(savedBlocks[0]?.catalogFingerprint).toBeString();
+      expect(savedBlocks[0]).toMatchObject({
+        roomJid,
+        condition: "forbidden",
+        catalogFingerprintFields: [
+          "spaceId",
+          "isGroupDm",
+          "isBookmarked",
+        ],
+      });
+
+      await client.discoverTopology();
+      expect(client.listRoomAccessRequirements()).toHaveLength(1);
     });
   });
 });

--- a/chat/tests/client-discovery-cache.test.ts
+++ b/chat/tests/client-discovery-cache.test.ts
@@ -26,10 +26,13 @@ function session(): WaddleSession {
 }
 
 describe("BrowserXmppClient room discovery cache", () => {
-  test("a degraded refresh preserves the last complete room and auto-join caches", async () => {
+  test("degraded refreshes preserve denial, room, and auto-join caches", async () => {
     await withFakeDomParser(async () => {
-      let catalogAvailable = true;
-      const joinRoom = mock(async () => undefined);
+      let mucCatalogAvailable = true;
+      let rejectUserBookmarks = false;
+      const joinRoom = mock(async () => {
+        throw new Error("a degraded refresh must not attempt a join");
+      });
       const xmpp = {
         join_room: joinRoom,
         async send_raw_iq(xml: string): Promise<string> {
@@ -44,7 +47,9 @@ describe("BrowserXmppClient room discovery cache", () => {
               return discoItemsXml([]);
             }
             if (xml.includes('to="muc.example.test"')) {
-              if (!catalogAvailable) throw new Error("temporary MUC catalog failure");
+              if (!mucCatalogAvailable) {
+                throw new Error("temporary MUC catalog failure");
+              }
               return discoItemsXml([{ jid: roomJid, name: "Private" }]);
             }
             return discoItemsXml([]);
@@ -75,8 +80,14 @@ describe("BrowserXmppClient room discovery cache", () => {
           }
 
           if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+            if (
+              rejectUserBookmarks
+              && xml.includes('to="alice@example.test"')
+            ) {
+              throw new Error("temporary bookmark failure");
+            }
             return pubsubItemsXml(
-              catalogAvailable
+              mucCatalogAvailable
                 ? [{ id: roomJid, name: "Private", autojoin: true }]
                 : [],
             );
@@ -108,7 +119,17 @@ describe("BrowserXmppClient room discovery cache", () => {
       expect(state.roomJidForChannel("private")).toBe(roomJid);
       expect(state.autoJoinRoomJids).toEqual([roomJid]);
 
-      catalogAvailable = false;
+      rejectUserBookmarks = true;
+      const bookmarkDegraded = await client.discoverTopology();
+
+      expect(bookmarkDegraded.roomCatalogComplete).toBe(false);
+      expect(bookmarkDegraded.rooms.map((room) => room.jid)).toEqual([roomJid]);
+      expect(state.roomJidForChannel("private")).toBe(roomJid);
+      expect(state.autoJoinRoomJids).toEqual([roomJid]);
+      expect(joinRoom).not.toHaveBeenCalled();
+
+      rejectUserBookmarks = false;
+      mucCatalogAvailable = false;
       const degraded = await client.discoverTopology();
 
       expect(degraded.roomCatalogComplete).toBe(false);

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1246,6 +1246,35 @@ describe("client send readiness", () => {
     );
   });
 
+  test("session-ready room queue flush does not rejoin a terminally denied current room", async () => {
+    const roomJid = roomBareJidFor(session(), "private");
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadAutoJoinBlocks: () => [{
+        roomJid,
+        condition: "forbidden",
+      }],
+    });
+    const xmpp = {
+      join_room: mock(async () => undefined),
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      currentRoom: string | null;
+      handleSessionReady: (
+        xmpp: typeof xmpp,
+        lifecycle: { type: "fresh" },
+      ) => void;
+    };
+    state.xmpp = xmpp;
+    state.currentRoom = roomJid;
+
+    state.handleSessionReady(xmpp, { type: "fresh" });
+    await settleReconnectCatchup();
+
+    expect(xmpp.join_room).not.toHaveBeenCalled();
+  });
+
   test("session-ready rejoins retained non-current rooms", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = "side@muc.example.com";

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -713,6 +713,11 @@ describe("client send readiness", () => {
 
     await reloaded.fanOutAutoJoin([roomJid]);
     expect(reloadedJoinRoom).not.toHaveBeenCalled();
+
+    await expect(reloaded.switchRoom("", "private")).rejects.toThrow(
+      "You need access to this channel.",
+    );
+    expect(reloadedJoinRoom).not.toHaveBeenCalled();
   });
 
   test("explicit navigation can retry a room after a forbidden auto-join rejection", async () => {
@@ -759,7 +764,7 @@ describe("client send readiness", () => {
     });
     await rejected;
 
-    const explicitRetry = client.ensureJoined(roomJid);
+    const explicitRetry = client.retryRoomAccess("", "private");
     await Promise.resolve();
     onPresence?.({
       from: `${roomJid}/alice`,

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -8,7 +8,7 @@ import { BrowserXmppClient, roomBareJidFor, type DmConversationScope, type Inbox
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
-import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
+import { nullResumePersistence, type ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
@@ -582,7 +582,7 @@ describe("client send readiness", () => {
       error_type: "auth",
     });
 
-    await expect(joined).rejects.toThrow("Channel presence was rejected");
+    await expect(joined).rejects.toThrow("You need access to this channel.");
     expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
     expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
     expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
@@ -592,6 +592,256 @@ describe("client send readiness", () => {
     expect(errors[0].errorType).toBe("auth");
     expect(errors[0].roomLocalpart).toBe("c1");
     expect(staleJoinVisibleAtEmit).toEqual([false]);
+  });
+
+  test("terminal MUC authorization rejection evicts a retained room from later auto-join epochs", async () => {
+    const roomJid = roomBareJidFor(session(), "private");
+    const saveJoinedRooms = mock((_rooms: readonly string[]) => undefined);
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadJoinedRooms: () => [roomJid],
+      saveJoinedRooms,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      autoJoinAttemptedRoomKeys: Set<string>;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.wireEvents(xmpp);
+
+    const rejected = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "registration-required",
+      error_type: "auth",
+    });
+    await rejected;
+
+    expect(saveJoinedRooms).toHaveBeenLastCalledWith([]);
+
+    // A reconnect opens a new auto-join epoch. The terminally denied room
+    // must remain suppressed even though topology still advertises it.
+    state.autoJoinAttemptedRoomKeys.clear();
+    await client.fanOutAutoJoin([roomJid]);
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+  });
+
+  test("terminal MUC authorization rejection remains suppressed after a page reload", async () => {
+    const roomJid = roomBareJidFor(session(), "private");
+    let blockedRooms: Array<{
+      roomJid: string;
+      condition: "registration-required" | "forbidden";
+      catalogFingerprint?: string | null;
+    }> = [];
+    const persistence = {
+      ...nullResumePersistence,
+      loadAutoJoinBlocks: () => blockedRooms,
+      saveAutoJoinBlocks: (blocks: typeof blockedRooms) => {
+        blockedRooms = blocks.map((block) => ({ ...block }));
+      },
+      clearAutoJoinBlocks: () => {
+        blockedRooms = [];
+      },
+    };
+    const client = new BrowserXmppClient(session(), persistence);
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const firstJoinRoom = mock(async () => undefined);
+    const firstXmpp = {
+      join_room: firstJoinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const firstState = client as unknown as {
+      xmpp: typeof firstXmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof firstXmpp) => void;
+    };
+    firstState.xmpp = firstXmpp;
+    firstState.connected = true;
+    firstState.wireEvents(firstXmpp);
+
+    const rejected = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "registration-required",
+      error_type: "auth",
+    });
+    await rejected;
+
+    expect(blockedRooms).toEqual([{
+      roomJid,
+      condition: "registration-required",
+    }]);
+
+    const reloaded = new BrowserXmppClient(session(), persistence);
+    const reloadedJoinRoom = mock(async () => {
+      throw new Error("must remain suppressed");
+    });
+    const reloadedXmpp = { join_room: reloadedJoinRoom };
+    const reloadedState = reloaded as unknown as {
+      xmpp: typeof reloadedXmpp;
+      connected: boolean;
+    };
+    reloadedState.xmpp = reloadedXmpp;
+    reloadedState.connected = true;
+
+    await reloaded.fanOutAutoJoin([roomJid]);
+    expect(reloadedJoinRoom).not.toHaveBeenCalled();
+  });
+
+  test("explicit navigation can retry a room after a forbidden auto-join rejection", async () => {
+    const roomJid = roomBareJidFor(session(), "private");
+    const saveAutoJoinBlocks = mock((_blocks: readonly unknown[]) => undefined);
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      saveAutoJoinBlocks,
+    });
+    const roomAccessEvents: unknown[] = [];
+    client.onRoomAccessChanged((event) => roomAccessEvents.push(event));
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      fullJid: string;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.wireEvents(xmpp);
+
+    const rejected = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "forbidden",
+      error_type: "auth",
+    });
+    await rejected;
+
+    const explicitRetry = client.ensureJoined(roomJid);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await explicitRetry;
+
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    expect(saveAutoJoinBlocks).toHaveBeenLastCalledWith([]);
+    expect(roomAccessEvents).toEqual([
+      {
+        roomJid,
+        state: "required",
+        condition: "forbidden",
+      },
+      {
+        roomJid,
+        state: "available",
+      },
+    ]);
+  });
+
+  test("wait-type MUC rejection remains eligible for a later auto-join epoch", async () => {
+    const roomJid = roomBareJidFor(session(), "busy");
+    const saveJoinedRooms = mock((_rooms: readonly string[]) => undefined);
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadJoinedRooms: () => [roomJid],
+      saveJoinedRooms,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      autoJoinAttemptedRoomKeys: Set<string>;
+      fullJid: string;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.wireEvents(xmpp);
+
+    const rejected = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await rejected;
+
+    expect(saveJoinedRooms).not.toHaveBeenCalled();
+
+    state.autoJoinAttemptedRoomKeys.clear();
+    const retried = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await retried;
+
+    expect(joinRoom).toHaveBeenCalledTimes(2);
   });
 
   test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {

--- a/chat/tests/controller-room-sync.test.ts
+++ b/chat/tests/controller-room-sync.test.ts
@@ -131,7 +131,13 @@ describe("useRoomSync selectChannel", () => {
     expect(h.clearChannelActivity).toHaveBeenCalledWith("general@muc.example.com");
     expect(h.clearMessages).toHaveBeenCalledTimes(1);
     // Unread-at-load comes from the computed unread map.
-    expect(h.loadMessages).toHaveBeenCalledWith("", "general", 7);
+    expect(h.loadMessages).toHaveBeenCalledWith(
+      "",
+      "general",
+      7,
+      [],
+      { allowAccessRetry: true },
+    );
     expect(h.activeChannelId.value).toBe("general");
     h.scope.stop();
   });
@@ -166,7 +172,13 @@ describe("useRoomSync selectChannelByRoomJid", () => {
 
     expect(h.roomSync.pendingChannelRoomJidSelection.value).toBeNull();
     expect(h.activeChannelId.value).toBe("general");
-    expect(h.loadMessages).toHaveBeenCalledWith("", "general", 7);
+    expect(h.loadMessages).toHaveBeenCalledWith(
+      "",
+      "general",
+      7,
+      [],
+      { allowAccessRetry: true },
+    );
     h.scope.stop();
   });
 

--- a/chat/tests/controller-room-sync.test.ts
+++ b/chat/tests/controller-room-sync.test.ts
@@ -136,7 +136,7 @@ describe("useRoomSync selectChannel", () => {
       "general",
       7,
       [],
-      { allowAccessRetry: true },
+      { intent: "explicit-navigation" },
     );
     expect(h.activeChannelId.value).toBe("general");
     h.scope.stop();
@@ -177,7 +177,7 @@ describe("useRoomSync selectChannelByRoomJid", () => {
       "general",
       7,
       [],
-      { allowAccessRetry: true },
+      { intent: "explicit-navigation" },
     );
     h.scope.stop();
   });

--- a/chat/tests/controller-route-sync.test.ts
+++ b/chat/tests/controller-route-sync.test.ts
@@ -253,10 +253,37 @@ describe("useRouteSync applyRouteTarget", () => {
     expect(h.activeChannelId.value).toBe("general");
     expect(h.reloadChannelMembers).toHaveBeenCalledWith("general");
     expect(h.clearMessages).toHaveBeenCalledTimes(1);
-    expect(h.loadMessages).toHaveBeenCalledWith("space-1", "general");
+    expect(h.loadMessages).toHaveBeenCalledWith(
+      "space-1",
+      "general",
+      0,
+      [],
+      { allowAccessRetry: false },
+    );
     expect(h.activeThreadStack.value).toEqual(["t1"]);
     expect(h.activeRightPanel.value).toBe("thread");
     expect(h.channelBackfill).toHaveBeenCalledWith("t1");
+    h.scope.stop();
+  });
+
+  test("explicit history navigation may retry a denied channel", async () => {
+    const h = makeHarness();
+
+    await h.routeSync.applyRouteTarget({
+      id: "channel",
+      params: { channelId: "general" },
+      search: { thread: [], pinned: false },
+    } as RouteMatch, h.routeSync.beginRouteRequest(), {
+      allowAccessRetry: true,
+    });
+
+    expect(h.loadMessages).toHaveBeenCalledWith(
+      "space-1",
+      "general",
+      0,
+      [],
+      { allowAccessRetry: true },
+    );
     h.scope.stop();
   });
 

--- a/chat/tests/controller-route-sync.test.ts
+++ b/chat/tests/controller-route-sync.test.ts
@@ -258,7 +258,7 @@ describe("useRouteSync applyRouteTarget", () => {
       "general",
       0,
       [],
-      { allowAccessRetry: false },
+      { intent: "automatic" },
     );
     expect(h.activeThreadStack.value).toEqual(["t1"]);
     expect(h.activeRightPanel.value).toBe("thread");
@@ -274,7 +274,7 @@ describe("useRouteSync applyRouteTarget", () => {
       params: { channelId: "general" },
       search: { thread: [], pinned: false },
     } as RouteMatch, h.routeSync.beginRouteRequest(), {
-      allowAccessRetry: true,
+      intent: "explicit-navigation",
     });
 
     expect(h.loadMessages).toHaveBeenCalledWith(
@@ -282,7 +282,7 @@ describe("useRouteSync applyRouteTarget", () => {
       "general",
       0,
       [],
-      { allowAccessRetry: true },
+      { intent: "explicit-navigation" },
     );
     h.scope.stop();
   });

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -23,6 +23,7 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
       const room = topology.rooms.find((candidate) => candidate.jid === "general@muc.example.test");
       expect(room?.autojoin).toBe(true);
       expect(room?.isBookmarked).toBe(true);
+      expect(topology.roomCatalogComplete).toBe(true);
     });
   });
 

--- a/chat/tests/discovery-bookmark-autojoin.test.ts
+++ b/chat/tests/discovery-bookmark-autojoin.test.ts
@@ -20,7 +20,9 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
         "alice@example.test",
       );
 
-      expect(topology.rooms.find((room) => room.jid === "general@muc.example.test")?.autojoin).toBe(true);
+      const room = topology.rooms.find((candidate) => candidate.jid === "general@muc.example.test");
+      expect(room?.autojoin).toBe(true);
+      expect(room?.isBookmarked).toBe(true);
     });
   });
 
@@ -66,7 +68,9 @@ describe("discoverTopology XEP-0402 bookmark autojoin", () => {
         "alice@example.test",
       );
 
-      expect(topology.rooms.find((room) => room.jid === "orphan@muc.example.test")?.autojoin).toBe(true);
+      const room = topology.rooms.find((candidate) => candidate.jid === "orphan@muc.example.test");
+      expect(room?.autojoin).toBe(true);
+      expect(room?.isBookmarked).toBe(false);
     });
   });
 

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -164,6 +164,7 @@ describe("discoverTopology partial-failure resilience", () => {
 
       // Spaces discovery succeeded.
       expect(topology.spaces.map((space) => space.id)).toContain("space-engineering");
+      expect(topology.roomCatalogComplete).toBe(false);
       // MUC items hung → rooms array stays empty rather than the whole
       // topology call rejecting.
       expect(topology.rooms).toEqual([]);
@@ -181,6 +182,7 @@ describe("discoverTopology partial-failure resilience", () => {
       // channelFromRoom record without hydrated fields.
       const ids = topology.rooms.map((room) => room.id).sort();
       expect(ids).toEqual(["broken", "general"]);
+      expect(topology.roomCatalogComplete).toBe(false);
     });
   });
 });

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -186,9 +186,10 @@ describe("discoverTopology partial-failure resilience", () => {
       expect(
         topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
       ).toBe(true);
-      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([
-        "general@muc.example.test",
-      ]);
+      expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([{
+        roomKey: "general@muc.example.test",
+        fields: ["spaceId", "autojoin", "isGroupDm", "isBookmarked"],
+      }]);
     });
   });
 
@@ -207,7 +208,7 @@ describe("discoverTopology partial-failure resilience", () => {
       expect(
         topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
       ).toBe(false);
-      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([]);
+      expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([]);
     });
   });
 
@@ -226,7 +227,51 @@ describe("discoverTopology partial-failure resilience", () => {
       expect(
         topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
       ).toBe(false);
-      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([]);
+      expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([]);
+    });
+  });
+
+  test("keeps exact space-bookmark authority when user bookmarks fail", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        resilientClient({
+          rejectUserBookmarks: true,
+          spaceBookmarks: [{
+            id: "general@muc.example.test",
+            name: "General",
+            autojoin: false,
+          }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.roomCatalogComplete).toBe(false);
+      expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([{
+        roomKey: "general@muc.example.test",
+        fields: ["isGroupDm", "isBookmarked", "spaceId"],
+      }]);
+    });
+  });
+
+  test("keeps exact user-bookmark authority when space bookmarks fail", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        resilientClient({
+          rejectSpaceBookmarks: true,
+          userBookmarks: [{
+            id: "general@muc.example.test",
+            name: "General",
+            autojoin: false,
+          }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.roomCatalogComplete).toBe(false);
+      expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([{
+        roomKey: "general@muc.example.test",
+        fields: ["isGroupDm", "isBookmarked", "autojoin"],
+      }]);
     });
   });
 });
@@ -237,6 +282,8 @@ type ResilientClientOptions = {
   rejectSpaceBookmarks?: boolean;
   rejectUserBookmarks?: boolean;
   rejectRoomInfo?: string;
+  spaceBookmarks?: Array<{ id: string; name: string; autojoin: boolean }>;
+  userBookmarks?: Array<{ id: string; name: string; autojoin: boolean }>;
 };
 
 function neverResolvesForComponent(jid: string) {
@@ -417,7 +464,10 @@ function resilientClient(options: ResilientClientOptions = {}) {
         ) {
           throw new Error("simulated user bookmark failure");
         }
-        return pubsubItemsXml([]);
+        if (xml.includes('to="spaces.example.test"')) {
+          return pubsubItemsXml(options.spaceBookmarks ?? []);
+        }
+        return pubsubItemsXml(options.userBookmarks ?? []);
       }
       throw new Error(`Unexpected IQ: ${xml}`);
     },

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -185,11 +185,43 @@ describe("discoverTopology partial-failure resilience", () => {
       expect(topology.roomCatalogComplete).toBe(false);
     });
   });
+
+  test("marks the room catalog incomplete when user bookmarks fail", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        resilientClient({ rejectUserBookmarks: true }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.map((room) => room.id).sort()).toEqual([
+        "broken",
+        "general",
+      ]);
+      expect(topology.roomCatalogComplete).toBe(false);
+    });
+  });
+
+  test("marks the room catalog incomplete when space bookmarks fail", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(
+        resilientClient({ rejectSpaceBookmarks: true }),
+        "alice@example.test",
+      );
+
+      expect(topology.rooms.map((room) => room.id).sort()).toEqual([
+        "broken",
+        "general",
+      ]);
+      expect(topology.roomCatalogComplete).toBe(false);
+    });
+  });
 });
 
 type ResilientClientOptions = {
   hangComponent?: string;
   hangMucItems?: boolean;
+  rejectSpaceBookmarks?: boolean;
+  rejectUserBookmarks?: boolean;
   rejectRoomInfo?: string;
 };
 
@@ -359,6 +391,18 @@ function resilientClient(options: ResilientClientOptions = {}) {
         return discoInfoXml();
       }
       if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        if (
+          options.rejectSpaceBookmarks
+          && xml.includes('to="spaces.example.test"')
+        ) {
+          throw new Error("simulated space bookmark failure");
+        }
+        if (
+          options.rejectUserBookmarks
+          && xml.includes('to="alice@example.test"')
+        ) {
+          throw new Error("simulated user bookmark failure");
+        }
         return pubsubItemsXml([]);
       }
       throw new Error(`Unexpected IQ: ${xml}`);

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -183,6 +183,12 @@ describe("discoverTopology partial-failure resilience", () => {
       const ids = topology.rooms.map((room) => room.id).sort();
       expect(ids).toEqual(["broken", "general"]);
       expect(topology.roomCatalogComplete).toBe(false);
+      expect(
+        topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(true);
+      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([
+        "general@muc.example.test",
+      ]);
     });
   });
 
@@ -198,6 +204,10 @@ describe("discoverTopology partial-failure resilience", () => {
         "general",
       ]);
       expect(topology.roomCatalogComplete).toBe(false);
+      expect(
+        topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(false);
+      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([]);
     });
   });
 
@@ -213,6 +223,10 @@ describe("discoverTopology partial-failure resilience", () => {
         "general",
       ]);
       expect(topology.roomCatalogComplete).toBe(false);
+      expect(
+        topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(false);
+      expect(topology.roomReconciliationAuthority.fingerprintRoomKeys).toEqual([]);
     });
   });
 });

--- a/chat/tests/discovery-resilience.test.ts
+++ b/chat/tests/discovery-resilience.test.ts
@@ -185,11 +185,57 @@ describe("discoverTopology partial-failure resilience", () => {
       expect(topology.roomCatalogComplete).toBe(false);
       expect(
         topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
-      ).toBe(true);
+      ).toBe(false);
       expect(topology.roomReconciliationAuthority.roomFingerprints).toEqual([{
         roomKey: "general@muc.example.test",
         fields: ["spaceId", "autojoin", "isGroupDm", "isBookmarked"],
       }]);
+    });
+  });
+
+  test("does not authorize absence when failed hydration omits a bookmark-only room", async () => {
+    await withFakeDomParser(async () => {
+      const omittedRoomJid = "private@muc.example.test";
+      const topology = await discoverTopology(
+        resilientClient({
+          rejectRoomInfo: omittedRoomJid,
+          userBookmarks: [{
+            id: omittedRoomJid,
+            name: "Private",
+            autojoin: true,
+          }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.roomCatalogComplete).toBe(false);
+      expect(topology.rooms.some((room) => room.jid === omittedRoomJid)).toBe(false);
+      expect(
+        topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(false);
+    });
+  });
+
+  test("does not authorize absence when incomplete hydration omits a bookmark-only room", async () => {
+    await withFakeDomParser(async () => {
+      const omittedRoomJid = "private@muc.example.test";
+      const topology = await discoverTopology(
+        resilientClient({
+          incompleteRoomInfo: omittedRoomJid,
+          userBookmarks: [{
+            id: omittedRoomJid,
+            name: "Private",
+            autojoin: true,
+          }],
+        }),
+        "alice@example.test",
+      );
+
+      expect(topology.roomCatalogComplete).toBe(false);
+      expect(topology.rooms.some((room) => room.jid === omittedRoomJid)).toBe(false);
+      expect(
+        topology.roomReconciliationAuthority.absentRoomKeysAuthoritative,
+      ).toBe(false);
     });
   });
 
@@ -279,6 +325,7 @@ describe("discoverTopology partial-failure resilience", () => {
 type ResilientClientOptions = {
   hangComponent?: string;
   hangMucItems?: boolean;
+  incompleteRoomInfo?: string;
   rejectSpaceBookmarks?: boolean;
   rejectUserBookmarks?: boolean;
   rejectRoomInfo?: string;
@@ -411,6 +458,12 @@ function resilientClient(options: ResilientClientOptions = {}) {
         }
         if (options.rejectRoomInfo && xml.includes(`to="${options.rejectRoomInfo}"`)) {
           throw new Error("simulated room disco#info failure");
+        }
+        if (
+          options.incompleteRoomInfo
+          && xml.includes(`to="${options.incompleteRoomInfo}"`)
+        ) {
+          return '<iq type="result"/>';
         }
         if (xml.includes('to="muc.example.test"')) {
           return discoInfoXml({

--- a/chat/tests/extension-route-rail-ui.test.ts
+++ b/chat/tests/extension-route-rail-ui.test.ts
@@ -85,7 +85,7 @@ describe("extension route rail UI contract", () => {
     expect(routeView).toContain("type-caption inline-flex min-h-8");
     expect(controller).toContain("applyMatchToShellState(ui, match)");
     const extensionStart = controller.indexOf('if (match.id === "channelExtension") {');
-    const loadIndex = controller.indexOf("await messaging.loadMessages(ch.spaceId ?? \"\", ch.id);", extensionStart);
+    const loadIndex = controller.indexOf("await messaging.loadMessages(", extensionStart);
     const guardIndex = controller.indexOf("if (requestId !== routeRequestId) return;", loadIndex);
     const pinnedIndex = controller.indexOf("ui.showPinnedPanel.value = match.search.pinned;", guardIndex);
     const panelIndex = controller.indexOf('activeRightPanel.value = "extension";', pinnedIndex);

--- a/chat/tests/helpers/xmpp-client-mock.ts
+++ b/chat/tests/helpers/xmpp-client-mock.ts
@@ -18,5 +18,7 @@ export function handlerStubs() {
     setLastSeenHandler: () => {},
     setActivityHandler: () => {},
     setRoomAvatarHandler: () => {},
+    listRoomAccessRequirements: () => [],
+    onRoomAccessChanged: () => () => {},
   };
 }

--- a/chat/tests/mam-paging-recovery.test.ts
+++ b/chat/tests/mam-paging-recovery.test.ts
@@ -49,6 +49,50 @@ function makeDmMessage(id: string, body: string, peerJid: string): LiveDmMessage
 }
 
 describe("useChannelMamPaging — XEP-0313 §4.3.4 recovery", () => {
+  test("automatic route hydration does not query a room that still requires access", async () => {
+    const queryMamPage = mock(async () => ({
+      messages: [],
+      firstArchiveId: null,
+      complete: true,
+    }));
+    const fetchRoomPins = mock(async () => []);
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref({
+        queryMamPage,
+        fetchRoomPins,
+      } as unknown as BrowserXmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages: ref<TimelineMessage[]>([]),
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds: new Set<string>(),
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => true,
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    await expect(
+      paging.loadMessages("space", "space_room", 0, [], {
+        allowAccessRetry: false,
+      }),
+    ).resolves.toBe("loaded");
+
+    expect(queryMamPage).not.toHaveBeenCalled();
+    expect(fetchRoomPins).not.toHaveBeenCalled();
+    expect(paging.isLoadingMessages.value).toBe(false);
+    expect(paging.hasOlderMessages.value).toBe(false);
+  });
+
   test("loadOlderMessages: item-not-found on a before-cursor triggers cursor reset + tail-page refetch", async () => {
     const tailMessages = [makeRoomMessage("m1", "older"), makeRoomMessage("m2", "newer")];
 
@@ -84,6 +128,7 @@ describe("useChannelMamPaging — XEP-0313 §4.3.4 recovery", () => {
       pendingEchoClientIds: new Set<string>(),
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });
@@ -141,6 +186,7 @@ describe("useChannelMamPaging — XEP-0313 §4.3.4 recovery", () => {
       pendingEchoClientIds: new Set<string>(),
       appendQueuedMessages: (timeline) => timeline,
       roomJidForChannel: () => "space_room@muc.example.com",
+      isRoomAccessRequired: () => false,
       scrollToPinnedEdgeAndPin: async () => true,
       persistLastSeen: () => {},
     });

--- a/chat/tests/mam-paging-recovery.test.ts
+++ b/chat/tests/mam-paging-recovery.test.ts
@@ -83,7 +83,7 @@ describe("useChannelMamPaging — XEP-0313 §4.3.4 recovery", () => {
 
     await expect(
       paging.loadMessages("space", "space_room", 0, [], {
-        allowAccessRetry: false,
+        intent: "automatic",
       }),
     ).resolves.toBe("loaded");
 

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -712,6 +712,34 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     expect(persistence.loadJoinedRooms()).toEqual([]);
   });
 
+  test("round-trips terminal room auto-join blocks within the owning browser tab", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    const otherTab = createLocalStorageResumePersistence("alice@example.com", "tab-b");
+    persistence.saveAutoJoinBlocks?.([
+      {
+        roomJid: "Private@Conference.Example.com/alice",
+        condition: "registration-required",
+        catalogFingerprint: "private@conference.example.com|private|space|1|0",
+      },
+      {
+        roomJid: "private@conference.example.com",
+        condition: "forbidden",
+        catalogFingerprint: null,
+      },
+    ]);
+
+    expect(persistence.loadAutoJoinBlocks?.()).toEqual([
+      {
+        roomJid: "private@conference.example.com",
+        condition: "forbidden",
+        catalogFingerprint: null,
+      },
+    ]);
+    expect(otherTab.loadAutoJoinBlocks?.()).toEqual([]);
+    persistence.clearAutoJoinBlocks?.();
+    expect(persistence.loadAutoJoinBlocks?.()).toEqual([]);
+  });
+
   test("consumeSm rejects a delayed claimant that observed the same original resource", () => {
     const first = createLocalStorageResumePersistence("alice@example.com");
     const second = createLocalStorageResumePersistence("alice@example.com");

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -726,6 +726,12 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
         condition: "forbidden",
         catalogFingerprint: null,
       },
+      {
+        roomJid: "Limited@Conference.Example.com",
+        condition: "forbidden",
+        catalogFingerprint: "{\"spaceId\":\"space-a\"}",
+        catalogFingerprintFields: ["spaceId", "isBookmarked"],
+      },
     ]);
 
     expect(persistence.loadAutoJoinBlocks?.()).toEqual([
@@ -733,6 +739,12 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
         roomJid: "private@conference.example.com",
         condition: "forbidden",
         catalogFingerprint: null,
+      },
+      {
+        roomJid: "limited@conference.example.com",
+        condition: "forbidden",
+        catalogFingerprint: "{\"spaceId\":\"space-a\"}",
+        catalogFingerprintFields: ["spaceId", "isBookmarked"],
       },
     ]);
     expect(otherTab.loadAutoJoinBlocks?.()).toEqual([]);

--- a/chat/tests/room-access-ui.test.ts
+++ b/chat/tests/room-access-ui.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelMessages } from "../src/channels/messages";
+import { createNotifySettingsStore } from "../src/lib/notify-settings";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type {
+  BrowserXmppClient,
+  RoomAccessChangedEvent,
+} from "../src/lib/xmpp-client";
+import { handlerStubs } from "./helpers/xmpp-client-mock";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+
+const roomJid = "private@muc.example.com";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+describe("channel access-required UI state", () => {
+  test("tracks the active room's typed access state until the room becomes available", () => {
+    let roomAccessHandler: ((event: RoomAccessChangedEvent) => void) | null = null;
+    const client = {
+      ...handlerStubs(),
+      onRoomAccessChanged(handler: (event: RoomAccessChangedEvent) => void) {
+        roomAccessHandler = handler;
+        return () => {
+          roomAccessHandler = null;
+        };
+      },
+    } as unknown as BrowserXmppClient;
+    const actionError = ref("");
+    const messaging = useChannelMessages(
+      ref(session()),
+      ref(client),
+      ref("space"),
+      ref("private"),
+      ref({
+        id: "private",
+        name: "Private",
+        jid: roomJid,
+        channel_type: "text",
+      }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    roomAccessHandler?.({
+      roomJid,
+      state: "required",
+      condition: "registration-required",
+    });
+    expect(messaging.currentRoomAccessRequirement.value).toEqual({
+      roomJid,
+      condition: "registration-required",
+    });
+
+    roomAccessHandler?.({
+      roomJid,
+      state: "available",
+    });
+    expect(messaging.currentRoomAccessRequirement.value).toBeNull();
+  });
+
+  test("hydrates a persisted access requirement when the client binds after reload", () => {
+    const client = {
+      ...handlerStubs(),
+      listRoomAccessRequirements: () => [{
+        roomJid,
+        state: "required" as const,
+        condition: "forbidden" as const,
+      }],
+    } as unknown as BrowserXmppClient;
+    const messaging = useChannelMessages(
+      ref(session()),
+      ref(client),
+      ref("space"),
+      ref("private"),
+      ref({
+        id: "private",
+        name: "Private",
+        jid: roomJid,
+        channel_type: "text",
+      }),
+      String,
+      ref(""),
+      () => {},
+    );
+
+    expect(messaging.currentRoomAccessRequirement.value).toEqual({
+      roomJid,
+      condition: "forbidden",
+    });
+  });
+
+  test("renders an accessible channel-specific access explanation", async () => {
+    const html = await renderVueComponent(
+      "../src/components/chat/TimelineEmptyState.vue",
+      {
+        variant: "access-required",
+        isForumChannel: false,
+        channelName: "Private",
+      },
+      import.meta.url,
+    );
+
+    expect(html).toContain('role="status"');
+    expect(html).toContain("You need access to this channel");
+    expect(html).toContain("Ask a space admin for access");
+  });
+
+  test("the channel surface replaces loading and composing with the access state", async () => {
+    const html = await renderVueComponent(
+      "../src/components/chat/ContentArea.vue",
+      {
+        draft: "",
+        forumTitle: "",
+        pinnedPanelOpen: false,
+        waddle: { id: "space", name: "Space" },
+        channel: { id: "private", name: "Private", jid: roomJid, spaceId: "space" },
+        roomJid,
+        dmPeer: null,
+        sidebarMode: "channels",
+        messages: [],
+        firstUnseenId: null,
+        xmppStatus: { state: "online" },
+        actionError: "Generic join failure",
+        errorActionLabel: null,
+        channelAccessRequired: true,
+        updateAvailable: false,
+        isApplyingUpdate: false,
+        isLoadingMessages: true,
+        isLoadingOlderMessages: false,
+        hasOlderMessages: false,
+        isSending: false,
+        canManageChannels: false,
+        memberCount: 0,
+        memberState: "ready",
+        typingUsers: [],
+        currentUser: "alice",
+        currentUserJid: "alice@example.com",
+        selfFullJid: "alice@example.com/web",
+        selfDomain: "example.com",
+        avatarUrlByAuthor: {},
+        authorJidByNick: {},
+        mentionCandidates: [],
+        roomHats: {},
+        roomAuthority: {},
+        roomPresence: {},
+        roomLastSeen: {},
+        slowModeCooldown: 0,
+        searchResults: [],
+        isSearching: false,
+        uploadProgress: { uploading: false, progress: 0, filename: "" },
+        threadIndex: new Map(),
+        xmppClient: null,
+        notifySettings: createNotifySettingsStore(),
+        reactionMode: null,
+      },
+      import.meta.url,
+    );
+
+    expect(html).toContain("You need access to this channel");
+    expect(html).not.toContain("Generic join failure");
+    expect(html).not.toContain("message-list-skeleton");
+    expect(html).not.toContain("<textarea");
+  });
+});

--- a/chat/tests/room-auto-join-policy.test.ts
+++ b/chat/tests/room-auto-join-policy.test.ts
@@ -36,31 +36,57 @@ describe("room auto-join terminal authorization policy", () => {
   test("an identical first catalog observation preserves a restored denial", () => {
     const first = reconcileAutoJoinBlocks(deniedBlock(), [
       room({ jid: "Private@MUC.Example.com" }),
-    ]);
+    ], { catalogComplete: true });
     expect(first.unblockedRoomKeys).toEqual([]);
     expect(first.blocks.get(roomJid)?.catalogFingerprint).toBeString();
 
-    const refresh = reconcileAutoJoinBlocks(first.blocks, [room()]);
+    const refresh = reconcileAutoJoinBlocks(first.blocks, [room()], {
+      catalogComplete: true,
+    });
     expect(refresh.unblockedRoomKeys).toEqual([]);
     expect(refresh.blocks.has(roomJid)).toBe(true);
   });
 
   test("a bookmark membership change restores auto-join eligibility", () => {
-    const first = reconcileAutoJoinBlocks(deniedBlock(), [room()]);
+    const first = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
+      catalogComplete: true,
+    });
     const changed = reconcileAutoJoinBlocks(first.blocks, [
       room({ isBookmarked: true }),
-    ]);
+    ], { catalogComplete: true });
 
     expect(changed.unblockedRoomKeys).toEqual([roomJid]);
     expect(changed.blocks.has(roomJid)).toBe(false);
   });
 
-  test("a first bookmarked observation unblocks a pre-discovery denial", () => {
-    const reconciled = reconcileAutoJoinBlocks(deniedBlock(), [
+  test("a first bookmarked observation records a baseline instead of unblocking", () => {
+    const first = reconcileAutoJoinBlocks(deniedBlock(), [
       room({ isBookmarked: true }),
-    ]);
+    ], { catalogComplete: true });
 
-    expect(reconciled.unblockedRoomKeys).toEqual([roomJid]);
-    expect(reconciled.blocks.has(roomJid)).toBe(false);
+    expect(first.unblockedRoomKeys).toEqual([]);
+    expect(first.blocks.get(roomJid)?.catalogFingerprint).toBeString();
+
+    const changed = reconcileAutoJoinBlocks(first.blocks, [
+      room({ isBookmarked: false }),
+    ], { catalogComplete: true });
+
+    expect(changed.unblockedRoomKeys).toEqual([roomJid]);
+    expect(changed.blocks.has(roomJid)).toBe(false);
+  });
+
+  test("an incomplete catalog cannot clear a fingerprinted denial", () => {
+    const baseline = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
+      catalogComplete: true,
+    });
+    const incomplete = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [],
+      { catalogComplete: false },
+    );
+
+    expect(incomplete.unblockedRoomKeys).toEqual([]);
+    expect(incomplete.blocks).toEqual(baseline.blocks);
+    expect(incomplete.changed).toBe(false);
   });
 });

--- a/chat/tests/room-auto-join-policy.test.ts
+++ b/chat/tests/room-auto-join-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  reconcileAutoJoinBlocks,
+  type RoomAutoJoinBlock,
+} from "../src/lib/xmpp/room-auto-join-policy";
+import type { DiscoveredChannel } from "../src/lib/xmpp/types";
+
+const roomJid = "private@muc.example.com";
+
+function room(partial: Partial<DiscoveredChannel> = {}): DiscoveredChannel {
+  return {
+    id: "private",
+    name: "Private",
+    jid: roomJid,
+    channelType: "chat",
+    position: 0,
+    autojoin: true,
+    ...partial,
+  };
+}
+
+function deniedBlock(
+  partial: Partial<RoomAutoJoinBlock> = {},
+): ReadonlyMap<string, RoomAutoJoinBlock> {
+  return new Map([[
+    roomJid,
+    {
+      roomJid,
+      condition: "registration-required",
+      ...partial,
+    },
+  ]]);
+}
+
+describe("room auto-join terminal authorization policy", () => {
+  test("an identical first catalog observation preserves a restored denial", () => {
+    const first = reconcileAutoJoinBlocks(deniedBlock(), [
+      room({ jid: "Private@MUC.Example.com" }),
+    ]);
+    expect(first.unblockedRoomKeys).toEqual([]);
+    expect(first.blocks.get(roomJid)?.catalogFingerprint).toBeString();
+
+    const refresh = reconcileAutoJoinBlocks(first.blocks, [room()]);
+    expect(refresh.unblockedRoomKeys).toEqual([]);
+    expect(refresh.blocks.has(roomJid)).toBe(true);
+  });
+
+  test("a bookmark membership change restores auto-join eligibility", () => {
+    const first = reconcileAutoJoinBlocks(deniedBlock(), [room()]);
+    const changed = reconcileAutoJoinBlocks(first.blocks, [
+      room({ isBookmarked: true }),
+    ]);
+
+    expect(changed.unblockedRoomKeys).toEqual([roomJid]);
+    expect(changed.blocks.has(roomJid)).toBe(false);
+  });
+
+  test("a first bookmarked observation unblocks a pre-discovery denial", () => {
+    const reconciled = reconcileAutoJoinBlocks(deniedBlock(), [
+      room({ isBookmarked: true }),
+    ]);
+
+    expect(reconciled.unblockedRoomKeys).toEqual([roomJid]);
+    expect(reconciled.blocks.has(roomJid)).toBe(false);
+  });
+});

--- a/chat/tests/room-auto-join-policy.test.ts
+++ b/chat/tests/room-auto-join-policy.test.ts
@@ -190,7 +190,7 @@ describe("room auto-join terminal authorization policy", () => {
     expect(changedSpace.unblockedRoomKeys).toEqual([roomJid]);
   });
 
-  test("a first partial observation does not record unproven fingerprint fields", () => {
+  test("a first partial observation records only proven fingerprint fields", () => {
     const partial = reconcileAutoJoinBlocks(
       deniedBlock(),
       [room({ spaceId: "space-new", isBookmarked: true })],
@@ -204,7 +204,108 @@ describe("room auto-join terminal authorization policy", () => {
     );
 
     expect(partial.unblockedRoomKeys).toEqual([]);
-    expect(partial.blocks).toEqual(deniedBlock());
-    expect(partial.changed).toBe(false);
+    expect(partial.blocks.get(roomJid)?.catalogFingerprint).toBeString();
+    expect(partial.blocks.get(roomJid)?.catalogFingerprintFields).toEqual([
+      "spaceId",
+      "isBookmarked",
+    ]);
+    expect(partial.changed).toBe(true);
+  });
+
+  test("a later change to a previously proven field unblocks after a partial baseline", () => {
+    const partial = reconcileAutoJoinBlocks(
+      deniedBlock(),
+      [room({ spaceId: "space-old", isBookmarked: true })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+    const changed = reconcileAutoJoinBlocks(
+      partial.blocks,
+      [room({ spaceId: "space-new", isBookmarked: true })],
+      { absentRoomKeysAuthoritative: true },
+    );
+
+    expect(changed.unblockedRoomKeys).toEqual([roomJid]);
+    expect(changed.blocks.has(roomJid)).toBe(false);
+  });
+
+  test("newly proven fields extend a partial baseline without causing a false unblock", () => {
+    const partial = reconcileAutoJoinBlocks(
+      deniedBlock(),
+      [room({
+        spaceId: "space-old",
+        autojoin: true,
+        isBookmarked: true,
+      })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+    const completed = reconcileAutoJoinBlocks(
+      partial.blocks,
+      [room({
+        spaceId: "space-old",
+        autojoin: false,
+        isBookmarked: true,
+      })],
+      { absentRoomKeysAuthoritative: true },
+    );
+
+    expect(completed.unblockedRoomKeys).toEqual([]);
+    expect(completed.blocks.has(roomJid)).toBe(true);
+    expect(
+      completed.blocks.get(roomJid)?.catalogFingerprintFields,
+    ).toBeUndefined();
+
+    const laterChange = reconcileAutoJoinBlocks(
+      completed.blocks,
+      [room({
+        spaceId: "space-old",
+        autojoin: true,
+        isBookmarked: true,
+      })],
+      { absentRoomKeysAuthoritative: true },
+    );
+    expect(laterChange.unblockedRoomKeys).toEqual([roomJid]);
+  });
+
+  test("an unchanged complete observation promotes a partial baseline without unblocking", () => {
+    const observedRoom = room({
+      spaceId: "space-old",
+      autojoin: true,
+      isBookmarked: true,
+    });
+    const partial = reconcileAutoJoinBlocks(
+      deniedBlock(),
+      [observedRoom],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+    const completed = reconcileAutoJoinBlocks(
+      partial.blocks,
+      [observedRoom],
+      { absentRoomKeysAuthoritative: true },
+    );
+
+    expect(completed.unblockedRoomKeys).toEqual([]);
+    expect(completed.blocks.has(roomJid)).toBe(true);
+    expect(
+      completed.blocks.get(roomJid)?.catalogFingerprintFields,
+    ).toBeUndefined();
+    expect(completed.changed).toBe(true);
   });
 });

--- a/chat/tests/room-auto-join-policy.test.ts
+++ b/chat/tests/room-auto-join-policy.test.ts
@@ -36,12 +36,12 @@ describe("room auto-join terminal authorization policy", () => {
   test("an identical first catalog observation preserves a restored denial", () => {
     const first = reconcileAutoJoinBlocks(deniedBlock(), [
       room({ jid: "Private@MUC.Example.com" }),
-    ], { catalogComplete: true });
+    ], { absentRoomKeysAuthoritative: true });
     expect(first.unblockedRoomKeys).toEqual([]);
     expect(first.blocks.get(roomJid)?.catalogFingerprint).toBeString();
 
     const refresh = reconcileAutoJoinBlocks(first.blocks, [room()], {
-      catalogComplete: true,
+      absentRoomKeysAuthoritative: true,
     });
     expect(refresh.unblockedRoomKeys).toEqual([]);
     expect(refresh.blocks.has(roomJid)).toBe(true);
@@ -49,11 +49,11 @@ describe("room auto-join terminal authorization policy", () => {
 
   test("a bookmark membership change restores auto-join eligibility", () => {
     const first = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
-      catalogComplete: true,
+      absentRoomKeysAuthoritative: true,
     });
     const changed = reconcileAutoJoinBlocks(first.blocks, [
       room({ isBookmarked: true }),
-    ], { catalogComplete: true });
+    ], { absentRoomKeysAuthoritative: true });
 
     expect(changed.unblockedRoomKeys).toEqual([roomJid]);
     expect(changed.blocks.has(roomJid)).toBe(false);
@@ -62,14 +62,14 @@ describe("room auto-join terminal authorization policy", () => {
   test("a first bookmarked observation records a baseline instead of unblocking", () => {
     const first = reconcileAutoJoinBlocks(deniedBlock(), [
       room({ isBookmarked: true }),
-    ], { catalogComplete: true });
+    ], { absentRoomKeysAuthoritative: true });
 
     expect(first.unblockedRoomKeys).toEqual([]);
     expect(first.blocks.get(roomJid)?.catalogFingerprint).toBeString();
 
     const changed = reconcileAutoJoinBlocks(first.blocks, [
       room({ isBookmarked: false }),
-    ], { catalogComplete: true });
+    ], { absentRoomKeysAuthoritative: true });
 
     expect(changed.unblockedRoomKeys).toEqual([roomJid]);
     expect(changed.blocks.has(roomJid)).toBe(false);
@@ -77,16 +77,68 @@ describe("room auto-join terminal authorization policy", () => {
 
   test("an incomplete catalog cannot clear a fingerprinted denial", () => {
     const baseline = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
-      catalogComplete: true,
+      absentRoomKeysAuthoritative: true,
     });
     const incomplete = reconcileAutoJoinBlocks(
       baseline.blocks,
       [],
-      { catalogComplete: false },
+      { absentRoomKeysAuthoritative: false },
     );
 
     expect(incomplete.unblockedRoomKeys).toEqual([]);
     expect(incomplete.blocks).toEqual(baseline.blocks);
     expect(incomplete.changed).toBe(false);
+  });
+
+  test("an authoritative room change can unblock while unrelated discovery is incomplete", () => {
+    const baseline = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
+      absentRoomKeysAuthoritative: true,
+    });
+    const changed = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [room({ isBookmarked: true })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeRoomKeys: new Set([roomJid]),
+      },
+    );
+
+    expect(changed.unblockedRoomKeys).toEqual([roomJid]);
+    expect(changed.blocks.has(roomJid)).toBe(false);
+  });
+
+  test("an incomplete fingerprint preserves its room even when a sibling is authoritative", () => {
+    const baseline = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
+      absentRoomKeysAuthoritative: true,
+    });
+    const incomplete = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [room({ isBookmarked: true })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeRoomKeys: new Set(["sibling@muc.example.com"]),
+      },
+    );
+
+    expect(incomplete.unblockedRoomKeys).toEqual([]);
+    expect(incomplete.blocks).toEqual(baseline.blocks);
+    expect(incomplete.changed).toBe(false);
+  });
+
+  test("authoritative absence unblocks a room removed from the membership catalog", () => {
+    const baseline = reconcileAutoJoinBlocks(deniedBlock(), [room()], {
+      absentRoomKeysAuthoritative: true,
+    });
+    const removed = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [],
+      {
+        absentRoomKeysAuthoritative: true,
+        authoritativeRoomKeys: new Set(),
+      },
+    );
+
+    expect(removed.unblockedRoomKeys).toEqual([roomJid]);
+    expect(removed.blocks.has(roomJid)).toBe(false);
   });
 });

--- a/chat/tests/room-auto-join-policy.test.ts
+++ b/chat/tests/room-auto-join-policy.test.ts
@@ -99,7 +99,10 @@ describe("room auto-join terminal authorization policy", () => {
       [room({ isBookmarked: true })],
       {
         absentRoomKeysAuthoritative: false,
-        authoritativeRoomKeys: new Set([roomJid]),
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["isBookmarked"] as const),
+        ]]),
       },
     );
 
@@ -116,7 +119,10 @@ describe("room auto-join terminal authorization policy", () => {
       [room({ isBookmarked: true })],
       {
         absentRoomKeysAuthoritative: false,
-        authoritativeRoomKeys: new Set(["sibling@muc.example.com"]),
+        authoritativeFingerprintFields: new Map([[
+          "sibling@muc.example.com",
+          new Set(["isBookmarked"] as const),
+        ]]),
       },
     );
 
@@ -134,11 +140,71 @@ describe("room auto-join terminal authorization policy", () => {
       [],
       {
         absentRoomKeysAuthoritative: true,
-        authoritativeRoomKeys: new Set(),
+        authoritativeFingerprintFields: new Map(),
       },
     );
 
     expect(removed.unblockedRoomKeys).toEqual([roomJid]);
     expect(removed.blocks.has(roomJid)).toBe(false);
+  });
+
+  test("partial bookmark authority compares only the fields its source proved", () => {
+    const baseline = reconcileAutoJoinBlocks(deniedBlock(), [
+      room({ spaceId: "space-old", autojoin: true, isBookmarked: true }),
+    ], { absentRoomKeysAuthoritative: true });
+    const unrelatedAutojoinValue = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [room({
+        spaceId: "space-old",
+        autojoin: false,
+        isBookmarked: true,
+      })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+
+    expect(unrelatedAutojoinValue.unblockedRoomKeys).toEqual([]);
+    expect(unrelatedAutojoinValue.blocks).toEqual(baseline.blocks);
+
+    const changedSpace = reconcileAutoJoinBlocks(
+      baseline.blocks,
+      [room({
+        spaceId: "space-new",
+        autojoin: false,
+        isBookmarked: true,
+      })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+
+    expect(changedSpace.unblockedRoomKeys).toEqual([roomJid]);
+  });
+
+  test("a first partial observation does not record unproven fingerprint fields", () => {
+    const partial = reconcileAutoJoinBlocks(
+      deniedBlock(),
+      [room({ spaceId: "space-new", isBookmarked: true })],
+      {
+        absentRoomKeysAuthoritative: false,
+        authoritativeFingerprintFields: new Map([[
+          roomJid,
+          new Set(["spaceId", "isBookmarked"] as const),
+        ]]),
+      },
+    );
+
+    expect(partial.unblockedRoomKeys).toEqual([]);
+    expect(partial.blocks).toEqual(deniedBlock());
+    expect(partial.changed).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Stops background MUC auto-join retries after XEP-0045 terminal authorization failures (`registration-required` and `forbidden`) while preserving explicit user retry and transient wait/timeout behavior. Incomplete room hydration can no longer fabricate authoritative room absence, erase denial/discovery caches, or seed a fresh denial from stale topology evidence.

Closes #1314.

## Implementation

- classify only XEP-0045 `auth` denials for `registration-required` and `forbidden` as terminal background-join failures
- evict denied rooms from retained/resumed join state and persist a per-tab auto-join block across reloads
- keep session-ready, route bootstrap, reconnect hydration, MAM paging, and queued-message flushing from implicitly retrying a denied room
- allow channel clicks, browser back/forward, extension-route selection, and other explicit navigation to retry immediately
- represent automatic versus explicit channel loads with a typed intent instead of a retry-policy boolean
- isolate room-access requirement subscription and hydration in a focused channel composable
- treat the first authoritative room observation as the denial baseline instead of a membership change
- preserve denial records, room-JID mappings, and future auto-join caches whenever the affected room's discovery evidence is incomplete
- reconcile a blocked room from field-level evidence supplied by its exact successful personal or space bookmark source, even if unrelated discovery work fails
- persist partial denial baselines with the exact fields proven by each observation
- require a complete emitted room catalog before missing room keys are treated as authoritative
- bind fresh denial evidence to the latest accepted discovery generation
- reject stale discovery results after overlapping refreshes, transient disconnects, or explicit logout
- clear blocks after successful self-presence or a later material topology/XEP-0402 bookmark-membership change
- restore persisted access-required state into the channel UI after reload and clear it on logout
- replace loading, generic error, and composer surfaces with an accessible “You need access to this channel” state

## Review fixes

- fixed first-discovery bookmark reconciliation clearing a pre-discovery denial
- separated whole-catalog completeness from per-room reconciliation authority
- made failed user-bookmark, space-bookmark, space-list, and affected-room-info discovery non-authoritative for denial reconciliation
- allowed an authoritative room membership change to clear its stale denial despite an unrelated sibling hydration or MUC-items failure
- allowed exact personal/space bookmark evidence to clear a stale denial despite failures in unrelated bookmark sources
- prevented partial bookmark evidence from authorizing absence, unknown overrides, incomplete baselines, or immediate auto-join
- prevented rejected or incomplete bookmark-only hydration from making an omitted room definitively absent
- gated both denial reconciliation and wholesale discovery-cache replacement on complete room-catalog evidence
- retained partial authoritative baselines so later changes to already-proven fields clear denials without letting newly proven fields cause false retries
- persisted partial fingerprint authority across reloads and promoted it to a complete baseline without treating promotion as membership change
- prevented a fresh denial under F2 from inheriting a stale cached F1 fingerprint after incomplete hydration
- retained exact partial-field provenance when a degraded refresh still proves room-specific evidence
- generation-gated overlapping discovery so only the newest live result may mutate denial or room caches
- invalidated in-flight discovery evidence at transient disconnect and before explicit logout awaits
- kept discovered-room JIDs and autojoin caches aligned with the same authority model
- removed a newly `autojoin:false` room from the retained autojoin cache so session-ready cannot resurrect it
- prevented session-ready queued-message flushing from rejoining a terminally denied current room
- made automatic loads safe by default and reserved access retry for typed `explicit-navigation` entry points
- made the client-side denial guard authoritative even if Vue access state has not hydrated yet
- extracted room-access event state from the channel orchestration module

## XEP review

Reviewed against XEP-0045: `registration-required` and `forbidden` are terminal `auth` entry denials; `wait` conditions such as `resource-constraint` and self-presence timeouts remain retryable. No custom wire shape or out-of-band API was added. XEP-0402 and XEP-0503 bookmark/topology data are treated as typed membership signals, and incomplete results cannot masquerade as membership changes or authoritative absence.

## Verification

- `bun test`: 3,525 passed, 0 failed
- focused discovery/policy/send-readiness suite: 110 passed, 0 failed
- `bunx tsc --noEmit -p tsconfig.json`: passed
- `bunx astro check`: 0 errors
- `bun run build`: passed (WASM build, Astro check, production build)
- `bun run lint`: passed (WASM build + Knip clean)
- final adversarial reviews across correctness, tests, protocol/security, lifecycle races, maintainability, and repository standards: no remaining actionable findings

## Plan completed

1. Lock terminal-auth eviction, transient retry, explicit navigation, reload, and UI behavior with tests.
2. Add room-scoped persisted auto-join denial policy and topology/membership reconciliation.
3. Preserve denial and room caches when the relevant discovery evidence is incomplete.
4. Reconcile exact rooms field-by-field when their personal or space membership evidence is authoritative.
5. Require complete emitted room evidence before absence-based reconciliation or cache replacement.
6. Preserve partial authoritative baselines and promote newly proven fields without false unblocking.
7. Bind fresh denial baselines to the latest accepted discovery generation.
8. Reject stale overlapping or disconnected discovery results.
9. Separate automatic route hydration from explicit access retry with a typed intent.
10. Thread typed access state into the channel surface through a focused composable.
11. Run focused and full verification, then adversarial review until clean.

No dependencies were added.
