### PR TITLE
fix(chat): back off and deduplicate room join retries

### DIFF
--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -94,7 +94,7 @@ interface InitTelemetryOptions {
 }
 
 let faro: Faro | null = null;
-const recordedTelemetryExceptions = new WeakSet<object>();
+const TELEMETRY_EXCEPTION_RECORDED = Symbol("waddle.telemetry.exception-recorded");
 let configuredTrustedSpanOrigins = new Set<string>();
 const sensitiveSpanUrls = new Set<string>();
 
@@ -1043,7 +1043,6 @@ export function reportError(
   },
 ): void {
   if (!faro) return;
-  markTelemetryExceptionRecorded(error);
   const err = sanitizeErrorForTelemetry(error, kind);
   const contextStrings: Record<string, string> = { kind, recoverable: String(context.recoverable) };
   for (const [k, v] of Object.entries(context)) {
@@ -1056,6 +1055,15 @@ export function reportError(
   faro.api.pushError(err, { type: kind, context: contextStrings });
 }
 
+/**
+ * Claims a thrown error whose canonical exception was emitted separately.
+ * Manual spans may still report an error status, but they must not record
+ * another exception event for the same failure.
+ */
+export function markErrorReportedToTelemetry(error: unknown): void {
+  markTelemetryExceptionRecorded(error);
+}
+
 function recordSpanExceptionOnce(span: Span, error: unknown, fallbackMessage: string): void {
   if (telemetryExceptionWasRecorded(error)) return;
   markTelemetryExceptionRecorded(error);
@@ -1065,7 +1073,7 @@ function recordSpanExceptionOnce(span: Span, error: unknown, fallbackMessage: st
 function telemetryExceptionWasRecorded(error: unknown): boolean {
   return typeof error === "object"
     && error !== null
-    && recordedTelemetryExceptions.has(error);
+    && TELEMETRY_EXCEPTION_RECORDED in error;
 }
 
 function markTelemetryExceptionRecorded(error: unknown): void {
@@ -1073,7 +1081,14 @@ function markTelemetryExceptionRecorded(error: unknown): void {
   const visited = new Set<object>();
   while (typeof current === "object" && current !== null && !visited.has(current)) {
     visited.add(current);
-    recordedTelemetryExceptions.add(current);
+    if (Object.isExtensible(current)) {
+      Object.defineProperty(current, TELEMETRY_EXCEPTION_RECORDED, {
+        configurable: false,
+        enumerable: false,
+        value: true,
+        writable: false,
+      });
+    }
     current = current instanceof Error ? current.cause : undefined;
   }
 }

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -94,6 +94,7 @@ interface InitTelemetryOptions {
 }
 
 let faro: Faro | null = null;
+const recordedTelemetryExceptions = new WeakSet<object>();
 let configuredTrustedSpanOrigins = new Set<string>();
 const sensitiveSpanUrls = new Set<string>();
 
@@ -1015,7 +1016,7 @@ export async function withSpan<T>(
         code: SpanStatusCode.ERROR,
         message: sanitizedError.message,
       });
-      span.recordException(sanitizedError);
+      recordSpanExceptionOnce(span, err, `${name}.error`);
       throw err;
     } finally {
       span.end();
@@ -1042,6 +1043,7 @@ export function reportError(
   },
 ): void {
   if (!faro) return;
+  markTelemetryExceptionRecorded(error);
   const err = sanitizeErrorForTelemetry(error, kind);
   const contextStrings: Record<string, string> = { kind, recoverable: String(context.recoverable) };
   for (const [k, v] of Object.entries(context)) {
@@ -1052,6 +1054,40 @@ export function reportError(
     contextStrings[k] = sanitizeTelemetryText(serialized);
   }
   faro.api.pushError(err, { type: kind, context: contextStrings });
+}
+
+function recordSpanExceptionOnce(span: Span, error: unknown, fallbackMessage: string): void {
+  if (telemetryExceptionWasRecorded(error)) return;
+  markTelemetryExceptionRecorded(error);
+  span.recordException(sanitizeErrorForTelemetry(error, fallbackMessage));
+}
+
+function telemetryExceptionWasRecorded(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && recordedTelemetryExceptions.has(error);
+}
+
+function markTelemetryExceptionRecorded(error: unknown): void {
+  let current = error;
+  const visited = new Set<object>();
+  while (typeof current === "object" && current !== null && !visited.has(current)) {
+    visited.add(current);
+    recordedTelemetryExceptions.add(current);
+    current = current instanceof Error ? current.cause : undefined;
+  }
+}
+
+/** For tests only — exercise the same exception-once gate used by `withSpan`. */
+export function __recordSpanExceptionForTesting(error: unknown): number {
+  let records = 0;
+  const span = {
+    recordException: () => {
+      records += 1;
+    },
+  } as unknown as Span;
+  recordSpanExceptionOnce(span, error, "test-span.error");
+  return records;
 }
 
 function sanitizeErrorForTelemetry(error: unknown, fallbackMessage: string): Error {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1277,7 +1277,7 @@ export class BrowserXmppClient {
       );
       this.scheduleRoomJoinRetry(roomJid);
       this.emitError({
-        kind: "connect-timeout",
+        kind: "muc-join-timeout",
         recoverable: true,
         detail,
         cause: rejection,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -65,7 +65,10 @@ import {
 import { MucAdmin, type AdminUsersPage } from "./client-muc-admin";
 import { PresenceManager } from "./client-presence";
 import { VCardManager } from "./client-vcard";
-import { RoomJoinRetryCoordinator } from "./room-join-retry";
+import {
+  RoomJoinRetryCoordinator,
+  type ScheduleRoomJoinRetryOptions,
+} from "./room-join-retry";
 import {
   PubsubManager,
   type DmBookmarkItem,
@@ -1239,7 +1242,19 @@ export class BrowserXmppClient {
     if (!focused && !retained && !autoJoin) return;
     const source = focused ? "focused" : retained ? "retained" : "autojoin";
 
-    void this.roomJoinRetry.schedule(key, {
+    void this.roomJoinRetry.schedule(
+      key,
+      this.roomJoinRetryOptions(roomJid, key, xmpp, source),
+    ).catch(() => undefined);
+  }
+
+  private roomJoinRetryOptions(
+    roomJid: string,
+    key: string,
+    xmpp: XmppClientInstance,
+    source: "focused" | "retained" | "autojoin",
+  ): ScheduleRoomJoinRetryOptions {
+    return {
       // A focused retry belongs to that navigation intent and stops as soon
       // as focus moves elsewhere. A background retry likewise belongs to the
       // retained/autojoin source that admitted it; another source appearing
@@ -1252,7 +1267,7 @@ export class BrowserXmppClient {
             : this.autoJoinRoomJids.some((candidate) => this.roomJoinKey(candidate) === key)
       ),
       retry: () => this.ensureJoined(roomJid),
-    }).catch(() => undefined);
+    };
   }
 
   private waitForRoomSelfPresence(roomJid: string, requestedNick: string): Promise<void> {
@@ -1292,7 +1307,7 @@ export class BrowserXmppClient {
         this.roomJoinWaiters.delete(key);
         resolveJoin();
       },
-      reject: (error) => {
+      reject: (error: Error) => {
         clearTimeout(timeout);
         this.roomJoinWaiters.delete(key);
         rejectJoin(error);
@@ -1324,6 +1339,20 @@ export class BrowserXmppClient {
     if (scheduledRetry) return scheduledRetry;
     const existing = this.joinedMucs.get(key);
     if (existing) {
+      const xmpp = this.xmpp;
+      if (
+        xmpp
+        && this.currentRoom !== null
+        && this.roomJoinKey(this.currentRoom) === key
+      ) {
+        // A quick return adopts the still-running wire attempt. If it fails,
+        // the new focused intent may schedule another backoff window without
+        // sending a duplicate join presence in the meantime.
+        this.roomJoinRetry.reactivate(
+          key,
+          this.roomJoinRetryOptions(roomJid, key, xmpp, "focused"),
+        );
+      }
       const existingToken = this.joinedMucJoinTokens.get(key);
       await existing;
       if (existingToken && this.joinedMucJoinTokens.get(key) !== existingToken) {
@@ -1503,7 +1532,14 @@ export class BrowserXmppClient {
     const xmpp = this.xmpp;
     if (!xmpp) return;
     if (this.currentRoom && this.roomJoinKey(this.currentRoom) !== this.roomJoinKey(nextRoom)) {
-      this.roomJoinRetry.cancel(this.roomJoinKey(this.currentRoom));
+      const currentRoom = this.currentRoom;
+      const currentRoomKey = this.roomJoinKey(currentRoom);
+      const cancelledCurrentRetry = this.roomJoinRetry.cancel(currentRoomKey);
+      if (cancelledCurrentRetry) {
+        const cancellation = new Error("Room join retry cancelled");
+        this.revokeMucReadiness(currentRoom);
+        this.cancelRoomJoinWaiter(currentRoom, cancellation);
+      }
     }
     this.currentRoom = nextRoom;
     this.dispatchFocusedRoomHandlers();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1237,16 +1237,19 @@ export class BrowserXmppClient {
       (candidate) => this.roomJoinKey(candidate) === key,
     );
     if (!focused && !retained && !autoJoin) return;
+    const source = focused ? "focused" : retained ? "retained" : "autojoin";
 
     void this.roomJoinRetry.schedule(key, {
       // A focused retry belongs to that navigation intent and stops as soon
-      // as focus moves elsewhere. Background joins remain eligible only
-      // while their retained/autojoin source still contains the room.
+      // as focus moves elsewhere. A background retry likewise belongs to the
+      // retained/autojoin source that admitted it; another source appearing
+      // later must not silently extend the retry's lifetime.
       isEligible: () => this.isCurrentXmpp(xmpp) && (
-        focused
+        source === "focused"
           ? this.currentRoom !== null && this.roomJoinKey(this.currentRoom) === key
-          : this.retainedJoinedRoomJids.has(key)
-            || this.autoJoinRoomJids.some((candidate) => this.roomJoinKey(candidate) === key)
+          : source === "retained"
+            ? this.retainedJoinedRoomJids.has(key)
+            : this.autoJoinRoomJids.some((candidate) => this.roomJoinKey(candidate) === key)
       ),
       retry: () => this.ensureJoined(roomJid),
     }).catch(() => undefined);

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1532,14 +1532,7 @@ export class BrowserXmppClient {
     const xmpp = this.xmpp;
     if (!xmpp) return;
     if (this.currentRoom && this.roomJoinKey(this.currentRoom) !== this.roomJoinKey(nextRoom)) {
-      const currentRoom = this.currentRoom;
-      const currentRoomKey = this.roomJoinKey(currentRoom);
-      const cancelledCurrentRetry = this.roomJoinRetry.cancel(currentRoomKey);
-      if (cancelledCurrentRetry) {
-        const cancellation = new Error("Room join retry cancelled");
-        this.revokeMucReadiness(currentRoom);
-        this.cancelRoomJoinWaiter(currentRoom, cancellation);
-      }
+      this.roomJoinRetry.cancel(this.roomJoinKey(this.currentRoom));
     }
     this.currentRoom = nextRoom;
     this.dispatchFocusedRoomHandlers();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -65,6 +65,7 @@ import {
 import { MucAdmin, type AdminUsersPage } from "./client-muc-admin";
 import { PresenceManager } from "./client-presence";
 import { VCardManager } from "./client-vcard";
+import { RoomJoinRetryCoordinator } from "./room-join-retry";
 import {
   PubsubManager,
   type DmBookmarkItem,
@@ -486,6 +487,7 @@ export class BrowserXmppClient {
     string,
     { promise: Promise<void>; requestedNick: string; resolve: () => void; reject: (error: Error) => void }
   >();
+  private roomJoinRetry = new RoomJoinRetryCoordinator();
   // XEP-0280 dedupe memory: key → which representation was seen first
   // ("carbon" or "direct"). The source disambiguates a replayed carbon
   // (drop) from a carbon completing a direct-first pair (pass through
@@ -723,6 +725,7 @@ export class BrowserXmppClient {
   private markMucReadyFromSelfPresence(roomJid: string): void {
     const key = this.roomJoinKey(roomJid);
     if (!key) return;
+    this.roomJoinRetry.reset(key);
     if (!this.joinedMucs.has(key)) {
       this.joinedMucs.set(key, Promise.resolve());
     }
@@ -776,11 +779,13 @@ export class BrowserXmppClient {
       presence.error_type,
       presence.error_condition,
     );
-    waiter?.reject(new Error(
+    if (presence.error_type === "wait") this.scheduleRoomJoinRetry(room);
+    const rejection = new Error(
       terminalAuthorizationCondition
         ? "You need access to this channel."
         : "Channel presence was rejected. Try again in a moment.",
-    ));
+    );
+    waiter.reject(rejection);
     // Fully revoke — including the pending joinedMucs promise and its
     // token — BEFORE emitting, so an error listener that synchronously
     // retries the join starts a fresh one instead of awaiting the doomed
@@ -788,6 +793,7 @@ export class BrowserXmppClient {
     // microtasks later and its token guard makes this early delete safe).
     this.revokeMucReadiness(room);
     if (terminalAuthorizationCondition) {
+      this.roomJoinRetry.reset(key);
       const catalogFingerprintEvidence =
         this.currentRoomCatalogFingerprintEvidence.get(key);
       this.terminallyDeniedAutoJoinRooms.set(key, {
@@ -808,6 +814,7 @@ export class BrowserXmppClient {
       kind: "muc-join",
       recoverable: !terminalAuthorizationCondition,
       detail: `room join rejected — ${room}`,
+      cause: rejection,
       roomLocalpart: jidLocalpart(room),
       ...stanzaErrorContext({
         condition: presence.error_condition,
@@ -1174,6 +1181,7 @@ export class BrowserXmppClient {
     this.currentRoom = null;
     this.roomSwitchPromise = null;
     this.roomSwitchTarget = null;
+    this.roomJoinRetry.cancelAll();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     this.uploadServiceJid = null;
     this.clearRoomPresenceCaches();
@@ -1217,6 +1225,33 @@ export class BrowserXmppClient {
     this.discoveredRoomJids.set(channelId, normalizedRoomJid);
   }
 
+  private scheduleRoomJoinRetry(roomJid: string): void {
+    const key = this.roomJoinKey(roomJid);
+    const xmpp = this.xmpp;
+    if (!key || !xmpp || this.roomJoinRetry.pending(key)) return;
+
+    const focused = this.currentRoom !== null
+      && this.roomJoinKey(this.currentRoom) === key;
+    const retained = this.retainedJoinedRoomJids.has(key);
+    const autoJoin = this.autoJoinRoomJids.some(
+      (candidate) => this.roomJoinKey(candidate) === key,
+    );
+    if (!focused && !retained && !autoJoin) return;
+
+    void this.roomJoinRetry.schedule(key, {
+      // A focused retry belongs to that navigation intent and stops as soon
+      // as focus moves elsewhere. Background joins remain eligible only
+      // while their retained/autojoin source still contains the room.
+      isEligible: () => this.isCurrentXmpp(xmpp) && (
+        focused
+          ? this.currentRoom !== null && this.roomJoinKey(this.currentRoom) === key
+          : this.retainedJoinedRoomJids.has(key)
+            || this.autoJoinRoomJids.some((candidate) => this.roomJoinKey(candidate) === key)
+      ),
+      retry: () => this.ensureJoined(roomJid),
+    }).catch(() => undefined);
+  }
+
   private waitForRoomSelfPresence(roomJid: string, requestedNick: string): Promise<void> {
     const key = this.roomJoinKey(roomJid);
     // Concurrent joins for JIDs that normalize to the same room key
@@ -1234,8 +1269,17 @@ export class BrowserXmppClient {
     const timeout = setTimeout(() => {
       this.roomJoinWaiters.delete(key);
       const detail = `Timed out waiting for self-presence in ${roomJid}`;
-      this.emitError({ kind: "connect-timeout", recoverable: true, detail });
-      rejectJoin(new Error("Channel presence did not finish syncing. Try again in a moment."));
+      const rejection = new Error(
+        "Channel presence did not finish syncing. Try again in a moment.",
+      );
+      this.scheduleRoomJoinRetry(roomJid);
+      this.emitError({
+        kind: "connect-timeout",
+        recoverable: true,
+        detail,
+        cause: rejection,
+      });
+      rejectJoin(rejection);
     }, ROOM_SELF_PRESENCE_TIMEOUT_MS);
     this.roomJoinWaiters.set(key, {
       promise,
@@ -1273,6 +1317,8 @@ export class BrowserXmppClient {
     // the wire (`performMucJoin`, `rememberJoinedRoom`).
     const key = this.roomJoinKey(roomJid);
     if (this.joinedMucReady.has(key)) return;
+    const scheduledRetry = this.roomJoinRetry.pending(key);
+    if (scheduledRetry) return scheduledRetry;
     const existing = this.joinedMucs.get(key);
     if (existing) {
       const existingToken = this.joinedMucJoinTokens.get(key);
@@ -1293,6 +1339,7 @@ export class BrowserXmppClient {
     try {
       await promise;
       if (this.joinedMucJoinTokens.get(key) === joinToken) {
+        this.roomJoinRetry.reset(key);
         this.joinedMucReady.add(key);
         this.clearAutoJoinBlock(key);
         this.rememberJoinedRoom(roomJid);
@@ -1452,6 +1499,9 @@ export class BrowserXmppClient {
   private async performRoomSwitch(nextRoom: string) {
     const xmpp = this.xmpp;
     if (!xmpp) return;
+    if (this.currentRoom && this.roomJoinKey(this.currentRoom) !== this.roomJoinKey(nextRoom)) {
+      this.roomJoinRetry.cancel(this.roomJoinKey(this.currentRoom));
+    }
     this.currentRoom = nextRoom;
     this.dispatchFocusedRoomHandlers();
     try {
@@ -2703,6 +2753,7 @@ export class BrowserXmppClient {
   }
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
+    this.roomJoinRetry.cancelAll();
     const previouslyJoinedRooms = [...this.joinedMucs.keys()];
     // Snapshot the self-presence-confirmed (status 110) rooms before the
     // trackers clear so a subsequent `resumed` session-ready can restore

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -725,7 +725,7 @@ export class BrowserXmppClient {
   private markMucReadyFromSelfPresence(roomJid: string): void {
     const key = this.roomJoinKey(roomJid);
     if (!key) return;
-    this.roomJoinRetry.reset(key);
+    this.roomJoinRetry.complete(key);
     if (!this.joinedMucs.has(key)) {
       this.joinedMucs.set(key, Promise.resolve());
     }
@@ -1342,7 +1342,7 @@ export class BrowserXmppClient {
     try {
       await promise;
       if (this.joinedMucJoinTokens.get(key) === joinToken) {
-        this.roomJoinRetry.reset(key);
+        this.roomJoinRetry.complete(key);
         this.joinedMucReady.add(key);
         this.clearAutoJoinBlock(key);
         this.rememberJoinedRoom(roomJid);

--- a/chat/src/lib/xmpp/room-join-retry.ts
+++ b/chat/src/lib/xmpp/room-join-retry.ts
@@ -1,0 +1,140 @@
+export const ROOM_JOIN_RETRY_BASE_DELAY_MS = 2_000;
+export const ROOM_JOIN_RETRY_MAX_DELAY_MS = 60_000;
+
+export type RoomJoinRetryTimer = {
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+};
+
+type RoomJoinRetryOptions = {
+  timer?: RoomJoinRetryTimer;
+  random?: () => number;
+};
+
+type ScheduledRoomJoinRetry = {
+  promise: Promise<void>;
+  timer: ReturnType<typeof setTimeout>;
+  reject: (error: Error) => void;
+};
+
+type ScheduleRoomJoinRetryOptions = {
+  isEligible: () => boolean;
+  retry: () => Promise<void>;
+};
+
+const defaultTimer: RoomJoinRetryTimer = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
+
+/**
+ * Equal-jitter exponential backoff. The lower half of each exponential
+ * window is skipped so a transient failure cannot immediately hammer the
+ * room again, while the randomized upper half spreads clients that were
+ * rejected in the same server-side burst.
+ */
+export function roomJoinRetryDelayMs(
+  failureIndex: number,
+  random: () => number = Math.random,
+): number {
+  const exponent = Math.max(0, Math.floor(failureIndex));
+  const exponentialDelay = Math.min(
+    ROOM_JOIN_RETRY_MAX_DELAY_MS,
+    ROOM_JOIN_RETRY_BASE_DELAY_MS * (2 ** Math.min(exponent, 30)),
+  );
+  const jitter = 0.5 + (Math.min(1, Math.max(0, random())) * 0.5);
+  return Math.round(exponentialDelay * jitter);
+}
+
+/**
+ * Owns one pending retry per canonical room JID. Callers arriving during the
+ * backoff window receive the same promise, so they cannot turn one rejected
+ * attempt into a burst of immediate wire retries.
+ */
+export class RoomJoinRetryCoordinator {
+  private readonly timer: RoomJoinRetryTimer;
+  private readonly random: () => number;
+  private readonly failureCounts = new Map<string, number>();
+  private readonly scheduled = new Map<string, ScheduledRoomJoinRetry>();
+
+  constructor(options: RoomJoinRetryOptions = {}) {
+    this.timer = options.timer ?? defaultTimer;
+    this.random = options.random ?? Math.random;
+  }
+
+  pending(roomKey: string): Promise<void> | undefined {
+    return this.scheduled.get(roomKey)?.promise;
+  }
+
+  schedule(roomKey: string, options: ScheduleRoomJoinRetryOptions): Promise<void> {
+    const existing = this.scheduled.get(roomKey);
+    if (existing) return existing.promise;
+
+    const failureIndex = this.failureCounts.get(roomKey) ?? 0;
+    this.failureCounts.set(roomKey, failureIndex + 1);
+
+    let resolveRetry!: () => void;
+    let rejectRetry!: (error: Error) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveRetry = resolve;
+      rejectRetry = reject;
+    });
+    const entry = {} as ScheduledRoomJoinRetry;
+    const timer = this.timer.setTimeout(() => {
+      void this.run(roomKey, entry, options, resolveRetry, rejectRetry);
+    }, roomJoinRetryDelayMs(failureIndex, this.random));
+    Object.assign(entry, { promise, timer, reject: rejectRetry });
+    this.scheduled.set(roomKey, entry);
+    // The retry runs independently of any one UI listener. Keep cancellation
+    // or a failed scheduled attempt from becoming an unhandled rejection when
+    // nobody is currently awaiting the shared promise.
+    void promise.catch(() => undefined);
+    return promise;
+  }
+
+  cancel(roomKey: string): void {
+    const entry = this.scheduled.get(roomKey);
+    this.failureCounts.delete(roomKey);
+    if (!entry) return;
+    this.scheduled.delete(roomKey);
+    this.timer.clearTimeout(entry.timer);
+    entry.reject(new Error("Room join retry cancelled"));
+  }
+
+  cancelAll(): void {
+    for (const roomKey of [...this.scheduled.keys()]) this.cancel(roomKey);
+    this.failureCounts.clear();
+  }
+
+  reset(roomKey: string): void {
+    this.cancel(roomKey);
+    this.failureCounts.delete(roomKey);
+  }
+
+  private async run(
+    roomKey: string,
+    entry: ScheduledRoomJoinRetry,
+    options: ScheduleRoomJoinRetryOptions,
+    resolve: () => void,
+    reject: (error: Error) => void,
+  ): Promise<void> {
+    if (this.scheduled.get(roomKey) !== entry) return;
+    this.scheduled.delete(roomKey);
+    if (!options.isEligible()) {
+      this.failureCounts.delete(roomKey);
+      reject(new Error("Room join retry cancelled"));
+      return;
+    }
+    try {
+      await options.retry();
+      this.failureCounts.delete(roomKey);
+      resolve();
+    } catch (error) {
+      // A retryable failure schedules the next window synchronously from the
+      // join error handler before this promise rejects. If it did not, the
+      // chain ended for another reason and a future failure starts fresh.
+      if (!this.scheduled.has(roomKey)) this.failureCounts.delete(roomKey);
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}

--- a/chat/src/lib/xmpp/room-join-retry.ts
+++ b/chat/src/lib/xmpp/room-join-retry.ts
@@ -14,7 +14,14 @@ type RoomJoinRetryOptions = {
 type ScheduledRoomJoinRetry = {
   promise: Promise<void>;
   timer: ReturnType<typeof setTimeout>;
+  resolve: () => void;
   reject: (error: Error) => void;
+};
+
+type RunningRoomJoinRetry = {
+  entry: ScheduledRoomJoinRetry;
+  options: ScheduleRoomJoinRetryOptions;
+  cancelled: boolean;
 };
 
 type ScheduleRoomJoinRetryOptions = {
@@ -56,6 +63,7 @@ export class RoomJoinRetryCoordinator {
   private readonly random: () => number;
   private readonly failureCounts = new Map<string, number>();
   private readonly scheduled = new Map<string, ScheduledRoomJoinRetry>();
+  private readonly running = new Map<string, RunningRoomJoinRetry>();
 
   constructor(options: RoomJoinRetryOptions = {}) {
     this.timer = options.timer ?? defaultTimer;
@@ -69,6 +77,16 @@ export class RoomJoinRetryCoordinator {
   schedule(roomKey: string, options: ScheduleRoomJoinRetryOptions): Promise<void> {
     const existing = this.scheduled.get(roomKey);
     if (existing) return existing.promise;
+    const running = this.running.get(roomKey);
+    if (running) {
+      if (running.cancelled || !running.options.isEligible()) {
+        return cancelledRoomJoinRetry();
+      }
+      // The next window continues the source that admitted this chain. A
+      // failure callback may run after navigation changed the client's room
+      // sets; accepting freshly computed options here would resurrect it.
+      options = running.options;
+    }
 
     const failureIndex = this.failureCounts.get(roomKey) ?? 0;
     this.failureCounts.set(roomKey, failureIndex + 1);
@@ -83,7 +101,12 @@ export class RoomJoinRetryCoordinator {
     const timer = this.timer.setTimeout(() => {
       void this.run(roomKey, entry, options, resolveRetry, rejectRetry);
     }, roomJoinRetryDelayMs(failureIndex, this.random));
-    Object.assign(entry, { promise, timer, reject: rejectRetry });
+    Object.assign(entry, {
+      promise,
+      timer,
+      resolve: resolveRetry,
+      reject: rejectRetry,
+    });
     this.scheduled.set(roomKey, entry);
     // The retry runs independently of any one UI listener. Keep cancellation
     // or a failed scheduled attempt from becoming an unhandled rejection when
@@ -94,21 +117,38 @@ export class RoomJoinRetryCoordinator {
 
   cancel(roomKey: string): void {
     const entry = this.scheduled.get(roomKey);
+    const running = this.running.get(roomKey);
     this.failureCounts.delete(roomKey);
-    if (!entry) return;
-    this.scheduled.delete(roomKey);
-    this.timer.clearTimeout(entry.timer);
-    entry.reject(new Error("Room join retry cancelled"));
+    const cancellation = new Error("Room join retry cancelled");
+    if (entry) {
+      this.scheduled.delete(roomKey);
+      this.timer.clearTimeout(entry.timer);
+      entry.reject(cancellation);
+    }
+    if (running) {
+      running.cancelled = true;
+      running.entry.reject(cancellation);
+    }
   }
 
   cancelAll(): void {
-    for (const roomKey of [...this.scheduled.keys()]) this.cancel(roomKey);
+    const roomKeys = new Set([...this.scheduled.keys(), ...this.running.keys()]);
+    for (const roomKey of roomKeys) this.cancel(roomKey);
     this.failureCounts.clear();
   }
 
   reset(roomKey: string): void {
     this.cancel(roomKey);
     this.failureCounts.delete(roomKey);
+  }
+
+  complete(roomKey: string): void {
+    const entry = this.scheduled.get(roomKey);
+    this.failureCounts.delete(roomKey);
+    if (!entry) return;
+    this.scheduled.delete(roomKey);
+    this.timer.clearTimeout(entry.timer);
+    entry.resolve();
   }
 
   private async run(
@@ -125,6 +165,12 @@ export class RoomJoinRetryCoordinator {
       reject(new Error("Room join retry cancelled"));
       return;
     }
+    const running: RunningRoomJoinRetry = {
+      entry,
+      options,
+      cancelled: false,
+    };
+    this.running.set(roomKey, running);
     try {
       await options.retry();
       this.failureCounts.delete(roomKey);
@@ -135,6 +181,14 @@ export class RoomJoinRetryCoordinator {
       // chain ended for another reason and a future failure starts fresh.
       if (!this.scheduled.has(roomKey)) this.failureCounts.delete(roomKey);
       reject(error instanceof Error ? error : new Error(String(error)));
+    } finally {
+      if (this.running.get(roomKey) === running) this.running.delete(roomKey);
     }
   }
+}
+
+function cancelledRoomJoinRetry(): Promise<void> {
+  const promise = Promise.reject<void>(new Error("Room join retry cancelled"));
+  void promise.catch(() => undefined);
+  return promise;
 }

--- a/chat/src/lib/xmpp/room-join-retry.ts
+++ b/chat/src/lib/xmpp/room-join-retry.ts
@@ -125,7 +125,10 @@ export class RoomJoinRetryCoordinator {
   cancel(roomKey: string): void {
     const entry = this.scheduled.get(roomKey);
     const running = this.running.get(roomKey);
-    this.failureCounts.delete(roomKey);
+    // A running attempt may be re-adopted by a new navigation intent before
+    // it settles. Preserve its exponent until then; run() cleans it up when
+    // the cancelled chain actually ends.
+    if (!running) this.failureCounts.delete(roomKey);
     const cancellation = new Error("Room join retry cancelled");
     if (entry) {
       this.scheduled.delete(roomKey);

--- a/chat/src/lib/xmpp/room-join-retry.ts
+++ b/chat/src/lib/xmpp/room-join-retry.ts
@@ -28,10 +28,10 @@ const defaultTimer: RoomJoinRetryTimer = {
 };
 
 /**
- * Equal-jitter exponential backoff. The lower half of each exponential
- * window is skipped so a transient failure cannot immediately hammer the
- * room again, while the randomized upper half spreads clients that were
- * rejected in the same server-side burst.
+ * Equal-jitter exponential backoff. The first window is 2–4 seconds, so
+ * jitter never makes the existing two-second retry pressure worse. Later
+ * windows double up to a 30–60 second capped range, spreading clients that
+ * were rejected in the same server-side burst.
  */
 export function roomJoinRetryDelayMs(
   failureIndex: number,
@@ -40,7 +40,7 @@ export function roomJoinRetryDelayMs(
   const exponent = Math.max(0, Math.floor(failureIndex));
   const exponentialDelay = Math.min(
     ROOM_JOIN_RETRY_MAX_DELAY_MS,
-    ROOM_JOIN_RETRY_BASE_DELAY_MS * (2 ** Math.min(exponent, 30)),
+    ROOM_JOIN_RETRY_BASE_DELAY_MS * (2 ** Math.min(exponent + 1, 30)),
   );
   const jitter = 0.5 + (Math.min(1, Math.max(0, random())) * 0.5);
   return Math.round(exponentialDelay * jitter);

--- a/chat/src/lib/xmpp/room-join-retry.ts
+++ b/chat/src/lib/xmpp/room-join-retry.ts
@@ -24,7 +24,7 @@ type RunningRoomJoinRetry = {
   cancelled: boolean;
 };
 
-type ScheduleRoomJoinRetryOptions = {
+export type ScheduleRoomJoinRetryOptions = {
   isEligible: () => boolean;
   retry: () => Promise<void>;
 };
@@ -113,6 +113,13 @@ export class RoomJoinRetryCoordinator {
     // nobody is currently awaiting the shared promise.
     void promise.catch(() => undefined);
     return promise;
+  }
+
+  reactivate(roomKey: string, options: ScheduleRoomJoinRetryOptions): void {
+    const running = this.running.get(roomKey);
+    if (!running?.cancelled) return;
+    running.cancelled = false;
+    running.options = options;
   }
 
   cancel(roomKey: string): void {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -78,7 +78,8 @@ export type XmppErrorKind =
   | "connect-timeout"
   | "history"
   | "member-query"
-  | "muc-join";
+  | "muc-join"
+  | "muc-join-timeout";
 
 /** RFC 6120 §8.3.2 `type` attribute values of an `<error/>` element, plus
  * "unknown" for an unrecognised wire value (mirrors the wasm bridge's

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -36,6 +36,7 @@ const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
   "history": "xmpp.stream",
   "member-query": "xmpp.stream",
   "muc-join": "xmpp.stream",
+  "muc-join-timeout": "xmpp.disconnect",
 };
 export function installInstrumentation(client: BrowserXmppClient): void {
   setXmppResourceForTelemetry(client.xmppResource);
@@ -72,7 +73,7 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       : undefined;
     const errorSource = telemetryErrorSource(event.kind, condition);
     const isRoomJoinFailure = event.kind === "muc-join"
-      || (event.kind === "connect-timeout" && event.detail.includes("self-presence"));
+      || event.kind === "muc-join-timeout";
     if (isRoomJoinFailure && event.cause !== undefined) {
       markErrorReportedToTelemetry(event.cause);
     }
@@ -107,9 +108,7 @@ function telemetryErrorDetail(event: XmppErrorEvent, condition: string | undefin
     case "auth":
       return "auth-error";
     case "connect-timeout":
-      return event.detail.includes("self-presence")
-        ? "room-self-presence-timeout"
-        : "connect-timeout";
+      return "connect-timeout";
     case "history":
       return "reconnect-catchup-failed";
     case "member-query":
@@ -117,6 +116,8 @@ function telemetryErrorDetail(event: XmppErrorEvent, condition: string | undefin
       return condition ? `member-query-${condition}` : "member-query-failed";
     case "muc-join":
       return condition ? `room-join-${condition}` : "room-join-rejected";
+    case "muc-join-timeout":
+      return "room-self-presence-timeout";
     case "stream":
       if (
         condition === "undefined-condition" &&
@@ -169,15 +170,15 @@ function telemetryStreamManagementCounts(event: XmppErrorEvent): Record<string, 
 }
 
 /** Attribute the failure: a condition means the server answered with an
- * error stanza/stream error; `connect-timeout` events are client-side
- * timers (connect stall, room self-presence wait). Anything else is left
+ * error stanza/stream error; timeout events are client-side timers.
+ * Anything else is left
  * unattributed rather than guessed. */
 function telemetryErrorSource(
   kind: XmppErrorKind,
   condition: string | undefined,
 ): "server" | "local-timeout" | undefined {
   if (condition) return "server";
-  if (kind === "connect-timeout") return "local-timeout";
+  if (kind === "connect-timeout" || kind === "muc-join-timeout") return "local-timeout";
   return undefined;
 }
 

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -25,6 +25,7 @@ import {
   reportSendEnqueued,
   reportSessionLifecycle,
   reportStatusChange,
+  markErrorReportedToTelemetry,
   setXmppResourceForTelemetry,
 } from "@/lib/telemetry";
 
@@ -70,6 +71,7 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       ? telemetryStreamManagementCounts(event)
       : undefined;
     const errorSource = telemetryErrorSource(event.kind, condition);
+    if (event.cause !== undefined) markErrorReportedToTelemetry(event.cause);
     const cause = new Error(
       detail,
       event.cause === undefined ? undefined : { cause: event.cause },

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -70,7 +70,10 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       ? telemetryStreamManagementCounts(event)
       : undefined;
     const errorSource = telemetryErrorSource(event.kind, condition);
-    const cause = new Error(detail);
+    const cause = new Error(
+      detail,
+      event.cause === undefined ? undefined : { cause: event.cause },
+    );
     reportError(kind, cause, {
       recoverable: event.recoverable,
       detail,

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -71,7 +71,11 @@ export function installInstrumentation(client: BrowserXmppClient): void {
       ? telemetryStreamManagementCounts(event)
       : undefined;
     const errorSource = telemetryErrorSource(event.kind, condition);
-    if (event.cause !== undefined) markErrorReportedToTelemetry(event.cause);
+    const isRoomJoinFailure = event.kind === "muc-join"
+      || (event.kind === "connect-timeout" && event.detail.includes("self-presence"));
+    if (isRoomJoinFailure && event.cause !== undefined) {
+      markErrorReportedToTelemetry(event.cause);
+    }
     const cause = new Error(
       detail,
       event.cause === undefined ? undefined : { cause: event.cause },

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -564,6 +564,8 @@ describe("client send readiness", () => {
       presence_type: string;
       error_condition?: string;
       error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
     }) => void) | null = null;
     const xmpp = {
       join_room: mock(async () => undefined),
@@ -611,6 +613,8 @@ describe("client send readiness", () => {
       presence_type: string;
       error_condition?: string;
       error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
     }) => void) | null = null;
     const joinRoom = mock(async () => undefined);
     const xmpp = {
@@ -888,6 +892,7 @@ describe("client send readiness", () => {
       connected: boolean;
       wireEvents: (xmpp: typeof xmpp) => void;
       roomJoinRetry: RoomJoinRetryCoordinator;
+      fullJid: string;
     };
     state.xmpp = xmpp;
     state.connected = true;
@@ -926,6 +931,20 @@ describe("client send readiness", () => {
     expect(joinRoom).toHaveBeenCalledTimes(2);
     expect(errors).toHaveLength(2);
     expect(retryTimer.scheduledDelays).toEqual([4_000, 8_000]);
+
+    const recoveredListener = client.ensureJoined(roomJid);
+    retryTimer.runNext();
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await recoveredListener;
+
+    expect(joinRoom).toHaveBeenCalledTimes(3);
+    expect(retryTimer.pendingCount).toBe(0);
   });
 
   test("self-presence timeout enters the same room retry backoff", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -11,10 +11,10 @@ import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import { nullResumePersistence, type ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import {
   RoomJoinRetryCoordinator,
-  type RoomJoinRetryTimer,
 } from "../src/lib/xmpp/room-join-retry";
 import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
+import { ManualRoomJoinRetryTimer } from "./helpers/manual-room-join-retry-timer";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -28,35 +28,6 @@ function session(partial: Partial<WaddleSession> = {}): WaddleSession {
 
 function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-class ManualRoomJoinRetryTimer implements RoomJoinRetryTimer {
-  readonly scheduledDelays: number[] = [];
-  private nextId = 1;
-  private readonly callbacks = new Map<number, () => void>();
-
-  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
-    const id = this.nextId++;
-    this.scheduledDelays.push(delayMs);
-    this.callbacks.set(id, callback);
-    return id as unknown as ReturnType<typeof setTimeout>;
-  }
-
-  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
-    this.callbacks.delete(handle as unknown as number);
-  }
-
-  runNext(): void {
-    const next = this.callbacks.entries().next().value as [number, () => void] | undefined;
-    if (!next) throw new Error("No room join retry is scheduled");
-    const [id, callback] = next;
-    this.callbacks.delete(id);
-    callback();
-  }
-
-  get pendingCount(): number {
-    return this.callbacks.size;
-  }
 }
 
 function createStorageMock() {
@@ -935,7 +906,7 @@ describe("client send readiness", () => {
 
     expect(joinRoom).toHaveBeenCalledTimes(1);
     expect(errors).toHaveLength(1);
-    expect(retryTimer.scheduledDelays).toEqual([2_000]);
+    expect(retryTimer.scheduledDelays).toEqual([4_000]);
 
     const firstListener = client.ensureJoined(roomJid);
     const secondListener = client.ensureJoined(roomJid);
@@ -954,7 +925,7 @@ describe("client send readiness", () => {
 
     expect(joinRoom).toHaveBeenCalledTimes(2);
     expect(errors).toHaveLength(2);
-    expect(retryTimer.scheduledDelays).toEqual([2_000, 4_000]);
+    expect(retryTimer.scheduledDelays).toEqual([4_000, 8_000]);
   });
 
   test("self-presence timeout enters the same room retry backoff", async () => {
@@ -998,7 +969,7 @@ describe("client send readiness", () => {
       );
 
       expect(joinRoom).toHaveBeenCalledTimes(1);
-      expect(retryTimer.scheduledDelays).toEqual([2_000]);
+      expect(retryTimer.scheduledDelays).toEqual([4_000]);
     } finally {
       globalThis.setTimeout = originalSetTimeout;
     }
@@ -1100,10 +1071,12 @@ describe("client send readiness", () => {
       wireEvents: (xmpp: typeof xmpp) => void;
       roomJoinRetry: RoomJoinRetryCoordinator;
       retainedJoinedRoomJids: Set<string>;
+      autoJoinRoomJids: ReadonlyArray<string>;
     };
     state.xmpp = xmpp;
     state.connected = true;
     state.roomJoinRetry = retryCoordinator;
+    state.autoJoinRoomJids = [roomJid];
     state.wireEvents(xmpp);
 
     const firstAttempt = client.fanOutAutoJoin([roomJid]);

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -9,6 +9,10 @@ import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } fr
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import { nullResumePersistence, type ResumePersistence } from "../src/lib/xmpp/resume-persistence";
+import {
+  RoomJoinRetryCoordinator,
+  type RoomJoinRetryTimer,
+} from "../src/lib/xmpp/room-join-retry";
 import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
@@ -24,6 +28,35 @@ function session(partial: Partial<WaddleSession> = {}): WaddleSession {
 
 function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+class ManualRoomJoinRetryTimer implements RoomJoinRetryTimer {
+  readonly scheduledDelays: number[] = [];
+  private nextId = 1;
+  private readonly callbacks = new Map<number, () => void>();
+
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const id = this.nextId++;
+    this.scheduledDelays.push(delayMs);
+    this.callbacks.set(id, callback);
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
+    this.callbacks.delete(handle as unknown as number);
+  }
+
+  runNext(): void {
+    const next = this.callbacks.entries().next().value as [number, () => void] | undefined;
+    if (!next) throw new Error("No room join retry is scheduled");
+    const [id, callback] = next;
+    this.callbacks.delete(id);
+    callback();
+  }
+
+  get pendingCount(): number {
+    return this.callbacks.size;
+  }
 }
 
 function createStorageMock() {
@@ -817,6 +850,7 @@ describe("client send readiness", () => {
       connected: boolean;
       wireEvents: (xmpp: typeof xmpp) => void;
       autoJoinAttemptedRoomKeys: Set<string>;
+      roomJoinRetry: RoomJoinRetryCoordinator;
       fullJid: string;
     };
     state.xmpp = xmpp;
@@ -835,6 +869,9 @@ describe("client send readiness", () => {
 
     expect(saveJoinedRooms).not.toHaveBeenCalled();
 
+    // A reconnect cancels the old session's timer before opening a new
+    // auto-join epoch.
+    state.roomJoinRetry.cancelAll();
     state.autoJoinAttemptedRoomKeys.clear();
     const retried = client.fanOutAutoJoin([roomJid]);
     await Promise.resolve();
@@ -847,6 +884,245 @@ describe("client send readiness", () => {
     await retried;
 
     expect(joinRoom).toHaveBeenCalledTimes(2);
+  });
+
+  test("wait-type MUC retries back off and coalesce concurrent join listeners", async () => {
+    const roomJid = roomBareJidFor(session(), "busy");
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadJoinedRooms: () => [roomJid],
+    });
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    const errors: XmppErrorEvent[] = [];
+    client.onError((error) => errors.push(error));
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+    state.wireEvents(xmpp);
+
+    const firstAttempt = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await firstAttempt;
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect(retryTimer.scheduledDelays).toEqual([2_000]);
+
+    const firstListener = client.ensureJoined(roomJid);
+    const secondListener = client.ensureJoined(roomJid);
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+
+    retryTimer.runNext();
+    await Promise.resolve();
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await Promise.allSettled([firstListener, secondListener]);
+
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    expect(errors).toHaveLength(2);
+    expect(retryTimer.scheduledDelays).toEqual([2_000, 4_000]);
+  });
+
+  test("self-presence timeout enters the same room retry backoff", async () => {
+    const roomJid = roomBareJidFor(session(), "slow");
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadJoinedRooms: () => [roomJid],
+    });
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    const joinRoom = mock(async () => undefined);
+    const xmpp = { join_room: joinRoom };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+
+    const originalSetTimeout = globalThis.setTimeout;
+    let selfPresenceTimeout: (() => void) | null = null;
+    globalThis.setTimeout = ((callback: TimerHandler, delayMs?: number) => {
+      if (delayMs === 15_000 && typeof callback === "function") {
+        selfPresenceTimeout = callback;
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return originalSetTimeout(callback, delayMs);
+    }) as typeof setTimeout;
+    try {
+      const joined = client.ensureJoined(roomJid);
+      await Promise.resolve();
+      expect(selfPresenceTimeout).not.toBeNull();
+      selfPresenceTimeout?.();
+      await expect(joined).rejects.toThrow(
+        "Channel presence did not finish syncing. Try again in a moment.",
+      );
+
+      expect(joinRoom).toHaveBeenCalledTimes(1);
+      expect(retryTimer.scheduledDelays).toEqual([2_000]);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  test("navigating away cancels a focused room's pending retry", async () => {
+    const busyRoomJid = roomBareJidFor(session(), "busy");
+    const nextRoomJid = roomBareJidFor(session(), "next");
+    const client = new BrowserXmppClient(session());
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+      fullJid: string;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+    state.wireEvents(xmpp);
+
+    const firstSwitch = client.switchRoom("", "busy");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await expect(firstSwitch).rejects.toThrow(
+      "Channel presence was rejected. Try again in a moment.",
+    );
+    expect(retryTimer.pendingCount).toBe(1);
+
+    const nextSwitch = client.switchRoom("", "next");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${nextRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await nextSwitch;
+
+    expect(retryTimer.pendingCount).toBe(0);
+    expect(joinRoom.mock.calls.map(([room]) => room)).toEqual([
+      busyRoomJid,
+      nextRoomJid,
+    ]);
+  });
+
+  test("a room removed from retained state is not retried", async () => {
+    const roomJid = roomBareJidFor(session(), "removed");
+    const client = new BrowserXmppClient(session(), {
+      ...nullResumePersistence,
+      loadJoinedRooms: () => [roomJid],
+    });
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+      retainedJoinedRoomJids: Set<string>;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+    state.wireEvents(xmpp);
+
+    const firstAttempt = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await firstAttempt;
+    expect(retryTimer.pendingCount).toBe(1);
+
+    state.retainedJoinedRoomJids.delete(roomJid);
+    retryTimer.runNext();
+    await Promise.resolve();
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(retryTimer.pendingCount).toBe(0);
   });
 
   test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1203,7 +1203,11 @@ describe("client send readiness", () => {
 
     const returnSwitch = client.switchRoom("", "busy");
     await Promise.resolve();
-    expect(joinRoom).toHaveBeenCalledTimes(2);
+    expect(joinRoom.mock.calls.map(([room]) => room)).toEqual([
+      busyRoomJid,
+      busyRoomJid,
+      nextRoomJid,
+    ]);
     onPresence?.({
       from: `${busyRoomJid}/alice`,
       presence_type: "error",
@@ -1227,7 +1231,12 @@ describe("client send readiness", () => {
     });
     await recovered;
 
-    expect(joinRoom).toHaveBeenCalledTimes(3);
+    expect(joinRoom.mock.calls.map(([room]) => room)).toEqual([
+      busyRoomJid,
+      busyRoomJid,
+      nextRoomJid,
+      busyRoomJid,
+    ]);
     expect(retryTimer.pendingCount).toBe(0);
   });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1060,6 +1060,85 @@ describe("client send readiness", () => {
     ]);
   });
 
+  test("navigating away during a focused retry prevents another backoff window", async () => {
+    const busyRoomJid = roomBareJidFor(session(), "busy");
+    const nextRoomJid = roomBareJidFor(session(), "next");
+    const client = new BrowserXmppClient(session());
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+      fullJid: string;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+    state.wireEvents(xmpp);
+
+    const firstSwitch = client.switchRoom("", "busy");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await expect(firstSwitch).rejects.toThrow(
+      "Channel presence was rejected. Try again in a moment.",
+    );
+
+    const retryListener = client.ensureJoined(busyRoomJid);
+    retryTimer.runNext();
+    await Promise.resolve();
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+
+    const nextSwitch = client.switchRoom("", "next");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    onPresence?.({
+      from: `${nextRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await Promise.allSettled([retryListener]);
+    await nextSwitch;
+
+    expect(retryTimer.scheduledDelays).toEqual([4_000]);
+    expect(retryTimer.pendingCount).toBe(0);
+    expect(joinRoom.mock.calls.map(([room]) => room)).toEqual([
+      busyRoomJid,
+      busyRoomJid,
+      nextRoomJid,
+    ]);
+  });
+
   test("a room removed from retained state is not retried", async () => {
     const roomJid = roomBareJidFor(session(), "removed");
     const client = new BrowserXmppClient(session(), {
@@ -1109,11 +1188,19 @@ describe("client send readiness", () => {
     await firstAttempt;
     expect(retryTimer.pendingCount).toBe(1);
 
-    state.retainedJoinedRoomJids.delete(roomJid);
     retryTimer.runNext();
     await Promise.resolve();
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    state.retainedJoinedRoomJids.delete(roomJid);
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await Promise.resolve();
 
-    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(retryTimer.scheduledDelays).toEqual([4_000]);
     expect(retryTimer.pendingCount).toBe(0);
   });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1218,7 +1218,7 @@ describe("client send readiness", () => {
       "Channel presence was rejected. Try again in a moment.",
     );
 
-    expect(retryTimer.scheduledDelays).toEqual([4_000, 4_000]);
+    expect(retryTimer.scheduledDelays).toEqual([4_000, 8_000]);
     expect(retryTimer.pendingCount).toBe(1);
     const recovered = client.ensureJoined(busyRoomJid);
     retryTimer.runNext();

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1139,6 +1139,98 @@ describe("client send readiness", () => {
     ]);
   });
 
+  test("returning during an in-flight retry re-adopts it without a duplicate join", async () => {
+    const busyRoomJid = roomBareJidFor(session(), "busy");
+    const nextRoomJid = roomBareJidFor(session(), "next");
+    const client = new BrowserXmppClient(session());
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const retryCoordinator = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+      fullJid: string;
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.roomJoinRetry = retryCoordinator;
+    state.wireEvents(xmpp);
+
+    const firstSwitch = client.switchRoom("", "busy");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await expect(firstSwitch).rejects.toThrow(
+      "Channel presence was rejected. Try again in a moment.",
+    );
+
+    retryTimer.runNext();
+    await Promise.resolve();
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+
+    const nextSwitch = client.switchRoom("", "next");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${nextRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await nextSwitch;
+
+    const returnSwitch = client.switchRoom("", "busy");
+    await Promise.resolve();
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await expect(returnSwitch).rejects.toThrow(
+      "Channel presence was rejected. Try again in a moment.",
+    );
+
+    expect(retryTimer.scheduledDelays).toEqual([4_000, 4_000]);
+    expect(retryTimer.pendingCount).toBe(1);
+    const recovered = client.ensureJoined(busyRoomJid);
+    retryTimer.runNext();
+    await Promise.resolve();
+    onPresence?.({
+      from: `${busyRoomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await recovered;
+
+    expect(joinRoom).toHaveBeenCalledTimes(3);
+    expect(retryTimer.pendingCount).toBe(0);
+  });
+
   test("a room removed from retained state is not retried", async () => {
     const roomJid = roomBareJidFor(session(), "removed");
     const client = new BrowserXmppClient(session(), {

--- a/chat/tests/helpers/manual-room-join-retry-timer.ts
+++ b/chat/tests/helpers/manual-room-join-retry-timer.ts
@@ -1,0 +1,30 @@
+import type { RoomJoinRetryTimer } from "../../src/lib/xmpp/room-join-retry";
+
+export class ManualRoomJoinRetryTimer implements RoomJoinRetryTimer {
+  readonly scheduledDelays: number[] = [];
+  private nextId = 1;
+  private readonly callbacks = new Map<number, () => void>();
+
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const id = this.nextId++;
+    this.scheduledDelays.push(delayMs);
+    this.callbacks.set(id, callback);
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
+    this.callbacks.delete(handle as unknown as number);
+  }
+
+  runNext(): void {
+    const next = this.callbacks.entries().next().value as [number, () => void] | undefined;
+    if (!next) throw new Error("No room join retry is scheduled");
+    const [id, callback] = next;
+    this.callbacks.delete(id);
+    callback();
+  }
+
+  get pendingCount(): number {
+    return this.callbacks.size;
+  }
+}

--- a/chat/tests/room-join-retry.test.ts
+++ b/chat/tests/room-join-retry.test.ts
@@ -4,51 +4,22 @@ import {
   ROOM_JOIN_RETRY_MAX_DELAY_MS,
   RoomJoinRetryCoordinator,
   roomJoinRetryDelayMs,
-  type RoomJoinRetryTimer,
 } from "../src/lib/xmpp/room-join-retry";
-
-class ManualRetryTimer implements RoomJoinRetryTimer {
-  readonly scheduledDelays: number[] = [];
-  private nextId = 1;
-  private readonly callbacks = new Map<number, () => void>();
-
-  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
-    const id = this.nextId++;
-    this.scheduledDelays.push(delayMs);
-    this.callbacks.set(id, callback);
-    return id as unknown as ReturnType<typeof setTimeout>;
-  }
-
-  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
-    this.callbacks.delete(handle as unknown as number);
-  }
-
-  runNext(): void {
-    const next = this.callbacks.entries().next().value as [number, () => void] | undefined;
-    if (!next) throw new Error("No retry timer is scheduled");
-    const [id, callback] = next;
-    this.callbacks.delete(id);
-    callback();
-  }
-
-  get pendingCount(): number {
-    return this.callbacks.size;
-  }
-}
+import { ManualRoomJoinRetryTimer } from "./helpers/manual-room-join-retry-timer";
 
 describe("room join retry backoff", () => {
   test("uses exponential delays with equal jitter and a hard cap", () => {
-    expect(roomJoinRetryDelayMs(0, () => 0)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS / 2);
-    expect(roomJoinRetryDelayMs(0, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS);
-    expect(roomJoinRetryDelayMs(1, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 2);
-    expect(roomJoinRetryDelayMs(4, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 16);
-    expect(roomJoinRetryDelayMs(5, () => 1)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS);
+    expect(roomJoinRetryDelayMs(0, () => 0)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS);
+    expect(roomJoinRetryDelayMs(0, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 2);
+    expect(roomJoinRetryDelayMs(1, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 4);
+    expect(roomJoinRetryDelayMs(3, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 16);
+    expect(roomJoinRetryDelayMs(4, () => 1)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS);
     expect(roomJoinRetryDelayMs(50, () => 1)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS);
     expect(roomJoinRetryDelayMs(50, () => 0)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS / 2);
   });
 
   test("coalesces listeners onto one scheduled retry", async () => {
-    const timer = new ManualRetryTimer();
+    const timer = new ManualRoomJoinRetryTimer();
     const coordinator = new RoomJoinRetryCoordinator({
       timer,
       random: () => 1,
@@ -65,7 +36,7 @@ describe("room join retry backoff", () => {
     });
 
     expect(second).toBe(first);
-    expect(timer.scheduledDelays).toEqual([ROOM_JOIN_RETRY_BASE_DELAY_MS]);
+    expect(timer.scheduledDelays).toEqual([ROOM_JOIN_RETRY_BASE_DELAY_MS * 2]);
 
     timer.runNext();
     await first;
@@ -75,7 +46,7 @@ describe("room join retry backoff", () => {
   });
 
   test("cancellation clears the timer and rejects listeners without running a retry", async () => {
-    const timer = new ManualRetryTimer();
+    const timer = new ManualRoomJoinRetryTimer();
     const coordinator = new RoomJoinRetryCoordinator({
       timer,
       random: () => 1,

--- a/chat/tests/room-join-retry.test.ts
+++ b/chat/tests/room-join-retry.test.ts
@@ -95,4 +95,44 @@ describe("room join retry backoff", () => {
     expect(timer.scheduledDelays).toEqual([4_000]);
     expect(timer.pendingCount).toBe(0);
   });
+
+  test("a new intent can re-adopt a cancelled in-flight attempt", async () => {
+    const timer = new ManualRoomJoinRetryTimer();
+    const coordinator = new RoomJoinRetryCoordinator({
+      timer,
+      random: () => 1,
+    });
+    let rejectAttempt!: (error: Error) => void;
+    const firstRetry = mock(() => new Promise<void>((_resolve, reject) => {
+      rejectAttempt = reject;
+    }));
+    const first = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry: firstRetry,
+    });
+
+    timer.runNext();
+    expect(firstRetry).toHaveBeenCalledTimes(1);
+    coordinator.cancel("busy@muc.example.com");
+    await expect(first).rejects.toThrow("Room join retry cancelled");
+
+    const secondRetry = mock(async () => undefined);
+    coordinator.reactivate("busy@muc.example.com", {
+      isEligible: () => true,
+      retry: secondRetry,
+    });
+    const second = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry: secondRetry,
+    });
+
+    expect(timer.scheduledDelays).toEqual([4_000, 4_000]);
+    rejectAttempt(new Error("resource-constraint"));
+    await Promise.resolve();
+    timer.runNext();
+    await second;
+
+    expect(secondRetry).toHaveBeenCalledTimes(1);
+    expect(timer.pendingCount).toBe(0);
+  });
 });

--- a/chat/tests/room-join-retry.test.ts
+++ b/chat/tests/room-join-retry.test.ts
@@ -126,7 +126,7 @@ describe("room join retry backoff", () => {
       retry: secondRetry,
     });
 
-    expect(timer.scheduledDelays).toEqual([4_000, 4_000]);
+    expect(timer.scheduledDelays).toEqual([4_000, 8_000]);
     rejectAttempt(new Error("resource-constraint"));
     await Promise.resolve();
     timer.runNext();

--- a/chat/tests/room-join-retry.test.ts
+++ b/chat/tests/room-join-retry.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  ROOM_JOIN_RETRY_BASE_DELAY_MS,
+  ROOM_JOIN_RETRY_MAX_DELAY_MS,
+  RoomJoinRetryCoordinator,
+  roomJoinRetryDelayMs,
+  type RoomJoinRetryTimer,
+} from "../src/lib/xmpp/room-join-retry";
+
+class ManualRetryTimer implements RoomJoinRetryTimer {
+  readonly scheduledDelays: number[] = [];
+  private nextId = 1;
+  private readonly callbacks = new Map<number, () => void>();
+
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const id = this.nextId++;
+    this.scheduledDelays.push(delayMs);
+    this.callbacks.set(id, callback);
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
+    this.callbacks.delete(handle as unknown as number);
+  }
+
+  runNext(): void {
+    const next = this.callbacks.entries().next().value as [number, () => void] | undefined;
+    if (!next) throw new Error("No retry timer is scheduled");
+    const [id, callback] = next;
+    this.callbacks.delete(id);
+    callback();
+  }
+
+  get pendingCount(): number {
+    return this.callbacks.size;
+  }
+}
+
+describe("room join retry backoff", () => {
+  test("uses exponential delays with equal jitter and a hard cap", () => {
+    expect(roomJoinRetryDelayMs(0, () => 0)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS / 2);
+    expect(roomJoinRetryDelayMs(0, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS);
+    expect(roomJoinRetryDelayMs(1, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 2);
+    expect(roomJoinRetryDelayMs(4, () => 1)).toBe(ROOM_JOIN_RETRY_BASE_DELAY_MS * 16);
+    expect(roomJoinRetryDelayMs(5, () => 1)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS);
+    expect(roomJoinRetryDelayMs(50, () => 1)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS);
+    expect(roomJoinRetryDelayMs(50, () => 0)).toBe(ROOM_JOIN_RETRY_MAX_DELAY_MS / 2);
+  });
+
+  test("coalesces listeners onto one scheduled retry", async () => {
+    const timer = new ManualRetryTimer();
+    const coordinator = new RoomJoinRetryCoordinator({
+      timer,
+      random: () => 1,
+    });
+    const retry = mock(async () => undefined);
+
+    const first = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry,
+    });
+    const second = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry,
+    });
+
+    expect(second).toBe(first);
+    expect(timer.scheduledDelays).toEqual([ROOM_JOIN_RETRY_BASE_DELAY_MS]);
+
+    timer.runNext();
+    await first;
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(coordinator.pending("busy@muc.example.com")).toBeUndefined();
+  });
+
+  test("cancellation clears the timer and rejects listeners without running a retry", async () => {
+    const timer = new ManualRetryTimer();
+    const coordinator = new RoomJoinRetryCoordinator({
+      timer,
+      random: () => 1,
+    });
+    const retry = mock(async () => undefined);
+    const scheduled = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry,
+    });
+
+    coordinator.cancel("busy@muc.example.com");
+
+    expect(timer.pendingCount).toBe(0);
+    await expect(scheduled).rejects.toThrow("Room join retry cancelled");
+    expect(retry).not.toHaveBeenCalled();
+  });
+});

--- a/chat/tests/room-join-retry.test.ts
+++ b/chat/tests/room-join-retry.test.ts
@@ -63,4 +63,36 @@ describe("room join retry backoff", () => {
     await expect(scheduled).rejects.toThrow("Room join retry cancelled");
     expect(retry).not.toHaveBeenCalled();
   });
+
+  test("cancellation during an attempt prevents the failed chain from rescheduling", async () => {
+    const timer = new ManualRoomJoinRetryTimer();
+    const coordinator = new RoomJoinRetryCoordinator({
+      timer,
+      random: () => 1,
+    });
+    let rejectAttempt!: (error: Error) => void;
+    const retry = mock(() => new Promise<void>((_resolve, reject) => {
+      rejectAttempt = reject;
+    }));
+    const scheduled = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry,
+    });
+
+    timer.runNext();
+    expect(retry).toHaveBeenCalledTimes(1);
+    coordinator.cancel("busy@muc.example.com");
+    await expect(scheduled).rejects.toThrow("Room join retry cancelled");
+
+    const continuation = coordinator.schedule("busy@muc.example.com", {
+      isEligible: () => true,
+      retry,
+    });
+    await expect(continuation).rejects.toThrow("Room join retry cancelled");
+    rejectAttempt(new Error("resource-constraint"));
+    await Promise.resolve();
+
+    expect(timer.scheduledDelays).toEqual([4_000]);
+    expect(timer.pendingCount).toBe(0);
+  });
 });

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -4,6 +4,7 @@ import { BrowserXmppClient, type SessionLifecycleEvent } from "../src/lib/xmpp-c
 import { __createFallbackXmppResourceForTesting } from "../src/lib/xmpp/client";
 import {
   __clearSensitiveUrlsForTesting,
+  __recordSpanExceptionForTesting,
   __scrubMissingFetchSpanUrlForTesting,
   __scrubSpanUrlForTesting,
   __scrubXhrSpanUrlForTesting,
@@ -525,6 +526,30 @@ describe("telemetry module no-op behaviour", () => {
       queueSize: "2",
       storage_area: "outbound-queue",
     });
+  });
+
+  test("an explicitly reported join failure is not recorded again by nested spans", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    const joinFailure = new Error(
+      "Channel presence was rejected. Try again in a moment.",
+    );
+    const stableTelemetryError = new Error(
+      "room-join-resource-constraint",
+      { cause: joinFailure },
+    );
+
+    reportError("xmpp.stream", stableTelemetryError, {
+      recoverable: true,
+      detail: "room-join-resource-constraint",
+      condition: "resource-constraint",
+      errorType: "wait",
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0].error.message).toBe("room-join-resource-constraint");
+    expect(__recordSpanExceptionForTesting(joinFailure)).toBe(0);
+    expect(__recordSpanExceptionForTesting(joinFailure)).toBe(0);
   });
 
   test("transport sanitizer replaces Faro page URLs with route templates", () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -619,6 +619,33 @@ describe("telemetry module no-op behaviour", () => {
     }
   });
 
+  test("non-join XMPP failures remain available to span exception recording", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+    const failure = new Error("history replay failed");
+    const internal = client as unknown as {
+      emitError: (event: {
+        kind: "history";
+        recoverable: boolean;
+        detail: string;
+        cause: Error;
+      }) => void;
+    };
+
+    internal.emitError({
+      kind: "history",
+      recoverable: true,
+      detail: "history replay failed",
+      cause: failure,
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(__recordSpanExceptionForTesting(failure)).toBe(1);
+    expect(__recordSpanExceptionForTesting(failure)).toBe(0);
+  });
+
   test("transport sanitizer replaces Faro page URLs with route templates", () => {
     let currentUrl = new URL("https://chat.example/dm/alice?thread=secret-thread#waddle_session_id=tok");
     const location = {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -619,6 +619,85 @@ describe("telemetry module no-op behaviour", () => {
     }
   });
 
+  test("each self-presence timeout attempt emits one Faro exception across listeners and spans", async () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const observedByFirstListener: Error[] = [];
+    const observedBySecondListener: Error[] = [];
+    client.onError((event) => {
+      if (event.kind === "muc-join-timeout" && event.cause instanceof Error) {
+        observedByFirstListener.push(event.cause);
+      }
+    });
+    client.onError((event) => {
+      if (event.kind === "muc-join-timeout" && event.cause instanceof Error) {
+        observedBySecondListener.push(event.cause);
+      }
+    });
+
+    const roomJid = roomBareJidFor(session(), "slow");
+    const joinRoom = mock(async () => undefined);
+    const internal = client as unknown as {
+      xmpp: { join_room: typeof joinRoom };
+      connected: boolean;
+      retainedJoinedRoomJids: Set<string>;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+    };
+    internal.xmpp = { join_room: joinRoom };
+    internal.connected = true;
+    internal.retainedJoinedRoomJids.add(roomJid);
+    internal.roomJoinRetry = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+
+    const originalSetTimeout = globalThis.setTimeout;
+    let selfPresenceTimeout: (() => void) | null = null;
+    globalThis.setTimeout = ((callback: TimerHandler, delayMs?: number) => {
+      if (delayMs === 15_000 && typeof callback === "function") {
+        selfPresenceTimeout = callback;
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return originalSetTimeout(callback, delayMs);
+    }) as typeof setTimeout;
+
+    try {
+      const firstAttempt = client.fanOutAutoJoin([roomJid]);
+      await Promise.resolve();
+      expect(selfPresenceTimeout).not.toBeNull();
+      selfPresenceTimeout?.();
+      await firstAttempt;
+
+      expect(stub.errors).toHaveLength(1);
+      expect(stub.errors[0].error.message).toBe("room-self-presence-timeout");
+
+      const firstJoinListener = client.ensureJoined(roomJid);
+      const secondJoinListener = client.ensureJoined(roomJid);
+      retryTimer.runNext();
+      await Promise.resolve();
+      expect(selfPresenceTimeout).not.toBeNull();
+      selfPresenceTimeout?.();
+      await Promise.allSettled([firstJoinListener, secondJoinListener]);
+
+      expect(joinRoom).toHaveBeenCalledTimes(2);
+      expect(stub.errors).toHaveLength(2);
+      expect(stub.errors.map(({ error }) => error.message)).toEqual([
+        "room-self-presence-timeout",
+        "room-self-presence-timeout",
+      ]);
+      expect(observedByFirstListener).toHaveLength(2);
+      expect(observedBySecondListener).toHaveLength(2);
+      for (const failure of observedByFirstListener) {
+        expect(__recordSpanExceptionForTesting(failure)).toBe(0);
+      }
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   test("non-join XMPP failures remain available to span exception recording", () => {
     const stub = createFaroStub();
     __setFaroForTesting(stub as never);

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -1106,14 +1106,14 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     const internal = client as unknown as {
       emitError: (event: {
-        kind: "connect-timeout";
+        kind: "muc-join-timeout";
         recoverable: boolean;
         detail: string;
       }) => void;
     };
 
     internal.emitError({
-      kind: "connect-timeout",
+      kind: "muc-join-timeout",
       recoverable: true,
       detail: "Timed out waiting for self-presence in c1@muc.example.com",
     });

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
-import { BrowserXmppClient, type SessionLifecycleEvent } from "../src/lib/xmpp-client";
+import {
+  BrowserXmppClient,
+  roomBareJidFor,
+  type SessionLifecycleEvent,
+} from "../src/lib/xmpp-client";
 import { __createFallbackXmppResourceForTesting } from "../src/lib/xmpp/client";
+import { RoomJoinRetryCoordinator } from "../src/lib/xmpp/room-join-retry";
 import {
   __clearSensitiveUrlsForTesting,
   __recordSpanExceptionForTesting,
@@ -32,6 +37,7 @@ import {
 import { DiscoTimeoutError, discoverChannels } from "../src/lib/xmpp/discovery";
 import { installInstrumentation } from "../src/lib/xmpp/xmpp-instrumentation";
 import type { ReconnectCatchupEntry } from "../src/lib/xmpp/reconnect-catchup";
+import { ManualRoomJoinRetryTimer } from "./helpers/manual-room-join-retry-timer";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -528,28 +534,89 @@ describe("telemetry module no-op behaviour", () => {
     });
   });
 
-  test("an explicitly reported join failure is not recorded again by nested spans", () => {
+  test("each failed join attempt emits one Faro exception across listeners and spans", async () => {
     const stub = createFaroStub();
     __setFaroForTesting(stub as never);
-    const joinFailure = new Error(
-      "Channel presence was rejected. Try again in a moment.",
-    );
-    const stableTelemetryError = new Error(
-      "room-join-resource-constraint",
-      { cause: joinFailure },
-    );
-
-    reportError("xmpp.stream", stableTelemetryError, {
-      recoverable: true,
-      detail: "room-join-resource-constraint",
-      condition: "resource-constraint",
-      errorType: "wait",
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+    const retryTimer = new ManualRoomJoinRetryTimer();
+    const observedByFirstListener: Error[] = [];
+    const observedBySecondListener: Error[] = [];
+    client.onError((event) => {
+      if (event.kind === "muc-join" && event.cause instanceof Error) {
+        observedByFirstListener.push(event.cause);
+      }
     });
+    client.onError((event) => {
+      if (event.kind === "muc-join" && event.cause instanceof Error) {
+        observedBySecondListener.push(event.cause);
+      }
+    });
+    const roomJid = roomBareJidFor(session(), "busy");
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+    }) => void) | null = null;
+    const joinRoom = mock(async () => undefined);
+    const xmpp = {
+      join_room: joinRoom,
+      set_on_presence(callback: NonNullable<typeof onPresence>) {
+        onPresence = callback;
+      },
+    };
+    const internal = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      retainedJoinedRoomJids: Set<string>;
+      roomJoinRetry: RoomJoinRetryCoordinator;
+      wireEvents: (xmpp: typeof xmpp) => void;
+    };
+    internal.xmpp = xmpp;
+    internal.connected = true;
+    internal.retainedJoinedRoomJids.add(roomJid);
+    internal.roomJoinRetry = new RoomJoinRetryCoordinator({
+      timer: retryTimer,
+      random: () => 1,
+    });
+    internal.wireEvents(xmpp);
+
+    const firstAttempt = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await firstAttempt;
 
     expect(stub.errors).toHaveLength(1);
     expect(stub.errors[0].error.message).toBe("room-join-resource-constraint");
-    expect(__recordSpanExceptionForTesting(joinFailure)).toBe(0);
-    expect(__recordSpanExceptionForTesting(joinFailure)).toBe(0);
+    const firstJoinListener = client.ensureJoined(roomJid);
+    const secondJoinListener = client.ensureJoined(roomJid);
+    retryTimer.runNext();
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "resource-constraint",
+      error_type: "wait",
+    });
+    await Promise.allSettled([firstJoinListener, secondJoinListener]);
+
+    expect(joinRoom).toHaveBeenCalledTimes(2);
+    expect(stub.errors).toHaveLength(2);
+    expect(stub.errors.map(({ error }) => error.message)).toEqual([
+      "room-join-resource-constraint",
+      "room-join-resource-constraint",
+    ]);
+    expect(observedByFirstListener).toHaveLength(2);
+    expect(observedBySecondListener).toHaveLength(2);
+    for (const failure of observedByFirstListener) {
+      expect(__recordSpanExceptionForTesting(failure)).toBe(0);
+    }
   });
 
   test("transport sanitizer replaces Faro page URLs with route templates", () => {


### PR DESCRIPTION
## Summary

Fixes #1472 by replacing fixed wait-type room-join retry pressure with one coalesced, capped exponential-backoff chain per room and by emitting one Faro exception per failed join attempt.

## Implementation

- add equal-jitter exponential backoff with a 2–4 second first window and a 30–60 second capped window
- coalesce concurrent join listeners onto one scheduled retry promise
- apply the same policy to XMPP wait-type presence errors and local self-presence timeouts
- bind each retry chain to the focused, retained, or autojoin source that admitted it
- stop pending and in-flight retry chains after navigation, retained-room removal, or disconnect
- safely re-adopt an already-sent join after a quick return without emitting duplicate presence, while preserving the exponential counter
- retain the existing terminal auth eviction/blocking path unchanged
- preserve the original join failure as the telemetry cause and suppress duplicate span exceptions for that attempt
- use a typed `muc-join-timeout` event instead of classifying human-readable detail text

## XEP review

Reviewed XEP-0045 error and self-presence semantics. Retry cadence, jitter, cancellation, and operational telemetry are client policy; this change does not alter XMPP wire shapes, advertised features, namespaces, or XEP behavior, so no Rust XEP custom-suite update is applicable.

## Verification

- `bun test` — 3,539 passed, 0 failed across 312 files
- `bun run build` — passed; Astro check reported 0 errors and 4 existing hints
- `bun run lint` — passed, including Knip
- `bunx tsc --noEmit -p tsconfig.json` — passed
- focused retry/readiness/telemetry suite — 141 passed, 0 failed
- final adversarial spec and standards reviews — no actionable findings

## Plan completed

- mapped room-join lifecycle and reviewed XEP-0045
- added regression coverage before and alongside implementation
- implemented capped backoff, cancellation, coalescing, and exception deduplication
- hardened quick-navigation and admission-source races found in review
- completed full verification and adversarial review

No dependencies added.