### PR TITLE
obs(server): log, count, and span-mark session-init failures

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -18,22 +18,31 @@ pub(super) enum RegistrationAfterFrame {
 /// Every `SessionInitializationFailed` return routes through here so the
 /// client-visible stream `<internal-server-error/>` is never server-silent
 /// again: one `error!` with the bare JID, the XEP-0198 stream id when one
-/// exists, and the typed reason; the `waddle.session.init.failed` counter
-/// keyed by that reason so the rate is alertable; and an error mark on the
-/// current dispatch span so the failure surfaces in Tempo `status=error`
-/// queries (#1428). The bare JID lives on the log only — never as a metric
+/// exists (fresh binds enable SM only after bind, so it is empty there),
+/// the typed reason, and the failure detail; the
+/// `waddle.session.init.failed` counter keyed by that reason so the rate is
+/// alertable; and a dedicated error-status span. The span is created here —
+/// not recorded on `Span::current()` — because registration runs after
+/// `handle_xmpp_frame` returns, outside `xmpp.stanza.dispatch`, where a
+/// current-span mark would be a silent no-op; a short point-in-time root
+/// span is exactly the #1428 "internal failures export as error spans"
+/// shape. The bare JID lives on the log and span only — never as a metric
 /// attribute.
-fn record_session_init_failure(
+pub(super) fn record_session_init_failure(
     reason: waddle_xmpp::telemetry::attributes::SessionInitFailureReason,
     jid: &FullJid,
     stream_id: Option<&str>,
+    detail: Option<String>,
 ) {
     use waddle_xmpp::telemetry::attributes::MetricAttribute;
     error!(
         user = %jid.to_bare(),
         resource = %jid.resource(),
-        stream_id = stream_id.unwrap_or(""),
+        // Logged as an Option so a fresh bind (no SM yet → None) stays
+        // distinguishable from a genuinely empty id.
+        stream_id = ?stream_id,
         reason = reason.value(),
+        detail = detail.as_deref().unwrap_or(""),
         "session initialization failed; sending stream internal-server-error and closing"
     );
     waddle_xmpp::counter_add!(
@@ -44,6 +53,12 @@ fn record_session_init_failure(
         1,
         reason,
     );
+    let span = tracing::info_span!(
+        "xmpp.session.init",
+        user = %jid.to_bare(),
+        reason = reason.value(),
+    );
+    let _enter = span.enter();
     crate::telemetry::mark_span_error("session initialization failed");
 }
 
@@ -145,16 +160,15 @@ pub(super) async fn register_bound_connection_after_frame(
         match load_blocklist_for_bind(&state.deps.app_state.db_pool, &jid).await {
             Ok(blocklist) => blocklist,
             Err(error) => {
-                error!(
-                    jid = %jid,
-                    %error,
-                    "Failed to load XEP-0191 blocklist at bind; failing the bind to avoid a \
-                     session-long fail-open. Client should reconnect."
-                );
+                // Fail the bind rather than run the session with an empty
+                // blocklist (a session-long XEP-0191 fail-open). The choke
+                // point below is the single log line for this failure —
+                // #1175 log hygiene: no second free-standing error!.
                 record_session_init_failure(
                     waddle_xmpp::telemetry::attributes::SessionInitFailureReason::BlocklistLoad,
                     &jid,
                     conn.sm_state.stream_id.as_deref(),
+                    Some(format!("XEP-0191 blocklist load failed: {error}")),
                 );
                 return RegistrationAfterFrame::SessionInitializationFailed;
             }
@@ -274,6 +288,7 @@ pub(super) async fn register_bound_connection_after_frame(
                 waddle_xmpp::telemetry::attributes::SessionInitFailureReason::AuthoritativeRegistration,
                 &jid,
                 conn.sm_state.stream_id.as_deref(),
+                None,
             );
             return RegistrationAfterFrame::SessionInitializationFailed;
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -13,6 +13,40 @@ pub(super) enum RegistrationAfterFrame {
     SessionInitializationFailed,
 }
 
+/// Single choke point for a failed post-auth session initialization (#1454).
+///
+/// Every `SessionInitializationFailed` return routes through here so the
+/// client-visible stream `<internal-server-error/>` is never server-silent
+/// again: one `error!` with the bare JID, the XEP-0198 stream id when one
+/// exists, and the typed reason; the `waddle.session.init.failed` counter
+/// keyed by that reason so the rate is alertable; and an error mark on the
+/// current dispatch span so the failure surfaces in Tempo `status=error`
+/// queries (#1428). The bare JID lives on the log only — never as a metric
+/// attribute.
+fn record_session_init_failure(
+    reason: waddle_xmpp::telemetry::attributes::SessionInitFailureReason,
+    jid: &FullJid,
+    stream_id: Option<&str>,
+) {
+    use waddle_xmpp::telemetry::attributes::MetricAttribute;
+    error!(
+        user = %jid.to_bare(),
+        resource = %jid.resource(),
+        stream_id = stream_id.unwrap_or(""),
+        reason = reason.value(),
+        "session initialization failed; sending stream internal-server-error and closing"
+    );
+    waddle_xmpp::counter_add!(
+        "waddle.session.init.failed",
+        "1",
+        "Post-auth session initialization failures by reason; each one sent a \
+         client a stream-level internal-server-error.",
+        1,
+        reason,
+    );
+    crate::telemetry::mark_span_error("session initialization failed");
+}
+
 /// Publish the SM stream id onto the freshly-registered entry so the
 /// offline-flush path keys claims by the XEP-0198 session id, not the
 /// resource JID. For a fresh bind without SM enabled, sm_state.stream_id is
@@ -116,6 +150,11 @@ pub(super) async fn register_bound_connection_after_frame(
                     %error,
                     "Failed to load XEP-0191 blocklist at bind; failing the bind to avoid a \
                      session-long fail-open. Client should reconnect."
+                );
+                record_session_init_failure(
+                    waddle_xmpp::telemetry::attributes::SessionInitFailureReason::BlocklistLoad,
+                    &jid,
+                    conn.sm_state.stream_id.as_deref(),
                 );
                 return RegistrationAfterFrame::SessionInitializationFailed;
             }
@@ -229,6 +268,13 @@ pub(super) async fn register_bound_connection_after_frame(
             )
             .await;
             conn.registry_owner = None;
+            // This was the server-silent path from #1454: the rollback ran
+            // and the client got a stream error with no server-side trace.
+            record_session_init_failure(
+                waddle_xmpp::telemetry::attributes::SessionInitFailureReason::AuthoritativeRegistration,
+                &jid,
+                conn.sm_state.stream_id.as_deref(),
+            );
             return RegistrationAfterFrame::SessionInitializationFailed;
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -35,6 +35,18 @@ pub(super) fn record_session_init_failure(
     detail: Option<String>,
 ) {
     use waddle_xmpp::telemetry::attributes::MetricAttribute;
+    // `error_span!` (not `info_span!`): the registry-level `EnvFilter` gates
+    // span export too, so an operator running `RUST_LOG=warn`/`error` must
+    // not silently lose the failure span while keeping the log line.
+    let span = tracing::error_span!(
+        "xmpp.session.init",
+        user = %jid.to_bare(),
+        reason = reason.value(),
+    );
+    let _enter = span.enter();
+    // Inside the span scope so the OTLP log record carries this span's
+    // trace/span id — the alertable line pivots straight to the Tempo
+    // error span.
     error!(
         user = %jid.to_bare(),
         resource = %jid.resource(),
@@ -53,12 +65,6 @@ pub(super) fn record_session_init_failure(
         1,
         reason,
     );
-    let span = tracing::info_span!(
-        "xmpp.session.init",
-        user = %jid.to_bare(),
-        reason = reason.value(),
-    );
-    let _enter = span.enter();
     crate::telemetry::mark_span_error("session initialization failed");
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -684,6 +684,52 @@ async fn failed_authoritative_registration_logs_and_increments_counter() {
     );
 }
 
+/// #1454, blocklist-load arm + span half of the acceptance criteria. The
+/// blocklist DB failure itself cannot be forced through the public seam
+/// (`db_pool.global()` is a direct backend handle, not the killable
+/// actor), and the arm is a straight-line call into the choke point — so
+/// pin the choke point itself for the `blocklist_load` reason: counter,
+/// and the dedicated `xmpp.session.init` error-status span with typed
+/// attributes. Unlike dispatch-scoped spans (#1479), this span opens and
+/// closes synchronously with no actor children, so asserting its export
+/// does not race actor scheduling.
+#[tokio::test(flavor = "current_thread")]
+async fn session_init_failure_choke_point_counts_and_exports_error_span() {
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    super::super::registration::record_session_init_failure(
+        waddle_xmpp::telemetry::attributes::SessionInitFailureReason::BlocklistLoad,
+        &jid,
+        Some("stream-7"),
+        Some("XEP-0191 blocklist load failed: simulated".to_string()),
+    );
+
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.session.init.failed",
+            &[("reason", "blocklist_load")]
+        ),
+        Some(1),
+        "the failure must increment the alertable counter exactly once"
+    );
+    assert_eq!(
+        spans.attribute_of("xmpp.session.init", "reason"),
+        Some("blocklist_load".to_string()),
+        "the failure span must carry the typed reason"
+    );
+    assert_eq!(
+        spans.attribute_of("xmpp.session.init", "user"),
+        Some("alice@example.com".to_string()),
+        "the failure span must carry the bare user JID"
+    );
+    assert!(
+        spans.has_error_status("xmpp.session.init"),
+        "the failure span must export with error status (#1428)"
+    );
+}
+
 /// ADR-0017 Phase 1: the dominant (non-SM) disconnect teardown mirrors the
 /// unregister into the actor tree, so a bound-then-closed connection does not
 /// leak its resource — and the empty `UserActor` is pruned. Regression test

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -590,6 +590,100 @@ async fn stale_owner_publication_does_not_stamp_replacement_entry() {
     );
 }
 
+/// #1454: a failed authoritative registration used to send the client a
+/// stream `<internal-server-error/>` with NO server-side log or metric —
+/// 32 client-side Faro events over 7 days against zero server log lines.
+/// Drive the real failure path (kill the `UserRegistryActor` so the mirror
+/// ask fails, forcing the ADR-0017 fail-closed rollback) and assert the
+/// failure now logs at `error!` with typed context and increments the
+/// alertable `waddle.session.init.failed` counter. The span-error mark
+/// shares the centrally-tested `mark_span_error` helper; asserting its
+/// export here would race actor scheduling (#1479), so it is deliberately
+/// not export-asserted in this actor-heavy scope.
+#[tokio::test(flavor = "current_thread")]
+async fn failed_authoritative_registration_logs_and_increments_counter() {
+    use std::sync::{Arc as StdArc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(StdArc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let buffer = StdArc::new(Mutex::new(Vec::new()));
+    let _subscriber = tracing::subscriber::set_default(
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::ERROR)
+            .with_writer(CaptureWriter(buffer.clone()))
+            .finish(),
+    );
+
+    let state = create_test_websocket_state().await;
+    // Kill the authoritative registry so `mirror_register_outcome`'s ask
+    // fails — exactly the rollback path that was server-silent.
+    state.deps.protocol.user_registry.kill();
+    state.deps.protocol.user_registry.wait_for_shutdown().await;
+
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+
+    let outcome = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, RegistrationAfterFrame::SessionInitializationFailed),
+        "a failed authoritative registration must fail the bind"
+    );
+    assert!(
+        conn.registry_owner.is_none(),
+        "the rollback must clear the registry owner"
+    );
+    assert_eq!(
+        metrics.counter_sum(
+            "waddle.session.init.failed",
+            &[("reason", "authoritative_registration")]
+        ),
+        Some(1),
+        "the failure must increment the alertable counter exactly once"
+    );
+    let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
+        .expect("captured logs are valid UTF-8");
+    assert!(
+        logs.contains("session initialization failed")
+            && logs.contains("alice@example.com")
+            && logs.contains("authoritative_registration"),
+        "the failure must be logged at error! with the user and typed reason. Captured:\n{logs}"
+    );
+}
+
 /// ADR-0017 Phase 1: the dominant (non-SM) disconnect teardown mirrors the
 /// unregister into the actor tree, so a bound-then-closed connection does not
 /// leak its resource — and the empty `UserActor` is pruned. Regression test

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -610,3 +610,33 @@ impl MetricAttribute for PushProvider {
         }
     }
 }
+
+/// `reason` — why post-auth session initialization failed (#1454). One
+/// variant per `SessionInitializationFailed` return site in the WebSocket
+/// registration path, so the `waddle.session.init.failed` rate is
+/// attributable without unbounded values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionInitFailureReason {
+    /// The XEP-0191 blocklist load at bind failed; the bind fails closed
+    /// rather than running the session with an empty blocklist.
+    BlocklistLoad,
+    /// The authoritative `UserActor` registration (or clustered
+    /// remote-resource registration) could not confirm the resource; the
+    /// DashMap registration was rolled back and the bind failed closed
+    /// (ADR-0017 Phase 1: the two views must never disagree in the
+    /// miss-a-resource direction).
+    AuthoritativeRegistration,
+}
+
+impl sealed::Sealed for SessionInitFailureReason {}
+impl MetricAttribute for SessionInitFailureReason {
+    fn key(&self) -> &'static str {
+        "reason"
+    }
+    fn value(&self) -> &'static str {
+        match self {
+            Self::BlocklistLoad => "blocklist_load",
+            Self::AuthoritativeRegistration => "authoritative_registration",
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/telemetry/tests.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/tests.rs
@@ -2,7 +2,8 @@
 //! samples through the in-memory reader seam, never internal state.
 
 use super::attributes::{
-    Janitor, MessageKind, MetricAttribute, StanzaErrorCondition, SweepOutcome,
+    Janitor, MessageKind, MetricAttribute, SessionInitFailureReason, StanzaErrorCondition,
+    SweepOutcome,
 };
 use super::test_support;
 use super::validate_metric_name;
@@ -274,5 +275,14 @@ fn attribute_enums_expose_stable_keys_and_values() {
     assert_eq!(
         StanzaErrorCondition::PolicyViolation.value(),
         "policy-violation"
+    );
+    assert_eq!(SessionInitFailureReason::BlocklistLoad.key(), "reason");
+    assert_eq!(
+        SessionInitFailureReason::BlocklistLoad.value(),
+        "blocklist_load"
+    );
+    assert_eq!(
+        SessionInitFailureReason::AuthoritativeRegistration.value(),
+        "authoritative_registration"
     );
 }


### PR DESCRIPTION
Closes #1454.

## Problem

When post-auth session initialization fails, the server sends the client a stream-level `<internal-server-error/>` and closes the WebSocket with **no log, metric, or error span** on one of the two failure paths. Production evidence: 32 client-side `stream-internal-server-error` Faro events over 7 days against **zero** matching server-side log lines. The blocklist-load failure already logs `error!` but has no metric or span error; the authoritative-registration rollback (`registration.rs` mirror-register failure) is completely silent.

## What changed

1. **Typed reason attribute.** Add a `SessionInitFailureReason` enum (`blocklist_load`, `authoritative_registration`) to the metric-attribute allowlist in `telemetry/attributes.rs`, per the cardinality-budget rule.
2. **One choke point.** A `record_session_init_failure(reason, jid, stream_id)` helper in `registration.rs` emits the `error!` log (bare JID, XEP-0198 stream id when present, reason), increments `waddle.session.init.failed` via the create-at-increment `counter_add!` macro, and marks the current span error (`mark_span_error`, feeding #1428). Both `SessionInitializationFailed` return sites call it; the blocklist site keeps its detailed error-specific log line.
3. **A real error span, not a silent no-op.** Review caught that marking `Span::current()` would have done nothing — registration runs after `handle_xmpp_frame` returns, outside `xmpp.stanza.dispatch` and the deliberately-uninstrumented connection future. The choke point instead opens a dedicated short-lived `xmpp.session.init` span (bare user + typed reason) and marks that, matching the #1428 internal-failures-as-error-spans shape; it has no actor children, so its export is deterministic (the #1479 class of export race cannot occur).
4. **Log hygiene (#1175).** The blocklist arm's pre-existing free-standing `error!` folded into the choke point's single line via a `detail` field; `stream_id` logs as an `Option` so a fresh bind (SM enabled only after bind) is distinguishable from an empty id.
5. **Tests.** (a) The real authoritative-registration failure path is driven by killing the test state's `UserRegistryActor` so the ADR-0017 mirror ask fails and rolls back — asserting the typed outcome, the `waddle.session.init.failed{reason=authoritative_registration}` counter, and the `error!` line via a capture subscriber. (b) The choke point is pinned for `blocklist_load`: counter, span `reason`/`user` attributes, and error status (the blocklist DB failure is not forceable through the public seam — `db_pool.global()` is a direct backend handle — and that arm is a straight-line call into the choke point). (c) Reason labels are pinned in the attribute stability test.

## Review

Two independent reviews (standards+spec agent, gpt-5.6-terra codex) converged on the same major — the current-span error mark being a no-op — plus the double-log and Option-stream-id minors; all fixed. Both confirmed: both `SessionInitializationFailed` producers are covered and are the only two in the codebase, metric conventions hold (allowlist attribute, `counter_add!`, no JIDs on metrics), and the killed-actor test genuinely exercises `mirror_register_outcome → Failed → rollback`.

No wire-shape change: the client-facing stream error is untouched; only server-side observability is added. Post-deploy, the counter should reconcile with the client-side Faro volume (issue acceptance item — verified in Loki/Tempo after rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
