### PR TITLE
fix(ci): activate patched cuenv bootstrap

### DIFF
--- a/.github/workflows/waddle-android-default.yml
+++ b/.github/workflows/waddle-android-default.yml
@@ -82,24 +82,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: default'

--- a/.github/workflows/waddle-android-devicetests.yml
+++ b/.github/workflows/waddle-android-devicetests.yml
@@ -79,24 +79,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: deviceTests'

--- a/.github/workflows/waddle-android-pullrequest.yml
+++ b/.github/workflows/waddle-android-pullrequest.yml
@@ -33,6 +33,14 @@ on:
     - apps/android/settings.gradle.kts
     - apps/android/settings.gradle.kts/**
     - cue.mod/**
+    - env.cue
+    - env.cue/**
+    - flake.lock
+    - flake.lock/**
+    - flake.nix
+    - flake.nix/**
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch/**
     - scripts/build-android-rust.sh
     - scripts/build-android-rust.sh/**
     - scripts/check-android-ffi-bindings.sh
@@ -80,24 +88,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: pullRequest'

--- a/.github/workflows/waddle-chat-default.yml
+++ b/.github/workflows/waddle-chat-default.yml
@@ -82,24 +82,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-chat-pullrequest.yml
+++ b/.github/workflows/waddle-chat-pullrequest.yml
@@ -88,24 +88,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-cloud-default.yml
+++ b/.github/workflows/waddle-cloud-default.yml
@@ -47,24 +47,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup 1Password

--- a/.github/workflows/waddle-cloud-pullrequest.yml
+++ b/.github/workflows/waddle-cloud-pullrequest.yml
@@ -40,24 +40,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: pullRequest'

--- a/.github/workflows/waddle-colony-default.yml
+++ b/.github/workflows/waddle-colony-default.yml
@@ -59,24 +59,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-colony-pullrequest.yml
+++ b/.github/workflows/waddle-colony-pullrequest.yml
@@ -54,24 +54,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -7,15 +7,26 @@ on:
     branches:
     - main
     paths:
+    - .github/workflows/waddle-android-*.yml
+    - .github/workflows/waddle-chat-*.yml
+    - .github/workflows/waddle-cloud-*.yml
+    - .github/workflows/waddle-colony-*.yml
     - .github/workflows/waddle-server-*.yml
     - .github/workflows/waddle-server-default.yml
+    - .github/workflows/waddle-website-*.yml
     - .gitignore
     - .gitignore/**
     - .rules.cue
     - .rules.cue/**
+    - apps/android/env.cue
+    - apps/android/env.cue/**
     - apps/apple/**/Tests/**
     - apps/apple/Waddle/RustClient/Generated/**
+    - chat/env.cue
+    - chat/env.cue/**
     - chat/tests/**
+    - colony/env.cue
+    - colony/env.cue/**
     - cue.mod/**
     - cuenv.lock
     - cuenv.lock/**
@@ -34,11 +45,15 @@ on:
     - flake.lock/**
     - flake.nix
     - flake.nix/**
+    - infrastructure/waddle.cloud/env.cue
+    - infrastructure/waddle.cloud/env.cue/**
     - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml
     - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml/**
     - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml
     - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml/**
     - infrastructure/waddle.cloud/gitops/waddle-server/**
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch/**
     - server/**/env.cue
     - server/.config/nextest.toml
     - server/.config/nextest.toml/**
@@ -65,6 +80,8 @@ on:
     - server/scripts/**
     - server/wit/**
     - tests/**
+    - website/env.cue
+    - website/env.cue/**
     - xeps/xep-*.xml
   workflow_dispatch: {}
 concurrency:
@@ -77,10 +94,44 @@ permissions:
   packages: write
   id-token: write
 jobs:
+  build-cuenv:
+    name: build.cuenv
+    runs-on: namespace-profile-linux-x86
+    timeout-minutes: 30
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Build cuenv (nix)
+      run: |-
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload cuenv
+      uses: actions/upload-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: result/bin/cuenv
+        if-no-files-found: error
   buildExtensionModules:
     name: buildExtensionModules
     runs-on: namespace-profile-linux-x86
     needs:
+    - build-cuenv
     - fmt
     - clippy
     - test
@@ -100,26 +151,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: buildExtensionModules
       run: cuenv task buildExtensionModules --skip-dependencies
       working-directory: server
@@ -143,6 +183,8 @@ jobs:
   checkCiDrift:
     name: checkCiDrift
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -158,26 +200,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkCiDrift
       run: cuenv task checkCiDrift --skip-dependencies
       working-directory: server
@@ -189,6 +220,8 @@ jobs:
   checkRootSyncDrift:
     name: checkRootSyncDrift
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -204,26 +237,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
       working-directory: server
@@ -235,6 +257,8 @@ jobs:
   checkSwitchableAlternativeProgram:
     name: checkSwitchableAlternativeProgram
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -250,26 +274,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkSwitchableAlternativeProgram
       run: cuenv task checkSwitchableAlternativeProgram --skip-dependencies
       working-directory: server
@@ -281,6 +294,8 @@ jobs:
   checkXmppClientFfiBindings:
     name: checkXmppClientFfiBindings
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -296,26 +311,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkXmppClientFfiBindings
       run: cuenv task checkXmppClientFfiBindings --skip-dependencies
       working-directory: server
@@ -327,6 +331,8 @@ jobs:
   clippy:
     name: clippy
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -342,26 +348,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: clippy
       run: cuenv task clippy --skip-dependencies
       working-directory: server
@@ -373,6 +368,8 @@ jobs:
   doctest:
     name: doctest
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -388,26 +385,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: doctest
       run: cuenv task doctest --skip-dependencies
       working-directory: server
@@ -419,6 +405,8 @@ jobs:
   fmt:
     name: fmt
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -434,26 +422,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: fmt
       run: cuenv task fmt --skip-dependencies
       working-directory: server
@@ -466,6 +443,7 @@ jobs:
     name: publishContainerImage
     runs-on: namespace-profile-linux-x86
     needs:
+    - build-cuenv
     - fmt
     - clippy
     - test
@@ -487,26 +465,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: publishContainerImage
       run: cuenv task publishContainerImage --skip-dependencies
       working-directory: server
@@ -530,6 +497,8 @@ jobs:
   renderDeployment:
     name: renderDeployment
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -545,26 +514,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: renderDeployment
       run: cuenv task renderDeployment --skip-dependencies
       working-directory: server
@@ -575,6 +533,43 @@ jobs:
         GITHUB_REF_NAME: ${{ github.ref_name }}
   test:
     name: test
+    runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
+      run: |-
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
+    - name: test
+      run: cuenv task test --skip-dependencies
+      working-directory: server
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+  verifyCuenvBootstrap:
+    name: verifyCuenvBootstrap
     runs-on: namespace-profile-linux-x86
     steps:
     - name: Checkout
@@ -591,28 +586,8 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
-      run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: test
-      run: cuenv task test --skip-dependencies
+    - name: verifyCuenvBootstrap
+      run: nix build --print-build-logs --accept-flake-config ../#cuenv-source-coupling ../#cuenv-strict-discovery ../#cuenv-waddle-discovery
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
+++ b/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
@@ -49,24 +49,12 @@ jobs:
         name: waddle-social/waddle
         tag: ${{ inputs.tag }}
         visibility: public
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: 'Run pipeline: Publish tags to FlakeHub'

--- a/.github/workflows/waddle-server-pullrequest.yml
+++ b/.github/workflows/waddle-server-pullrequest.yml
@@ -5,15 +5,26 @@ name: waddle-server-pullRequest
 on:
   pull_request:
     paths:
+    - .github/workflows/waddle-android-*.yml
+    - .github/workflows/waddle-chat-*.yml
+    - .github/workflows/waddle-cloud-*.yml
+    - .github/workflows/waddle-colony-*.yml
     - .github/workflows/waddle-server-*.yml
     - .github/workflows/waddle-server-pullrequest.yml
+    - .github/workflows/waddle-website-*.yml
     - .gitignore
     - .gitignore/**
     - .rules.cue
     - .rules.cue/**
+    - apps/android/env.cue
+    - apps/android/env.cue/**
     - apps/apple/**/Tests/**
     - apps/apple/Waddle/RustClient/Generated/**
+    - chat/env.cue
+    - chat/env.cue/**
     - chat/tests/**
+    - colony/env.cue
+    - colony/env.cue/**
     - cue.mod/**
     - cuenv.lock
     - cuenv.lock/**
@@ -32,11 +43,15 @@ on:
     - flake.lock/**
     - flake.nix
     - flake.nix/**
+    - infrastructure/waddle.cloud/env.cue
+    - infrastructure/waddle.cloud/env.cue/**
     - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml
     - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml/**
     - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml
     - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml/**
     - infrastructure/waddle.cloud/gitops/waddle-server/**
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch/**
     - server/**/env.cue
     - server/.config/nextest.toml
     - server/.config/nextest.toml/**
@@ -63,6 +78,8 @@ on:
     - server/scripts/**
     - server/wit/**
     - tests/**
+    - website/env.cue
+    - website/env.cue/**
     - xeps/xep-*.xml
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -74,9 +91,10 @@ permissions:
   packages: read
   id-token: write
 jobs:
-  checkCiDrift:
-    name: checkCiDrift
+  build-cuenv:
+    name: build.cuenv
     runs-on: namespace-profile-linux-x86
+    timeout-minutes: 30
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -92,26 +110,49 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload cuenv
+      uses: actions/upload-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: result/bin/cuenv
+        if-no-files-found: error
+  checkCiDrift:
+    name: checkCiDrift
+    runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
+      run: |-
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkCiDrift
       run: cuenv task checkCiDrift --skip-dependencies
       working-directory: server
@@ -123,6 +164,8 @@ jobs:
   checkRootSyncDrift:
     name: checkRootSyncDrift
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -138,26 +181,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
       working-directory: server
@@ -169,6 +201,8 @@ jobs:
   checkSwitchableAlternativeProgram:
     name: checkSwitchableAlternativeProgram
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -184,26 +218,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkSwitchableAlternativeProgram
       run: cuenv task checkSwitchableAlternativeProgram --skip-dependencies
       working-directory: server
@@ -215,6 +238,8 @@ jobs:
   checkXmppClientFfiBindings:
     name: checkXmppClientFfiBindings
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -230,26 +255,15 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: checkXmppClientFfiBindings
       run: cuenv task checkXmppClientFfiBindings --skip-dependencies
       working-directory: server
@@ -417,6 +431,8 @@ jobs:
   renderDeployment:
     name: renderDeployment
     runs-on: namespace-profile-linux-x86
+    needs:
+    - build-cuenv
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -432,28 +448,43 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Download cuenv
+      uses: actions/download-artifact@v4
+      with:
+        name: cuenv-bootstrap-namespace-profile-linux-x86
+        path: ${{ runner.temp }}/cuenv-bootstrap
+    - name: Add cuenv to PATH
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        chmod +x "$RUNNER_TEMP/cuenv-bootstrap/cuenv"
+        echo "$RUNNER_TEMP/cuenv-bootstrap" >> "$GITHUB_PATH"
     - name: renderDeployment
       run: cuenv task renderDeployment --skip-dependencies
+      working-directory: server
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+  verifyCuenvBootstrap:
+    name: verifyCuenvBootstrap
+    runs-on: namespace-profile-linux-x86
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: verifyCuenvBootstrap
+      run: nix build --print-build-logs --accept-flake-config ../#cuenv-source-coupling ../#cuenv-strict-discovery ../#cuenv-waddle-discovery
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/waddle-server-xmppcompliance.yml
+++ b/.github/workflows/waddle-server-xmppcompliance.yml
@@ -13,6 +13,8 @@ on:
     - flake.lock/**
     - flake.nix
     - flake.nix/**
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch/**
     - server/.config/nextest.toml
     - server/.config/nextest.toml/**
     - server/Cargo.lock
@@ -37,6 +39,8 @@ on:
     - flake.lock/**
     - flake.nix
     - flake.nix/**
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+    - nix/patches/cuenv-0.54.0-fail-closed-discovery.patch/**
     - server/.config/nextest.toml
     - server/.config/nextest.toml/**
     - server/Cargo.lock

--- a/.github/workflows/waddle-website-default.yml
+++ b/.github/workflows/waddle-website-default.yml
@@ -63,24 +63,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/.github/workflows/waddle-website-pullrequest.yml
+++ b/.github/workflows/waddle-website-pullrequest.yml
@@ -53,24 +53,12 @@ jobs:
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: accept-flake-config = true
-    - name: Setup cuenv (release)
+    - name: Build cuenv (nix)
       run: |-
-        arch="$(uname -m)"
-        case "$arch" in
-          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
-          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
-          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
-        esac
-        cuenv_version="0.54.0"
-        if [ -z "$cuenv_version" ]; then
-          cuenv_version="latest"
-        fi
-        if [ "$cuenv_version" = "latest" ]; then
-          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
-        else
-          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
-        fi
-        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix build .#cuenv -L --accept-flake-config
+        echo "$(pwd)/result/bin" >> "$GITHUB_PATH" 2>/dev/null || echo "$(pwd)/result/bin" >> "$BUILDKITE_ENV_FILE" 2>/dev/null || true
+        ./result/bin/cuenv sync ci
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: cuenv:contributor:bun.workspace.setup

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -97,7 +97,7 @@ schema.#Project & {
 	ci: contributors: [
 		_NamespaceNix,
 		_NamespaceAndroidCache,
-		c.#CuenvRelease,
+		c.#CuenvNix,
 	]
 
 	ci: provider: github: {
@@ -175,8 +175,15 @@ schema.#Project & {
 
 		checkCiDrift: schema.#Task & {
 			command: "cuenv"
-			args: ["sync", "ci", "--check", "-A"]
-			inputs: ["env.cue", "../../.github/workflows/waddle-android-*.yml"]
+			args: ["sync", "ci", "--check", "-p", "."]
+			inputs: [
+				"../../env.cue",
+				"../../flake.lock",
+				"../../flake.nix",
+				"../../nix/patches/cuenv-0.54.0-fail-closed-discovery.patch",
+				"env.cue",
+				"../../.github/workflows/waddle-android-*.yml",
+			]
 		}
 
 		build: schema.#Task & {

--- a/chat/env.cue
+++ b/chat/env.cue
@@ -74,7 +74,7 @@ schema.#Project & {
 	ci: providers: ["github"]
 	ci: contributors: [
 		_NamespaceNix,
-		c.#CuenvRelease,
+		c.#CuenvNix,
 		c.#OnePassword,
 		c.#BunWorkspace,
 	]

--- a/colony/env.cue
+++ b/colony/env.cue
@@ -49,7 +49,7 @@ schema.#Project & {
 	ci: providers: ["github"]
 	ci: contributors: [
 		_NamespaceNix,
-		c.#CuenvRelease,
+		c.#CuenvNix,
 		c.#OnePassword,
 		c.#BunWorkspace,
 	]

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -3,37 +3,37 @@ version = 4
 [runtimes."apps/android"]
 type = "nix"
 flake = "../.."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "apps/android/../../flake.lock"
 
 [runtimes.chat]
 type = "nix"
 flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "chat/../flake.lock"
 
 [runtimes.colony]
 type = "nix"
 flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "colony/../flake.lock"
 
 [runtimes."infrastructure/waddle.cloud"]
 type = "nix"
 flake = "../.."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
 
 [runtimes.server]
 type = "nix"
 flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "server/../flake.lock"
 
 [runtimes.website]
 type = "nix"
 flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+digest = "sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359"
 lockfile = "website/../flake.lock"
 
 [vcs.cuenv-skills]

--- a/env.cue
+++ b/env.cue
@@ -6,6 +6,11 @@ import (
 )
 
 schema.#Base & {
+	config: ci: cuenv: {
+		source:  "nix"
+		version: "self"
+	}
+
 	runtime: type: "nix"
 
 	hooks: onEnter: nix: xNix.#NixFlake

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,23 @@
         "type": "github"
       }
     },
+    "cuenvSource": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781797758,
+        "narHash": "sha256-agTH3MrIva7Ax1n/M+Rdh8lb5PRbwtEBSE0iqNyAdtk=",
+        "owner": "cuenv",
+        "repo": "cuenv",
+        "rev": "e337a3f60af6944552f391facf2ed2e25efa3bc7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cuenv",
+        "repo": "cuenv",
+        "rev": "e337a3f60af6944552f391facf2ed2e25efa3bc7",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776255774,
@@ -34,6 +51,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "cuenvSource": "cuenvSource",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -82,21 +82,30 @@
             src = cuenvPatchedSrc;
             strictDeps = true;
             cargoExtraArgs = "--locked --package cuenv";
-            nativeBuildInputs = [ pkgs.go pkgs.pkg-config ];
+            nativeBuildInputs = [
+              pkgs.go
+              pkgs.pkg-config
+            ];
             buildInputs = lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
             CUE_BRIDGE_PATH = cuenvCueBridge;
           };
-          cuenvCargoArtifacts = craneLib.buildDepsOnly (cuenvBaseArgs // {
-            doCheck = false;
-          });
-          cuenv = craneLib.buildPackage (cuenvBaseArgs // {
-            cargoArtifacts = cuenvCargoArtifacts;
-            doCheck = false;
-            passthru = {
-              source = cuenvPatchedSrc;
-              cueBridge = cuenvCueBridge;
-            };
-          });
+          cuenvCargoArtifacts = craneLib.buildDepsOnly (
+            cuenvBaseArgs
+            // {
+              doCheck = false;
+            }
+          );
+          cuenv = craneLib.buildPackage (
+            cuenvBaseArgs
+            // {
+              cargoArtifacts = cuenvCargoArtifacts;
+              doCheck = false;
+              passthru = {
+                source = cuenvPatchedSrc;
+                cueBridge = cuenvCueBridge;
+              };
+            }
+          );
           cuenvFixtureModule = pkgs.writeText "waddle-cuenv-fixture-module.cue" ''
             module: "example.com/waddle-cuenv-fixture"
             language: {
@@ -106,76 +115,166 @@
           cuenvFixtureHealthy = pkgs.writeText "waddle-cuenv-fixture-healthy.cue" ''
             package cuenv
 
-            healthy: true
+            name: "healthy"
+            tasks: {
+              check: {
+                command: "true"
+                inputs: ["env.cue"]
+              }
+            }
           '';
           cuenvFixtureBrokenSelected = pkgs.writeText "waddle-cuenv-fixture-broken-selected.cue" ''
             package cuenv
 
             broken: {
           '';
-          cuenvSourceCoupling = pkgs.runCommand "waddle-cuenv-source-coupling" {
-            nativeBuildInputs = [ cuenv cuenvCueBridge ];
-            expectedSource = cuenvPatchedSrc;
-            cliSource = cuenv.passthru.source;
-            bridgeSource = cuenvCueBridge.passthru.source;
-          } ''
-            test "$expectedSource" = "$cliSource"
-            test "$expectedSource" = "$bridgeSource"
-            grep -F 'Selected CUE instances failed to evaluate' "$expectedSource/crates/cuengine/bridge.go"
-            {
-              printf '%s\n' "source=$expectedSource"
-              printf '%s\n' "cli_source=$cliSource"
-              printf '%s\n' "bridge_source=$bridgeSource"
-            } > "$out"
+          cuenvFixtureNoPackage = pkgs.writeText "waddle-cuenv-fixture-no-package.cue" ''
+            unknown: true
           '';
-          cuenvStrictDiscovery = pkgs.runCommand "waddle-cuenv-strict-discovery" {
-            nativeBuildInputs = [ cuenv ];
-          } ''
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME" "$TMPDIR/fixture/cue.mod" "$TMPDIR/fixture/bad-selected"
-            install -Dm444 ${cuenvFixtureModule} "$TMPDIR/fixture/cue.mod/module.cue"
-            install -Dm444 ${cuenvFixtureHealthy} "$TMPDIR/fixture/env.cue"
-            install -Dm444 ${cuenvFixtureBrokenSelected} "$TMPDIR/fixture/bad-selected/env.cue"
-            cd "$TMPDIR/fixture"
+          cuenvFixtureOpenList = pkgs.writeText "waddle-cuenv-fixture-open-list.cue" ''
+            package cuenv
 
-            expect_selected_failure() {
-              name="$1"
-              shift
-              if "$@" > "$TMPDIR/$name.log" 2>&1; then
-                echo "expected $name to fail" >&2
-                sed -n '1,240p' "$TMPDIR/$name.log" >&2
-                exit 1
-              fi
-              grep -F 'bad-selected' "$TMPDIR/$name.log"
+            open: [...string]
+          '';
+          cuenvFixtureNestedIncomplete = pkgs.writeText "waddle-cuenv-fixture-nested-incomplete.cue" ''
+            package cuenv
+
+            outer: {
+              ready: "yes"
+              pending: string
             }
-
-            expect_selected_failure info ${cuenv}/bin/cuenv info --json
-            expect_selected_failure sync-all ${cuenv}/bin/cuenv sync -A
-            expect_selected_failure sync-ci-check-all ${cuenv}/bin/cuenv sync ci --check -A
-
-            mkdir -p "$out"
-            cp "$TMPDIR"/*.log "$out/"
           '';
-          cuenvWaddleDiscovery = pkgs.runCommand "waddle-cuenv-waddle-discovery" {
-            nativeBuildInputs = [ cuenv pkgs.jq ];
-            waddleSource = self;
-          } ''
-            export HOME="$TMPDIR/home"
-            mkdir -p "$HOME" "$out"
-            cd "$waddleSource"
-            ${cuenv}/bin/cuenv info --json > "$out/info.json"
-            jq -e '
-              .project_count == 6
-              and .projects == [
-                {"name": "waddle-android", "path": "apps/android"},
-                {"name": "waddle-chat", "path": "chat"},
-                {"name": "waddle-cloud", "path": "infrastructure/waddle.cloud"},
-                {"name": "waddle-colony", "path": "colony"},
-                {"name": "waddle-server", "path": "server"},
-                {"name": "waddle-website", "path": "website"}
-              ]
-            ' "$out/info.json" > /dev/null
+          cuenvFixtureBrokenOther = pkgs.writeText "waddle-cuenv-fixture-broken-other.cue" ''
+            package other
+
+            broken: {
           '';
+          cuenvSourceCoupling =
+            pkgs.runCommand "waddle-cuenv-source-coupling"
+              {
+                nativeBuildInputs = [
+                  cuenv
+                  cuenvCueBridge
+                ];
+                expectedSource = cuenvPatchedSrc;
+                cliSource = cuenv.passthru.source;
+                bridgeSource = cuenvCueBridge.passthru.source;
+              }
+              ''
+                test "$expectedSource" = "$cliSource"
+                test "$expectedSource" = "$bridgeSource"
+                grep -F 'Selected CUE instances failed to evaluate' "$expectedSource/crates/cuengine/bridge.go"
+                {
+                  printf '%s\n' "source=$expectedSource"
+                  printf '%s\n' "cli_source=$cliSource"
+                  printf '%s\n' "bridge_source=$bridgeSource"
+                } > "$out"
+              '';
+          cuenvStrictDiscovery =
+            pkgs.runCommand "waddle-cuenv-strict-discovery"
+              {
+                nativeBuildInputs = [
+                  cuenv
+                  pkgs.git
+                  pkgs.jq
+                ];
+              }
+              ''
+                            export XDG_CONFIG_HOME="$TMPDIR/xdg-config"
+                            export XDG_CACHE_HOME="$TMPDIR/xdg-cache"
+                            mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$out"
+
+                            prepare_fixture() {
+                              fixture="$1"
+                  mkdir -p "$fixture/cue.mod"
+                  install -Dm444 ${cuenvFixtureModule} "$fixture/cue.mod/module.cue"
+                  install -Dm444 ${cuenvFixtureHealthy} "$fixture/env.cue"
+                  git -C "$fixture" init -q
+                              git -C "$fixture" config user.name "Waddle cuenv proof"
+                              git -C "$fixture" config user.email "cuenv-proof@example.invalid"
+                            }
+
+                            expect_failure() {
+                              name="$1"
+                              expected_path="$2"
+                              fixture="$3"
+                              shift 3
+                              if (cd "$fixture" && "$@") > "$out/$name.log" 2>&1; then
+                                echo "expected $name to fail" >&2
+                                sed -n '1,240p' "$out/$name.log" >&2
+                                exit 1
+                              fi
+                              grep -F "$expected_path" "$out/$name.log"
+                            }
+
+                            bad_selected="$TMPDIR/bad-selected-fixture"
+                            prepare_fixture "$bad_selected"
+                            mkdir -p "$bad_selected/bad-selected"
+                            install -Dm444 ${cuenvFixtureBrokenSelected} "$bad_selected/bad-selected/env.cue"
+                            expect_failure bad-selected-info bad-selected "$bad_selected" ${cuenv}/bin/cuenv info --json
+                            expect_failure bad-selected-sync-all bad-selected "$bad_selected" ${cuenv}/bin/cuenv sync -A
+                            expect_failure bad-selected-sync-ci-check-all bad-selected "$bad_selected" ${cuenv}/bin/cuenv sync ci --check -A
+
+                            no_package="$TMPDIR/no-package-fixture"
+                    prepare_fixture "$no_package"
+                    mkdir -p "$no_package/unknown-package"
+                    install -Dm444 ${cuenvFixtureNoPackage} "$no_package/unknown-package/env.cue"
+                    expect_failure no-package-sync-all unknown-package "$no_package" ${cuenv}/bin/cuenv sync -A
+
+                            open_list="$TMPDIR/open-list-fixture"
+                            prepare_fixture "$open_list"
+                            mkdir -p "$open_list/open-list"
+                            install -Dm444 ${cuenvFixtureOpenList} "$open_list/open-list/env.cue"
+                            expect_failure open-list-info open-list "$open_list" ${cuenv}/bin/cuenv info --json
+
+                            nested_incomplete="$TMPDIR/nested-incomplete-fixture"
+                            prepare_fixture "$nested_incomplete"
+                            mkdir -p "$nested_incomplete/nested-incomplete"
+                            install -Dm444 ${cuenvFixtureNestedIncomplete} "$nested_incomplete/nested-incomplete/env.cue"
+                            expect_failure nested-incomplete-info nested-incomplete "$nested_incomplete" ${cuenv}/bin/cuenv info --json
+
+                            other_package="$TMPDIR/other-package-fixture"
+                prepare_fixture "$other_package"
+                mkdir -p "$other_package/malformed-other"
+                install -Dm444 ${cuenvFixtureBrokenOther} "$other_package/malformed-other/env.cue"
+                if ! (cd "$other_package" && ${cuenv}/bin/cuenv info --json) \
+                              > "$out/malformed-other-info.json" \
+                              2> "$out/malformed-other-info.stderr"; then
+                              echo "expected malformed positively-other package to remain isolated" >&2
+                              sed -n '1,240p' "$out/malformed-other-info.stderr" >&2
+                              exit 1
+                            fi
+                            jq -e '
+                              .project_count == 1
+                              and .projects == [{"name": "healthy", "path": "."}]
+                            ' "$out/malformed-other-info.json" > /dev/null
+              '';
+          cuenvWaddleDiscovery =
+            pkgs.runCommand "waddle-cuenv-waddle-discovery"
+              {
+                nativeBuildInputs = [
+                  cuenv
+                  pkgs.jq
+                ];
+                waddleSource = self;
+              }
+              ''
+                export HOME="$TMPDIR/home"
+                mkdir -p "$HOME" "$out"
+                cd "$waddleSource"
+                ${cuenv}/bin/cuenv info --json > "$out/info.json"
+                jq -e '
+                  .project_count == 6
+                  and .projects == [
+                    {"name": "waddle-android", "path": "apps/android"},
+                    {"name": "waddle-chat", "path": "chat"},
+                    {"name": "waddle-cloud", "path": "infrastructure/waddle.cloud"},
+                    {"name": "waddle-colony", "path": "colony"},
+                    {"name": "waddle-server", "path": "server"},
+                    {"name": "waddle-website", "path": "website"}
+                  ]
+                ' "$out/info.json" > /dev/null
+              '';
           serverPackageSrc = lib.fileset.toSource {
             root = ./server;
             fileset =

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     crane.url = "github:ipetkov/crane";
+    cuenvSource = {
+      url = "github:cuenv/cuenv/e337a3f60af6944552f391facf2ed2e25efa3bc7";
+      flake = false;
+    };
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -13,6 +17,7 @@
       self,
       nixpkgs,
       crane,
+      cuenvSource,
       rust-overlay,
     }:
     let
@@ -38,6 +43,139 @@
           lib = pkgs.lib;
           rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./server/rust-toolchain.toml;
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+          cuenvVersion = "0.54.0";
+          # Both the Rust CLI and the Go CUE archive consume this one patched
+          # source derivation. Keeping the source identity explicit prevents a
+          # host or upstream bridge from masking a patched CLI build.
+          cuenvPatchedSrc = pkgs.applyPatches {
+            name = "cuenv-0.54.0-waddle-fail-closed-source";
+            src = cuenvSource;
+            patches = [ ./nix/patches/cuenv-0.54.0-fail-closed-discovery.patch ];
+          };
+          cuenvBridgeSrc = cuenvPatchedSrc + "/crates/cuengine";
+          cuenvCueBridge = pkgs.buildGoModule {
+            pname = "waddle-cuenv-cue-bridge";
+            version = cuenvVersion;
+            src = cuenvBridgeSrc;
+            vendorHash = "sha256-p8gfl2H0lThSmqIRQZWDYoQ3antrIslpCwRCNKQ1cKs=";
+            buildInputs = lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+            buildPhase = ''
+              runHook preBuild
+              export CGO_ENABLED=1
+              mkdir -p "$out/debug" "$out/release"
+              go_sources=$(find . -maxdepth 1 -name '*.go' ! -name '*_test.go' -print | sort)
+              go build -buildmode=c-archive -o "$out/debug/libcue_bridge.a" $go_sources
+              cp libcue_bridge.h "$out/debug/"
+              go build -buildmode=c-archive -o "$out/release/libcue_bridge.a" $go_sources
+              cp libcue_bridge.h "$out/release/"
+              runHook postBuild
+            '';
+            installPhase = ''
+              runHook preInstall
+              runHook postInstall
+            '';
+            passthru.source = cuenvPatchedSrc;
+          };
+          cuenvBaseArgs = {
+            pname = "cuenv";
+            version = cuenvVersion;
+            src = cuenvPatchedSrc;
+            strictDeps = true;
+            cargoExtraArgs = "--locked --package cuenv";
+            nativeBuildInputs = [ pkgs.go pkgs.pkg-config ];
+            buildInputs = lib.optionals pkgs.stdenv.isDarwin [ pkgs.libiconv ];
+            CUE_BRIDGE_PATH = cuenvCueBridge;
+          };
+          cuenvCargoArtifacts = craneLib.buildDepsOnly (cuenvBaseArgs // {
+            doCheck = false;
+          });
+          cuenv = craneLib.buildPackage (cuenvBaseArgs // {
+            cargoArtifacts = cuenvCargoArtifacts;
+            doCheck = false;
+            passthru = {
+              source = cuenvPatchedSrc;
+              cueBridge = cuenvCueBridge;
+            };
+          });
+          cuenvFixtureModule = pkgs.writeText "waddle-cuenv-fixture-module.cue" ''
+            module: "example.com/waddle-cuenv-fixture"
+            language: {
+              version: "v0.9.0"
+            }
+          '';
+          cuenvFixtureHealthy = pkgs.writeText "waddle-cuenv-fixture-healthy.cue" ''
+            package cuenv
+
+            healthy: true
+          '';
+          cuenvFixtureBrokenSelected = pkgs.writeText "waddle-cuenv-fixture-broken-selected.cue" ''
+            package cuenv
+
+            broken: {
+          '';
+          cuenvSourceCoupling = pkgs.runCommand "waddle-cuenv-source-coupling" {
+            nativeBuildInputs = [ cuenv cuenvCueBridge ];
+            expectedSource = cuenvPatchedSrc;
+            cliSource = cuenv.passthru.source;
+            bridgeSource = cuenvCueBridge.passthru.source;
+          } ''
+            test "$expectedSource" = "$cliSource"
+            test "$expectedSource" = "$bridgeSource"
+            grep -F 'Selected CUE instances failed to evaluate' "$expectedSource/crates/cuengine/bridge.go"
+            {
+              printf '%s\n' "source=$expectedSource"
+              printf '%s\n' "cli_source=$cliSource"
+              printf '%s\n' "bridge_source=$bridgeSource"
+            } > "$out"
+          '';
+          cuenvStrictDiscovery = pkgs.runCommand "waddle-cuenv-strict-discovery" {
+            nativeBuildInputs = [ cuenv ];
+          } ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME" "$TMPDIR/fixture/cue.mod" "$TMPDIR/fixture/bad-selected"
+            install -Dm444 ${cuenvFixtureModule} "$TMPDIR/fixture/cue.mod/module.cue"
+            install -Dm444 ${cuenvFixtureHealthy} "$TMPDIR/fixture/env.cue"
+            install -Dm444 ${cuenvFixtureBrokenSelected} "$TMPDIR/fixture/bad-selected/env.cue"
+            cd "$TMPDIR/fixture"
+
+            expect_selected_failure() {
+              name="$1"
+              shift
+              if "$@" > "$TMPDIR/$name.log" 2>&1; then
+                echo "expected $name to fail" >&2
+                sed -n '1,240p' "$TMPDIR/$name.log" >&2
+                exit 1
+              fi
+              grep -F 'bad-selected' "$TMPDIR/$name.log"
+            }
+
+            expect_selected_failure info ${cuenv}/bin/cuenv info --json
+            expect_selected_failure sync-all ${cuenv}/bin/cuenv sync -A
+            expect_selected_failure sync-ci-check-all ${cuenv}/bin/cuenv sync ci --check -A
+
+            mkdir -p "$out"
+            cp "$TMPDIR"/*.log "$out/"
+          '';
+          cuenvWaddleDiscovery = pkgs.runCommand "waddle-cuenv-waddle-discovery" {
+            nativeBuildInputs = [ cuenv pkgs.jq ];
+            waddleSource = self;
+          } ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME" "$out"
+            cd "$waddleSource"
+            ${cuenv}/bin/cuenv info --json > "$out/info.json"
+            jq -e '
+              .project_count == 6
+              and .projects == [
+                {"name": "waddle-android", "path": "apps/android"},
+                {"name": "waddle-chat", "path": "chat"},
+                {"name": "waddle-cloud", "path": "infrastructure/waddle.cloud"},
+                {"name": "waddle-colony", "path": "colony"},
+                {"name": "waddle-server", "path": "server"},
+                {"name": "waddle-website", "path": "website"}
+              ]
+            ' "$out/info.json" > /dev/null
+          '';
           serverPackageSrc = lib.fileset.toSource {
             root = ./server;
             fileset =
@@ -170,7 +308,11 @@
           };
         in
         {
-          inherit waddle-server;
+          inherit waddle-server cuenv;
+          cuenv-cue-bridge = cuenvCueBridge;
+          cuenv-source-coupling = cuenvSourceCoupling;
+          cuenv-strict-discovery = cuenvStrictDiscovery;
+          cuenv-waddle-discovery = cuenvWaddleDiscovery;
           waddle-server-deps = cargoArtifacts;
           waddle-server-workspace-deps = workspaceArtifacts;
           waddle-server-workspace-all-features-deps = workspaceAllFeaturesArtifacts;

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -49,7 +49,7 @@ schema.#Project & {
 	let _t = tasks
 
 	ci: providers: ["github"]
-	ci: contributors: [_NamespaceNix, c.#CuenvRelease, c.#OnePassword]
+	ci: contributors: [_NamespaceNix, c.#CuenvNix, c.#OnePassword]
 
 	// Grafana Cloud ruler credentials for rulesSync (#1324). Resolved
 	// via 1Password on main-push CI (the OnePassword contributor +

--- a/nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+++ b/nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
@@ -1,7 +1,7 @@
-diff --git a/crates/ci/src/discovery.rs b/crates/ci/src/discovery.rs
+diff --git i/crates/ci/src/discovery.rs w/crates/ci/src/discovery.rs
 index f0da20a..9c63cfa 100644
---- a/crates/ci/src/discovery.rs
-+++ b/crates/ci/src/discovery.rs
+--- i/crates/ci/src/discovery.rs
++++ w/crates/ci/src/discovery.rs
 @@ -64,7 +64,7 @@ pub fn evaluate_module_from_cwd() -> Result<ModuleEvaluation> {
      })?;
  
@@ -43,10 +43,10 @@ index f0da20a..9c63cfa 100644
          )));
      }
  
-diff --git a/crates/core/src/cue/discovery.rs b/crates/core/src/cue/discovery.rs
+diff --git i/crates/core/src/cue/discovery.rs w/crates/core/src/cue/discovery.rs
 index 0b72190..7043bbe 100644
---- a/crates/core/src/cue/discovery.rs
-+++ b/crates/core/src/cue/discovery.rs
+--- i/crates/core/src/cue/discovery.rs
++++ w/crates/core/src/cue/discovery.rs
 @@ -239,8 +239,16 @@ fn collect_ancestor_env_files(
  /// # Returns
  /// A vector of directory paths (relative to module_root) containing matching env.cue files.
@@ -137,11 +137,11 @@ index 0b72190..7043bbe 100644
  fn is_env_cue_file(path: &Path) -> bool {
      path.file_name() == Some("env.cue".as_ref())
  }
-diff --git a/crates/cuengine/bridge.go b/crates/cuengine/bridge.go
-index e02dbd6..89b1b5d 100644
---- a/crates/cuengine/bridge.go
-+++ b/crates/cuengine/bridge.go
-@@ -328,10 +328,29 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
+diff --git i/crates/cuengine/bridge.go w/crates/cuengine/bridge.go
+index e02dbd6..ab3776d 100644
+--- i/crates/cuengine/bridge.go
++++ w/crates/cuengine/bridge.go
+@@ -328,10 +328,31 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
  	var loadErrors []string
  	var packageMismatches []string
  	for _, inst := range loadedInstances {
@@ -149,6 +149,8 @@ index e02dbd6..89b1b5d 100644
 -			packageMismatches = append(packageMismatches, fmt.Sprintf("%s has package '%s'", inst.Dir, inst.PkgName))
 +		classification, classificationErr := classifyInstancePackage(inst, effectivePackageName)
 +		switch classification {
++		case packageAbsent:
+ 			continue
 +		case packageOther:
 +			packageMismatches = append(
 +				packageMismatches,
@@ -159,7 +161,7 @@ index e02dbd6..89b1b5d 100644
 +					inst.PkgName,
 +				),
 +			)
- 			continue
++			continue
 +		case packageUnknown:
 +			diagnostic := fmt.Sprintf("%s: %v", inst.Dir, classificationErr)
 +			if inst.Err != nil {
@@ -173,7 +175,7 @@ index e02dbd6..89b1b5d 100644
  		if inst.Err != nil {
  			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", inst.Dir, inst.Err))
  			continue
-@@ -453,10 +472,17 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
+@@ -453,10 +474,17 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
  		}
  	}
  
@@ -193,12 +195,12 @@ index e02dbd6..89b1b5d 100644
  		result = createErrorResponse(ErrorCodeBuildValue, "No instances could be evaluated", &hint)
  		return result
  	}
-diff --git a/crates/cuengine/package_classification.go b/crates/cuengine/package_classification.go
+diff --git i/crates/cuengine/package_classification.go w/crates/cuengine/package_classification.go
 new file mode 100644
-index 0000000..c3425fe
+index 0000000..9cdcdaf
 --- /dev/null
-+++ b/crates/cuengine/package_classification.go
-@@ -0,0 +1,118 @@
++++ w/crates/cuengine/package_classification.go
+@@ -0,0 +1,142 @@
 +package main
 +
 +import (
@@ -217,6 +219,7 @@ index 0000000..c3425fe
 +	packageUnknown packageClassification = iota
 +	packageSelected
 +	packageOther
++	packageAbsent
 +)
 +
 +// classifyInstancePackage keeps package filtering ahead of evaluation errors.
@@ -238,6 +241,15 @@ index 0000000..c3425fe
 +	sources, err := packageSourcesForInstance(inst)
 +	if err != nil {
 +		return packageUnknown, err
++	}
++	if len(sources) == 0 {
++		if inst.Err != nil {
++			return packageUnknown, fmt.Errorf(
++				"could not establish CUE package for failed loader instance in %s: no CUE sources",
++				inst.Dir,
++			)
++		}
++		return packageAbsent, nil
 +	}
 +
 +	var unknownSources []string
@@ -285,12 +297,14 @@ index 0000000..c3425fe
 +
 +func packageSourcesForInstance(inst *build.Instance) ([]*build.File, error) {
 +	var sources []*build.File
-+	for _, file := range inst.InvalidFiles {
-+		if file == nil {
-+			continue
-+		}
-+		if file.Encoding == build.CUE || strings.HasSuffix(file.Filename, ".cue") {
-+			sources = append(sources, file)
++	for _, files := range [][]*build.File{inst.BuildFiles, inst.InvalidFiles} {
++		for _, file := range files {
++			if file == nil {
++				continue
++			}
++			if file.Encoding == build.CUE || strings.HasSuffix(file.Filename, ".cue") {
++				sources = append(sources, file)
++			}
 +		}
 +	}
 +	if len(sources) > 0 {
@@ -306,6 +320,18 @@ index 0000000..c3425fe
 +		)
 +	}
 +
++	// With Package="*", CUE retains a synthetic anonymous instance when a
++	// directory contains both a named CUE package and non-CUE orphan files.
++	// That instance owns no CUE files: the named sibling owns BuildFiles.
++	// A successful, source-free loader entry is therefore absent even though
++	// the directory itself contains the sibling package's .cue files.
++	if inst.Err == nil {
++		return nil, nil
++	}
++
++	// Failed loader entries do not always retain their source in InvalidFiles.
++	// Limit directory-wide recovery to that error case so malformed selected
++	// packages remain discoverable and terminal.
 +	for _, entry := range entries {
 +		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".cue") {
 +			continue
@@ -317,12 +343,12 @@ index 0000000..c3425fe
 +	}
 +	return sources, nil
 +}
-diff --git a/crates/cuengine/package_classification_test.go b/crates/cuengine/package_classification_test.go
+diff --git i/crates/cuengine/package_classification_test.go w/crates/cuengine/package_classification_test.go
 new file mode 100644
-index 0000000..f083835
+index 0000000..f5b0d99
 --- /dev/null
-+++ b/crates/cuengine/package_classification_test.go
-@@ -0,0 +1,143 @@
++++ w/crates/cuengine/package_classification_test.go
+@@ -0,0 +1,291 @@
 +package main
 +
 +import (
@@ -422,6 +448,132 @@ index 0000000..f083835
 +	}
 +}
 +
++func TestClassifyInstancePackageIgnoresSourceFreeLoaderEntry(t *testing.T) {
++	dir := t.TempDir()
++	instance := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++	}
++
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if err != nil {
++		t.Fatalf("classify source-free loader entry: %v", err)
++	}
++	if classification != packageAbsent {
++		t.Fatalf("classification = %v, want absent", classification)
++	}
++}
++
++func TestClassifyInstancePackageRejectsFailedSourceFreeLoaderEntry(t *testing.T) {
++	dir := t.TempDir()
++	instance := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++		Err:     errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if classification != packageUnknown {
++		t.Fatalf("classification = %v, want unknown", classification)
++	}
++	if err == nil || !strings.Contains(err.Error(), "failed loader instance") {
++		t.Fatalf("expected failed source-free loader error, got %v", err)
++	}
++}
++
++func TestClassifyInstancePackageIgnoresSyntheticAnonymousSibling(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(
++		filepath.Join(dir, "env.cue"),
++		[]byte("package cuenv\n\nhealthy: true\n"),
++		0o600,
++	); err != nil {
++		t.Fatalf("write named sibling source: %v", err)
++	}
++	orphanPath := filepath.Join(dir, "main.rs")
++	if err := os.WriteFile(orphanPath, []byte("fn main() {}\n"), 0o600); err != nil {
++		t.Fatalf("write non-CUE orphan: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++		OrphanedFiles: []*build.File{{
++			Filename: orphanPath,
++		}},
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if err != nil {
++		t.Fatalf("classify synthetic anonymous sibling: %v", err)
++	}
++	if classification != packageAbsent {
++		t.Fatalf("classification = %v, want absent", classification)
++	}
++}
++
++func TestClassifyInstancePackageRejectsOwnedAnonymousCUESource(t *testing.T) {
++	dir := t.TempDir()
++	sourcePath := filepath.Join(dir, "anonymous.cue")
++	if err := os.WriteFile(sourcePath, []byte("healthy: true\n"), 0o600); err != nil {
++		t.Fatalf("write anonymous CUE source: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++		BuildFiles: []*build.File{{
++			Filename: sourcePath,
++			Encoding: build.CUE,
++		}},
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if classification != packageUnknown {
++		t.Fatalf("classification = %v, want unknown", classification)
++	}
++	if err == nil || !strings.Contains(err.Error(), "has no package declaration") {
++		t.Fatalf("expected anonymous-source error, got %v", err)
++	}
++}
++
++func TestClassifyInstancePackageIgnoresSyntheticOtherPackageSibling(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(
++		filepath.Join(dir, "env.cue"),
++		[]byte("package other\n\nhealthy: true\n"),
++		0o600,
++	); err != nil {
++		t.Fatalf("write other-package sibling source: %v", err)
++	}
++	orphanPath := filepath.Join(dir, "README.md")
++	if err := os.WriteFile(orphanPath, []byte("fixture\n"), 0o600); err != nil {
++		t.Fatalf("write non-CUE orphan: %v", err)
++	}
++
++	synthetic := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++		OrphanedFiles: []*build.File{{
++			Filename: orphanPath,
++		}},
++	}
++	classification, err := classifyInstancePackage(synthetic, "cuenv")
++	if err != nil {
++		t.Fatalf("classify synthetic other-package sibling: %v", err)
++	}
++	if classification != packageAbsent {
++		t.Fatalf("classification = %v, want absent", classification)
++	}
++
++	authoritative := &build.Instance{Dir: dir, PkgName: "other"}
++	classification, err = classifyInstancePackage(authoritative, "cuenv")
++	if err != nil {
++		t.Fatalf("classify authoritative other package: %v", err)
++	}
++	if classification != packageOther {
++		t.Fatalf("classification = %v, want other", classification)
++	}
++}
++
 +func TestClassifyInstancePackageRejectsSourceWithoutPackageAST(t *testing.T) {
 +	dir := t.TempDir()
 +	sourcePath := filepath.Join(dir, "env.cue")
@@ -466,10 +618,32 @@ index 0000000..f083835
 +		t.Fatalf("incomplete container serialized as %s; want concrete-value error", encoded)
 +	}
 +}
-diff --git a/crates/cuengine/tests/package_filter_tests.rs b/crates/cuengine/tests/package_filter_tests.rs
-index f223b5a..9df0aa2 100644
---- a/crates/cuengine/tests/package_filter_tests.rs
-+++ b/crates/cuengine/tests/package_filter_tests.rs
++
++func TestBuildJSONCleanAllowsNonExportedIncompleteSchemaState(t *testing.T) {
++	value := cuecontext.New().CompileString(`{
++		ready: "yes"
++		_hidden: string
++		#Schema: {
++			pending: string
++		}
++		optional?: string
++	}`)
++	if err := value.Err(); err != nil {
++		t.Fatalf("compile schema-bearing value: %v", err)
++	}
++
++	encoded, err := buildJSONClean(value)
++	if err != nil {
++		t.Fatalf("serialize exported concrete value: %v", err)
++	}
++	if got, want := string(encoded), `{"ready":"yes"}`; got != want {
++		t.Fatalf("encoded value = %s, want %s", got, want)
++	}
++}
+diff --git i/crates/cuengine/tests/package_filter_tests.rs w/crates/cuengine/tests/package_filter_tests.rs
+index f223b5a..f75899f 100644
+--- i/crates/cuengine/tests/package_filter_tests.rs
++++ w/crates/cuengine/tests/package_filter_tests.rs
 @@ -23,6 +23,35 @@ fn create_module() -> TestResult<TempDir> {
      Ok(temp_dir)
  }
@@ -477,7 +651,10 @@ index f223b5a..9df0aa2 100644
 +fn write_env(root: &std::path::Path, relative_dir: &str, package: &str, body: &str) -> TestResult {
 +    let directory = root.join(relative_dir);
 +    fs::create_dir_all(&directory)?;
-+    fs::write(directory.join("env.cue"), format!("package {package}\n\n{body}\n"))?;
++    fs::write(
++        directory.join("env.cue"),
++        format!("package {package}\n\n{body}\n"),
++    )?;
 +    Ok(())
 +}
 +
@@ -489,10 +666,7 @@ index f223b5a..9df0aa2 100644
 +    }
 +}
 +
-+fn assert_selected_failure(
-+    root: &std::path::Path,
-+    expected_path: &str,
-+) -> TestResult {
++fn assert_selected_failure(root: &std::path::Path, expected_path: &str) -> TestResult {
 +    let error = evaluate_module(root, "cuenv", Some(&recursive_options()))
 +        .expect_err("a selected cuenv package error must be terminal");
 +    let message = error.to_string();
@@ -506,7 +680,7 @@ index f223b5a..9df0aa2 100644
  #[test]
  fn recursive_eval_ignores_other_packages_in_same_directory() -> TestResult {
      let temp_dir = create_module()?;
-@@ -65,3 +94,63 @@ ignored: "this belongs to another CUE package"
+@@ -65,3 +94,146 @@ ignored: "this belongs to another CUE package"
  
      Ok(())
  }
@@ -558,6 +732,42 @@ index f223b5a..9df0aa2 100644
 +}
 +
 +#[test]
++fn recursive_eval_allows_non_exported_incomplete_schema_state() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(
++        root,
++        "",
++        "cuenv",
++        r#"
++let _ready = ready
++
++ready: "yes"
++selected: _ready
++_hidden: string
++#Schema: {
++    pending: string
++}
++optional?: string
++"#,
++    )?;
++
++    let result = evaluate_module(root, "cuenv", Some(&recursive_options()))?;
++    let root_instance = result
++        .instances
++        .get(".")
++        .ok_or_else(|| std::io::Error::other("missing root cuenv instance"))?;
++    assert_eq!(root_instance["ready"], Value::String("yes".to_string()));
++    assert_eq!(root_instance["selected"], Value::String("yes".to_string()));
++    assert!(root_instance.get("_hidden").is_none());
++    assert!(root_instance.get("#Schema").is_none());
++    assert!(root_instance.get("optional").is_none());
++
++    Ok(())
++}
++
++#[test]
 +fn recursive_eval_ignores_failing_non_cuenv_packages() -> TestResult {
 +    let temp_dir = create_module()?;
 +    let root = temp_dir.path();
@@ -570,10 +780,57 @@ index f223b5a..9df0aa2 100644
 +    assert!(result.instances.contains_key("."));
 +    Ok(())
 +}
-diff --git a/crates/cuengine/values.go b/crates/cuengine/values.go
-index 88520ae..fbcc692 100644
---- a/crates/cuengine/values.go
-+++ b/crates/cuengine/values.go
++
++#[test]
++fn recursive_eval_ignores_directories_without_cue_sources() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    let ordinary_source = root.join("ordinary/src/deep");
++    fs::create_dir_all(&ordinary_source)?;
++    fs::write(ordinary_source.join("main.rs"), "fn main() {}\n")?;
++
++    let result = evaluate_module(root, "cuenv", Some(&recursive_options()))?;
++    assert_eq!(result.instances.len(), 1);
++    assert!(result.instances.contains_key("."));
++    Ok(())
++}
++
++#[test]
++fn recursive_eval_ignores_synthetic_anonymous_project_sibling() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    fs::write(root.join("main.rs"), "fn main() {}\n")?;
++
++    let result = evaluate_module(root, "cuenv", Some(&recursive_options()))?;
++    assert_eq!(result.instances.len(), 1);
++    let root_instance = result
++        .instances
++        .get(".")
++        .ok_or_else(|| std::io::Error::other("missing root cuenv instance"))?;
++    assert_eq!(root_instance["healthy"], Value::Bool(true));
++    Ok(())
++}
++
++#[test]
++fn recursive_eval_rejects_owned_anonymous_cue_source() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    let anonymous_dir = root.join("anonymous");
++    fs::create_dir_all(&anonymous_dir)?;
++    fs::write(anonymous_dir.join("anonymous.cue"), "value: true\n")?;
++
++    assert_selected_failure(root, "anonymous")
++}
+diff --git i/crates/cuengine/values.go w/crates/cuengine/values.go
+index 88520ae..8b99ed4 100644
+--- i/crates/cuengine/values.go
++++ w/crates/cuengine/values.go
 @@ -9,7 +9,10 @@ import (
  // buildJSONClean builds a JSON representation without any _meta injection.
  // This returns clean JSON that can be correlated with the separate meta map.
@@ -592,10 +849,6 @@ index 88520ae..fbcc692 100644
  // buildValueClean recursively builds a clean value without metadata
 -func buildValueClean(v cue.Value) interface{} {
 +func buildValueClean(v cue.Value) (interface{}, error) {
-+	if err := v.Validate(cue.Concrete(true)); err != nil {
-+		return nil, err
-+	}
-+
  	switch v.Kind() {
  	case cue.StructKind:
  		result := make(map[string]interface{})
@@ -643,6 +896,10 @@ index 88520ae..fbcc692 100644
  
  	default:
  		// Concrete value (string, number, bool, null)
++		if err := v.Validate(cue.Concrete(true)); err != nil {
++			return nil, err
++		}
++
  		var val interface{}
 -		v.Decode(&val)
 -		return val
@@ -652,10 +909,10 @@ index 88520ae..fbcc692 100644
 +		return val, nil
  	}
  }
-diff --git a/crates/cuenv/src/commands/info.rs b/crates/cuenv/src/commands/info.rs
+diff --git i/crates/cuenv/src/commands/info.rs w/crates/cuenv/src/commands/info.rs
 index 9b28ddb..e3ab109 100644
---- a/crates/cuenv/src/commands/info.rs
-+++ b/crates/cuenv/src/commands/info.rs
+--- i/crates/cuenv/src/commands/info.rs
++++ w/crates/cuenv/src/commands/info.rs
 @@ -10,7 +10,7 @@
  use crate::commands::convert_engine_error;
  use crate::commands::env_file::{discover_env_cue_directories, find_cue_module_root};
@@ -710,10 +967,10 @@ index 9b28ddb..e3ab109 100644
      }
  
      if discovered.instances.is_empty() {
-diff --git a/crates/cuenv/src/commands/module_evaluation.rs b/crates/cuenv/src/commands/module_evaluation.rs
+diff --git i/crates/cuenv/src/commands/module_evaluation.rs w/crates/cuenv/src/commands/module_evaluation.rs
 index a4d29d0..d73855d 100644
---- a/crates/cuenv/src/commands/module_evaluation.rs
-+++ b/crates/cuenv/src/commands/module_evaluation.rs
+--- i/crates/cuenv/src/commands/module_evaluation.rs
++++ w/crates/cuenv/src/commands/module_evaluation.rs
 @@ -1,9 +1,8 @@
  use super::{CommandExecutor, convert_engine_error, env_file, schema_compat};
  use crate::commands::module_utils::EvaluationMetadataBuilder;
@@ -862,10 +1119,10 @@ index a4d29d0..d73855d 100644
 -        }))
 -    }
  }
-diff --git a/crates/cuenv/src/completions.rs b/crates/cuenv/src/completions.rs
+diff --git i/crates/cuenv/src/completions.rs w/crates/cuenv/src/completions.rs
 index 9c7f43c..60ae96e 100644
---- a/crates/cuenv/src/completions.rs
-+++ b/crates/cuenv/src/completions.rs
+--- i/crates/cuenv/src/completions.rs
++++ w/crates/cuenv/src/completions.rs
 @@ -48,7 +48,9 @@ fn get_available_tasks(path: &str, package: &str) -> Vec<(String, Option<String>
      };
  
@@ -877,11 +1134,11 @@ index 9c7f43c..60ae96e 100644
      if env_cue_dirs.is_empty() {
          return Vec::new();
      }
-diff --git a/crates/cuenv/tests/sync_scope_rules.rs b/crates/cuenv/tests/sync_scope_rules.rs
-index a255660..18466f7 100644
---- a/crates/cuenv/tests/sync_scope_rules.rs
-+++ b/crates/cuenv/tests/sync_scope_rules.rs
-@@ -624,6 +624,77 @@ fn sync_all_from_nested_generates_all_ci_in_repo_root() -> TestResult {
+diff --git i/crates/cuenv/tests/sync_scope_rules.rs w/crates/cuenv/tests/sync_scope_rules.rs
+index a255660..b1d0b80 100644
+--- i/crates/cuenv/tests/sync_scope_rules.rs
++++ w/crates/cuenv/tests/sync_scope_rules.rs
+@@ -624,6 +624,151 @@ fn sync_all_from_nested_generates_all_ci_in_repo_root() -> TestResult {
      Ok(())
  }
  
@@ -940,17 +1197,91 @@ index a255660..18466f7 100644
 +
 +    let unrelated = root.join("apps/non-cuenv");
 +    fs::create_dir_all(&unrelated)?;
-+    fs::write(
-+        unrelated.join("env.cue"),
-+        "package other\n\nbroken: {\n",
-+    )?;
++    fs::write(unrelated.join("env.cue"), "package other\n\nbroken: {\n")?;
 +
 +    let output = run_cuenv(root, &["sync", "-A"])?;
 +    assert!(
 +        output.success,
 +        "sync -A must ignore malformed non-cuenv packages\nstdout: {}\nstderr: {}",
-+        output.stdout,
-+        output.stderr
++        output.stdout, output.stderr
++    );
++
++    Ok(())
++}
++
++#[test]
++fn workspace_sync_ignores_ordinary_directories_without_cue_sources() -> TestResult {
++    let tmp = create_repo()?;
++    let root = tmp.path();
++
++    fs::write(
++        root.join("env.cue"),
++        project_env_cue("healthy", "build", "build", "@healthy"),
++    )?;
++
++    let ordinary_source = root.join("apps/ordinary/src/deep");
++    fs::create_dir_all(&ordinary_source)?;
++    fs::write(ordinary_source.join("main.rs"), "fn main() {}\n")?;
++
++    let output = run_cuenv(root, &["sync", "-A"])?;
++    assert!(
++        output.success,
++        "sync -A must ignore ordinary directories without CUE sources\nstdout: {}\nstderr: {}",
++        output.stdout, output.stderr
++    );
++
++    Ok(())
++}
++
++#[test]
++fn workspace_sync_ci_ignores_synthetic_anonymous_project_sibling() -> TestResult {
++    let tmp = create_repo()?;
++    let root = tmp.path();
++
++    fs::write(
++        root.join("env.cue"),
++        project_env_cue("healthy", "build", "build", "@healthy"),
++    )?;
++    fs::write(root.join("main.rs"), "fn main() {}\n")?;
++
++    let output = run_cuenv(root, &["sync", "ci", "--dry-run", "-A"])?;
++    assert!(
++        output.success,
++        "sync ci --dry-run -A must ignore the source-free synthetic anonymous sibling\nstdout: {}\nstderr: {}",
++        output.stdout, output.stderr
++    );
++    assert!(
++        output.stdout.contains("healthy-build.yml"),
++        "dry-run must still generate the named package workflow: {}",
++        output.stdout
++    );
++
++    Ok(())
++}
++
++#[test]
++fn workspace_sync_rejects_owned_anonymous_cue_source() -> TestResult {
++    let tmp = create_repo()?;
++    let root = tmp.path();
++
++    fs::write(
++        root.join("env.cue"),
++        project_env_cue("healthy", "build", "build", "@healthy"),
++    )?;
++
++    let anonymous = root.join("apps/anonymous");
++    fs::create_dir_all(&anonymous)?;
++    fs::write(anonymous.join("env.cue"), "value: true\n")?;
++
++    let output = run_cuenv(root, &["sync", "ci", "--dry-run", "-A"])?;
++    assert!(
++        !output.success,
++        "sync ci --dry-run -A must reject an owned anonymous CUE source"
++    );
++    let combined = format!("{}{}", output.stdout, output.stderr);
++    assert!(
++        combined.contains("anonymous"),
++        "anonymous-source error must name its path: {combined}"
 +    );
 +
 +    Ok(())

--- a/nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
+++ b/nix/patches/cuenv-0.54.0-fail-closed-discovery.patch
@@ -1,0 +1,961 @@
+diff --git a/crates/ci/src/discovery.rs b/crates/ci/src/discovery.rs
+index f0da20a..9c63cfa 100644
+--- a/crates/ci/src/discovery.rs
++++ b/crates/ci/src/discovery.rs
+@@ -64,7 +64,7 @@ pub fn evaluate_module_from_cwd() -> Result<ModuleEvaluation> {
+     })?;
+ 
+     // Discover all directories with env.cue files matching our package
+-    let env_cue_dirs = discover_env_cue_directories(&module_root, PACKAGE);
++    let env_cue_dirs = discover_env_cue_directories(&module_root, PACKAGE)?;
+ 
+     if env_cue_dirs.is_empty() {
+         return Err(cuenv_core::Error::configuration(format!(
+@@ -117,21 +117,21 @@ pub fn evaluate_module_from_cwd() -> Result<ModuleEvaluation> {
+                     all_meta.insert(adjusted_key, meta_value);
+                 }
+             }
+-            Err(e) => {
+-                tracing::warn!(
+-                    dir = %dir.display(),
+-                    error = %e,
+-                    "Failed to evaluate env.cue - skipping directory"
+-                );
+-                eval_errors.push((dir, e));
+-            }
++            Err(e) => eval_errors.push((dir, e)),
+         }
+     }
+ 
+-    if all_instances.is_empty() {
++    if !eval_errors.is_empty() {
+         let error_summary = format_eval_errors(&eval_errors);
+         return Err(cuenv_core::Error::configuration(format!(
+-            "No instances could be evaluated. All directories failed:\n{error_summary}"
++            "Selected CUE projects failed during CI discovery:\n{error_summary}"
++        )));
++    }
++
++    if all_instances.is_empty() {
++        return Err(cuenv_core::Error::configuration(format!(
++            "No instances could be evaluated from selected CUE projects in module: {}",
++            module_root.display()
+         )));
+     }
+ 
+diff --git a/crates/core/src/cue/discovery.rs b/crates/core/src/cue/discovery.rs
+index 0b72190..7043bbe 100644
+--- a/crates/core/src/cue/discovery.rs
++++ b/crates/core/src/cue/discovery.rs
+@@ -239,8 +239,16 @@ fn collect_ancestor_env_files(
+ /// # Returns
+ /// A vector of directory paths (relative to module_root) containing matching env.cue files.
+ /// The paths are suitable for use with `cuengine::evaluate_module` with `TargetDir` option.
+-#[must_use]
+-pub fn discover_env_cue_directories(module_root: &Path, expected_package: &str) -> Vec<PathBuf> {
++///
++/// # Errors
++///
++/// Returns an error when workspace traversal, selected-package inspection, or path
++/// canonicalization fails. Callers that act on the discovered package must not
++/// continue with a partial project set.
++pub fn discover_env_cue_directories(
++    module_root: &Path,
++    expected_package: &str,
++) -> Result<Vec<PathBuf>> {
+     let mut directories = Vec::new();
+ 
+     let walker = WalkBuilder::new(module_root)
+@@ -249,27 +257,45 @@ pub fn discover_env_cue_directories(module_root: &Path, expected_package: &str)
+         .build();
+ 
+     for result in walker {
+-        let Ok(entry) = result else {
+-            continue;
+-        };
++        let entry = result.map_err(|error| {
++            Error::configuration(format!(
++                "Failed to scan CUE module '{}' while discovering package '{}': {error}",
++                module_root.display(),
++                expected_package,
++            ))
++        })?;
+ 
+         let path = entry.path();
+         if !is_env_cue_file(path) {
+             continue;
+         }
+ 
+-        if !matches_package(path, expected_package) {
++        let package_name = detect_package_name(path).map_err(|error| {
++            Error::configuration(format!(
++                "Failed to inspect package declaration in '{}': {error}",
++                path.display(),
++            ))
++        })?;
++        if package_name.as_deref() != Some(expected_package) {
+             continue;
+         }
+ 
+-        if let Some(dir) = path.parent()
+-            && let Ok(canonical) = dir.canonicalize()
+-        {
+-            directories.push(canonical);
+-        }
++        let dir = path.parent().ok_or_else(|| {
++            Error::configuration(format!(
++                "Cannot determine parent directory for selected env.cue: {}",
++                path.display(),
++            ))
++        })?;
++        let canonical = dir.canonicalize().map_err(|error| {
++            Error::configuration(format!(
++                "Failed to canonicalize selected CUE project '{}': {error}",
++                dir.display(),
++            ))
++        })?;
++        directories.push(canonical);
+     }
+ 
+-    directories
++    Ok(directories)
+ }
+ 
+ /// Discover all directories containing an env.cue file, regardless of package.
+@@ -312,14 +338,6 @@ pub fn discover_all_env_cue_directories(module_root: &Path) -> Vec<PathBuf> {
+     directories
+ }
+ 
+-fn matches_package(path: &Path, expected_package: &str) -> bool {
+-    let Ok(package_name) = detect_package_name(path) else {
+-        return false;
+-    };
+-
+-    package_name.as_deref() == Some(expected_package)
+-}
+-
+ fn is_env_cue_file(path: &Path) -> bool {
+     path.file_name() == Some("env.cue".as_ref())
+ }
+diff --git a/crates/cuengine/bridge.go b/crates/cuengine/bridge.go
+index e02dbd6..89b1b5d 100644
+--- a/crates/cuengine/bridge.go
++++ b/crates/cuengine/bridge.go
+@@ -328,10 +328,29 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
+ 	var loadErrors []string
+ 	var packageMismatches []string
+ 	for _, inst := range loadedInstances {
+-		if effectivePackageName != "" && inst.PkgName != effectivePackageName {
+-			packageMismatches = append(packageMismatches, fmt.Sprintf("%s has package '%s'", inst.Dir, inst.PkgName))
++		classification, classificationErr := classifyInstancePackage(inst, effectivePackageName)
++		switch classification {
++		case packageOther:
++			packageMismatches = append(
++				packageMismatches,
++				fmt.Sprintf(
++					"%s is positively classified outside package '%s' (loader package '%s')",
++					inst.Dir,
++					effectivePackageName,
++					inst.PkgName,
++				),
++			)
+ 			continue
++		case packageUnknown:
++			diagnostic := fmt.Sprintf("%s: %v", inst.Dir, classificationErr)
++			if inst.Err != nil {
++				diagnostic = fmt.Sprintf("%s; load error: %v", diagnostic, inst.Err)
++			}
++			loadErrors = append(loadErrors, diagnostic)
++			continue
++		case packageSelected:
+ 		}
++
+ 		if inst.Err != nil {
+ 			loadErrors = append(loadErrors, fmt.Sprintf("%s: %v", inst.Dir, inst.Err))
+ 			continue
+@@ -453,10 +472,17 @@ func cue_eval_module(moduleRootPath *C.char, packageName *C.char, optionsJSON *C
+ 		}
+ 	}
+ 
+-	if len(instances) == 0 {
+-		allErrors := append(loadErrors, buildErrors...)
++	allErrors := append(loadErrors, buildErrors...)
++	if len(allErrors) > 0 {
+ 		hint := fmt.Sprintf("evalDir=%s, moduleRoot=%s, loadPattern=%s, package=%s, loadedInstances=%d, validInstances=%d, builtInstances=%d, errors=%v, packageMismatches=%v",
+ 			evalDir, goModuleRoot, loadPattern, effectivePackageName, len(loadedInstances), len(validInstances), len(builtInstances), allErrors, packageMismatches)
++		result = createErrorResponse(ErrorCodeBuildValue, "Selected CUE instances failed to evaluate", &hint)
++		return result
++	}
++
++	if len(instances) == 0 {
++		hint := fmt.Sprintf("evalDir=%s, moduleRoot=%s, loadPattern=%s, package=%s, loadedInstances=%d, validInstances=%d, builtInstances=%d, packageMismatches=%v",
++			evalDir, goModuleRoot, loadPattern, effectivePackageName, len(loadedInstances), len(validInstances), len(builtInstances), packageMismatches)
+ 		result = createErrorResponse(ErrorCodeBuildValue, "No instances could be evaluated", &hint)
+ 		return result
+ 	}
+diff --git a/crates/cuengine/package_classification.go b/crates/cuengine/package_classification.go
+new file mode 100644
+index 0000000..c3425fe
+--- /dev/null
++++ b/crates/cuengine/package_classification.go
+@@ -0,0 +1,118 @@
++package main
++
++import (
++	"fmt"
++	"os"
++	"path/filepath"
++	"strings"
++
++	"cuelang.org/go/cue/build"
++	"cuelang.org/go/cue/parser"
++)
++
++type packageClassification uint8
++
++const (
++	packageUnknown packageClassification = iota
++	packageSelected
++	packageOther
++)
++
++// classifyInstancePackage keeps package filtering ahead of evaluation errors.
++// A loader PkgName is authoritative. When a parser failure leaves it blank,
++// partial ASTs can still positively identify a selected or non-selected
++// package. Anything that cannot be proven either way is unknown and therefore
++// terminal: only positively identified non-selected packages may be ignored.
++func classifyInstancePackage(
++	inst *build.Instance,
++	expectedPackage string,
++) (packageClassification, error) {
++	if expectedPackage == "" || inst.PkgName == expectedPackage {
++		return packageSelected, nil
++	}
++	if inst.PkgName != "" && inst.PkgName != "_" {
++		return packageOther, nil
++	}
++
++	sources, err := packageSourcesForInstance(inst)
++	if err != nil {
++		return packageUnknown, err
++	}
++
++	var unknownSources []string
++	sawOtherPackage := false
++	for _, source := range sources {
++		file, parseErr := parser.ParseFile(source.Filename, source.Source)
++		if file == nil {
++			unknownSources = append(
++				unknownSources,
++				fmt.Sprintf("%s has no parseable CUE AST: %v", source.Filename, parseErr),
++			)
++			continue
++		}
++
++		packageName := file.PackageName()
++		if packageName == "" {
++			detail := fmt.Sprintf("%s has no package declaration", source.Filename)
++			if parseErr != nil {
++				detail = fmt.Sprintf("%s: %v", detail, parseErr)
++			}
++			unknownSources = append(unknownSources, detail)
++			continue
++		}
++		if packageName == expectedPackage {
++			return packageSelected, nil
++		}
++		sawOtherPackage = true
++	}
++
++	if len(unknownSources) > 0 {
++		return packageUnknown, fmt.Errorf(
++			"could not establish CUE package for loader instance: %s",
++			strings.Join(unknownSources, "; "),
++		)
++	}
++	if sawOtherPackage {
++		return packageOther, nil
++	}
++
++	return packageUnknown, fmt.Errorf(
++		"could not establish CUE package for loader instance in %s: no CUE sources",
++		inst.Dir,
++	)
++}
++
++func packageSourcesForInstance(inst *build.Instance) ([]*build.File, error) {
++	var sources []*build.File
++	for _, file := range inst.InvalidFiles {
++		if file == nil {
++			continue
++		}
++		if file.Encoding == build.CUE || strings.HasSuffix(file.Filename, ".cue") {
++			sources = append(sources, file)
++		}
++	}
++	if len(sources) > 0 {
++		return sources, nil
++	}
++
++	entries, err := os.ReadDir(inst.Dir)
++	if err != nil {
++		return nil, fmt.Errorf(
++			"could not inspect CUE sources for loader instance in %s: %w",
++			inst.Dir,
++			err,
++		)
++	}
++
++	for _, entry := range entries {
++		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".cue") {
++			continue
++		}
++		sources = append(sources, &build.File{
++			Filename: filepath.Join(inst.Dir, entry.Name()),
++			Encoding: build.CUE,
++		})
++	}
++	return sources, nil
++}
+diff --git a/crates/cuengine/package_classification_test.go b/crates/cuengine/package_classification_test.go
+new file mode 100644
+index 0000000..f083835
+--- /dev/null
++++ b/crates/cuengine/package_classification_test.go
+@@ -0,0 +1,143 @@
++package main
++
++import (
++	"os"
++	"path/filepath"
++	"strings"
++	"testing"
++
++	"cuelang.org/go/cue/build"
++	"cuelang.org/go/cue/cuecontext"
++	"cuelang.org/go/cue/errors"
++	"cuelang.org/go/cue/token"
++)
++
++func TestClassifyInstancePackageRecoversSelectedPackageFromMalformedSource(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(
++		filepath.Join(dir, "env.cue"),
++		[]byte("package cuenv\n\nbroken: {\n"),
++		0o600,
++	); err != nil {
++		t.Fatalf("write malformed selected source: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir: dir,
++		Err: errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if err != nil {
++		t.Fatalf("classify malformed selected package: %v", err)
++	}
++	if classification != packageSelected {
++		t.Fatalf("classification = %v, want selected", classification)
++	}
++}
++
++func TestClassifyInstancePackageRecoversAnonymousLoaderPackage(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(
++		filepath.Join(dir, "env.cue"),
++		[]byte("package cuenv\n\nbroken: {\n"),
++		0o600,
++	); err != nil {
++		t.Fatalf("write malformed selected source: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir:     dir,
++		PkgName: "_",
++		Err:     errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if err != nil {
++		t.Fatalf("classify anonymous loader package: %v", err)
++	}
++	if classification != packageSelected {
++		t.Fatalf("classification = %v, want selected", classification)
++	}
++}
++
++func TestClassifyInstancePackageLeavesMalformedOtherPackageUnselected(t *testing.T) {
++	dir := t.TempDir()
++	if err := os.WriteFile(
++		filepath.Join(dir, "env.cue"),
++		[]byte("package other\n\nbroken: {\n"),
++		0o600,
++	); err != nil {
++		t.Fatalf("write malformed non-selected source: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir: dir,
++		Err: errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if err != nil {
++		t.Fatalf("classify malformed non-selected package: %v", err)
++	}
++	if classification != packageOther {
++		t.Fatalf("classification = %v, want other", classification)
++	}
++}
++
++func TestClassifyInstancePackageRejectsMissingSourceDirectory(t *testing.T) {
++	instance := &build.Instance{
++		Dir: filepath.Join(t.TempDir(), "missing"),
++		Err: errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if classification != packageUnknown {
++		t.Fatalf("classification = %v, want unknown", classification)
++	}
++	if err == nil || !strings.Contains(err.Error(), "could not inspect CUE sources") {
++		t.Fatalf("expected source inspection error, got %v", err)
++	}
++}
++
++func TestClassifyInstancePackageRejectsSourceWithoutPackageAST(t *testing.T) {
++	dir := t.TempDir()
++	sourcePath := filepath.Join(dir, "env.cue")
++	if err := os.WriteFile(sourcePath, []byte("broken: {\n"), 0o600); err != nil {
++		t.Fatalf("write unclassifiable source: %v", err)
++	}
++
++	instance := &build.Instance{
++		Dir: dir,
++		Err: errors.Newf(token.NoPos, "simulated loader failure"),
++	}
++	classification, err := classifyInstancePackage(instance, "cuenv")
++	if classification != packageUnknown {
++		t.Fatalf("classification = %v, want unknown", classification)
++	}
++	if err == nil || !strings.Contains(err.Error(), sourcePath) {
++		t.Fatalf("expected error naming unclassifiable source, got %v", err)
++	}
++}
++
++func TestBuildJSONCleanRejectsOpenList(t *testing.T) {
++	value := cuecontext.New().CompileString("[...string]")
++	if err := value.Err(); err != nil {
++		t.Fatalf("compile open list: %v", err)
++	}
++	if encoded, err := buildJSONClean(value); err == nil {
++		t.Fatalf("open list serialized as %s; want concrete-value error", encoded)
++	}
++}
++
++func TestBuildJSONCleanRejectsNestedIncompleteContainer(t *testing.T) {
++	value := cuecontext.New().CompileString(`{
++		outer: {
++			ready: "yes"
++			pending: string
++		}
++	}`)
++	if err := value.Err(); err != nil {
++		t.Fatalf("compile nested incomplete container: %v", err)
++	}
++	if encoded, err := buildJSONClean(value); err == nil {
++		t.Fatalf("incomplete container serialized as %s; want concrete-value error", encoded)
++	}
++}
+diff --git a/crates/cuengine/tests/package_filter_tests.rs b/crates/cuengine/tests/package_filter_tests.rs
+index f223b5a..9df0aa2 100644
+--- a/crates/cuengine/tests/package_filter_tests.rs
++++ b/crates/cuengine/tests/package_filter_tests.rs
+@@ -23,6 +23,35 @@ fn create_module() -> TestResult<TempDir> {
+     Ok(temp_dir)
+ }
+ 
++fn write_env(root: &std::path::Path, relative_dir: &str, package: &str, body: &str) -> TestResult {
++    let directory = root.join(relative_dir);
++    fs::create_dir_all(&directory)?;
++    fs::write(directory.join("env.cue"), format!("package {package}\n\n{body}\n"))?;
++    Ok(())
++}
++
++fn recursive_options() -> ModuleEvalOptions {
++    ModuleEvalOptions {
++        recursive: true,
++        package_name: Some("cuenv".to_string()),
++        ..Default::default()
++    }
++}
++
++fn assert_selected_failure(
++    root: &std::path::Path,
++    expected_path: &str,
++) -> TestResult {
++    let error = evaluate_module(root, "cuenv", Some(&recursive_options()))
++        .expect_err("a selected cuenv package error must be terminal");
++    let message = error.to_string();
++    assert!(
++        message.contains(expected_path),
++        "selected failure must name its path '{expected_path}': {message}"
++    );
++    Ok(())
++}
++
+ #[test]
+ fn recursive_eval_ignores_other_packages_in_same_directory() -> TestResult {
+     let temp_dir = create_module()?;
+@@ -65,3 +94,63 @@ ignored: "this belongs to another CUE package"
+ 
+     Ok(())
+ }
++
++#[test]
++fn recursive_eval_fails_closed_for_selected_load_errors() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    write_env(root, "load-error", "cuenv", "broken: {")?;
++
++    assert_selected_failure(root, "load-error")
++}
++
++#[test]
++fn recursive_eval_fails_closed_for_unclassifiable_load_errors() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    let unknown_dir = root.join("unknown-package");
++    fs::create_dir_all(&unknown_dir)?;
++    fs::write(unknown_dir.join("env.cue"), "broken: {\n")?;
++
++    assert_selected_failure(root, "unknown-package")
++}
++
++#[test]
++fn recursive_eval_fails_closed_for_selected_build_errors() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    write_env(root, "build-error", "cuenv", "conflict: 1 & 2")?;
++
++    assert_selected_failure(root, "build-error")
++}
++
++#[test]
++fn recursive_eval_fails_closed_for_selected_json_errors() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    write_env(root, "json-error", "cuenv", "incomplete: string")?;
++
++    assert_selected_failure(root, "json-error")
++}
++
++#[test]
++fn recursive_eval_ignores_failing_non_cuenv_packages() -> TestResult {
++    let temp_dir = create_module()?;
++    let root = temp_dir.path();
++
++    write_env(root, "", "cuenv", "healthy: true")?;
++    write_env(root, "nested/non-cuenv", "other", "broken: {")?;
++
++    let result = evaluate_module(root, "cuenv", Some(&recursive_options()))?;
++    assert_eq!(result.instances.len(), 1);
++    assert!(result.instances.contains_key("."));
++    Ok(())
++}
+diff --git a/crates/cuengine/values.go b/crates/cuengine/values.go
+index 88520ae..fbcc692 100644
+--- a/crates/cuengine/values.go
++++ b/crates/cuengine/values.go
+@@ -9,7 +9,10 @@ import (
+ // buildJSONClean builds a JSON representation without any _meta injection.
+ // This returns clean JSON that can be correlated with the separate meta map.
+ func buildJSONClean(v cue.Value) ([]byte, error) {
+-	result := buildValueClean(v)
++	result, err := buildValueClean(v)
++	if err != nil {
++		return nil, err
++	}
+ 	return json.Marshal(result)
+ }
+ 
+@@ -25,31 +28,55 @@ func unquoteSelector(s string) string {
+ }
+ 
+ // buildValueClean recursively builds a clean value without metadata
+-func buildValueClean(v cue.Value) interface{} {
++func buildValueClean(v cue.Value) (interface{}, error) {
++	if err := v.Validate(cue.Concrete(true)); err != nil {
++		return nil, err
++	}
++
+ 	switch v.Kind() {
+ 	case cue.StructKind:
+ 		result := make(map[string]interface{})
+-		iter, _ := v.Fields(cue.Definitions(false))
++		iter, err := v.Fields(cue.Definitions(false))
++		if err != nil {
++			return nil, err
++		}
+ 		for iter.Next() {
+ 			sel := iter.Selector()
+ 			fieldName := unquoteSelector(sel.String())
+-			result[fieldName] = buildValueClean(iter.Value())
++			value, err := buildValueClean(iter.Value())
++			if err != nil {
++				return nil, err
++			}
++			result[fieldName] = value
+ 		}
+-		return result
++		return result, nil
+ 
+ 	case cue.ListKind:
++		if err := v.Len().Validate(cue.Concrete(true)); err != nil {
++			return nil, err
++		}
++
+ 		// Use a non-nil slice so empty CUE lists serialize to [] (not null).
+ 		items := make([]interface{}, 0)
+-		iter, _ := v.List()
+-		for iter.Next() {
+-			items = append(items, buildValueClean(iter.Value()))
++		iter, err := v.List()
++		if err != nil {
++			return nil, err
+ 		}
+-		return items
++		for iter.Next() {
++			value, err := buildValueClean(iter.Value())
++			if err != nil {
++				return nil, err
++			}
++			items = append(items, value)
++		}
++		return items, nil
+ 
+ 	default:
+ 		// Concrete value (string, number, bool, null)
+ 		var val interface{}
+-		v.Decode(&val)
+-		return val
++		if err := v.Decode(&val); err != nil {
++			return nil, err
++		}
++		return val, nil
+ 	}
+ }
+diff --git a/crates/cuenv/src/commands/info.rs b/crates/cuenv/src/commands/info.rs
+index 9b28ddb..e3ab109 100644
+--- a/crates/cuenv/src/commands/info.rs
++++ b/crates/cuenv/src/commands/info.rs
+@@ -10,7 +10,7 @@
+ use crate::commands::convert_engine_error;
+ use crate::commands::env_file::{discover_env_cue_directories, find_cue_module_root};
+ use cuengine::ModuleEvalOptions;
+-use cuenv_core::cue::discovery::{adjust_meta_key_path, compute_relative_path};
++use cuenv_core::cue::discovery::{adjust_meta_key_path, compute_relative_path, format_eval_errors};
+ use cuenv_core::{ModuleEvaluation, Result};
+ use serde::Serialize;
+ use std::collections::HashMap;
+@@ -172,7 +172,7 @@ fn evaluate_discovered_env_cue_directories(
+     context: &InfoContext,
+     options: InfoOptions<'_>,
+ ) -> Result<cuengine::ModuleResult> {
+-    let env_cue_dirs = discover_env_cue_directories(&context.module_root, options.package);
++    let env_cue_dirs = discover_env_cue_directories(&context.module_root, options.package)?;
+ 
+     if env_cue_dirs.is_empty() {
+         return Err(cuenv_core::Error::configuration(format!(
+@@ -184,6 +184,8 @@ fn evaluate_discovered_env_cue_directories(
+ 
+     let mut discovered = DiscoveredModuleResults::default();
+ 
++    let mut evaluation_errors = Vec::new();
++
+     for dir in env_cue_dirs {
+         let dir_rel_path = compute_relative_path(&dir, &context.module_root);
+         let eval_options = ModuleEvalOptions {
+@@ -193,14 +195,19 @@ fn evaluate_discovered_env_cue_directories(
+             ..Default::default()
+         };
+ 
+-        let Ok(raw) =
+-            cuengine::evaluate_module(&context.module_root, options.package, Some(&eval_options))
+-                .map_err(convert_engine_error)
+-        else {
+-            continue;
+-        };
++        match cuengine::evaluate_module(&context.module_root, options.package, Some(&eval_options))
++            .map_err(convert_engine_error)
++        {
++            Ok(raw) => discovered.merge(raw, &dir_rel_path),
++            Err(error) => evaluation_errors.push((dir, error)),
++        }
++    }
+ 
+-        discovered.merge(raw, &dir_rel_path);
++    if !evaluation_errors.is_empty() {
++        let error_summary = format_eval_errors(&evaluation_errors);
++        return Err(cuenv_core::Error::configuration(format!(
++            "Selected CUE projects failed during info discovery:\n{error_summary}"
++        )));
+     }
+ 
+     if discovered.instances.is_empty() {
+diff --git a/crates/cuenv/src/commands/module_evaluation.rs b/crates/cuenv/src/commands/module_evaluation.rs
+index a4d29d0..d73855d 100644
+--- a/crates/cuenv/src/commands/module_evaluation.rs
++++ b/crates/cuenv/src/commands/module_evaluation.rs
+@@ -1,9 +1,8 @@
+ use super::{CommandExecutor, convert_engine_error, env_file, schema_compat};
+ use crate::commands::module_utils::EvaluationMetadataBuilder;
+ use cuengine::ModuleEvalOptions;
+-use cuenv_core::cue::discovery::{adjust_meta_key_path, compute_relative_path, format_eval_errors};
++use cuenv_core::cue::discovery::{adjust_meta_key_path, compute_relative_path};
+ use cuenv_core::{ModuleEvaluation, ModuleEvaluationInput, Result};
+-use rayon::prelude::*;
+ use std::collections::HashMap;
+ use std::path::Path;
+ 
+@@ -70,26 +69,18 @@ impl CommandExecutor {
+         // Fast path: evaluate the entire module in a single recursive CUE
+         // evaluation (equivalent to `cue eval ./...`). This loads the module
+         // and compiles imported schema packages once instead of once per
+-        // directory, which is significantly faster for monorepos.
+-        match self.evaluate_workspace_module_recursive(module_root) {
+-            Ok(module) => Ok(module),
+-            Err(e) => {
+-                tracing::warn!(
+-                    module_root = %module_root.display(),
+-                    error = %e,
+-                    "Recursive workspace evaluation failed - falling back to per-directory evaluation"
+-                );
+-                self.evaluate_workspace_module_fan_out(module_root)
+-            }
+-        }
++        // directory, which is significantly faster for monorepos. A selected
++        // package failure is terminal: a partial fan-out result must never
++        // hide a failed project from workspace-wide commands.
++        self.evaluate_workspace_module_recursive(module_root)
+     }
+ 
+     /// Evaluate the whole workspace with one recursive CUE evaluation.
+     ///
+-    /// The Go bridge loads the module once and builds every package instance
+-    /// in a shared CUE context, skipping directories whose package does not
+-    /// match or that fail to build (matching the per-directory fan-out
+-    /// semantics).
++    /// The Go bridge loads the module once and builds every selected package
++    /// instance in a shared CUE context. Non-selected packages are ignored;
++    /// an error in any selected package is terminal so workspace commands
++    /// cannot act on a partial project set.
+     fn evaluate_workspace_module_recursive(&self, module_root: &Path) -> Result<ModuleEvaluation> {
+         let options = ModuleEvalOptions {
+             recursive: true,
+@@ -114,101 +105,4 @@ impl CommandExecutor {
+             metadata: metadata.finish(),
+         }))
+     }
+-
+-    fn evaluate_workspace_module_fan_out(&self, module_root: &Path) -> Result<ModuleEvaluation> {
+-        let env_cue_dirs =
+-            cuenv_core::cue::discovery::discover_env_cue_directories(module_root, &self.package);
+-
+-        if env_cue_dirs.is_empty() {
+-            return Err(cuenv_core::Error::configuration(format!(
+-                "No env.cue files declaring package '{}' found in module: {}",
+-                self.package,
+-                module_root.display(),
+-            )));
+-        }
+-
+-        let package = &self.package;
+-        tracing::info!(
+-            env_cue_dirs = env_cue_dirs.len(),
+-            rayon_threads = rayon::current_num_threads(),
+-            "evaluate_workspace_module fan-out"
+-        );
+-        let results: Vec<_> = env_cue_dirs
+-            .par_iter()
+-            .map(|dir| {
+-                tracing::debug!(dir = %dir.display(), "cuengine::evaluate_module begin");
+-                let options = ModuleEvalOptions {
+-                    recursive: false,
+-                    with_meta: true,
+-                    with_references: true,
+-                    target_dir: Some(dir.to_string_lossy().to_string()),
+-                    ..Default::default()
+-                };
+-                let dir_rel_path = compute_relative_path(dir, module_root);
+-
+-                match cuengine::evaluate_module(module_root, package, Some(&options)) {
+-                    Ok(raw) => Ok((dir_rel_path, raw)),
+-                    Err(e) => {
+-                        tracing::warn!(
+-                            dir = %dir.display(),
+-                            error = %e,
+-                            "Failed to evaluate env.cue - skipping directory"
+-                        );
+-                        Err((dir.clone(), e))
+-                    }
+-                }
+-            })
+-            .collect();
+-
+-        let mut all_instances = HashMap::new();
+-        let mut all_projects = Vec::new();
+-        let mut metadata = EvaluationMetadataBuilder::default();
+-        let mut eval_errors = Vec::new();
+-
+-        for result in results {
+-            match result {
+-                Ok((dir_rel_path, raw)) => {
+-                    for (path_str, value) in raw.instances {
+-                        let rel_path = if path_str == "." {
+-                            dir_rel_path.clone()
+-                        } else {
+-                            path_str
+-                        };
+-                        all_instances.insert(rel_path, value);
+-                    }
+-
+-                    for project_path in raw.projects {
+-                        let rel_project_path = if project_path == "." {
+-                            dir_rel_path.clone()
+-                        } else {
+-                            project_path
+-                        };
+-                        if !all_projects.contains(&rel_project_path) {
+-                            all_projects.push(rel_project_path);
+-                        }
+-                    }
+-
+-                    for (meta_key, meta_value) in raw.meta {
+-                        let adjusted_key = adjust_meta_key_path(&meta_key, &dir_rel_path);
+-                        metadata.insert(adjusted_key, meta_value);
+-                    }
+-                }
+-                Err((dir, e)) => eval_errors.push((dir, e)),
+-            }
+-        }
+-
+-        if all_instances.is_empty() {
+-            let error_summary = format_eval_errors(&eval_errors);
+-            return Err(cuenv_core::Error::configuration(format!(
+-                "No instances could be evaluated. All directories failed:\n{error_summary}"
+-            )));
+-        }
+-
+-        Ok(ModuleEvaluation::from_raw_parts(ModuleEvaluationInput {
+-            root: module_root.to_path_buf(),
+-            raw_instances: all_instances,
+-            project_paths: all_projects,
+-            metadata: metadata.finish(),
+-        }))
+-    }
+ }
+diff --git a/crates/cuenv/src/completions.rs b/crates/cuenv/src/completions.rs
+index 9c7f43c..60ae96e 100644
+--- a/crates/cuenv/src/completions.rs
++++ b/crates/cuenv/src/completions.rs
+@@ -48,7 +48,9 @@ fn get_available_tasks(path: &str, package: &str) -> Vec<(String, Option<String>
+     };
+ 
+     // Discover all directories with env.cue files matching our package
+-    let env_cue_dirs = discover_env_cue_directories(&module_root, package);
++    let Ok(env_cue_dirs) = discover_env_cue_directories(&module_root, package) else {
++        return Vec::new();
++    };
+     if env_cue_dirs.is_empty() {
+         return Vec::new();
+     }
+diff --git a/crates/cuenv/tests/sync_scope_rules.rs b/crates/cuenv/tests/sync_scope_rules.rs
+index a255660..18466f7 100644
+--- a/crates/cuenv/tests/sync_scope_rules.rs
++++ b/crates/cuenv/tests/sync_scope_rules.rs
+@@ -624,6 +624,77 @@ fn sync_all_from_nested_generates_all_ci_in_repo_root() -> TestResult {
+     Ok(())
+ }
+ 
++#[test]
++fn workspace_commands_fail_closed_for_malformed_selected_projects() -> TestResult {
++    let tmp = create_repo()?;
++    let root = tmp.path();
++
++    fs::write(
++        root.join("env.cue"),
++        project_env_cue("healthy", "build", "build", "@healthy"),
++    )?;
++
++    let invalid_project = root.join("apps/bad-selected");
++    fs::create_dir_all(&invalid_project)?;
++    fs::write(
++        invalid_project.join("env.cue"),
++        "package cuenv\n\nbroken: {\n",
++    )?;
++
++    let commands: &[&[&str]] = &[
++        &["info", "--json"],
++        &["sync", "-A"],
++        &["sync", "ci", "--check", "-A"],
++    ];
++
++    for args in commands {
++        let output = run_cuenv(root, args)?;
++        assert!(
++            !output.success,
++            "cuenv {} must reject a malformed selected project\nstdout: {}\nstderr: {}",
++            args.join(" "),
++            output.stdout,
++            output.stderr
++        );
++        let combined = format!("{}{}", output.stdout, output.stderr);
++        assert!(
++            combined.contains("bad-selected"),
++            "cuenv {} must name the malformed selected path: {combined}",
++            args.join(" ")
++        );
++    }
++
++    Ok(())
++}
++
++#[test]
++fn workspace_sync_ignores_malformed_non_cuenv_projects() -> TestResult {
++    let tmp = create_repo()?;
++    let root = tmp.path();
++
++    fs::write(
++        root.join("env.cue"),
++        project_env_cue("healthy", "build", "build", "@healthy"),
++    )?;
++
++    let unrelated = root.join("apps/non-cuenv");
++    fs::create_dir_all(&unrelated)?;
++    fs::write(
++        unrelated.join("env.cue"),
++        "package other\n\nbroken: {\n",
++    )?;
++
++    let output = run_cuenv(root, &["sync", "-A"])?;
++    assert!(
++        output.success,
++        "sync -A must ignore malformed non-cuenv packages\nstdout: {}\nstderr: {}",
++        output.stdout,
++        output.stderr
++    );
++
++    Ok(())
++}
++
+ #[test]
+ fn sync_ci_rejects_schema_only_gitlab_provider() -> TestResult {
+     let tmp = create_repo()?;

--- a/server/env.cue
+++ b/server/env.cue
@@ -21,6 +21,7 @@ let _rustInputs = [
 let _nixInputs = [
 	"../flake.nix",
 	"../flake.lock",
+	"../nix/patches/cuenv-0.54.0-fail-closed-discovery.patch",
 	"Cargo.toml",
 	"Cargo.lock",
 	".config/nextest.toml",
@@ -28,6 +29,33 @@ let _nixInputs = [
 	"crates/**",
 	"extensions/**",
 	"wit/**",
+]
+
+let _cuenvRootInputs = [
+	"../env.cue",
+	"../flake.lock",
+	"../flake.nix",
+	"../nix/patches/cuenv-0.54.0-fail-closed-discovery.patch",
+]
+
+let _cuenvProjectInputs = [
+	"../apps/android/env.cue",
+	"../chat/env.cue",
+	"../colony/env.cue",
+	"../infrastructure/waddle.cloud/env.cue",
+	"env.cue",
+	"../website/env.cue",
+]
+
+let _cuenvBootstrapInputs = list.Concat([_cuenvRootInputs, _cuenvProjectInputs])
+
+let _cuenvWorkflowInputs = [
+	"../.github/workflows/waddle-android-*.yml",
+	"../.github/workflows/waddle-chat-*.yml",
+	"../.github/workflows/waddle-cloud-*.yml",
+	"../.github/workflows/waddle-colony-*.yml",
+	"../.github/workflows/waddle-server-*.yml",
+	"../.github/workflows/waddle-website-*.yml",
 ]
 
 // cargo-nextest task template: xRust.#Test pins args[0] to "test", but the
@@ -92,7 +120,7 @@ schema.#Project & {
 	ci: providers: ["github"]
 	ci: contributors: [
 		_NamespaceNix,
-		c.#CuenvRelease,
+		c.#CuenvNix,
 		c.#OnePassword,
 		schema.#Contributor & {
 			id: "flakehub"
@@ -154,6 +182,7 @@ schema.#Project & {
 				}
 			}
 			tasks: [
+				_t.verifyCuenvBootstrap,
 				_t.checkRootSyncDrift,
 				_t.checkCiDrift,
 				_t.checkSwitchableAlternativeProgram,
@@ -196,7 +225,7 @@ schema.#Project & {
 				packages:        "read"
 				"pull-requests": "none"
 			}
-			tasks: [_t.checkRootSyncDrift, _t.checkCiDrift, _t.checkSwitchableAlternativeProgram, _t.nixFmt, _t.nixClippy, _t.nixTest, _t.nixDoctest, _t.checkXmppClientFfiBindings, _t.renderDeployment, _t.nixBuildExtensionModules, _t.nixBuildCi]
+			tasks: [_t.verifyCuenvBootstrap, _t.checkRootSyncDrift, _t.checkCiDrift, _t.checkSwitchableAlternativeProgram, _t.nixFmt, _t.nixClippy, _t.nixTest, _t.nixDoctest, _t.checkXmppClientFfiBindings, _t.renderDeployment, _t.nixBuildExtensionModules, _t.nixBuildCi]
 		}
 		xmppCompliance: {
 			mode: "expanded"
@@ -222,28 +251,48 @@ schema.#Project & {
 	}
 
 	tasks: {
+		verifyCuenvBootstrap: schema.#Task & {
+			command: "nix"
+			args: [
+				"build",
+				"--print-build-logs",
+				"--accept-flake-config",
+				"../#cuenv-source-coupling",
+				"../#cuenv-strict-discovery",
+				"../#cuenv-waddle-discovery",
+			]
+			inputs: _cuenvBootstrapInputs
+		}
+
 		checkCiDrift: schema.#Task & {
 			command: "bash"
 			args: ["-c", #"""
 					set -euo pipefail
 					cd ..
-					projects="$(
-					  cuenv info --json |
-					    bun -e 'const info = JSON.parse(await Bun.stdin.text()); if (!Array.isArray(info.projects) || info.projects.length === 0) throw new Error("cuenv info returned no projects"); for (const project of info.projects) { if (typeof project.path !== "string" || project.path.length === 0 || project.path.includes("\n")) throw new Error("cuenv info returned an invalid project path"); console.log(project.path); }'
-					)"
+					projects=(
+					  apps/android
+					  chat
+					  colony
+					  infrastructure/waddle.cloud
+					  server
+					  website
+					)
 					overall_status=0
-					while IFS= read -r project; do
+					for project in "${projects[@]}"; do
 					  if ! cuenv sync ci --check -p "${project}"; then
 					    overall_status=1
 					  fi
-					done <<< "${projects}"
+					done
 					exit "${overall_status}"
 				"""#]
-			inputs: [
-				"**/env.cue",
-				"deployment.cue",
-				"../.github/workflows/waddle-server-*.yml",
-			]
+			inputs: list.Concat([
+				_cuenvBootstrapInputs,
+				_cuenvWorkflowInputs,
+				[
+					"**/env.cue",
+					"deployment.cue",
+				],
+			])
 		}
 
 		checkRootSyncDrift: schema.#Task & {
@@ -253,12 +302,14 @@ schema.#Project & {
 					cuenv sync --check -p ..
 					git diff --exit-code -- ../.gitignore ../cuenv.lock
 				"""#]
-			inputs: [
-				"../env.cue",
-				"../cuenv.lock",
-				"../.rules.cue",
-				"../.gitignore",
-			]
+			inputs: list.Concat([
+				_cuenvRootInputs,
+				[
+					"../cuenv.lock",
+					"../.rules.cue",
+					"../.gitignore",
+				],
+			])
 		}
 
 		checkSwitchableAlternativeProgram: schema.#Task & {

--- a/website/env.cue
+++ b/website/env.cue
@@ -49,7 +49,7 @@ schema.#Project & {
 	ci: providers: ["github"]
 	ci: contributors: [
 		_NamespaceNix,
-		c.#CuenvRelease,
+		c.#CuenvNix,
 		c.#OnePassword,
 		c.#BunWorkspace,
 	]


### PR DESCRIPTION
## Summary

This PR replaces release-downloaded cuenv bootstrapping with one repository-pinned, fail-closed cuenv build and uses that same build to generate and verify Waddle CI.

The published remote head remains signed commit [`ea68db0`](https://github.com/waddle-social/waddle/commit/ea68db0ed803ece80bddaa8f56c6627b56b9d8c4), based on signed Phase A commit [`1af9bf7`](https://github.com/waddle-social/waddle/commit/1af9bf7f90d1bd87932559cd775a1c696f3e48ac) and `main` commit `b511bff136f98638a6cebfae1599f83a52c1d9de`. Clean-checkout verification and GitHub CI rejected that exact head: generated Nix bootstrap steps source a daemon-profile path that is absent on the runner, and the root-sync gate does not provision locked VCS dependencies before checking them. A clean local successor has been rebased on current `main` commit `a465746a04251560dbfb37c0ed2f87dce4344a05`, but no remediated SHA has been published. This PR remains draft.

## Phase A: fail-closed cuenv discovery

- Pin official cuenv 0.54.0 source commit `e337a3f60af6944552f391facf2ed2e25efa3bc7`.
- Carry a checked-in patch that makes selected, unknown, unreadable, malformed, and recursively incomplete CUE project failures terminal while continuing to isolate positively identified non-cuenv packages.
- Remove partial recursive-evaluation fallback so workspace commands cannot silently operate on a subset of selected projects.
- Validate serialized project data recursively, including open lists and nested incomplete scalar values.
- Build the Go CUE bridge and Rust CLI from the same patched source and prove that coupling in Nix.
- Add focused Go, Rust package-filter, Rust sync-scope, and CLI regression coverage for selected-package failure, same-directory synthetic siblings, owned anonymous CUE sources, missing packages, and malformed unrelated packages.

## Phase B: activate the patched bootstrap

- Configure root CI with `config.ci.cuenv: {source: "nix", version: "self"}`.
- Switch Android, chat, colony, cloud, server, and website from `#CuenvRelease` to `#CuenvNix`.
- Regenerate `cuenv.lock` with one deterministic Nix runtime digest across all six projects.
- Regenerate exactly 15 cuenv-owned GitHub workflows; the three hand-owned Apple and CodeQL workflows remain byte-identical.
- Remove release downloader/fallback steps. Direct jobs build `.#cuenv`; server orchestration builds it once and distributes a runner-specific artifact to dependent jobs.
- Add `verifyCuenvBootstrap` to server default and pull-request pipelines.
- Make server CI drift checks cover the literal six-project set, every generated workflow family, the root flake/lock/patch inputs, and the retained `server/**/env.cue` trigger.
- Keep Android drift verification project-local while adding the root bootstrap inputs needed to invalidate it correctly.
- Add Nix proofs for source coupling, strict fail-closed fixtures, and exact Waddle discovery.

## Generator/provider exception

The final patched binary intentionally ran the lock and CI providers directly:

```text
cuenv sync lock -A
cuenv sync ci -A
cuenv sync lock --check -A
cuenv sync ci --check -A
```

Both generation commands were run twice; the second pass produced no tracked change. Those provider-specific passes remain valid local evidence, but clean-checkout verification exposed a missing prerequisite in `checkRootSyncDrift`: locked VCS dependencies must be materialized before the full root sync check. GitHub CI separately exposed an obsolete hardcoded Nix daemon-profile source in every generated `Build cuenv (nix)` step. The published head is rejected until both generator/task defects are remediated and all evidence is rerun against a new signed SHA.

## Local acceptance evidence

| Gate | Result |
|---|---|
| Patch matches the reviewed upstream diff | Passed; both SHA-256 values are `505297cb2d8e63ae02601ea877a3ff468b357e0c4bda58ebf863e45315e87a6a` |
| Focused Go discovery/classifier tests | Passed |
| Rust package-filter tests | Passed, 10/10 |
| Rust sync-scope tests | Passed, 21/21 |
| Final patched Nix cuenv build | Passed |
| Nix source-coupling, strict-discovery, and Waddle-discovery proofs | Passed |
| Waddle discovery | Exactly six projects: Android, chat, colony, cloud, server, website |
| Lock generation | Stable on second pass; all six runtimes use `sha256:3eda40e104e201944dbc76841a36ef4f4ad3951d2c111e186c0af0c3cb643359` |
| CI generation | Exactly 15 generated workflows; stable on second pass and provider check |
| Server and Android `checkCiDrift` tasks | Passed |
| Server `verifyCuenvBootstrap` task | Passed |
| Independent Nix, XMPP, and bootstrap checks | Passed on published `ea68db0`; they do not establish overall CI success |
| Clean-checkout generated Nix bootstrap | Rejected on published `ea68db0`; the generated step sources an absent Nix daemon profile before `nix build` |
| Clean-checkout root-sync gate | Rejected on published `ea68db0`; locked VCS dependencies are not provisioned before `cuenv sync --check -p ..` |
| Overall GitHub CI | Rejected on published `ea68db0`; no green-CI claim is made |
| Generated workflow semantic comparison | Passed, 15/15; existing triggers, permissions, runners, jobs, task steps, and dependencies preserved except the intended bootstrap additions |
| Bootstrap/artifact ordering | Passed, 15/15 |
| YAML parsing | Passed, 18/18 workflows |
| CUE formatting, nixfmt, patch reverse-apply, and upstream diff check | Passed |
| `nix flake check --no-build --all-systems --accept-flake-config` | Passed |
| Signed custody | Phase A and Phase B signatures verify good; Phase B tree is `b08083861fc9bcc42ade3eb96400984fbf3870fa` |
| Local full root-sync gate | Prior provider checks passed, but the required clean-checkout full-sync gate rejected the published head as described above |

Hand-owned workflow hashes remained unchanged:

- CodeQL: `e4906d50e53c829ed6fe61556ed2ddb68bb71da8d8efb529b80e6d8f09988edf`
- Apple default: `85fe3b08f3467e8c48cfa6d84a9c52974706ef7b6bf34f376dd131775ce314bd`
- Apple pull request: `f40fe16a36bf0bec86e1f69eea253deee214575f411b4d8af8efcadfa1adcffd`

## Required publication gates

Before this draft can be marked ready:

- Remove the obsolete hardcoded Nix daemon-profile source in the pinned generator and regenerate every cuenv-owned workflow.
- Provision only locked root VCS dependencies before `checkRootSyncDrift`, then prove the lockfile and tracked tree remain unchanged.
- Publish a new signed successor based on current `main` commit `a465746a04251560dbfb37c0ed2f87dce4344a05`; no remediation SHA exists on the remote yet.
- `build.cuenv`, `verifyCuenvBootstrap`, `checkCiDrift`, and `checkRootSyncDrift` must pass in the clean GitHub checkout on that exact successor.
- All triggered generated workflows, independent Nix/XMPP/bootstrap checks, adversarial reviews, and CodeQL checks must complete successfully on the same immutable SHA.
- The stored and rendered PR metadata must continue to identify `main` as the base and `codex/root-sync-drift` as the draft head.

## Delegation and evidence ledger

| Responsibility | Custody/evidence |
|---|---|
| Sole source writer | Clean local successor rebased on current-main base `a465746a04251560dbfb37c0ed2f87dce4344a05`; no remediation SHA published |
| Phase A | Published signed `1af9bf7f90d1bd87932559cd775a1c696f3e48ac`: fail-closed discovery and proof foundation; successor evidence must be rerun after remediation |
| Phase B and PR custody | Published signed `ea68db0ed803ece80bddaa8f56c6627b56b9d8c4`: rejected by clean-checkout verification and CI; remote head is unchanged |
| Source diagnostic review | Recursive serialization and package-classification review completed clean before the published commit; remediation review pending |
| Immutable-SHA verification and adversarial review | Published `ea68db0ed803ece80bddaa8f56c6627b56b9d8c4` rejected; review of a new immutable remediation SHA is pending |
| GitHub CI sentinel | Independent Nix/XMPP/bootstrap checks passed, but generated bootstrap and root-sync gates rejected `ea68db0`; no overall CI-success claim is made |

## XEP review

This is build and CI bootstrap plumbing only. It changes no XMPP wire behavior, advertised feature, namespace, or XEP implementation.