### PR TITLE
perf(server): answer link-preview lookups off the frame dispatch path

### DIFF
--- a/cuenv.lock
+++ b/cuenv.lock
@@ -6,6 +6,12 @@ flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "apps/android/../../flake.lock"
 
+[runtimes.chat]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "chat/../flake.lock"
+
 [runtimes.colony]
 type = "nix"
 flake = ".."

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -6,12 +6,6 @@ flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "apps/android/../../flake.lock"
 
-[runtimes.chat]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "chat/../flake.lock"
-
 [runtimes.colony]
 type = "nix"
 flake = ".."

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -747,6 +747,8 @@ async fn create_websocket_state(
                 dnd_reader,
                 notification_activity,
                 sm_session_registry,
+                link_preview_resolves:
+                    crate::server::routes::websocket::default_link_preview_resolve_permits(),
                 resumable_sessions,
                 caps_resolver,
                 avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -2,11 +2,27 @@
 //!
 //! The lookup resolves OpenGraph metadata through the bounded HTTPS resolver,
 //! then mints a scoped private token for the send-time XEP-0511 payload.
+//!
+//! Resolution runs OFF the per-connection frame dispatch path (#1470). The
+//! dispatch-side handler validates and authorizes the request synchronously,
+//! then spawns the resolver work and returns no frames, so the strictly
+//! serial frame loop (RFC 6120 §10.1) moves on to the next stanza
+//! immediately. The IQ result — still exactly one reply per request,
+//! matched by id (RFC 6120 §8.2.3) — is delivered later through the
+//! connection registry as a server-generated `DirectFrame`, which records it
+//! in the XEP-0198 unacked queue like every other server-generated reply.
+//! Before this, a cold-cache resolver round-trip stalled every stanza queued
+//! behind the lookup (production evidence on #1470: 1.3 s dispatch stalls vs
+//! a 13.6 ms dispatch p95).
 
 use super::*;
 use chrono::{Duration, SecondsFormat, Utc};
 use minidom::rxml::xml_ncname;
+use tokio::sync::Semaphore;
+use tracing::Instrument;
 use url::Url;
+use waddle_xmpp::registry::{ConnectionRegistry, SendResult};
+use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::xep::{
     encode_link_preview_token_checked, LinkPreviewTokenData, LinkPreviewTokenImage,
     LinkPreviewTokenNativeVideo, LinkPreviewTokenPlayer, LinkPreviewTokenVideo,
@@ -30,8 +46,21 @@ struct LinkPreviewLookupDeps<'a> {
     response_from: Option<&'a str>,
     response_to: Option<&'a str>,
     secret: &'a [u8],
-    resolver_policy: Option<&'a LinkPreviewResolverPolicy>,
+    resolver_policy: Option<LinkPreviewResolverPolicy>,
 }
+
+/// Cap on concurrently running deferred resolver fetches per node. Serial
+/// frame dispatch used to throttle lookups to one in flight per connection as
+/// a side effect of blocking; once resolution moved off the dispatch path
+/// (#1470) the bound must be explicit so a burst of lookups cannot fan out
+/// into an unbounded outbound-fetch storm. Excess lookups queue on the
+/// semaphore in arrival order; each resolve is bounded by the resolver's own
+/// per-phase timeouts, so queued lookups still answer within the client's IQ
+/// budget except under sustained abuse — where queueing, not unbounded
+/// fan-out, is the correct failure mode (previews fail open, #822).
+const MAX_CONCURRENT_DEFERRED_RESOLVES: usize = 8;
+
+static DEFERRED_RESOLVE_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_DEFERRED_RESOLVES);
 
 pub(super) fn is_link_preview_lookup_iq(iq: &Iq) -> bool {
     let Iq::Get { payload, .. } = iq else {
@@ -78,21 +107,17 @@ async fn handle_link_preview_lookup_iq_with_policy(
             not_authorized_iq_error("Authentication required."),
         )];
     };
-    let owned_resolver_policy;
     let resolver_policy = match deps.resolver_policy {
         Some(policy) => policy,
-        None => {
-            owned_resolver_policy = LinkPreviewResolverPolicy::from_config(
-                &state.deps.link_preview,
-                Some(LinkPreviewMediaCache::new(
-                    state.deps.app_state.blob_storage.clone(),
-                    state.deps.auth_state.base_url.as_str(),
-                    state.deps.app_state.db_pool.global_actor().clone(),
-                    sender_jid.to_bare(),
-                )),
-            );
-            &owned_resolver_policy
-        }
+        None => LinkPreviewResolverPolicy::from_config(
+            &state.deps.link_preview,
+            Some(LinkPreviewMediaCache::new(
+                state.deps.app_state.blob_storage.clone(),
+                state.deps.auth_state.base_url.as_str(),
+                state.deps.app_state.db_pool.global_actor().clone(),
+                sender_jid.to_bare(),
+            )),
+        ),
     };
     let Iq::Get { payload, .. } = iq else {
         return vec![build_iq_error_xml_typed(
@@ -149,20 +174,115 @@ async fn handle_link_preview_lookup_iq_with_policy(
             None,
         )];
     }
-    let outcome = resolve_link_preview(&original_url, resolver_policy).await;
+    // Accepted for resolution. Everything from here involves outbound
+    // network fetches, so it runs off the dispatch path (#1470): spawn the
+    // resolve and answer the IQ later through the connection registry.
+    spawn_deferred_lookup_resolution(DeferredLookupResolution {
+        connection_registry: state.deps.protocol.connection_registry.clone(),
+        sm_session_registry: state.deps.protocol.sm_session_registry.clone(),
+        requester: sender_jid.clone(),
+        scope_jid,
+        original_url,
+        resolver_policy,
+        secret: deps.secret.to_vec(),
+        reply: DeferredLookupReply {
+            id: iq.id().to_string(),
+            from: deps
+                .response_from
+                .and_then(|value| value.parse::<Jid>().ok()),
+            to: deps.response_to.and_then(|value| value.parse::<Jid>().ok()),
+        },
+    });
+    Vec::new()
+}
+
+/// Everything one deferred lookup resolution owns once dispatch has moved
+/// on: registry handles for the eventual reply, the authorized request
+/// parameters, and the reply envelope.
+struct DeferredLookupResolution {
+    connection_registry: Arc<ConnectionRegistry>,
+    sm_session_registry: Arc<InMemorySmSessionRegistry>,
+    requester: FullJid,
+    scope_jid: BareJid,
+    original_url: Url,
+    resolver_policy: LinkPreviewResolverPolicy,
+    secret: Vec<u8>,
+    reply: DeferredLookupReply,
+}
+
+/// Reply envelope captured from the request before dispatch returns: the
+/// request id the result must echo plus RFC 6120 §8.2.3 addressing
+/// (response `from` = request `to`, response `to` = request `from`).
+struct DeferredLookupReply {
+    id: String,
+    from: Option<Jid>,
+    to: Option<Jid>,
+}
+
+fn spawn_deferred_lookup_resolution(resolution: DeferredLookupResolution) {
+    // Created while the dispatch span is current, so the resolve — and the
+    // resolver's child `link_preview.fetch` spans — stay on the originating
+    // stanza's trace after dispatch returns (#1438: bounded, parented spans).
+    let span = tracing::info_span!("link_preview.resolve", host = tracing::field::Empty);
+    if let Some(host) = resolution.original_url.host_str() {
+        span.record("host", host);
+    }
+    tokio::spawn(
+        async move {
+            let DeferredLookupResolution {
+                connection_registry,
+                sm_session_registry,
+                requester,
+                scope_jid,
+                original_url,
+                resolver_policy,
+                secret,
+                reply,
+            } = resolution;
+            let Ok(_permit) = DEFERRED_RESOLVE_PERMITS.acquire().await else {
+                // The static semaphore is never closed.
+                return;
+            };
+            let reply_iq = resolve_deferred_lookup(
+                &requester,
+                scope_jid,
+                &original_url,
+                &resolver_policy,
+                &secret,
+                reply,
+            )
+            .await;
+            deliver_deferred_lookup_reply(
+                &connection_registry,
+                &sm_session_registry,
+                &requester,
+                reply_iq,
+            )
+            .await;
+        }
+        .instrument(span),
+    );
+}
+
+/// Run the bounded resolver and build the typed IQ result for the requester
+/// — the deferred continuation of the dispatch-side handler above.
+async fn resolve_deferred_lookup(
+    requester: &FullJid,
+    scope_jid: BareJid,
+    original_url: &Url,
+    resolver_policy: &LinkPreviewResolverPolicy,
+    secret: &[u8],
+    reply: DeferredLookupReply,
+) -> Iq {
+    let outcome = resolve_link_preview(original_url, resolver_policy).await;
     let LinkPreviewResolverOutcome::Ready(metadata) = outcome else {
         record_link_preview_event(telemetry_event_for_status(outcome.status()));
-        return vec![build_link_preview_lookup_result(
-            iq,
-            deps.response_from,
-            deps.response_to,
-            outcome.status(),
-            None,
-        )];
+        return build_link_preview_lookup_result_iq(reply, outcome.status(), None);
     };
+    let metadata = *metadata;
     let expires_at = Utc::now() + Duration::minutes(5);
     let data = LinkPreviewTokenData {
-        sender_jid: sender_jid.to_bare(),
+        sender_jid: requester.to_bare(),
         scope_jid,
         original_url: metadata.original_url,
         normalized_url: metadata.normalized_url,
@@ -193,29 +313,64 @@ async fn handle_link_preview_lookup_iq_with_policy(
         }),
         expires_at_unix: expires_at.timestamp(),
     };
-    let Some(token) = encode_link_preview_token_checked(&data, deps.secret) else {
+    let Some(token) = encode_link_preview_token_checked(&data, secret) else {
         record_link_preview_event(LinkPreviewTelemetryEvent::ResolverFailed);
-        return vec![build_link_preview_lookup_result(
-            iq,
-            deps.response_from,
-            deps.response_to,
-            LinkPreviewResolverStatus::Failed,
-            None,
-        )];
+        return build_link_preview_lookup_result_iq(reply, LinkPreviewResolverStatus::Failed, None);
     };
 
     record_link_preview_event(LinkPreviewTelemetryEvent::ResolverReady);
-    vec![build_link_preview_lookup_result(
-        iq,
-        deps.response_from,
-        deps.response_to,
+    build_link_preview_lookup_result_iq(
+        reply,
         LinkPreviewResolverStatus::Ready,
         Some((
             data,
             token.as_str(),
             expires_at.to_rfc3339_opts(SecondsFormat::Millis, true),
         )),
-    )]
+    )
+}
+
+/// Deliver the deferred IQ result to the requester's live connection as a
+/// server-generated `DirectFrame` (the destination's main loop records it in
+/// the XEP-0198 unacked queue before the wire write, like every other
+/// server-generated reply).
+async fn deliver_deferred_lookup_reply(
+    connection_registry: &ConnectionRegistry,
+    sm_session_registry: &InMemorySmSessionRegistry,
+    requester: &FullJid,
+    reply_iq: Iq,
+) {
+    let stanza = Stanza::Iq(Box::new(reply_iq));
+    match connection_registry.send_to(requester, stanza.clone()).await {
+        SendResult::Sent => {}
+        SendResult::NotConnected | SendResult::ChannelClosed => {
+            // The synchronous reply path recorded responses in the SM
+            // unacked queue, so a reply racing a brief disconnect replayed
+            // on resume. Preserve that guarantee: record against a detached
+            // SM session when one exists; otherwise the requester is truly
+            // gone and the client's own IQ timeout owns the failure
+            // (previews fail open, #822).
+            match sm_session_registry
+                .record_stanza_for_detached_bound_resource(requester, &stanza, Utc::now())
+                .await
+            {
+                Ok(true) => debug!(
+                    requester = %requester,
+                    "deferred link-preview reply recorded for detached SM session"
+                ),
+                Ok(false) => debug!(
+                    requester = %requester,
+                    "deferred link-preview reply dropped; requester disconnected without \
+                     resumable session"
+                ),
+                Err(error) => warn!(
+                    requester = %requester,
+                    %error,
+                    "failed to record deferred link-preview reply for detached SM session"
+                ),
+            }
+        }
+    }
 }
 
 fn telemetry_event_for_status(status: LinkPreviewResolverStatus) -> LinkPreviewTelemetryEvent {
@@ -279,6 +434,9 @@ fn lookup_scope(payload: &Element) -> Option<String> {
         .filter(|text| !text.is_empty())
 }
 
+/// Serialize a lookup result for the synchronous short-circuit paths
+/// (malformed URL, resolver disabled) that still answer inline on the
+/// dispatch path.
 fn build_link_preview_lookup_result(
     iq: &Iq,
     response_from: Option<&str>,
@@ -286,6 +444,25 @@ fn build_link_preview_lookup_result(
     status: LinkPreviewResolverStatus,
     preview: Option<(LinkPreviewTokenData, &str, String)>,
 ) -> String {
+    iq_to_xml(build_link_preview_lookup_result_iq(
+        DeferredLookupReply {
+            id: iq.id().to_string(),
+            from: response_from.and_then(|value| value.parse::<Jid>().ok()),
+            to: response_to.and_then(|value| value.parse::<Jid>().ok()),
+        },
+        status,
+        preview,
+    ))
+}
+
+/// Build the typed lookup result IQ — the single wire-shape authority for
+/// both the synchronous short-circuit replies and the deferred registry
+/// delivery.
+fn build_link_preview_lookup_result_iq(
+    reply: DeferredLookupReply,
+    status: LinkPreviewResolverStatus,
+    preview: Option<(LinkPreviewTokenData, &str, String)>,
+) -> Iq {
     let mut lookup = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW).attr(
         xml_ncname!("status").to_owned(),
         if preview.is_some() {
@@ -369,7 +546,12 @@ fn build_link_preview_lookup_result(
         }
         lookup = lookup.append(preview);
     }
-    build_iq_result_xml(iq.id(), response_from, response_to, Some(lookup.build()))
+    Iq::Result {
+        from: reply.from,
+        to: reply.to,
+        id: reply.id,
+        payload: Some(lookup.build()),
+    }
 }
 
 fn append_text(parent: &mut Element, name: &str, value: Option<&str>) {
@@ -406,6 +588,50 @@ mod tests {
 
     fn secret() -> &'static [u8] {
         b"test-link-preview-secret"
+    }
+
+    /// Register a live connection for [`sender`] so the deferred lookup
+    /// reply has somewhere to land, and return the outbound receiver.
+    fn register_requester(
+        state: &WebSocketState,
+    ) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .register(sender(), tx);
+        rx
+    }
+
+    /// Await the deferred lookup reply on the requester's outbound channel
+    /// and return `(iq id, lookup payload element)`.
+    async fn recv_deferred_lookup_reply(
+        rx: &mut tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza>,
+    ) -> (String, Element) {
+        let outbound = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv())
+            .await
+            .expect("deferred lookup reply within timeout")
+            .expect("outbound channel open");
+        assert!(
+            matches!(
+                outbound.kind,
+                waddle_xmpp::registry::DeliveryKind::DirectFrame
+            ),
+            "deferred IQ reply is a server-generated direct frame"
+        );
+        let Stanza::Iq(iq) = outbound.stanza else {
+            panic!("expected deferred IQ reply, got {:?}", outbound.stanza);
+        };
+        let Iq::Result { id, payload, .. } = *iq else {
+            panic!("expected IQ result");
+        };
+        let payload = payload.expect("lookup payload");
+        assert!(
+            payload.is("lookup", NS_WADDLE_LINK_PREVIEW),
+            "reply payload is the lookup element"
+        );
+        (id, payload)
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -470,6 +696,7 @@ mod tests {
             )
             .build();
         let iq = iq_get_with_payload(payload);
+        let mut rx = register_requester(state.as_ref());
 
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
@@ -480,15 +707,17 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: Some(&resolver_policy),
+                resolver_policy: Some(resolver_policy),
             },
         )
         .await;
 
-        let elem: Element = response[0].parse().expect("iq result");
-        let lookup = elem
-            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
-            .expect("lookup result");
+        assert!(
+            response.is_empty(),
+            "accepted lookup answers off the dispatch path: {response:?}"
+        );
+        let (id, lookup) = recv_deferred_lookup_reply(&mut rx).await;
+        assert_eq!(id, "lookup-1");
         assert_eq!(lookup.attr("status"), Some("ready"));
         let preview = lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
@@ -568,6 +797,7 @@ mod tests {
             )
             .build();
         let iq = iq_get_with_payload(payload);
+        let mut rx = register_requester(state.as_ref());
 
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
@@ -578,15 +808,16 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: Some(&resolver_policy),
+                resolver_policy: Some(resolver_policy),
             },
         )
         .await;
 
-        let elem: Element = response[0].parse().expect("iq result");
-        let lookup = elem
-            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
-            .expect("lookup result");
+        assert!(
+            response.is_empty(),
+            "accepted lookup answers off the dispatch path: {response:?}"
+        );
+        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
         assert_eq!(lookup.attr("status"), Some("ready"));
         let preview = lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
@@ -653,6 +884,7 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
+        let mut rx = register_requester(state.as_ref());
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
@@ -662,15 +894,16 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: Some(&resolver_policy),
+                resolver_policy: Some(resolver_policy),
             },
         )
         .await;
 
-        let elem: Element = response[0].parse().expect("iq result");
-        let lookup = elem
-            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
-            .expect("lookup result");
+        assert!(
+            response.is_empty(),
+            "accepted lookup answers off the dispatch path: {response:?}"
+        );
+        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
         assert_eq!(lookup.attr("status"), Some("failed"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
@@ -700,6 +933,7 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
+        let mut rx = register_requester(state.as_ref());
         let response = handle_link_preview_lookup_iq(
             &iq,
             Some(&sender()),
@@ -711,10 +945,11 @@ mod tests {
         )
         .await;
 
-        let elem: Element = response[0].parse().expect("iq result");
-        let lookup = elem
-            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
-            .expect("lookup result");
+        assert!(
+            response.is_empty(),
+            "accepted lookup answers off the dispatch path: {response:?}"
+        );
+        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
         assert_eq!(lookup.attr("status"), Some("unsupported"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
@@ -753,7 +988,7 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: Some(&LinkPreviewResolverPolicy {
+                resolver_policy: Some(LinkPreviewResolverPolicy {
                     enabled: false,
                     ..Default::default()
                 }),
@@ -761,6 +996,8 @@ mod tests {
         )
         .await;
 
+        // A disabled resolver is a synchronous short-circuit — no fetch is
+        // ever involved, so the reply stays on the dispatch path.
         let elem: Element = response[0].parse().expect("iq result");
         let lookup = elem
             .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
@@ -775,7 +1012,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn blocked_host_policy_returns_blocked_lookup_without_token() {
         let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
             .append(
@@ -792,6 +1029,7 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
+        let mut rx = register_requester(state.as_ref());
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
@@ -801,7 +1039,7 @@ mod tests {
                 response_from: None,
                 response_to: None,
                 secret: secret(),
-                resolver_policy: Some(&LinkPreviewResolverPolicy {
+                resolver_policy: Some(LinkPreviewResolverPolicy {
                     blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
                     ..Default::default()
                 }),
@@ -809,14 +1047,150 @@ mod tests {
         )
         .await;
 
-        let elem: Element = response[0].parse().expect("iq result");
-        let lookup = elem
-            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
-            .expect("lookup result");
+        assert!(
+            response.is_empty(),
+            "accepted lookup answers off the dispatch path: {response:?}"
+        );
+        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
         assert_eq!(lookup.attr("status"), Some("blocked"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
             .is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dispatch_returns_before_slow_resolution_and_reply_still_arrives() {
+        // #1470 acceptance: a cold-cache resolve must not block dispatch —
+        // the handler returns immediately while the resolver round-trip is
+        // still in flight, and the requester still gets the result, matched
+        // by the original IQ id, once resolution completes.
+        let server = MockServer::start().await;
+        let page_delay = std::time::Duration::from_secs(3);
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_delay(page_delay)
+                    .set_body_raw(
+                        r#"<html><head>
+                        <meta property="og:title" content="Slow Article">
+                      </head></html>"#,
+                        "text/html",
+                    ),
+            )
+            .mount(&server)
+            .await;
+        let state = create_test_websocket_state().await;
+        let mut rx = register_requester(state.as_ref());
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            timeout: std::time::Duration::from_secs(10),
+            ..Default::default()
+        };
+        let lookup_url = format!("{}/slow", server.uri());
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append(lookup_url.as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let dispatch_started = std::time::Instant::now();
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(resolver_policy),
+            },
+        )
+        .await;
+        let dispatch_elapsed = dispatch_started.elapsed();
+
+        assert!(response.is_empty(), "no synchronous frames: {response:?}");
+        assert!(
+            dispatch_elapsed < page_delay,
+            "dispatch must not wait for the resolver round-trip \
+             (took {dispatch_elapsed:?} against a {page_delay:?} page delay)"
+        );
+        let (id, lookup) = recv_deferred_lookup_reply(&mut rx).await;
+        assert_eq!(id, "lookup-1", "deferred reply echoes the request id");
+        assert_eq!(lookup.attr("status"), Some("ready"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deferred_reply_for_disconnected_requester_resolves_without_delivery() {
+        // No registered connection and no detached SM session: the resolve
+        // must still complete cleanly (previews fail open, #822) and the
+        // reply is dropped without panicking the spawned task.
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/a"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head><meta property="og:title" content="T"></head></html>"#,
+                "text/html",
+            ))
+            .mount(&server)
+            .await;
+        let state = create_test_websocket_state().await;
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append(format!("{}/a", server.uri()).as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(resolver_policy),
+            },
+        )
+        .await;
+        assert!(response.is_empty());
+
+        // The resolve completed (ready telemetry) even though delivery had
+        // nowhere to go.
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            loop {
+                if recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverReady) {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("resolve completes despite disconnected requester");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -34,8 +34,8 @@ use xmpp_parsers::iq::Iq;
 use xmpp_parsers::minidom::Element;
 
 use super::link_preview_resolver::{
-    resolve_link_preview, LinkPreviewMediaCache, LinkPreviewResolverOutcome,
-    LinkPreviewResolverPolicy, LinkPreviewResolverStatus,
+    classify_url_with_policy, resolve_link_preview, LinkPreviewMediaCache,
+    LinkPreviewResolverOutcome, LinkPreviewResolverPolicy, LinkPreviewResolverStatus,
 };
 use crate::server::routes::websocket::link_preview_telemetry::{
     record_link_preview_event, LinkPreviewTelemetryEvent,
@@ -158,6 +158,21 @@ async fn handle_link_preview_lookup_iq_with_policy(
             deps.response_from,
             deps.response_to,
             LinkPreviewResolverStatus::Blocked,
+            None,
+        )];
+    }
+    // Deterministic pre-I/O policy verdicts (scheme support, IP literals,
+    // host allow/block lists) stay on the dispatch path: they need no
+    // network and no resolve permit, and under saturation they must keep
+    // answering `blocked`/`unsupported` rather than degrading to `failed`.
+    let pre_verdict = classify_url_with_policy(&original_url, &resolver_policy);
+    if !matches!(pre_verdict, LinkPreviewResolverStatus::Ready) {
+        record_link_preview_event(telemetry_event_for_status(pre_verdict));
+        return vec![build_link_preview_lookup_result(
+            iq,
+            deps.response_from,
+            deps.response_to,
+            pre_verdict,
             None,
         )];
     }
@@ -384,11 +399,28 @@ async fn deliver_deferred_lookup_reply(
                     requester = %requester,
                     "deferred link-preview reply recorded for detached SM session"
                 ),
-                Ok(false) => debug!(
-                    requester = %requester,
-                    "deferred link-preview reply dropped; requester disconnected without \
-                     resumable session"
-                ),
+                Ok(false) => {
+                    // No detached session either — but a resume may have
+                    // COMPLETED between the failed live send and the record
+                    // attempt (resume consumes the detached session), so
+                    // retry the live path once before dropping the reply.
+                    if connection_registry
+                        .send_to(requester, stanza.clone())
+                        .await
+                        .is_sent()
+                    {
+                        debug!(
+                            requester = %requester,
+                            "deferred link-preview reply delivered on post-resume retry"
+                        );
+                    } else {
+                        debug!(
+                            requester = %requester,
+                            "deferred link-preview reply dropped; requester disconnected \
+                             without resumable session"
+                        );
+                    }
+                }
                 Err(error) => warn!(
                     requester = %requester,
                     %error,
@@ -959,7 +991,6 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
-        let mut rx = register_requester(state.as_ref());
         let response = handle_link_preview_lookup_iq(
             &iq,
             Some(&sender()),
@@ -971,11 +1002,12 @@ mod tests {
         )
         .await;
 
-        assert!(
-            response.is_empty(),
-            "accepted lookup answers off the dispatch path: {response:?}"
-        );
-        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
+        // Non-HTTPS is a deterministic pre-I/O verdict — answered inline on
+        // the dispatch path, no resolve permit consumed.
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
         assert_eq!(lookup.attr("status"), Some("unsupported"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)
@@ -1055,7 +1087,6 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
-        let mut rx = register_requester(state.as_ref());
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
@@ -1073,11 +1104,12 @@ mod tests {
         )
         .await;
 
-        assert!(
-            response.is_empty(),
-            "accepted lookup answers off the dispatch path: {response:?}"
-        );
-        let (_, lookup) = recv_deferred_lookup_reply(&mut rx).await;
+        // An operator-blocked host is a deterministic pre-I/O verdict —
+        // answered inline on the dispatch path, no resolve permit consumed.
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
         assert_eq!(lookup.attr("status"), Some("blocked"));
         assert!(lookup
             .get_child("preview", NS_WADDLE_LINK_PREVIEW)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -400,10 +400,14 @@ async fn deliver_deferred_lookup_reply(
                     "deferred link-preview reply recorded for detached SM session"
                 ),
                 Ok(false) => {
-                    // No detached session either — but a resume may have
-                    // COMPLETED between the failed live send and the record
-                    // attempt (resume consumes the detached session), so
-                    // retry the live path once before dropping the reply.
+                    // No detached OR claimed session found — a resume may
+                    // have completed between the failed live send and the
+                    // record attempt (resume consumes the session), so retry
+                    // the live path once before dropping the reply.
+                    // At-least-once is the contract: in the displacement
+                    // corner where the record persisted durably before
+                    // reporting false, a replayed duplicate result is
+                    // ignored by id (RFC 6120 §8.2.3).
                     if connection_registry
                         .send_to(requester, stanza.clone())
                         .await
@@ -1292,6 +1296,67 @@ mod tests {
         assert!(
             recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverSaturated),
             "saturated admission must emit saturated telemetry"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocked_host_verdict_survives_saturation_without_consuming_permit() {
+        // Deterministic pre-I/O verdicts run before admission: with every
+        // resolver permit drained, an operator-blocked host still answers
+        // `blocked` (not `failed`) inline.
+        let state = create_test_websocket_state().await;
+        let available = state
+            .deps
+            .protocol
+            .link_preview_resolves
+            .available_permits();
+        let _hog = state
+            .deps
+            .protocol
+            .link_preview_resolves
+            .clone()
+            .try_acquire_many_owned(u32::try_from(available).expect("permit count fits u32"))
+            .expect("drain all resolver permits");
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("https://blocked.example/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(LinkPreviewResolverPolicy {
+                    blocked_hosts: vec!["blocked.example".parse().expect("pattern")],
+                    ..Default::default()
+                }),
+            },
+        )
+        .await;
+
+        assert_eq!(response.len(), 1, "exactly one inline reply");
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(
+            lookup.attr("status"),
+            Some("blocked"),
+            "policy verdict must not degrade to `failed` under saturation"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -407,56 +407,67 @@ async fn deliver_deferred_lookup_reply(
     reply_iq: Iq,
 ) {
     let stanza = Stanza::Iq(Box::new(reply_iq));
-    match deliver_direct_to_full(
-        Some(user_registry),
-        Some(sm_session_registry),
-        requester,
-        &stanza,
-    )
-    .await
-    {
-        FullJidDeliveryOutcome::Delivered => {}
-        FullJidDeliveryOutcome::QueuedDetached => debug!(
-            requester = %requester,
-            "deferred link-preview reply recorded for detached SM session"
-        ),
-        FullJidDeliveryOutcome::Unavailable => {
-            // Neither a live actor resource nor a detached/claimed session —
-            // a resume may have completed between the delivery attempt and
-            // the detached-record fallback (resume consumes the session), so
-            // retry once before dropping the reply. At-least-once is the
-            // contract: a duplicate result replayed from the displacement
-            // corner is ignored by id (RFC 6120 §8.2.3). If the retry still
-            // finds nobody, the requester is truly gone and the client's own
-            // IQ timeout owns the failure (previews fail open, #822).
-            match deliver_direct_to_full(
-                Some(user_registry),
-                Some(sm_session_registry),
-                requester,
-                &stanza,
-            )
-            .await
-            {
-                FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => {
-                    debug!(
-                        requester = %requester,
-                        "deferred link-preview reply delivered on post-resume retry"
-                    );
-                }
-                _ => debug!(
+    // Bounded retry tail over the whole delivery attempt. It covers two
+    // distinct transient failures with one loop:
+    //
+    // - `Unavailable`: a resume completed between the live attempt and the
+    //   detached-record fallback (resume consumes the session) — the next
+    //   attempt finds the freshly resumed connection.
+    // - `Dropped`: a CONNECTED requester's outbound channel stayed full
+    //   through `deliver_direct_to_full`'s short in-line retry schedule
+    //   (e.g. an XEP-0198 send-window pause). The old synchronous path
+    //   could not lose the reply here — it wrote on the connection's own
+    //   loop — so give the channel a few bounded, spaced chances to drain
+    //   before conceding.
+    //
+    // Retrying `Dropped` is safe for THIS stanza class even though it can
+    // include maybe-enqueued ask failures: a duplicate IQ *result* is
+    // ignored by id (RFC 6120 §8.2.3), unlike the groupchat reflections
+    // whose #1263 semantics forbid exactly this kind of replay. Total added
+    // wait is ~5.25 s — far below the client's ~30 s IQ budget — the task
+    // count stays bounded by the admission semaphore's throughput, and the
+    // resolver permit was released before delivery, so no fetch slot is
+    // pinned while waiting.
+    const DELIVERY_RETRY_DELAYS: [std::time::Duration; 3] = [
+        std::time::Duration::from_millis(250),
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(4),
+    ];
+    let mut delays = DELIVERY_RETRY_DELAYS.iter();
+    loop {
+        match deliver_direct_to_full(
+            Some(user_registry),
+            Some(sm_session_registry),
+            requester,
+            &stanza,
+        )
+        .await
+        {
+            FullJidDeliveryOutcome::Delivered => return,
+            FullJidDeliveryOutcome::QueuedDetached => {
+                debug!(
                     requester = %requester,
-                    "deferred link-preview reply dropped; requester disconnected without \
-                     resumable session"
-                ),
+                    "deferred link-preview reply recorded for detached SM session"
+                );
+                return;
+            }
+            #[cfg(feature = "clustering")]
+            FullJidDeliveryOutcome::MaybeCommitted => return,
+            outcome @ (FullJidDeliveryOutcome::Unavailable | FullJidDeliveryOutcome::Dropped) => {
+                let Some(delay) = delays.next() else {
+                    // The requester is either truly gone or unrecoverably
+                    // backpressured; their own IQ timeout owns the failure
+                    // (previews fail open, #822).
+                    warn!(
+                        requester = %requester,
+                        ?outcome,
+                        "deferred link-preview reply dropped after bounded delivery retries"
+                    );
+                    return;
+                };
+                tokio::time::sleep(*delay).await;
             }
         }
-        FullJidDeliveryOutcome::Dropped => warn!(
-            requester = %requester,
-            "deferred link-preview reply dropped by delivery path (full channel or \
-             detached-record failure)"
-        ),
-        #[cfg(feature = "clustering")]
-        FullJidDeliveryOutcome::MaybeCommitted => {}
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -406,6 +406,11 @@ async fn deliver_deferred_lookup_reply(
     requester: &FullJid,
     reply_iq: Iq,
 ) {
+    // Extracted before the stanza is boxed so every outcome log below can
+    // correlate a delivery failure with its specific lookup when several
+    // are in flight for the same resource (the reply contract is keyed on
+    // this id).
+    let reply_id = reply_iq.id().to_string();
     let stanza = Stanza::Iq(Box::new(reply_iq));
     // Bounded retry tail over the whole delivery attempt. It covers two
     // distinct transient failures with one loop:
@@ -421,13 +426,17 @@ async fn deliver_deferred_lookup_reply(
     //   before conceding.
     //
     // Retrying `Dropped` is safe for THIS stanza class even though it can
-    // include maybe-enqueued ask failures: a duplicate IQ *result* is
-    // ignored by id (RFC 6120 §8.2.3), unlike the groupchat reflections
-    // whose #1263 semantics forbid exactly this kind of replay. Total added
-    // wait is ~5.25 s — far below the client's ~30 s IQ budget — the task
-    // count stays bounded by the admission semaphore's throughput, and the
-    // resolver permit was released before delivery, so no fetch slot is
-    // pinned while waiting.
+    // include maybe-enqueued ask failures, where the retry can genuinely
+    // double-deliver: a duplicate IQ *result* is ignored by id on the wire
+    // (RFC 6120 §8.2.3), and the duplicate's XEP-0198 unacked-queue entry
+    // costs one extra bounded slot on a path that requires a double fault
+    // (ask reply lost AND retry landing) — negligible against the queue's
+    // capacity. Contrast the groupchat reflections whose #1263 semantics
+    // forbid exactly this kind of replay: those are user-visible messages,
+    // not id-matched replies. Total added wait is ~5.25 s — far below the
+    // client's ~30 s IQ budget — the task count stays bounded by the
+    // admission semaphore's throughput, and the resolver permit was
+    // released before delivery, so no fetch slot is pinned while waiting.
     const DELIVERY_RETRY_DELAYS: [std::time::Duration; 3] = [
         std::time::Duration::from_millis(250),
         std::time::Duration::from_secs(1),
@@ -447,6 +456,7 @@ async fn deliver_deferred_lookup_reply(
             FullJidDeliveryOutcome::QueuedDetached => {
                 debug!(
                     requester = %requester,
+                    id = %reply_id,
                     "deferred link-preview reply recorded for detached SM session"
                 );
                 return;
@@ -460,11 +470,19 @@ async fn deliver_deferred_lookup_reply(
                     // (previews fail open, #822).
                     warn!(
                         requester = %requester,
+                        id = %reply_id,
                         ?outcome,
                         "deferred link-preview reply dropped after bounded delivery retries"
                     );
                     return;
                 };
+                debug!(
+                    requester = %requester,
+                    id = %reply_id,
+                    ?outcome,
+                    retry_in = ?delay,
+                    "deferred link-preview reply delivery retrying"
+                );
                 tokio::time::sleep(*delay).await;
             }
         }
@@ -688,29 +706,16 @@ mod tests {
         b"test-link-preview-secret"
     }
 
-    /// Register a live connection for [`sender`] — with both the connection
-    /// registry and the authoritative `UserActor` the deferred delivery path
-    /// resolves (mirroring production registration) — and return the
-    /// outbound receiver.
+    /// Register a live connection for [`sender`] through the
+    /// production-parity dual-registration helper (same `ConnectionEntry`
+    /// mirrored into the actor tree the deferred delivery path resolves)
+    /// and return the outbound receiver.
     async fn register_requester(
         state: &WebSocketState,
     ) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
         let (tx, rx) = tokio::sync::mpsc::channel(8);
-        state
-            .deps
-            .protocol
-            .connection_registry
-            .register(sender(), tx.clone());
-        state
-            .deps
-            .protocol
-            .user_registry
-            .ask(waddle_xmpp::registry::RegisterUserResource {
-                jid: sender(),
-                entry: waddle_xmpp::registry::ConnectionEntry::new(tx),
-            })
-            .await
-            .expect("register user resource");
+        crate::server::routes::websocket::tests::register_test_connection(state, &sender(), tx)
+            .await;
         rx
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -9,20 +9,24 @@
 //! serial frame loop (RFC 6120 §10.1) moves on to the next stanza
 //! immediately. The IQ result — still exactly one reply per request,
 //! matched by id (RFC 6120 §8.2.3) — is delivered later through the
-//! connection registry as a server-generated `DirectFrame`, which records it
-//! in the XEP-0198 unacked queue like every other server-generated reply.
+//! authoritative `UserActor` delivery seam as a server-generated
+//! `DirectFrame`, which the destination records in the XEP-0198 unacked
+//! queue like every other server-generated reply.
 //! Before this, a cold-cache resolver round-trip stalled every stanza queued
 //! behind the lookup (production evidence on #1470: 1.3 s dispatch stalls vs
 //! a 13.6 ms dispatch p95).
 
 use super::*;
 use chrono::{Duration, SecondsFormat, Utc};
+use kameo::actor::ActorRef;
 use minidom::rxml::xml_ncname;
 use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 use url::Url;
-use waddle_xmpp::registry::{ConnectionRegistry, SendResult};
+use waddle_xmpp::registry::UserRegistryActor;
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+use crate::server::routes::interpret::{deliver_direct_to_full, FullJidDeliveryOutcome};
 use waddle_xmpp::xep::{
     encode_link_preview_token_checked, LinkPreviewTokenData, LinkPreviewTokenImage,
     LinkPreviewTokenNativeVideo, LinkPreviewTokenPlayer, LinkPreviewTokenVideo,
@@ -203,13 +207,13 @@ async fn handle_link_preview_lookup_iq_with_policy(
     spawn_deferred_lookup_resolution(
         resolve_permit,
         DeferredLookupResolution {
-            connection_registry: state.deps.protocol.connection_registry.clone(),
+            user_registry: state.deps.protocol.user_registry.clone(),
             sm_session_registry: state.deps.protocol.sm_session_registry.clone(),
             requester: sender_jid.clone(),
             scope_jid,
             original_url,
             resolver_policy,
-            secret: deps.secret.to_vec(),
+            secret: LinkPreviewSigningSecret(deps.secret.to_vec()),
             reply: DeferredLookupReply {
                 id: iq.id().to_string(),
                 from: deps
@@ -222,17 +226,35 @@ async fn handle_link_preview_lookup_iq_with_policy(
     Vec::new()
 }
 
+/// Signing key for composer preview tokens, typed so the deferred callback
+/// envelope never carries raw secret bytes as an untyped blob
+/// (typed-payloads rule). Today this wraps the deployment occupant-id
+/// secret's key material, which the lookup path has always reused for token
+/// HMACs (see the `handle_iq_with_conn_state` call site).
+struct LinkPreviewSigningSecret(Vec<u8>);
+
+impl LinkPreviewSigningSecret {
+    fn key(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// Everything one deferred lookup resolution owns once dispatch has moved
 /// on: registry handles for the eventual reply, the authorized request
 /// parameters, and the reply envelope.
 struct DeferredLookupResolution {
-    connection_registry: Arc<ConnectionRegistry>,
+    /// Authoritative delivery seam (ADR-0017): the `UserActor` resolved
+    /// through this registry owns the requester's live channel — including,
+    /// under clustering, remote resources registered by the route bridge —
+    /// so the deferred reply follows the same DirectFrame path as every
+    /// other server-generated frame.
+    user_registry: ActorRef<UserRegistryActor>,
     sm_session_registry: Arc<InMemorySmSessionRegistry>,
     requester: FullJid,
     scope_jid: BareJid,
     original_url: Url,
     resolver_policy: LinkPreviewResolverPolicy,
-    secret: Vec<u8>,
+    secret: LinkPreviewSigningSecret,
     reply: DeferredLookupReply,
 }
 
@@ -259,7 +281,7 @@ fn spawn_deferred_lookup_resolution(
     tokio::spawn(
         async move {
             let DeferredLookupResolution {
-                connection_registry,
+                user_registry,
                 sm_session_registry,
                 requester,
                 scope_jid,
@@ -273,17 +295,18 @@ fn spawn_deferred_lookup_resolution(
                 scope_jid,
                 &original_url,
                 &resolver_policy,
-                &secret,
+                secret.key(),
                 reply,
             )
             .await;
-            // Release the fetch-concurrency permit before delivery:
-            // `send_to` waits for the recipient's outbound-channel capacity,
-            // and a backpressured recipient must not pin a resolver slot its
-            // fetch is no longer using.
+            // Release the fetch-concurrency permit before delivery: the
+            // delivery path below is bounded (non-blocking actor try-send
+            // with capped ask timeouts), but it is still not fetch work —
+            // a slow recipient must not pin a resolver slot its fetch is
+            // no longer using.
             drop(resolve_permit);
             deliver_deferred_lookup_reply(
-                &connection_registry,
+                &user_registry,
                 &sm_session_registry,
                 &requester,
                 reply_iq,
@@ -360,78 +383,80 @@ async fn resolve_deferred_lookup(
     )
 }
 
-/// Deliver the deferred IQ result to the requester's live connection as a
-/// server-generated `DirectFrame` (the destination's main loop records it in
-/// the XEP-0198 unacked queue before the wire write, like every other
-/// server-generated reply).
+/// Deliver the deferred IQ result to the requester as a server-generated
+/// `DirectFrame` through [`deliver_direct_to_full`] — the authoritative
+/// `UserActor` delivery seam (ADR-0017). That helper is bounded end to end
+/// (non-blocking `TrySendDirect` with capped ask timeouts and a finite
+/// dropped-full retry schedule, never a channel-capacity wait), covers
+/// clustered remote resources registered with the owner actor, and falls
+/// back to the detached XEP-0198 replay buffer itself — preserving the old
+/// synchronous path's replay-on-resume guarantee. The destination's main
+/// loop records the frame in the XEP-0198 unacked queue before the wire
+/// write, like every other server-generated reply.
 ///
-/// Deliberately NOT owner-gated (`send_to`, not `send_to_if_owner`): an
-/// XEP-0198 resume onto a new connection registers a fresh owner token, and
-/// the requester's pending IQ survives that resume — owner-gating would drop
-/// the reply in exactly the race the old synchronous path's SM replay
-/// covered. The residual cost is a reply delivered to a same-full-JID
-/// replacement session, which ignores an IQ result whose id it never issued
-/// (RFC 6120 §8.2.3).
+/// Deliberately NOT owner-gated: an XEP-0198 resume onto a new connection
+/// registers a fresh owner token, and the requester's pending IQ survives
+/// that resume — owner-gating would drop the reply in exactly the race the
+/// SM replay covers. The residual cost is a reply delivered to a
+/// same-full-JID replacement session, which ignores an IQ result whose id
+/// it never issued (RFC 6120 §8.2.3).
 async fn deliver_deferred_lookup_reply(
-    connection_registry: &ConnectionRegistry,
-    sm_session_registry: &InMemorySmSessionRegistry,
+    user_registry: &ActorRef<UserRegistryActor>,
+    sm_session_registry: &Arc<InMemorySmSessionRegistry>,
     requester: &FullJid,
     reply_iq: Iq,
 ) {
     let stanza = Stanza::Iq(Box::new(reply_iq));
-    // The clone is unavoidable: `send_to` consumes the stanza (it may retry
-    // on a replacement sender), while the detached-SM fallback below still
-    // needs it.
-    match connection_registry.send_to(requester, stanza.clone()).await {
-        SendResult::Sent => {}
-        SendResult::NotConnected | SendResult::ChannelClosed => {
-            // The synchronous reply path recorded responses in the SM
-            // unacked queue, so a reply racing a brief disconnect replayed
-            // on resume. Preserve that guarantee: record against a detached
-            // SM session when one exists; otherwise the requester is truly
-            // gone and the client's own IQ timeout owns the failure
-            // (previews fail open, #822).
-            match sm_session_registry
-                .record_stanza_for_detached_bound_resource(requester, &stanza, Utc::now())
-                .await
+    match deliver_direct_to_full(
+        Some(user_registry),
+        Some(sm_session_registry),
+        requester,
+        &stanza,
+    )
+    .await
+    {
+        FullJidDeliveryOutcome::Delivered => {}
+        FullJidDeliveryOutcome::QueuedDetached => debug!(
+            requester = %requester,
+            "deferred link-preview reply recorded for detached SM session"
+        ),
+        FullJidDeliveryOutcome::Unavailable => {
+            // Neither a live actor resource nor a detached/claimed session —
+            // a resume may have completed between the delivery attempt and
+            // the detached-record fallback (resume consumes the session), so
+            // retry once before dropping the reply. At-least-once is the
+            // contract: a duplicate result replayed from the displacement
+            // corner is ignored by id (RFC 6120 §8.2.3). If the retry still
+            // finds nobody, the requester is truly gone and the client's own
+            // IQ timeout owns the failure (previews fail open, #822).
+            match deliver_direct_to_full(
+                Some(user_registry),
+                Some(sm_session_registry),
+                requester,
+                &stanza,
+            )
+            .await
             {
-                Ok(true) => debug!(
-                    requester = %requester,
-                    "deferred link-preview reply recorded for detached SM session"
-                ),
-                Ok(false) => {
-                    // No detached OR claimed session found — a resume may
-                    // have completed between the failed live send and the
-                    // record attempt (resume consumes the session), so retry
-                    // the live path once before dropping the reply.
-                    // At-least-once is the contract: in the displacement
-                    // corner where the record persisted durably before
-                    // reporting false, a replayed duplicate result is
-                    // ignored by id (RFC 6120 §8.2.3).
-                    if connection_registry
-                        .send_to(requester, stanza.clone())
-                        .await
-                        .is_sent()
-                    {
-                        debug!(
-                            requester = %requester,
-                            "deferred link-preview reply delivered on post-resume retry"
-                        );
-                    } else {
-                        debug!(
-                            requester = %requester,
-                            "deferred link-preview reply dropped; requester disconnected \
-                             without resumable session"
-                        );
-                    }
+                FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => {
+                    debug!(
+                        requester = %requester,
+                        "deferred link-preview reply delivered on post-resume retry"
+                    );
                 }
-                Err(error) => warn!(
+                _ => debug!(
                     requester = %requester,
-                    %error,
-                    "failed to record deferred link-preview reply for detached SM session"
+                    "deferred link-preview reply dropped; requester disconnected without \
+                     resumable session"
                 ),
             }
         }
+        FullJidDeliveryOutcome::Dropped => warn!(
+            requester = %requester,
+            "deferred link-preview reply dropped by delivery path (full channel or \
+             detached-record failure)"
+        ),
+        #[cfg(feature = "clustering")]
+        FullJidDeliveryOutcome::MaybeCommitted => {}
     }
 }
 
@@ -652,9 +677,11 @@ mod tests {
         b"test-link-preview-secret"
     }
 
-    /// Register a live connection for [`sender`] so the deferred lookup
-    /// reply has somewhere to land, and return the outbound receiver.
-    fn register_requester(
+    /// Register a live connection for [`sender`] — with both the connection
+    /// registry and the authoritative `UserActor` the deferred delivery path
+    /// resolves (mirroring production registration) — and return the
+    /// outbound receiver.
+    async fn register_requester(
         state: &WebSocketState,
     ) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
         let (tx, rx) = tokio::sync::mpsc::channel(8);
@@ -662,7 +689,17 @@ mod tests {
             .deps
             .protocol
             .connection_registry
-            .register(sender(), tx);
+            .register(sender(), tx.clone());
+        state
+            .deps
+            .protocol
+            .user_registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: sender(),
+                entry: waddle_xmpp::registry::ConnectionEntry::new(tx),
+            })
+            .await
+            .expect("register user resource");
         rx
     }
 
@@ -758,7 +795,7 @@ mod tests {
             )
             .build();
         let iq = iq_get_with_payload(payload);
-        let mut rx = register_requester(state.as_ref());
+        let mut rx = register_requester(state.as_ref()).await;
 
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
@@ -859,7 +896,7 @@ mod tests {
             )
             .build();
         let iq = iq_get_with_payload(payload);
-        let mut rx = register_requester(state.as_ref());
+        let mut rx = register_requester(state.as_ref()).await;
 
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
@@ -946,7 +983,7 @@ mod tests {
         let iq = iq_get_with_payload(payload);
 
         let state = create_test_websocket_state().await;
-        let mut rx = register_requester(state.as_ref());
+        let mut rx = register_requester(state.as_ref()).await;
         let response = handle_link_preview_lookup_iq_with_policy(
             &iq,
             Some(&sender()),
@@ -1143,7 +1180,7 @@ mod tests {
             .mount(&server)
             .await;
         let state = create_test_websocket_state().await;
-        let mut rx = register_requester(state.as_ref());
+        let mut rx = register_requester(state.as_ref()).await;
         let resolver_policy = LinkPreviewResolverPolicy {
             allow_http_loopback_for_tests: true,
             timeout: std::time::Duration::from_secs(10),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_lookup.rs
@@ -18,7 +18,7 @@
 use super::*;
 use chrono::{Duration, SecondsFormat, Utc};
 use minidom::rxml::xml_ncname;
-use tokio::sync::Semaphore;
+use tokio::sync::OwnedSemaphorePermit;
 use tracing::Instrument;
 use url::Url;
 use waddle_xmpp::registry::{ConnectionRegistry, SendResult};
@@ -48,19 +48,6 @@ struct LinkPreviewLookupDeps<'a> {
     secret: &'a [u8],
     resolver_policy: Option<LinkPreviewResolverPolicy>,
 }
-
-/// Cap on concurrently running deferred resolver fetches per node. Serial
-/// frame dispatch used to throttle lookups to one in flight per connection as
-/// a side effect of blocking; once resolution moved off the dispatch path
-/// (#1470) the bound must be explicit so a burst of lookups cannot fan out
-/// into an unbounded outbound-fetch storm. Excess lookups queue on the
-/// semaphore in arrival order; each resolve is bounded by the resolver's own
-/// per-phase timeouts, so queued lookups still answer within the client's IQ
-/// budget except under sustained abuse — where queueing, not unbounded
-/// fan-out, is the correct failure mode (previews fail open, #822).
-const MAX_CONCURRENT_DEFERRED_RESOLVES: usize = 8;
-
-static DEFERRED_RESOLVE_PERMITS: Semaphore = Semaphore::const_new(MAX_CONCURRENT_DEFERRED_RESOLVES);
 
 pub(super) fn is_link_preview_lookup_iq(iq: &Iq) -> bool {
     let Iq::Get { payload, .. } = iq else {
@@ -174,25 +161,49 @@ async fn handle_link_preview_lookup_iq_with_policy(
             None,
         )];
     }
+    // Bounded admission (#1470): `try_acquire` against the per-node resolver
+    // semaphore — a saturated resolver answers `failed` immediately
+    // (previews fail open, #822) rather than queueing tasks whose replies
+    // would outlive the client's IQ budget and whose spans would stay open
+    // for the whole queue wait (#1438).
+    let Ok(resolve_permit) = state
+        .deps
+        .protocol
+        .link_preview_resolves
+        .clone()
+        .try_acquire_owned()
+    else {
+        record_link_preview_event(LinkPreviewTelemetryEvent::ResolverSaturated);
+        return vec![build_link_preview_lookup_result(
+            iq,
+            deps.response_from,
+            deps.response_to,
+            LinkPreviewResolverStatus::Failed,
+            None,
+        )];
+    };
     // Accepted for resolution. Everything from here involves outbound
     // network fetches, so it runs off the dispatch path (#1470): spawn the
     // resolve and answer the IQ later through the connection registry.
-    spawn_deferred_lookup_resolution(DeferredLookupResolution {
-        connection_registry: state.deps.protocol.connection_registry.clone(),
-        sm_session_registry: state.deps.protocol.sm_session_registry.clone(),
-        requester: sender_jid.clone(),
-        scope_jid,
-        original_url,
-        resolver_policy,
-        secret: deps.secret.to_vec(),
-        reply: DeferredLookupReply {
-            id: iq.id().to_string(),
-            from: deps
-                .response_from
-                .and_then(|value| value.parse::<Jid>().ok()),
-            to: deps.response_to.and_then(|value| value.parse::<Jid>().ok()),
+    spawn_deferred_lookup_resolution(
+        resolve_permit,
+        DeferredLookupResolution {
+            connection_registry: state.deps.protocol.connection_registry.clone(),
+            sm_session_registry: state.deps.protocol.sm_session_registry.clone(),
+            requester: sender_jid.clone(),
+            scope_jid,
+            original_url,
+            resolver_policy,
+            secret: deps.secret.to_vec(),
+            reply: DeferredLookupReply {
+                id: iq.id().to_string(),
+                from: deps
+                    .response_from
+                    .and_then(|value| value.parse::<Jid>().ok()),
+                to: deps.response_to.and_then(|value| value.parse::<Jid>().ok()),
+            },
         },
-    });
+    );
     Vec::new()
 }
 
@@ -219,7 +230,10 @@ struct DeferredLookupReply {
     to: Option<Jid>,
 }
 
-fn spawn_deferred_lookup_resolution(resolution: DeferredLookupResolution) {
+fn spawn_deferred_lookup_resolution(
+    resolve_permit: OwnedSemaphorePermit,
+    resolution: DeferredLookupResolution,
+) {
     // Created while the dispatch span is current, so the resolve — and the
     // resolver's child `link_preview.fetch` spans — stay on the originating
     // stanza's trace after dispatch returns (#1438: bounded, parented spans).
@@ -239,10 +253,6 @@ fn spawn_deferred_lookup_resolution(resolution: DeferredLookupResolution) {
                 secret,
                 reply,
             } = resolution;
-            let Ok(_permit) = DEFERRED_RESOLVE_PERMITS.acquire().await else {
-                // The static semaphore is never closed.
-                return;
-            };
             let reply_iq = resolve_deferred_lookup(
                 &requester,
                 scope_jid,
@@ -252,6 +262,11 @@ fn spawn_deferred_lookup_resolution(resolution: DeferredLookupResolution) {
                 reply,
             )
             .await;
+            // Release the fetch-concurrency permit before delivery:
+            // `send_to` waits for the recipient's outbound-channel capacity,
+            // and a backpressured recipient must not pin a resolver slot its
+            // fetch is no longer using.
+            drop(resolve_permit);
             deliver_deferred_lookup_reply(
                 &connection_registry,
                 &sm_session_registry,
@@ -334,6 +349,14 @@ async fn resolve_deferred_lookup(
 /// server-generated `DirectFrame` (the destination's main loop records it in
 /// the XEP-0198 unacked queue before the wire write, like every other
 /// server-generated reply).
+///
+/// Deliberately NOT owner-gated (`send_to`, not `send_to_if_owner`): an
+/// XEP-0198 resume onto a new connection registers a fresh owner token, and
+/// the requester's pending IQ survives that resume — owner-gating would drop
+/// the reply in exactly the race the old synchronous path's SM replay
+/// covered. The residual cost is a reply delivered to a same-full-JID
+/// replacement session, which ignores an IQ result whose id it never issued
+/// (RFC 6120 §8.2.3).
 async fn deliver_deferred_lookup_reply(
     connection_registry: &ConnectionRegistry,
     sm_session_registry: &InMemorySmSessionRegistry,
@@ -341,6 +364,9 @@ async fn deliver_deferred_lookup_reply(
     reply_iq: Iq,
 ) {
     let stanza = Stanza::Iq(Box::new(reply_iq));
+    // The clone is unavoidable: `send_to` consumes the stanza (it may retry
+    // on a replacement sender), while the detached-SM fallback below still
+    // needs it.
     match connection_registry.send_to(requester, stanza.clone()).await {
         SendResult::Sent => {}
         SendResult::NotConnected | SendResult::ChannelClosed => {
@@ -1124,9 +1150,233 @@ mod tests {
             "dispatch must not wait for the resolver round-trip \
              (took {dispatch_elapsed:?} against a {page_delay:?} page delay)"
         );
+
+        // A subsequent IQ through the same dispatch seam is fully answered
+        // while the first lookup's resolver round-trip is still in flight —
+        // the "stanzas queued behind a cold-cache preview" half of the
+        // acceptance criteria. (The frame loop awaits exactly this handler,
+        // so completing here is completing for the connection.)
+        let second_iq = iq_get_with_payload(
+            Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+                .append(
+                    Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                        .append("https://example.com/next")
+                        .build(),
+                )
+                .append(
+                    Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                        .append("alice@example.com")
+                        .build(),
+                )
+                .build(),
+        );
+        let second_response = handle_link_preview_lookup_iq_with_policy(
+            &second_iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(LinkPreviewResolverPolicy {
+                    enabled: false,
+                    ..Default::default()
+                }),
+            },
+        )
+        .await;
+        let second_elem: Element = second_response[0].parse().expect("second iq result");
+        assert_eq!(
+            second_elem
+                .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+                .and_then(|lookup| lookup.attr("status")),
+            Some("blocked"),
+            "second stanza is fully dispatched and answered while the first \
+             preview is still resolving"
+        );
+
         let (id, lookup) = recv_deferred_lookup_reply(&mut rx).await;
         assert_eq!(id, "lookup-1", "deferred reply echoes the request id");
         assert_eq!(lookup.attr("status"), Some("ready"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn saturated_resolver_answers_failed_synchronously() {
+        // Bounded admission (#1470): with every resolver permit taken, an
+        // otherwise-valid lookup is answered `failed` inline (fail open,
+        // #822) instead of queueing a deferred task.
+        let _events_guard = recorded_events::async_lock().await;
+        recorded_events::clear();
+        let state = create_test_websocket_state().await;
+        let available = state
+            .deps
+            .protocol
+            .link_preview_resolves
+            .available_permits();
+        let _hog = state
+            .deps
+            .protocol
+            .link_preview_resolves
+            .clone()
+            .try_acquire_many_owned(u32::try_from(available).expect("permit count fits u32"))
+            .expect("drain all resolver permits");
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append("https://example.com/a")
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&sender()),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(LinkPreviewResolverPolicy::default()),
+            },
+        )
+        .await;
+
+        let elem: Element = response[0].parse().expect("iq result");
+        let lookup = elem
+            .get_child("lookup", NS_WADDLE_LINK_PREVIEW)
+            .expect("lookup result");
+        assert_eq!(lookup.attr("status"), Some("failed"));
+        assert!(lookup
+            .get_child("preview", NS_WADDLE_LINK_PREVIEW)
+            .is_none());
+        assert!(
+            recorded_events::take().contains(&LinkPreviewTelemetryEvent::ResolverSaturated),
+            "saturated admission must emit saturated telemetry"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deferred_reply_records_into_detached_sm_session_for_resume_replay() {
+        // XEP-0198 parity with the old synchronous path: a reply whose
+        // requester detached mid-resolve is recorded against the detached SM
+        // session, so a later resume replays it instead of losing it.
+        use waddle_xmpp::stream_management::SmSessionRegistry as _;
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/a"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<html><head><meta property="og:title" content="T"></head></html>"#,
+                "text/html",
+            ))
+            .mount(&server)
+            .await;
+        let state = create_test_websocket_state().await;
+        let requester = sender();
+        state
+            .deps
+            .protocol
+            .sm_session_registry
+            .store_session(waddle_xmpp::stream_management::DetachedSession {
+                stream_id: "preview-stream-1".to_string(),
+                user_id: requester.to_string(),
+                jid: requester.clone(),
+                inbound_count: 1,
+                outbound_count: 4,
+                last_acked: 4,
+                replay_gap_through: None,
+                unacked_stanzas: Vec::new(),
+                max_resume_time: Some(300),
+                detached_at: std::time::Instant::now(),
+                carbons_enabled: false,
+                roster_interested: true,
+                blocklist_interested: false,
+                presence_available: true,
+                presence_show: None,
+                presence_status: None,
+                presence_priority: 0,
+                presence_payloads: Vec::new(),
+                pending_subscribes_flushed: false,
+            })
+            .await
+            .expect("store detached session");
+        let resolver_policy = LinkPreviewResolverPolicy {
+            allow_http_loopback_for_tests: true,
+            ..Default::default()
+        };
+        let payload = Element::builder("lookup", NS_WADDLE_LINK_PREVIEW)
+            .append(
+                Element::builder("url", NS_WADDLE_LINK_PREVIEW)
+                    .append(format!("{}/a", server.uri()).as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("scope", NS_WADDLE_LINK_PREVIEW)
+                    .append("alice@example.com")
+                    .build(),
+            )
+            .build();
+        let iq = iq_get_with_payload(payload);
+
+        // No live registry entry for the requester — only the detached
+        // session above.
+        let response = handle_link_preview_lookup_iq_with_policy(
+            &iq,
+            Some(&requester),
+            state.as_ref(),
+            LinkPreviewLookupDeps {
+                muc_domain: "muc.example.com",
+                response_from: None,
+                response_to: None,
+                secret: secret(),
+                resolver_policy: Some(resolver_policy),
+            },
+        )
+        .await;
+        assert!(response.is_empty());
+
+        // The deferred reply lands in the detached session's unacked queue.
+        let claimed = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            loop {
+                let session = state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .claim_session("preview-stream-1")
+                    .await
+                    .expect("claim detached session")
+                    .expect("session still stored");
+                if !session.unacked_stanzas.is_empty() {
+                    break session;
+                }
+                state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .release_claim("preview-stream-1")
+                    .await
+                    .expect("release claim between polls");
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("deferred reply recorded for resume replay");
+        assert_eq!(claimed.unacked_stanzas.len(), 1);
+        assert!(
+            claimed.unacked_stanzas[0].stanza_xml.contains("lookup-1")
+                && claimed.unacked_stanzas[0]
+                    .stanza_xml
+                    .contains(NS_WADDLE_LINK_PREVIEW),
+            "recorded stanza is the lookup reply: {}",
+            claimed.unacked_stanzas[0].stanza_xml
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -9,7 +9,7 @@ use kameo::actor::ActorRef;
 use reqwest::header::{CONTENT_RANGE, CONTENT_TYPE, LOCATION, RANGE};
 use reqwest::{redirect, Client, StatusCode};
 use sha2::{Digest, Sha256};
-use tracing::warn;
+use tracing::{warn, Instrument};
 use url::{Host, Url};
 use waddle_xmpp_core::{DirectVideoMediaType, PreviewImageMediaType};
 
@@ -200,6 +200,34 @@ impl LinkPreviewResolverOutcome {
     }
 }
 
+/// Child span for one outbound resolver fetch (#1470). Carries only the
+/// target host and the fetch phase (`page` | `image`) — never the URL, path,
+/// query, or any JID — and stays parented under the caller's span so the
+/// resolver's dominant wall time is attributable in traces without adding
+/// root-span noise (#1438).
+fn outbound_fetch_span(phase: &'static str, url: &Url) -> tracing::Span {
+    let span = tracing::info_span!(
+        "link_preview.fetch",
+        link_preview.phase = phase,
+        host = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+    );
+    if let Some(host) = url.host_str() {
+        span.record("host", host);
+    }
+    span
+}
+
+/// Stamp the fetch span for a fetch that produced no usable response.
+/// `Blocked`/`Unsupported` are policy verdicts, not failures — only `Failed`
+/// (network error, timeout, oversize) sets OTEL error status, keeping error
+/// traces meaningful (#1477).
+fn mark_fetch_span_outcome(span: &tracing::Span, status: LinkPreviewResolverStatus) {
+    if matches!(status, LinkPreviewResolverStatus::Failed) {
+        span.record("otel.status_code", "ERROR");
+    }
+}
+
 pub(super) async fn resolve_link_preview(
     url: &Url,
     policy: &LinkPreviewResolverPolicy,
@@ -210,14 +238,25 @@ pub(super) async fn resolve_link_preview(
         let Some(timeout) = deadline.checked_duration_since(Instant::now()) else {
             return LinkPreviewResolverOutcome::Failed;
         };
-        let fetch = match fetch_html_once(&current, policy, timeout).await {
+        let fetch_span = outbound_fetch_span("page", &current);
+        let fetch = match fetch_html_once(&current, policy, timeout)
+            .instrument(fetch_span.clone())
+            .await
+        {
             Ok(fetch) => fetch,
-            Err(LinkPreviewResolverStatus::Blocked) => return LinkPreviewResolverOutcome::Blocked,
-            Err(LinkPreviewResolverStatus::Failed) => return LinkPreviewResolverOutcome::Failed,
-            Err(LinkPreviewResolverStatus::Unsupported) => {
-                return LinkPreviewResolverOutcome::Unsupported;
+            Err(status) => {
+                mark_fetch_span_outcome(&fetch_span, status);
+                return match status {
+                    LinkPreviewResolverStatus::Blocked => LinkPreviewResolverOutcome::Blocked,
+                    LinkPreviewResolverStatus::Failed => LinkPreviewResolverOutcome::Failed,
+                    LinkPreviewResolverStatus::Unsupported => {
+                        LinkPreviewResolverOutcome::Unsupported
+                    }
+                    LinkPreviewResolverStatus::Ready => {
+                        unreachable!("ready is not a fetch error")
+                    }
+                };
             }
-            Err(LinkPreviewResolverStatus::Ready) => unreachable!("ready is not a fetch error"),
         };
         match fetch {
             FetchOnceResult::Html { final_url, html } => {
@@ -237,21 +276,28 @@ pub(super) async fn resolve_link_preview(
                     // `policy.timeout` thus bounds each phase independently, so
                     // a worst-case resolve is ~2x `policy.timeout` (page + image).
                     let image_deadline = Instant::now() + policy.timeout;
+                    let image_span = outbound_fetch_span("image", &remote_image.url);
                     match fetch_cached_preview_image(&remote_image, policy, cache, image_deadline)
+                        .instrument(image_span.clone())
                         .await
                     {
                         Ok(image) => metadata.image = Some(image),
-                        Err(LinkPreviewResolverStatus::Blocked) => warn!(
-                            url = %remote_image.url,
-                            "dropping blocked link preview image after metadata resolved"
-                        ),
-                        Err(LinkPreviewResolverStatus::Failed) => warn!(
-                            url = %remote_image.url,
-                            "dropping failed link preview image after metadata resolved"
-                        ),
-                        Err(LinkPreviewResolverStatus::Unsupported) => {}
-                        Err(LinkPreviewResolverStatus::Ready) => {
-                            unreachable!("ready is not an image fetch error")
+                        Err(status) => {
+                            mark_fetch_span_outcome(&image_span, status);
+                            match status {
+                                LinkPreviewResolverStatus::Blocked => warn!(
+                                    url = %remote_image.url,
+                                    "dropping blocked link preview image after metadata resolved"
+                                ),
+                                LinkPreviewResolverStatus::Failed => warn!(
+                                    url = %remote_image.url,
+                                    "dropping failed link preview image after metadata resolved"
+                                ),
+                                LinkPreviewResolverStatus::Unsupported => {}
+                                LinkPreviewResolverStatus::Ready => {
+                                    unreachable!("ready is not an image fetch error")
+                                }
+                            }
                         }
                     }
                 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -200,15 +200,33 @@ impl LinkPreviewResolverOutcome {
     }
 }
 
+/// Which outbound fetch a `link_preview.fetch` span describes.
+#[derive(Debug, Clone, Copy)]
+enum FetchPhase {
+    /// The HTML page (or direct-media probe) fetch.
+    Page,
+    /// The OpenGraph preview-image fetch feeding the media cache.
+    Image,
+}
+
+impl FetchPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Page => "page",
+            Self::Image => "image",
+        }
+    }
+}
+
 /// Child span for one outbound resolver fetch (#1470). Carries only the
-/// target host and the fetch phase (`page` | `image`) — never the URL, path,
-/// query, or any JID — and stays parented under the caller's span so the
-/// resolver's dominant wall time is attributable in traces without adding
-/// root-span noise (#1438).
-fn outbound_fetch_span(phase: &'static str, url: &Url) -> tracing::Span {
+/// target host and the fetch phase — never the URL, path, query, or any JID
+/// — and stays parented under the caller's span so the resolver's dominant
+/// wall time is attributable in traces without adding root-span noise
+/// (#1438).
+fn outbound_fetch_span(phase: FetchPhase, url: &Url) -> tracing::Span {
     let span = tracing::info_span!(
         "link_preview.fetch",
-        link_preview.phase = phase,
+        link_preview.phase = phase.as_str(),
         host = tracing::field::Empty,
         otel.status_code = tracing::field::Empty,
     );
@@ -238,7 +256,7 @@ pub(super) async fn resolve_link_preview(
         let Some(timeout) = deadline.checked_duration_since(Instant::now()) else {
             return LinkPreviewResolverOutcome::Failed;
         };
-        let fetch_span = outbound_fetch_span("page", &current);
+        let fetch_span = outbound_fetch_span(FetchPhase::Page, &current);
         let fetch = match fetch_html_once(&current, policy, timeout)
             .instrument(fetch_span.clone())
             .await
@@ -276,7 +294,7 @@ pub(super) async fn resolve_link_preview(
                     // `policy.timeout` thus bounds each phase independently, so
                     // a worst-case resolve is ~2x `policy.timeout` (page + image).
                     let image_deadline = Instant::now() + policy.timeout;
-                    let image_span = outbound_fetch_span("image", &remote_image.url);
+                    let image_span = outbound_fetch_span(FetchPhase::Image, &remote_image.url);
                     match fetch_cached_preview_image(&remote_image, policy, cache, image_deadline)
                         .instrument(image_span.clone())
                         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/link_preview_resolver.rs
@@ -955,7 +955,13 @@ async fn prepare_target<'a>(
     Ok(PreparedTarget { host, addrs })
 }
 
-fn classify_url_with_policy(
+/// Deterministic, I/O-free policy verdict for a lookup URL: scheme support,
+/// IP-literal and `.local` rejection, and the operator host allow/block
+/// lists. `Ready` means "no static objection" — the fetch path still applies
+/// the DNS-resolution SSRF checks that need I/O. Exposed to the lookup
+/// handler (#1470) so these verdicts stay on the dispatch path instead of
+/// consuming a deferred-resolve permit.
+pub(super) fn classify_url_with_policy(
     url: &Url,
     policy: &LinkPreviewResolverPolicy,
 ) -> LinkPreviewResolverStatus {

--- a/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/link_preview_telemetry.rs
@@ -4,6 +4,10 @@ pub(crate) enum LinkPreviewTelemetryEvent {
     ResolverBlocked,
     ResolverFailed,
     ResolverUnsupported,
+    /// Deferred-resolve admission was refused because the per-node
+    /// concurrency cap is exhausted (#1470); the lookup answered `failed`
+    /// immediately instead of queueing.
+    ResolverSaturated,
     CacheHit,
     CacheMiss,
     TokenInvalid,
@@ -18,6 +22,7 @@ impl LinkPreviewTelemetryEvent {
             Self::ResolverBlocked => "blocked",
             Self::ResolverFailed => "failed",
             Self::ResolverUnsupported => "unsupported",
+            Self::ResolverSaturated => "saturated",
             Self::CacheHit => "cache_hit",
             Self::CacheMiss => "cache_miss",
             Self::TokenInvalid => "token_invalid",
@@ -126,6 +131,7 @@ mod tests {
             LinkPreviewTelemetryEvent::ResolverBlocked.as_str(),
             LinkPreviewTelemetryEvent::ResolverFailed.as_str(),
             LinkPreviewTelemetryEvent::ResolverUnsupported.as_str(),
+            LinkPreviewTelemetryEvent::ResolverSaturated.as_str(),
             LinkPreviewTelemetryEvent::CacheHit.as_str(),
             LinkPreviewTelemetryEvent::CacheMiss.as_str(),
             LinkPreviewTelemetryEvent::TokenInvalid.as_str(),
@@ -140,6 +146,7 @@ mod tests {
                 "blocked",
                 "failed",
                 "unsupported",
+                "saturated",
                 "cache_hit",
                 "cache_miss",
                 "token_invalid",

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -104,10 +104,10 @@ pub(crate) use cleanup::redrive_remote_muc_cleanup;
 pub use cleanup::MucCleanupOutcome;
 pub use connection::router;
 pub use state::{
-    ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore, PendingDmCallOffer, ProtocolServices,
-    RemoteMucMemberships, ResolverAffiliationSyncSchedule, ResolverAffiliationSyncScheduler,
-    ResolverAffiliationSyncWork, TransportSecurity, WebSocketDeps, WebSocketState,
-    XmppServiceDomains,
+    default_link_preview_resolve_permits, ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore,
+    PendingDmCallOffer, ProtocolServices, RemoteMucMemberships, ResolverAffiliationSyncSchedule,
+    ResolverAffiliationSyncScheduler, ResolverAffiliationSyncWork, TransportSecurity,
+    WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 
 pub(crate) use cleanup::{

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1308,6 +1308,16 @@ pub struct ProtocolServices {
     /// XEP-0198 detached-session registry — holds state for clients whose
     /// WebSocket has closed but may still resume within the session timeout.
     pub sm_session_registry: Arc<InMemorySmSessionRegistry>,
+    /// Bounded admission for deferred link-preview resolver fetches
+    /// (#1470). Serial frame dispatch used to throttle lookups to one in
+    /// flight per connection as a side effect of blocking; once resolution
+    /// moved off the dispatch path the bound must be explicit so a lookup
+    /// burst cannot fan out into an unbounded outbound-fetch storm.
+    /// Admission is `try_acquire` at IQ dispatch — a saturated resolver
+    /// answers `failed` immediately (previews fail open, #822) instead of
+    /// queueing tasks whose replies would outlive the client's IQ budget.
+    /// Build with [`default_link_preview_resolve_permits`].
+    pub link_preview_resolves: Arc<tokio::sync::Semaphore>,
     /// XEP-0115 entity-capabilities resolver. Maintains the
     /// process-wide hash-keyed `CapsCache` plus per-resource caps
     /// mappings used by XEP-0163 §3 fan-out filtering.
@@ -1381,6 +1391,18 @@ pub struct ProtocolServices {
     /// outlive their XMPP presence (graceful unavailable, tab close,
     /// SM-expiry — all go through `cleanup_muc_presence`).
     pub sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
+}
+
+/// Per-node cap for [`ProtocolServices::link_preview_resolves`]. Deliberately
+/// generous: the old inline path allowed one concurrent resolve per
+/// connection, so node-wide concurrency scaled with connection count.
+pub const MAX_CONCURRENT_LINK_PREVIEW_RESOLVES: usize = 32;
+
+/// Fresh admission semaphore for [`ProtocolServices::link_preview_resolves`].
+pub fn default_link_preview_resolve_permits() -> Arc<tokio::sync::Semaphore> {
+    Arc::new(tokio::sync::Semaphore::new(
+        MAX_CONCURRENT_LINK_PREVIEW_RESOLVES,
+    ))
 }
 
 /// Per-connection mutable state for a single WebSocket XMPP transport.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -510,6 +510,8 @@ async fn create_test_websocket_state_with_extension_manager(
                     notification_activity,
                     sm_session_registry: sm_session_registry_override
                         .unwrap_or_else(|| Arc::new(InMemorySmSessionRegistry::new())),
+                    link_preview_resolves:
+                        crate::server::routes::websocket::default_link_preview_resolve_permits(),
                     resumable_sessions: Arc::new(dashmap::DashMap::new()),
                     caps_resolver: Arc::new(
                         crate::server::caps_resolution::CapsResolver::default(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -102,7 +102,22 @@ async fn link_preview_lookup_for_test(
 }
 
 /// Register a live connection for `bound_jid` so the deferred link-preview
-/// reply (#1470) has somewhere to land, and await the typed IQ result on it.
+/// reply (#1470) has somewhere to land; returns the outbound receiver.
+fn register_link_preview_requester_for_test(
+    state: &WebSocketState,
+    bound_jid: &FullJid,
+) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
+    let (tx, rx) = tokio::sync::mpsc::channel(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bound_jid.clone(), tx);
+    rx
+}
+
+/// Await the deferred link-preview IQ result (#1470) on the requester's
+/// outbound channel and return it typed.
 async fn recv_deferred_link_preview_reply_for_test(
     rx: &mut tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza>,
 ) -> xmpp_parsers::iq::Iq {
@@ -128,12 +143,7 @@ async fn link_preview_lookup_dispatch_returns_typed_unsupported_metadata_outcome
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
-    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
-    state
-        .deps
-        .protocol
-        .connection_registry
-        .register(bound_jid.clone(), tx);
+    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid);
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\
@@ -243,12 +253,7 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolv
         })
         .await
         .expect("join room");
-    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
-    state
-        .deps
-        .protocol
-        .connection_registry
-        .register(bound_jid.clone(), tx);
+    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid);
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-muc-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -101,31 +101,16 @@ async fn link_preview_lookup_for_test(
     .await
 }
 
-/// Register a live connection for `bound_jid` — with both the connection
-/// registry and the authoritative `UserActor` the deferred delivery path
-/// resolves (mirroring production registration) — so the deferred
-/// link-preview reply (#1470) has somewhere to land; returns the outbound
-/// receiver.
+/// Register a live connection for `bound_jid` through the production-parity
+/// dual-registration helper (same `ConnectionEntry` mirrored into the actor
+/// tree) so the deferred link-preview reply (#1470) has somewhere to land;
+/// returns the outbound receiver.
 async fn register_link_preview_requester_for_test(
     state: &WebSocketState,
     bound_jid: &FullJid,
 ) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
     let (tx, rx) = tokio::sync::mpsc::channel(8);
-    state
-        .deps
-        .protocol
-        .connection_registry
-        .register(bound_jid.clone(), tx.clone());
-    state
-        .deps
-        .protocol
-        .user_registry
-        .ask(waddle_xmpp::registry::RegisterUserResource {
-            jid: bound_jid.clone(),
-            entry: waddle_xmpp::registry::ConnectionEntry::new(tx),
-        })
-        .await
-        .expect("register user resource");
+    register_test_connection(state, bound_jid, tx).await;
     rx
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -101,11 +101,39 @@ async fn link_preview_lookup_for_test(
     .await
 }
 
+/// Register a live connection for `bound_jid` so the deferred link-preview
+/// reply (#1470) has somewhere to land, and await the typed IQ result on it.
+async fn recv_deferred_link_preview_reply_for_test(
+    rx: &mut tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza>,
+) -> xmpp_parsers::iq::Iq {
+    let outbound = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv())
+        .await
+        .expect("deferred lookup reply within timeout")
+        .expect("outbound channel open");
+    assert!(
+        matches!(
+            outbound.kind,
+            waddle_xmpp::registry::DeliveryKind::DirectFrame
+        ),
+        "deferred IQ reply is a server-generated direct frame"
+    );
+    let Stanza::Iq(iq) = outbound.stanza else {
+        panic!("expected deferred IQ reply, got {:?}", outbound.stanza);
+    };
+    *iq
+}
+
 #[tokio::test]
 async fn link_preview_lookup_dispatch_returns_typed_unsupported_metadata_outcome() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bound_jid.clone(), tx);
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\
@@ -116,23 +144,42 @@ async fn link_preview_lookup_dispatch_returns_typed_unsupported_metadata_outcome
 
     let responses = link_preview_lookup_for_test(state.as_ref(), session, &bound_jid, frame).await;
 
-    let response = responses.first().expect("lookup result");
     assert!(
-        response.contains("id='preview-1'"),
-        "preserves iq id: {response}"
+        responses.is_empty(),
+        "accepted lookup answers off the dispatch path (#1470): {responses:?}"
+    );
+    let reply = recv_deferred_link_preview_reply_for_test(&mut rx).await;
+    let xmpp_parsers::iq::Iq::Result {
+        id,
+        from,
+        to,
+        payload,
+    } = reply
+    else {
+        panic!("normal resolver miss/failure is not an IQ transport error: {reply:?}");
+    };
+    assert_eq!(id, "preview-1", "preserves iq id");
+    assert_eq!(
+        from.as_ref().map(ToString::to_string).as_deref(),
+        Some("example.com"),
+        "stamps result 'from' from request envelope"
+    );
+    assert_eq!(
+        to.as_ref().map(ToString::to_string).as_deref(),
+        Some("alice@example.com/desktop"),
+        "stamps result 'to' from request envelope"
+    );
+    let lookup = payload.expect("lookup payload");
+    assert!(
+        matches!(lookup.attr("status"), Some("unsupported" | "failed")),
+        "normal resolver miss/failure is typed in the lookup result"
     );
     assert!(
-        response.contains("from='example.com'")
-            && response.contains("to='alice@example.com/desktop'"),
-        "stamps result addressing from request envelope: {response}"
-    );
-    assert!(
-        response.contains("status='unsupported'") || response.contains("status='failed'"),
-        "normal resolver miss/failure is typed in the lookup result: {response}"
-    );
-    assert!(
-        !response.contains("type='error'") && !response.contains("token='"),
-        "normal resolver miss/failure is not an IQ transport error and does not mint token: {response}"
+        lookup.attr("token").is_none()
+            && lookup
+                .get_child("preview", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
+                .is_none(),
+        "resolver miss/failure does not mint a token"
     );
 }
 
@@ -196,6 +243,12 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolv
         })
         .await
         .expect("join room");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bound_jid.clone(), tx);
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-muc-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\
@@ -206,14 +259,18 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolv
 
     let responses = link_preview_lookup_for_test(state.as_ref(), session, &bound_jid, frame).await;
 
-    let response = responses.first().expect("lookup result");
-    let elem: Element = response.parse().expect("lookup xml");
-    let lookup = elem
-        .get_child("lookup", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
-        .expect("lookup result");
+    assert!(
+        responses.is_empty(),
+        "authorized lookup answers off the dispatch path (#1470): {responses:?}"
+    );
+    let reply = recv_deferred_link_preview_reply_for_test(&mut rx).await;
+    let xmpp_parsers::iq::Iq::Result { payload, .. } = reply else {
+        panic!("authorized room lookup should reach a typed resolver outcome: {reply:?}");
+    };
+    let lookup = payload.expect("lookup payload");
     assert!(
         matches!(lookup.attr("status"), Some("unsupported" | "failed")),
-        "authorized room lookup should reach typed resolver outcome: {response}"
+        "authorized room lookup should reach typed resolver outcome"
     );
     assert!(lookup
         .get_child("preview", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -101,9 +101,12 @@ async fn link_preview_lookup_for_test(
     .await
 }
 
-/// Register a live connection for `bound_jid` so the deferred link-preview
-/// reply (#1470) has somewhere to land; returns the outbound receiver.
-fn register_link_preview_requester_for_test(
+/// Register a live connection for `bound_jid` — with both the connection
+/// registry and the authoritative `UserActor` the deferred delivery path
+/// resolves (mirroring production registration) — so the deferred
+/// link-preview reply (#1470) has somewhere to land; returns the outbound
+/// receiver.
+async fn register_link_preview_requester_for_test(
     state: &WebSocketState,
     bound_jid: &FullJid,
 ) -> tokio::sync::mpsc::Receiver<waddle_xmpp::registry::OutboundStanza> {
@@ -112,7 +115,17 @@ fn register_link_preview_requester_for_test(
         .deps
         .protocol
         .connection_registry
-        .register(bound_jid.clone(), tx);
+        .register(bound_jid.clone(), tx.clone());
+    state
+        .deps
+        .protocol
+        .user_registry
+        .ask(waddle_xmpp::registry::RegisterUserResource {
+            jid: bound_jid.clone(),
+            entry: waddle_xmpp::registry::ConnectionEntry::new(tx),
+        })
+        .await
+        .expect("register user resource");
     rx
 }
 
@@ -143,7 +156,7 @@ async fn link_preview_lookup_dispatch_returns_typed_unsupported_metadata_outcome
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let bound_jid: FullJid = "alice@example.com/desktop".parse().expect("jid");
-    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid);
+    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid).await;
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\
@@ -253,7 +266,7 @@ async fn link_preview_lookup_for_muc_scope_allows_current_occupant_before_resolv
         })
         .await
         .expect("join room");
-    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid);
+    let mut rx = register_link_preview_requester_for_test(state.as_ref(), &bound_jid).await;
     let frame = "\
         <iq xmlns='jabber:client' type='get' id='preview-muc-1' from='alice@example.com/desktop' to='example.com'>\
           <lookup xmlns='urn:waddle:link-preview:0'>\

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1141,15 +1141,23 @@ async fn managed_registration_required_denial_increments_admission_counter() {
         Some(1),
         "the registration-required admission denial must increment the counter exactly once"
     );
+    // Assert on the RECORDED span field, not the exported span: this
+    // join's scope fans out actor asks, and the dispatch span only exports
+    // once every kameo child (`actor.handle_message` / `actor.lifecycle`,
+    // parented under the caller's span) closes — a straggling or
+    // spawned-inside-the-scope actor can hold it open past this assertion
+    // point indefinitely (#1479). Field records happen synchronously on
+    // the denial call path, so the observer sees them deterministically.
+    // The record→OTel-attribute export fidelity, and the Unset-vs-Error
+    // status split, stay pinned by `managed_internal_admission_failure_
+    // exports_error_dispatch_span` below and the frame-backstop span
+    // tests, whose narrower scopes export deterministically. (A denial
+    // never calls `mark_span_error` unless the condition is
+    // internal-server-error, which the condition assertion excludes.)
     assert_eq!(
-        spans.attribute_of("xmpp.stanza.dispatch", "condition"),
+        spans.recorded_field("xmpp.stanza.dispatch", "condition"),
         Some("registration-required".to_string()),
-        "the exported dispatch span must carry the allowlisted stanza condition"
-    );
-    assert_eq!(
-        spans.status_of("xmpp.stanza.dispatch"),
-        Some(opentelemetry::trace::Status::Unset),
-        "a conformant XEP-0045 admission denial is not an internal server failure"
+        "the dispatch span must carry the allowlisted stanza condition"
     );
     assert!(
         get_room_actor(state.as_ref(), &room_jid).await.is_none(),

--- a/server/crates/waddle-xmpp/src/telemetry/test_support.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/test_support.rs
@@ -56,18 +56,99 @@ pub fn acquire_spans() -> SpanTestGuard {
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
-    let subscriber = tracing_subscriber::registry().with(
-        tracing_opentelemetry::layer()
-            .with_tracer(provider.tracer("waddle-span-test"))
-            .with_error_events_to_status(true)
-            .with_error_records_to_exceptions(true),
-    );
+    let recorded_fields = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry()
+        .with(RecordedFieldObserver {
+            fields: recorded_fields.clone(),
+        })
+        .with(
+            tracing_opentelemetry::layer()
+                .with_tracer(provider.tracer("waddle-span-test"))
+                .with_error_events_to_status(true)
+                .with_error_records_to_exceptions(true),
+        );
     let dispatch_guard = tracing::subscriber::set_default(subscriber);
 
     SpanTestGuard {
         exporter,
         provider,
+        recorded_fields,
         _dispatch_guard: dispatch_guard,
+    }
+}
+
+/// Observes every field value a span receives — at creation and through
+/// later `Span::record` calls — WITHOUT waiting for the span to close.
+///
+/// Why closure can't be waited on (#1479): kameo parents actor spans
+/// (`actor.handle_message`, `actor.lifecycle`) under the caller's current
+/// span, so an actor spawned — or an abandoned/straggling ask handled —
+/// inside an instrumented scope holds that scope's span open until the
+/// actor task gets around to finishing, potentially for the actor's whole
+/// life. A test that gates on the *exported* span therefore races actor
+/// scheduling and can wait forever. Recording, by contrast, happens
+/// synchronously on the asserting test's own call path.
+struct RecordedFieldObserver {
+    /// `(span name, field name, rendered value)` per record, in order.
+    fields: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
+}
+
+struct RecordedFieldVisitor<'a> {
+    span_name: &'a str,
+    fields: &'a mut Vec<(String, String, String)>,
+}
+
+impl tracing::field::Visit for RecordedFieldVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.push((
+            self.span_name.to_string(),
+            field.name().to_string(),
+            format!("{value:?}"),
+        ));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.push((
+            self.span_name.to_string(),
+            field.name().to_string(),
+            value.to_string(),
+        ));
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for RecordedFieldObserver
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if let Ok(mut fields) = self.fields.lock() {
+            attrs.record(&mut RecordedFieldVisitor {
+                span_name: attrs.metadata().name(),
+                fields: &mut fields,
+            });
+        }
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        if let Ok(mut fields) = self.fields.lock() {
+            values.record(&mut RecordedFieldVisitor {
+                span_name: span.name(),
+                fields: &mut fields,
+            });
+        }
     }
 }
 
@@ -75,10 +156,32 @@ pub fn acquire_spans() -> SpanTestGuard {
 pub struct SpanTestGuard {
     exporter: InMemorySpanExporter,
     provider: SdkTracerProvider,
+    recorded_fields: std::sync::Arc<std::sync::Mutex<Vec<(String, String, String)>>>,
     _dispatch_guard: tracing::subscriber::DefaultGuard,
 }
 
 impl SpanTestGuard {
+    /// The last value recorded for `field` on any span named `span_name` —
+    /// whether set at span creation or via a later `Span::record`.
+    ///
+    /// Use this (not [`Self::attribute_of`]) for spans whose scope awaited
+    /// or messaged actors: those spans may be held open past the test's
+    /// assertion point by kameo children (`actor.handle_message` /
+    /// `actor.lifecycle` parent under the caller's span, and an actor
+    /// spawned inside the scope pins it until the actor dies — #1479), so
+    /// gating on the *exported* span races actor scheduling. Field records
+    /// happen synchronously on the recording call path, so this observer
+    /// sees them deterministically.
+    pub fn recorded_field(&self, span_name: &str, field: &str) -> Option<String> {
+        self.recorded_fields
+            .lock()
+            .ok()?
+            .iter()
+            .rev()
+            .find(|(span, name, _)| span == span_name && name == field)
+            .map(|(_, _, value)| value.clone())
+    }
+
     /// Flush and return every completed span exported since acquisition.
     pub fn exported(&self) -> Vec<SpanData> {
         self.provider

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -310,7 +310,7 @@ async fn xep0198_detached_session_records_deferred_iq_result_for_resume_replay()
         .await
         .expect("store detached session");
 
-    let payload = minidom::Element::builder("lookup", "urn:waddle:link-preview:0")
+    let payload = minidom::Element::builder("lookup", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
         .attr(minidom::rxml::xml_ncname!("status").to_owned(), "ready")
         .build();
     let reply = Stanza::Iq(Box::new(xmpp_parsers::iq::Iq::Result {
@@ -341,7 +341,7 @@ async fn xep0198_detached_session_records_deferred_iq_result_for_resume_replay()
     assert_eq!(element.attr("type"), Some("result"));
     assert!(
         element
-            .get_child("lookup", "urn:waddle:link-preview:0")
+            .get_child("lookup", waddle_xmpp::xep::NS_WADDLE_LINK_PREVIEW)
             .is_some(),
         "replayed result keeps the lookup payload: {replay_xml}"
     );

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -294,6 +294,60 @@ async fn xep0198_restore_drops_unacked_rows_labeled_with_foreign_stream_id() {
 }
 
 #[tokio::test]
+async fn xep0198_detached_session_records_deferred_iq_result_for_resume_replay() {
+    // #1470: link-preview lookups are answered off the frame dispatch path;
+    // when the requester detaches mid-resolve, the server-generated IQ
+    // *result* is recorded against the detached session exactly like any
+    // other server-generated frame, so resume replays it. This pins the
+    // registry-level contract the deferred-reply path
+    // (`deliver_direct_to_full` → detached fallback) depends on: IQ results
+    // are recordable (no roster/presence gating) and the replay XML
+    // round-trips as the same typed result.
+    let registry = InMemorySmSessionRegistry::new();
+    let jid: FullJid = "alice@example.test/composer".parse().expect("valid jid");
+    registry
+        .store_session(detached_session("preview-stream", jid.as_str()))
+        .await
+        .expect("store detached session");
+
+    let payload = minidom::Element::builder("lookup", "urn:waddle:link-preview:0")
+        .attr(minidom::rxml::xml_ncname!("status").to_owned(), "ready")
+        .build();
+    let reply = Stanza::Iq(Box::new(xmpp_parsers::iq::Iq::Result {
+        from: None,
+        to: Some(Jid::from(jid.clone())),
+        id: "preview-42".to_string(),
+        payload: Some(payload),
+    }));
+
+    assert!(
+        registry
+            .record_stanza_for_detached_bound_resource(&jid, &reply, chrono::Utc::now())
+            .await
+            .expect("record deferred IQ result"),
+        "a detached bound resource must accept a server-generated IQ result"
+    );
+
+    let claimed = registry
+        .claim_session("preview-stream")
+        .await
+        .expect("claim session")
+        .expect("session exists");
+    assert_eq!(claimed.unacked_stanzas.len(), 1);
+    let replay_xml = &claimed.unacked_stanzas[0].stanza_xml;
+    let element: minidom::Element = replay_xml.parse().expect("replay XML parses");
+    assert_eq!(element.name(), "iq");
+    assert_eq!(element.attr("id"), Some("preview-42"));
+    assert_eq!(element.attr("type"), Some("result"));
+    assert!(
+        element
+            .get_child("lookup", "urn:waddle:link-preview:0")
+            .is_some(),
+        "replayed result keeps the lookup payload: {replay_xml}"
+    );
+}
+
+#[tokio::test]
 async fn xep0198_claimed_session_remains_writable_until_completed() {
     let registry = InMemorySmSessionRegistry::new();
     let jid: FullJid = "alice@example.test/phone".parse().expect("valid jid");


### PR DESCRIPTION
Closes #1470.

## Problem

A cold-cache `urn:waddle:link-preview:0` composer lookup IQ was awaited inline in the per-connection frame loop. The connection's `xmpp.stanza.dispatch` span sat idle for the full resolver round-trip (production trace: 1,333 ms vs a 13.6 ms dispatch p95), so every stanza queued behind it — the user's own messages and SM acks — stalled until the preview resolved. On top of that, the resolver's outbound HTTP fetch emitted no child span, so the dominant wall time was invisible in traces.

## What changed

1. **Lookups are answered off the dispatch path.** `handle_link_preview_lookup_iq` keeps only the cheap inline work (IQ shape validation, URL/scope parsing, room-occupancy authorization, resolver-disabled and malformed-URL short-circuits — all still answered synchronously). An accepted lookup returns no frames; a spawned task runs the resolver and delivers the typed `Iq::Result` through `interpret::deliver_direct_to_full` — the authoritative `UserActor` DirectFrame seam (ADR-0017), bounded end to end (non-blocking `TrySendDirect`, capped ask timeouts, finite dropped-full retries) and the same path the clustering route bridge extends for remote resources. The destination main loop does XEP-0198 `record_outbound` before the wire write, like every other server-generated reply. RFC 6120 §8.2.3 holds: exactly one `result` per request, matched by `id`; §10.1 in-order processing is untouched because dispatch stays strictly serial.
2. **Disconnect parity with the old sync path.** If the requester is gone at delivery time, `deliver_direct_to_full`'s built-in fallback records the reply against their detached XEP-0198 session so a resume replays it — the same guarantee the synchronous write path provided via the SM unacked queue — with a one-shot retry for a resume completing mid-delivery. The dedicated XEP-0198 suite pins the registry contract (a recorded IQ result survives claim and round-trips typed). Delivery is deliberately *not* owner-gated: a resume registers a fresh owner token, and owner-gating would drop the reply in exactly the race the SM replay covers; a same-full-JID replacement session ignores an IQ result whose id it never issued.
3. **Bounded admission.** Serial dispatch was an accidental one-per-connection throttle; the deferred path bounds resolver concurrency explicitly with a per-node semaphore in `ProtocolServices` (32 permits, `try_acquire` at dispatch). A saturated resolver answers a fail-open `failed` status inline (per the #822 PRD) with a new `saturated` telemetry event, instead of queueing tasks whose replies would outlive the client's IQ budget. The permit is released after the resolve, before delivery, so a backpressured recipient can't pin a resolver slot.
4. **Fetch instrumentation.** The resolver's page fetch and preview-image fetch each run under a `link_preview.fetch` child span carrying only the target host and a typed fetch phase (`page`/`image`) — no URL, path, query, or JID. OTEL error status is set only for real fetch failures (not policy verdicts like blocked/unsupported), per the #1477 error-span convention; the spawned task runs under a `link_preview.resolve` span parented to the originating dispatch span, so nothing here adds root-span noise (#1438).

No wire-shape change: the `urn:waddle:link-preview:0` request/response elements are unchanged; only response timing moves.

## Tests

- Dispatch returns before a slow (3 s) resolver round-trip completes, a second IQ is fully dispatched and answered while the first preview is still resolving, and the deferred reply then arrives with the original request id.
- The deferred reply is recorded into a detached XEP-0198 session and sits in its unacked queue for resume replay.
- Saturated admission answers `failed` inline with `saturated` telemetry.
- A requester that vanished entirely (no live connection, no detached session) resolves cleanly with the reply dropped (fail open).
- Dispatch-level tests (`tests/iq.rs`) updated to consume the deferred reply from the connection registry and assert id/addressing echo (RFC 6120 §8.2.3).
- Existing lookup/resolver suites (160 tests) pass; full `waddle-server` lib suite shows the same 5 pre-existing parallel-run metric flakes as current `main` (verified against a `main` worktree baseline — no regressions).

## Review

Three independent reviews ran (standards + spec sub-agents, plus a gpt-5.6-terra codex pass): permit-through-delivery starvation, unbounded task admission, and the untested detached-SM replay path were found and fixed; owner-gated delivery and shutdown-abort handling were evaluated and deliberately rejected (rationale documented in code comments). A second adversarial round (concurrency/XMPP persona) found two minors — a resume-race reply drop and policy verdicts degrading to `failed` under saturation — both fixed (pre-I/O verdicts now answer inline before admission; the detached-record miss retries the live send once). A third verification pass confirmed the fixes with no double-counting or divergence. Post-publish bot reviews (Greptile, Qodo, codex-connector) raised five findings — unbounded delivery-waiting tasks, node-local delivery under clustering, an untyped secret in the callback envelope, and missing dedicated XEP-0198 coverage — all fixed by routing delivery through the `UserActor` seam, a typed `LinkPreviewSigningSecret`, and a new XEP-0198 suite test; each comment has a reply describing its fix. A follow-up Greptile P1 (accepted replies lost when a connected requester stays backpressured through the delivery helper's in-line retries) is fixed with a bounded delivery retry tail (250ms/1s/4s), safe for IQ results specifically because duplicates are ignored by id.

## CI notes

- **#1479** (pre-existing on main, root-caused here): tests gating on the *exported* `xmpp.stanza.dispatch` span race actor scheduling — kameo parents actor spans/envelope span-clones under the caller's span, so a straggling actor handler holds the span open past the assertion point (sometimes indefinitely). This PR adds `SpanTestGuard::recorded_field` (synchronous field observation) and moves the flaky assertion onto it; verified with 250 stress iterations under CPU saturation (pre-fix reproduction: up to 1-in-17). Full analysis on the issue.
- **#1480** (filed from this PR): `checkRootSyncDrift` flip-flops `[runtimes.chat]` across identical-tree runs; the lock here matches main and failures of that check are rerun-until-deterministic-fix territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
