### PR TITLE
fix(server): export internal failures as error spans

### DIFF
--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -68,6 +68,7 @@ const MARK_DRAINING_BOUND: Duration = Duration::from_secs(2);
 /// complete within budget is left claimed — abandoned, not lost: the claim
 /// stays fenced-safe and is reclaimed later by another node's orphan
 /// reaper, or by this node itself once its own lease naturally lapses.
+#[tracing::instrument(name = "clustering.shutdown_drain", skip_all)]
 pub(crate) async fn run_shutdown_drain<L>(
     lease: &L,
     claim_store: &Arc<dyn ClaimStore>,
@@ -140,6 +141,9 @@ pub(crate) async fn run_shutdown_drain<L>(
         }
     }
     if abandoned > 0 {
+        // All abandonment causes are internal drain failures even though the
+        // claims remain fenced-safe for later recovery.
+        crate::telemetry::mark_span_error("clustering drain abandoned claims");
         metrics::record_claims_abandoned_on_drain(abandoned);
     }
     metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
@@ -418,8 +422,10 @@ mod tests {
         )
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn drain_seals_then_releases_only_room_entities_skipping_sm_sessions() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
         let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
         let me = identity();
         let room_a = room("room-a@muc.example.com");
@@ -473,10 +479,16 @@ mod tests {
             "the sm_session entity must be left untouched by the generic drain loop \
              (owned by the separate Q6 SM drain path instead)"
         );
+        assert_eq!(
+            spans.status_of("clustering.shutdown_drain"),
+            Some(opentelemetry::trace::Status::Unset)
+        );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn drain_abandons_a_failed_seal_and_leaves_the_claim_held() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
         let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
         let me = identity();
         let room_a = room("room-fails@muc.example.com");
@@ -505,6 +517,10 @@ mod tests {
                 .unwrap_or(false),
             "a failed seal must leave the claim held, not release it"
         );
+        assert!(matches!(
+            spans.status_of("clustering.shutdown_drain"),
+            Some(opentelemetry::trace::Status::Error { .. })
+        ));
     }
 
     #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -161,6 +161,7 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
     /// reclaim and the general reaper share one hydration implementation.
     /// A no-op before `wire` runs, mirroring `demote`/`owned`'s identical
     /// unwired behavior.
+    #[tracing::instrument(name = "clustering.sm_session.hydrate_reclaimed", skip_all)]
     async fn hydrate_reclaimed(
         &self,
         entities: &[(
@@ -191,6 +192,11 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
                         .release_reclaimed_claim(entity, &fence, *reservation)
                         .await
                     {
+                        // Internal reclaim repair failure should stay visible for postmortem
+                        // analysis: leave ownership in place and let retry logic reclaim later.
+                        crate::telemetry::mark_span_error(
+                            "sm_session_rehydrate: failed to release reclaimed claim",
+                        );
                         tracing::warn!(
                             entity_id = %entity.id,
                             %error,
@@ -200,6 +206,12 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
                 }
                 Ok(_) => {}
                 Err(error) => {
+                    // Rehydrate failed before ownership transfer: this is not protocol
+                    // failure, but it should still export a failed span for incident
+                    // detection and operator alerting.
+                    crate::telemetry::mark_span_error(
+                        "sm_session_rehydrate: failed to hydrate reclaimed claim",
+                    );
                     tracing::warn!(
                         entity_id = %entity.id,
                         %error,
@@ -537,6 +549,12 @@ impl UserLocalClaims {
             Ok(Some(actor_ref)) => actor_ref,
             Ok(None) => return Vec::new(),
             Err(error) => {
+                // Missing actor handle after lookup means this claim is no longer
+                // actively represented; demotion continues via best-effort cleanup,
+                // but the span must still record the dependency failure.
+                crate::telemetry::mark_span_error(
+                    "user_local_claims: user registry lookup failed before force-detach",
+                );
                 tracing::warn!(
                     jid = %bare_jid,
                     ?error,
@@ -553,6 +571,12 @@ impl UserLocalClaims {
         {
             Ok(resources) => resources,
             Err(error) => {
+                // Resource enumeration requires a live actor for force-detach;
+                // failure here means an internal path diverged from best-effort
+                // cleanup assumptions.
+                crate::telemetry::mark_span_error(
+                    "user_local_claims: failed to enumerate user actor resources",
+                );
                 tracing::warn!(
                     jid = %bare_jid,
                     ?error,
@@ -591,6 +615,12 @@ impl UserLocalClaims {
                 jid = %bare_jid,
                 resource_count = resources.len(),
                 "UserLocalClaims::demote: no ConnectionRegistry wired; cannot force-detach live resources"
+            );
+            // Without ConnectionRegistry we cannot complete demotion cleanup for live
+            // connections on this process; this is an internal miswire/internal
+            // dependency failure.
+            crate::telemetry::mark_span_error(
+                "user_local_claims: no connection registry available for force-detach",
             );
             return;
         };
@@ -652,11 +682,21 @@ impl UserLocalClaims {
                             requester = %bare_jid,
                             "UserLocalClaims::demote: force-detach identity mismatch; leaving registry entry untouched"
                         );
+                        // Identity changed while detach was in flight; keep failure
+                        // visibility in traces for later reconciliation debugging.
+                        crate::telemetry::mark_span_error(
+                            "user_local_claims: force-detach identity mismatch",
+                        );
                     }
                     Ok(Err(_closed)) => {
                         tracing::warn!(
                             jid = %jid,
                             "UserLocalClaims::demote: force-detach ack channel closed before response; leaving registry entry for connection-owned cleanup"
+                        );
+                        // Ack channel closure is an internal detach-path failure even
+                        // if cleanup can continue asynchronously.
+                        crate::telemetry::mark_span_error(
+                            "user_local_claims: force-detach ack channel closed",
                         );
                     }
                     Err(_elapsed) => {
@@ -665,6 +705,12 @@ impl UserLocalClaims {
                             timeout_ms = USER_FORCE_DETACH_ACK_TIMEOUT.as_millis() as u64,
                             "UserLocalClaims::demote: force-detach timed out; leaving registry entry so the connection task does not misclassify cleanup as superseded"
                         );
+                        // Timeout indicates stalled force-detach coordination; mark span
+                        // failed to keep this in incident triage, even though it remains
+                        // best-effort.
+                        crate::telemetry::mark_span_error(
+                            "user_local_claims: force-detach timed out",
+                        );
                     }
                 },
                 Err(error) => {
@@ -672,6 +718,11 @@ impl UserLocalClaims {
                         jid = %jid,
                         ?error,
                         "UserLocalClaims::demote: force-detach request could not be queued; leaving registry entry for connection-owned cleanup"
+                    );
+                    // If the detach request cannot be queued, we intentionally defer cleanup,
+                    // but this is still an internal failure and should become a span error.
+                    crate::telemetry::mark_span_error(
+                        "user_local_claims: force-detach request could not be queued",
                     );
                 }
             }
@@ -726,6 +777,7 @@ impl LocallyClaimedEntities for UserLocalClaims {
         owned
     }
 
+    #[tracing::instrument(name = "clustering.user_actor.demote", skip_all)]
     async fn demote(&self, entity: &Entity) {
         let Some(registry) = self.registry.get() else {
             return;
@@ -757,6 +809,9 @@ impl LocallyClaimedEntities for UserLocalClaims {
             }
             Ok(false) => {}
             Err(error) => {
+                // UserActor demotion failed in local-claim cleanup; this is an internal
+                // operation failure and should remain queryable by span status.
+                crate::telemetry::mark_span_error("user_local_claims: user actor demotion failed");
                 tracing::warn!(
                     jid = %bare_jid,
                     ?error,
@@ -822,6 +877,7 @@ impl LocallyClaimedEntities for UserLocalClaims {
         }
     }
 
+    #[tracing::instrument(name = "clustering.user_actor.demote_owned_by", skip_all)]
     async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
         let Some(registry) = self.registry.get() else {
             return;
@@ -861,6 +917,11 @@ impl LocallyClaimedEntities for UserLocalClaims {
                 }
                 Ok(None) => {}
                 Err(error) => {
+                    // Exact-owner demotion failed after ownership check; this is an
+                    // internal consistency error during cluster recovery.
+                    crate::telemetry::mark_span_error(
+                        "user_local_claims: exact-owner demotion failed",
+                    );
                     tracing::warn!(jid = %bare_jid, ?error, "exact-owner UserActor demotion failed");
                 }
             }

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -56,10 +56,17 @@ use crate::clustering::NodeId;
 use crate::db::{Database, DatabaseError, Transaction};
 
 fn db_err(error: DatabaseError) -> XmppError {
+    // Durable MUC operations translate database failures into typed XMPP
+    // errors, so record the internal failure before returning the protocol
+    // response to the caller.
+    crate::telemetry::mark_span_error("MUC durable storage operation failed");
     XmppError::internal(format!("MUC durable store backend error: {error}"))
 }
 
 fn fence_db_unavailable(error: DatabaseError, fence: &RoomClaimFenceContext) -> XmppError {
+    // An unavailable fence proof is a backend failure, unlike a successful
+    // proof that reports ownership was lost.
+    crate::telemetry::mark_span_error("MUC durable ownership fence check failed");
     tracing::warn!(
         %error,
         entity = %fence.entity,

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -132,6 +132,7 @@ impl StanzaBackstop {
             stanza_kind = kind,
             payload_ns = %payload_ns,
             otel.status_code = tracing::field::Empty,
+            condition = tracing::field::Empty,
             message_id = tracing::field::Empty,
             room = tracing::field::Empty,
             xmpp.resource = tracing::field::Empty,
@@ -166,6 +167,13 @@ impl StanzaBackstop {
         let _enter = self.span.enter();
         match &self.iq_reply {
             Some(reply) => {
+                // The synthesized IQ rejection is typed as
+                // `resource-constraint`; expose that bounded condition on the
+                // same failed dispatch span as every handler-level rejection.
+                self.span.record(
+                    "condition",
+                    waddle_xmpp::StanzaErrorCondition::ResourceConstraint.as_str(),
+                );
                 warn!(
                     stanza_kind = self.kind,
                     id = %reply.id,

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -191,6 +191,33 @@ async fn iq_get_timeout_yields_conformant_resource_constraint() {
     );
 }
 
+#[tokio::test(start_paused = true, flavor = "current_thread")]
+async fn iq_timeout_exports_span_status_error() {
+    let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+    let stanza = iq_get_stanza("disco-1", "alice@example.com/web", "upload.example.com");
+    let backstop = StanzaBackstop::capture(&stanza, None);
+
+    let mut fut = Box::pin(run_with_backstop(backstop, pending::<Vec<String>>()));
+    assert!(
+        futures::poll!(fut.as_mut()).is_pending(),
+        "must not resolve before the wedge budget elapses"
+    );
+    tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
+    let (_, disposition) = responses_and_disposition(fut.await);
+    assert_eq!(disposition, InboundDisposition::Handled);
+
+    assert!(matches!(
+        spans.status_of("xmpp.stanza.dispatch"),
+        Some(opentelemetry::trace::Status::Error { .. })
+    ));
+    assert_eq!(
+        spans.attribute_of("xmpp.stanza.dispatch", "condition"),
+        Some("resource-constraint".to_string()),
+        "the timeout fallback should expose its retryable stanza condition"
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn message_timeout_yields_no_response() {
     let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -676,6 +676,23 @@ struct JoinAdmissionDenial {
     message: &'static str,
 }
 
+fn record_stanza_error_condition(
+    condition: waddle_xmpp::telemetry::attributes::StanzaErrorCondition,
+) {
+    // The dispatch span declares this bounded field; recording it here keeps
+    // rejection taxonomy queryable without promoting protocol denials to
+    // failed operations.
+    tracing::Span::current().record("condition", condition.as_str());
+}
+
+fn mark_internal_join_failure(
+    condition: waddle_xmpp::telemetry::attributes::StanzaErrorCondition,
+    description: &'static str,
+) {
+    record_stanza_error_condition(condition);
+    crate::telemetry::mark_span_error(description);
+}
+
 /// Central choke point for join-admission denials covered by #1315.
 ///
 /// Every managed-channel join rejection routes through here so the
@@ -694,6 +711,16 @@ fn deny_join_admission(
     managed_channel_confirmed: bool,
     denial: JoinAdmissionDenial,
 ) -> Vec<String> {
+    record_stanza_error_condition(denial.condition);
+    if matches!(
+        denial.condition,
+        waddle_xmpp::telemetry::attributes::StanzaErrorCondition::InternalServerError
+    ) {
+        // `internal-server-error` is emitted only for server-side admission
+        // failures; policy conditions such as `registration-required` remain
+        // successful protocol handling with an UNSET span status.
+        crate::telemetry::mark_span_error("MUC join admission failed internally");
+    }
     if managed_channel_confirmed {
         info!(
             room = %room_jid,
@@ -1355,6 +1382,10 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         waddle_xmpp::muc::room_actor::RoomActorError::RestorePending
                     )
                 ) {
+                    mark_internal_join_failure(
+                        waddle_xmpp::telemetry::attributes::StanzaErrorCondition::ResourceConstraint,
+                        "MUC durable restore remained pending",
+                    );
                     return vec![build_muc_presence_error_xml(
                         room_jid,
                         &nick,
@@ -1373,6 +1404,10 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         waddle_xmpp::muc::room_actor::RoomActorError::OwnershipUnavailable
                     )
                 ) {
+                    mark_internal_join_failure(
+                        waddle_xmpp::telemetry::attributes::StanzaErrorCondition::ResourceConstraint,
+                        "MUC ownership reconciliation unavailable",
+                    );
                     return vec![build_muc_presence_error_xml(
                         room_jid,
                         &nick,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::permissions::CheckPermission;
 use std::io;
 use std::sync::{Arc, Mutex};
+use tracing::Instrument as _;
 
 #[derive(Clone, Default)]
 struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
@@ -1086,9 +1087,10 @@ async fn managed_members_only_join_requires_explicit_channel_member_affiliation(
 /// rejected with `<registration-required/>`, and that denial must now
 /// be visible — the `waddle.muc.admission.denied` counter records it,
 /// keyed by the stanza error condition, through the metric-reader seam.
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn managed_registration_required_denial_increments_admission_counter() {
     let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
     let state = create_test_websocket_state().await;
     let session = crate::auth::Session::new("alice@example.com", "alice", "alice");
     let room_jid: BareJid = "locked-space@muc.example.com".parse().expect("room jid");
@@ -1111,6 +1113,10 @@ async fn managed_registration_required_denial_increments_admission_counter() {
     .await
     .expect("channel upsert");
 
+    // Match the production dispatch span declaration so the denial helper
+    // records the allowlisted condition without classifying policy as failure.
+    let dispatch_span =
+        tracing::info_span!("xmpp.stanza.dispatch", condition = tracing::field::Empty);
     let denied = handle_muc_join(
         state.as_ref(),
         "example.com",
@@ -1120,6 +1126,7 @@ async fn managed_registration_required_denial_increments_admission_counter() {
         None,
         &Some(session),
     )
+    .instrument(dispatch_span)
     .await;
     assert_eq!(denied.len(), 1);
     assert!(
@@ -1133,6 +1140,16 @@ async fn managed_registration_required_denial_increments_admission_counter() {
         ),
         Some(1),
         "the registration-required admission denial must increment the counter exactly once"
+    );
+    assert_eq!(
+        spans.attribute_of("xmpp.stanza.dispatch", "condition"),
+        Some("registration-required".to_string()),
+        "the exported dispatch span must carry the allowlisted stanza condition"
+    );
+    assert_eq!(
+        spans.status_of("xmpp.stanza.dispatch"),
+        Some(opentelemetry::trace::Status::Unset),
+        "a conformant XEP-0045 admission denial is not an internal server failure"
     );
     assert!(
         get_room_actor(state.as_ref(), &room_jid).await.is_none(),
@@ -1310,6 +1327,64 @@ async fn managed_internal_server_error_denial_emits_admission_telemetry() {
         denial_log.contains("\"resolver_outcome\":\"session-jid-malformed\""),
         "{denial_log}"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn managed_internal_admission_failure_exports_error_dispatch_span() {
+    let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+    let state = create_test_websocket_state().await;
+    let malformed_session = crate::auth::Session::new("not a jid", "alice", "alice");
+    let room_jid: BareJid = "resolver-span-failure@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: "resolver-span-failure".to_string(),
+            name: "Resolver Span Failure".to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only: true,
+            public_room: false,
+        },
+    )
+    .await
+    .expect("channel upsert");
+
+    // This malformed authenticated identity is an internal resolver failure,
+    // not a policy denial, so the same condition attribute carries ERROR status.
+    let dispatch_span =
+        tracing::info_span!("xmpp.stanza.dispatch", condition = tracing::field::Empty);
+    let denied = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(malformed_session),
+    )
+    .instrument(dispatch_span)
+    .await;
+
+    assert!(
+        denied[0].contains("internal-server-error"),
+        "malformed identity must fail closed: {denied:?}"
+    );
+    assert_eq!(
+        spans.attribute_of("xmpp.stanza.dispatch", "condition"),
+        Some("internal-server-error".to_string())
+    );
+    assert!(matches!(
+        spans.status_of("xmpp.stanza.dispatch"),
+        Some(opentelemetry::trace::Status::Error { .. })
+    ));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -431,13 +431,10 @@ pub fn init_local() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 /// Mark the current tracing span as failed so it matches Tempo
 /// `status=error` queries (#1428).
 ///
-/// The single home for the idiom: every failure site marks its span
-/// through this helper, keeping the "what counts as an error span"
-/// decision in one place. The description is deliberately
-/// `&'static str`: span status is exported trace metadata, so it must
-/// be a short, stable phrase — full error text (which can embed raw
-/// row values or DSN-adjacent detail) belongs only on the adjacent
-/// log line.
+/// The single home for the server-side idiom: every warn-level failure site
+/// marks its span through this helper. The protocol crate records the reserved
+/// `otel.status_code` tracing field instead, avoiding a dependency on the
+/// production OpenTelemetry tracing layer.
 pub(crate) fn mark_span_error(description: &'static str) {
     use tracing_opentelemetry::OpenTelemetrySpanExt;
     tracing::Span::current().set_status(opentelemetry::trace::Status::error(description));

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -17,7 +17,7 @@ use kameo::error::SendError;
 use kameo::message::Context;
 use kameo::Actor;
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::connection_registry::{ConnectionEntry, ForceDetachOutcome, ForceDetachRequest};
 use super::user_actor::delivery::GetConnectionEntry;
@@ -85,6 +85,11 @@ impl UserRegistryActor {
         }
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.acquire_claim",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn acquire_user_claim(
         &self,
         bare_jid: &BareJid,
@@ -101,7 +106,10 @@ impl UserRegistryActor {
                     .await
             }
             Err(error) => {
-                warn!(
+                // This is a claim-store failure, not ordinary contention; the
+                // explicit status survives the typed actor-error translation.
+                crate::telemetry::mark_span_error();
+                error!(
                     jid = %bare_jid,
                     %error,
                     "UserActor claim acquisition failed"
@@ -111,6 +119,11 @@ impl UserRegistryActor {
         }
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.steal_stale_claim",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn steal_from_dead_user_owner(
         &self,
         entity: &Entity,
@@ -119,8 +132,13 @@ impl UserRegistryActor {
     ) -> Result<UserClaimLease, UserRegistryError> {
         let snapshot = match self.claim_store.current_claim(entity).await {
             Ok(Some(snapshot)) => snapshot,
-            Ok(None) | Err(_) => {
-                return Err(UserRegistryError::ClaimHeldByAnotherNode(bare_jid.clone()))
+            Ok(None) => return Err(UserRegistryError::ClaimHeldByAnotherNode(bare_jid.clone())),
+            Err(error) => {
+                // A failed ownership lookup cannot safely be treated as proof
+                // that the foreign claim disappeared.
+                crate::telemetry::mark_span_error();
+                error!(jid = %bare_jid, %error, "UserActor claim owner lookup failed");
+                return Err(UserRegistryError::ClaimHeldByAnotherNode(bare_jid.clone()));
             }
         };
         if snapshot.owner_lease_fresh {
@@ -194,6 +212,11 @@ impl UserRegistryActor {
         Ok(self.spawn_user_actor(bare_jid, claim))
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.release_claim",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn release_user_claim(&self, bare_jid: &BareJid, claim: &UserClaimLease) {
         let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
         if let Err(error) = self
@@ -201,7 +224,10 @@ impl UserRegistryActor {
             .release(&entity, &claim.owner, claim.epoch)
             .await
         {
-            warn!(
+            // Release is best-effort for actor cleanup, but a backend failure
+            // leaves ownership behind and must remain visible in trace queries.
+            crate::telemetry::mark_span_error();
+            error!(
                 jid = %bare_jid,
                 owner = %claim.owner.node_id,
                 epoch = claim.epoch.0,
@@ -211,6 +237,11 @@ impl UserRegistryActor {
         }
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.validate_claim",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn validate_existing_user_entry_claim(
         &self,
         bare_jid: &BareJid,
@@ -242,7 +273,10 @@ impl UserRegistryActor {
                 UserEntryClaimStatus::ProvenStale
             }
             Err(error) => {
-                warn!(
+                // Refusing reuse is the safe response, but the unavailable
+                // fence proof is still an internal dependency failure.
+                crate::telemetry::mark_span_error();
+                error!(
                     jid = %bare_jid,
                     epoch = entry.claim.epoch.0,
                     %error,
@@ -253,6 +287,11 @@ impl UserRegistryActor {
         }
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.reuse_claim",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn existing_user_actor_for_current_claim(
         &mut self,
         bare_jid: &BareJid,
@@ -261,7 +300,10 @@ impl UserRegistryActor {
             return Ok(None);
         };
         if !entry.actor_ref.is_alive() {
-            debug!(jid = %bare_jid, "Detected dead UserActor; failing fast");
+            // A registry entry pointing at a dead actor is an internal state
+            // loss even though the caller receives a typed recoverable error.
+            crate::telemetry::mark_span_error();
+            error!(jid = %bare_jid, "Detected dead UserActor; failing fast");
             return Err(self.mark_actor_state_lost(bare_jid).await);
         }
         match self
@@ -287,6 +329,11 @@ impl UserRegistryActor {
         Ok(None)
     }
 
+    #[tracing::instrument(
+        name = "xmpp.user_registry.force_detach_stale",
+        skip_all,
+        fields(otel.status_code = tracing::field::Empty)
+    )]
     async fn force_detach_stale_actor_resources(
         &self,
         bare_jid: &BareJid,
@@ -300,7 +347,10 @@ impl UserRegistryActor {
         {
             Ok(resources) => resources,
             Err(error) => {
-                warn!(
+                // Refused claim reuse is an internal actor-coordination
+                // failure, so mark the active operation before returning false.
+                crate::telemetry::mark_span_error();
+                error!(
                     jid = %bare_jid,
                     ?error,
                     "failed to enumerate stale UserActor resources; refusing claim reuse"
@@ -319,7 +369,8 @@ impl UserRegistryActor {
                 Ok(Some(entry)) => entry,
                 Ok(None) => continue,
                 Err(error) => {
-                    warn!(
+                    crate::telemetry::mark_span_error();
+                    error!(
                         jid = %jid,
                         ?error,
                         "failed to read stale UserActor resource entry; refusing claim reuse"
@@ -333,7 +384,8 @@ impl UserRegistryActor {
                 ack,
             };
             if let Err(error) = entry.force_detach_sender().try_send(request) {
-                warn!(
+                crate::telemetry::mark_span_error();
+                error!(
                     jid = %jid,
                     ?error,
                     "failed to queue stale UserActor resource force-detach; refusing claim reuse"
@@ -349,7 +401,8 @@ impl UserRegistryActor {
             match outcome {
                 Ok(Ok(ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted)) => {}
                 Ok(Ok(ForceDetachOutcome::IdentityMismatch)) => {
-                    warn!(
+                    crate::telemetry::mark_span_error();
+                    error!(
                         jid = %jid,
                         requester = %bare_jid,
                         "stale UserActor resource force-detach identity mismatch; refusing claim reuse"
@@ -357,14 +410,16 @@ impl UserRegistryActor {
                     return false;
                 }
                 Ok(Err(_closed)) => {
-                    warn!(
+                    crate::telemetry::mark_span_error();
+                    error!(
                         jid = %jid,
                         "stale UserActor resource force-detach ack channel closed; refusing claim reuse"
                     );
                     return false;
                 }
                 Err(_elapsed) => {
-                    warn!(
+                    crate::telemetry::mark_span_error();
+                    error!(
                         jid = %jid,
                         timeout_ms = CHILD_ACTOR_TIMEOUT.as_millis() as u64,
                         "stale UserActor resource force-detach timed out; refusing claim reuse"

--- a/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
@@ -912,8 +912,9 @@ async fn test_register_after_identity_rotation_force_detaches_stale_actor_resour
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn test_register_claim_validation_error_does_not_force_detach_or_remove_live_actor() {
+    let spans = crate::telemetry::test_support::acquire_spans();
     let registry = spawn_registry().await;
     let claim_store = Arc::new(RecordingClaimStore::empty());
     let claim_store_trait: Arc<dyn ClaimStore> = claim_store.clone();
@@ -981,6 +982,10 @@ async fn test_register_claim_validation_error_does_not_force_detach_or_remove_li
     assert_eq!(resources, vec![old_jid]);
     assert!(old_actor.is_alive());
     assert!(claim_store.release_owners().is_empty());
+    assert!(
+        spans.has_error_status("xmpp.user_registry.validate_claim"),
+        "claim validation failure must export at least one ERROR operation span"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/telemetry/mod.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/mod.rs
@@ -76,6 +76,16 @@ pub fn meter() -> opentelemetry::metrics::Meter {
     opentelemetry::global::meter("waddle")
 }
 
+/// Mark the current protocol span as failed without coupling this crate to the
+/// production OpenTelemetry tracing layer.
+///
+/// Callers must declare `otel.status_code` as an empty tracing field on their
+/// operation span. `tracing-opentelemetry` interprets the recorded `ERROR`
+/// value at the server boundary.
+pub(crate) fn mark_span_error() {
+    tracing::Span::current().record("otel.status_code", "ERROR");
+}
+
 /// Force-flush a meter provider without blocking the async runtime or
 /// waiting longer than `timeout` for the SDK's synchronous flush.
 ///

--- a/server/crates/waddle-xmpp/src/telemetry/test_support.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/test_support.rs
@@ -96,6 +96,24 @@ impl SpanTestGuard {
             .find(|span| span.name == span_name)
             .map(|span| span.status)
     }
+
+    /// Whether any exported instance of the named span has error status.
+    pub fn has_error_status(&self, span_name: &str) -> bool {
+        self.exported()
+            .into_iter()
+            .any(|span| span.name == span_name && matches!(span.status, Status::Error { .. }))
+    }
+
+    /// Return a string-valued attribute from the named exported span.
+    pub fn attribute_of(&self, span_name: &str, key: &str) -> Option<String> {
+        self.exported()
+            .into_iter()
+            .find(|span| span.name == span_name)?
+            .attributes
+            .into_iter()
+            .find(|attribute| attribute.key.as_str() == key)
+            .map(|attribute| attribute.value.to_string())
+    }
 }
 
 struct TestPipeline {


### PR DESCRIPTION
## Summary

Fixes #1471 by making server-internal failures queryable through OpenTelemetry span status while keeping conformant XMPP stanza denials aggregatable without misclassifying them as server errors.

## Completed plan

- mapped the telemetry export seam and every failure class named by the issue
- reviewed the relevant XEP-0045 denial semantics before assigning error status
- added export-backed regression tests for error status and bounded stanza conditions
- marked claim/fence failures, refused claim reuse, force-detach failures and timeouts, fenced durable writes, and drain abandonment as failed operations
- recorded typed `condition` attributes for MUC denials and synthesized timeout rejections
- documented each changed failure branch inline
- completed independent acceptance, code, and XMPP-conformance reviews

## Behavior

- Internal recovery and backend failures now export `Status::Error`.
- `xmpp.stanza.dispatch` exports the allowlisted stanza `condition`.
- Expected XEP-0045 denials such as `registration-required` and `forbidden` remain `Status::Unset`.
- IQ wedge timeouts export both `Status::Error` and `condition=resource-constraint`.
- No XMPP wire shape changed, and no serialized XML is reparsed to infer telemetry.

## Verification

- `cargo nextest run --workspace --all-features` — 7,960 passed, 1 skipped
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- focused telemetry-export tests for claim validation, drain abandonment, MUC internal failure, conformant MUC denial, and IQ timeout — passed
- adversarial acceptance review — passed
- XEP-0045 semantics review — approved

## Remaining risk

- The live OTLP collector and Tempo query were not exercised locally; the in-memory OpenTelemetry exporter verifies the emitted status and attributes.
