### PR TITLE
obs(server): restore process metrics via OTLP and cut ~95% trace-ingest noise (#1435, #1438)

### DIFF
--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -326,6 +326,7 @@ impl Database {
         let conn = match self.guard().await {
             Ok(conn) => conn,
             Err(e) => {
+                crate::telemetry::mark_span_error("database health check guard failed");
                 Self::record_health_check_failure();
                 return Err(e);
             }

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -300,14 +300,42 @@ impl Database {
         &self.database_url
     }
 
+    /// Export the alertable DB health-check failure counter. The probe
+    /// spans that used to carry this signal are suppressed as trace
+    /// noise (#1438). Shared with the pool so its ask-failure branch
+    /// (actor unreachable — [`Database::health_check`] never runs)
+    /// counts through the same instrument.
+    pub(crate) fn record_health_check_failure() {
+        waddle_xmpp::counter_add!(
+            "waddle.db.health_check.failed",
+            "1",
+            "Database health-check failures (failed probe query, unavailable \
+             connection, or unreachable DB actor), across the pool and direct \
+             liveness paths.",
+            1,
+        );
+    }
+
     #[instrument(skip_all, fields(name = %self.name), err)]
     pub async fn health_check(&self) -> Result<bool, DatabaseError> {
-        let conn = self.guard().await?;
+        // The deepest common point of every health probe — the pool's
+        // actor ask and the direct /health `/healthz` liveness handlers
+        // both land here. The probe-driven `health_check` spans are
+        // suppressed as trace noise (#1438), so the counter is the
+        // alertable failure signal for all of them.
+        let conn = match self.guard().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                Self::record_health_check_failure();
+                return Err(e);
+            }
+        };
         match conn.query("SELECT 1", ()).await {
             Ok(_) => Ok(true),
             Err(e) => {
                 crate::telemetry::mark_span_error("database health check failed");
                 tracing::warn!(error = %e, "Database health check failed");
+                Self::record_health_check_failure();
                 Ok(false)
             }
         }

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -54,6 +54,16 @@ impl DatabasePool {
             Err(e) => {
                 crate::telemetry::mark_span_error("global database health check failed");
                 tracing::warn!(error = %e, "Global DB health check failed");
+                // The probe-driven `health_check` spans that used to carry
+                // this failure are suppressed as trace noise (#1438), so
+                // the counter is the alertable signal.
+                waddle_xmpp::counter_add!(
+                    "waddle.db.health_check.failed",
+                    "1",
+                    "Global database health-check failures observed by the \
+                     readiness/liveness path.",
+                    1,
+                );
                 false
             }
         };
@@ -92,6 +102,25 @@ mod tests {
         let health = pool.health_check().await.unwrap();
         assert!(health.global_healthy);
         assert_eq!(health.loaded_waddle_count, 1);
+    }
+
+    #[tokio::test]
+    async fn failed_health_check_increments_the_failure_counter() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("pool");
+        pool.global_actor().kill();
+        pool.global_actor().wait_for_shutdown().await;
+
+        let health = pool.health_check().await.expect("health result");
+
+        assert!(!health.global_healthy);
+        assert_eq!(
+            metrics.counter_sum("waddle.db.health_check.failed", &[]),
+            Some(1),
+            "a failed DB health check must export the alertable counter"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -54,23 +54,13 @@ impl DatabasePool {
             Err(e) => {
                 crate::telemetry::mark_span_error("global database health check failed");
                 tracing::warn!(error = %e, "Global DB health check failed");
+                // Query-level failures count inside
+                // `Database::health_check`; this branch is the one case
+                // that never reaches it (actor unreachable).
+                super::Database::record_health_check_failure();
                 false
             }
         };
-        if !global_healthy {
-            // Covers both the ask failure above and the actor answering
-            // Ok(false) for a failed probe query. The probe-driven
-            // `health_check` spans that used to carry this failure are
-            // suppressed as trace noise (#1438), so the counter is the
-            // alertable signal.
-            waddle_xmpp::counter_add!(
-                "waddle.db.health_check.failed",
-                "1",
-                "Global database health-check failures observed by the \
-                 readiness/liveness path.",
-                1,
-            );
-        }
 
         Ok(PoolHealth {
             global_healthy,

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -54,19 +54,23 @@ impl DatabasePool {
             Err(e) => {
                 crate::telemetry::mark_span_error("global database health check failed");
                 tracing::warn!(error = %e, "Global DB health check failed");
-                // The probe-driven `health_check` spans that used to carry
-                // this failure are suppressed as trace noise (#1438), so
-                // the counter is the alertable signal.
-                waddle_xmpp::counter_add!(
-                    "waddle.db.health_check.failed",
-                    "1",
-                    "Global database health-check failures observed by the \
-                     readiness/liveness path.",
-                    1,
-                );
                 false
             }
         };
+        if !global_healthy {
+            // Covers both the ask failure above and the actor answering
+            // Ok(false) for a failed probe query. The probe-driven
+            // `health_check` spans that used to carry this failure are
+            // suppressed as trace noise (#1438), so the counter is the
+            // alertable signal.
+            waddle_xmpp::counter_add!(
+                "waddle.db.health_check.failed",
+                "1",
+                "Global database health-check failures observed by the \
+                 readiness/liveness path.",
+                1,
+            );
+        }
 
         Ok(PoolHealth {
             global_healthy,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -9,6 +9,7 @@ mod extension_host_tools;
 mod fixed_account;
 mod health;
 mod http;
+pub(crate) mod process_metrics;
 pub(crate) mod profile_publish_route;
 mod room_registry_gauge;
 mod session_janitors;

--- a/server/crates/waddle-server/src/server/process_metrics.rs
+++ b/server/crates/waddle-server/src/server/process_metrics.rs
@@ -7,8 +7,14 @@
 //! through the OTLP pipeline:
 //!
 //! - `waddle.process.start_time` (unit `s`): unix-epoch seconds
-//!   captured once at telemetry init. A restart is detectable from
-//!   metrics alone via `changes(waddle_process_start_time_seconds[1h]) > 0`.
+//!   captured once at telemetry init. Every restart mints a new series
+//!   (`service.instance.id` carries the pod name + pid, and the value
+//!   is constant within a series), so restart detection is
+//!   young-process presence — `time() - waddle_process_start_time_seconds
+//!   < 600` — or series churn, never `changes()` on one series.
+//!   Verify the normalized series name against the live datasource
+//!   before writing alerts; this stack has produced both `_seconds`-
+//!   and raw-UCUM-suffixed names (see `rules/README.md`).
 //! - `waddle.process.cpu.time` (unit `s`, monotonic sum): user+system
 //!   CPU seconds from `/proc/self/stat`.
 //! - `waddle.process.open_file_descriptors` (unit `{fd}`): entry count
@@ -112,7 +118,8 @@ pub(crate) fn init_process_instruments() {
             .i64_observable_gauge("waddle.process.start_time")
             .with_description(
                 "Unix time the server process started, captured at telemetry init. \
-                 changes(...) > 0 detects a restart from metrics alone (#1435).",
+                 Each restart is a new series (pid-suffixed instance id), so detect \
+                 restarts via time() - value < threshold, not changes() (#1435).",
             )
             .with_unit("s")
             .with_callback(|observer| observer.observe(start_time_unix_seconds(), &[]))

--- a/server/crates/waddle-server/src/server/process_metrics.rs
+++ b/server/crates/waddle-server/src/server/process_metrics.rs
@@ -1,0 +1,238 @@
+//! Process-level OTel instruments: start time, CPU time, open FDs (#1435).
+//!
+//! Since the `/metrics` contract phase (#1330/#1426) reduced the
+//! Prometheus text endpoint to a liveness stub, waddle-server exported
+//! no restart/uptime signal at all — crash-loops were only inferable
+//! from ReplicaSet-hash churn. These instruments restore that signal
+//! through the OTLP pipeline:
+//!
+//! - `waddle.process.start_time` (unit `s`): unix-epoch seconds
+//!   captured once at telemetry init. A restart is detectable from
+//!   metrics alone via `changes(waddle_process_start_time_seconds[1h]) > 0`.
+//! - `waddle.process.cpu.time` (unit `s`, monotonic sum): user+system
+//!   CPU seconds from `/proc/self/stat`.
+//! - `waddle.process.open_file_descriptors` (unit `{fd}`): entry count
+//!   of `/proc/self/fd`.
+//!
+//! Observable instruments with callbacks (the `init_pod_gauges`
+//! pattern) rather than the periodic publisher: values are read at
+//! every reader collection, so they export from the first OTLP push
+//! with no sidecar task. The `/proc` readers are Linux-only and degrade
+//! to "no series" elsewhere, mirroring
+//! `state_inventory_metrics::read_process_rss_bytes`.
+
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn meter() -> &'static opentelemetry::metrics::Meter {
+    static METER: OnceLock<opentelemetry::metrics::Meter> = OnceLock::new();
+    METER.get_or_init(|| opentelemetry::global::meter("waddle-server"))
+}
+
+/// Unix-epoch seconds captured on first use — telemetry init runs
+/// within milliseconds of exec, so this is the process start time for
+/// every restart-detection purpose. Reading the kernel's exact value
+/// (`/proc/self/stat` field 22 + boot time) would buy sub-second
+/// precision at the cost of a Linux-only start-time signal.
+fn start_time_unix_seconds() -> i64 {
+    static START: OnceLock<i64> = OnceLock::new();
+    *START.get_or_init(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|since_epoch| i64::try_from(since_epoch.as_secs()).unwrap_or(i64::MAX))
+            .unwrap_or(0)
+    })
+}
+
+/// Parse total CPU seconds (utime + stime) from a `/proc/<pid>/stat`
+/// line. The second field, `comm`, is parenthesized and may itself
+/// contain spaces and `)` — fields are therefore indexed after the
+/// *last* `)`. After it, `state` is overall field 3, so `utime`
+/// (overall field 14) sits at index 11 and `stime` (15) follows.
+fn cpu_seconds_from_stat(stat: &str, clock_ticks_per_second: u64) -> Option<f64> {
+    if clock_ticks_per_second == 0 {
+        return None;
+    }
+    let (_, after_comm) = stat.rsplit_once(')')?;
+    let mut fields = after_comm.split_whitespace();
+    let utime: u64 = fields.nth(11)?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+    Some((utime.saturating_add(stime)) as f64 / clock_ticks_per_second as f64)
+}
+
+/// The kernel's ticks-per-second constant. `None` when unavailable or
+/// nonsensical (≤ 0) rather than dividing by a bogus value.
+fn clock_ticks_per_second() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        // SAFETY: `sysconf(_SC_CLK_TCK)` is signal-safe and has no
+        // preconditions.
+        let ticks = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        u64::try_from(ticks).ok().filter(|ticks| *ticks > 0)
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+/// Read total process CPU seconds. `None` off Linux (`/proc` does not
+/// exist, so the read fails) or when `/proc/self/stat` is malformed;
+/// the callback then records no sample instead of a wrong one.
+fn read_cpu_seconds() -> Option<f64> {
+    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+    cpu_seconds_from_stat(&stat, clock_ticks_per_second()?)
+}
+
+/// Count this process's open file descriptors via `/proc/self/fd`.
+/// The count includes the directory handle the read itself opens —
+/// a constant +1 that never matters for the leak trends the metric
+/// exists to show. `None` off Linux.
+fn read_open_fd_count() -> Option<i64> {
+    let entries = std::fs::read_dir("/proc/self/fd").ok()?;
+    i64::try_from(entries.count()).ok()
+}
+
+/// Register the process instruments eagerly so a fresh pod exports its
+/// start time on the very first OTLP push (a restart signal that only
+/// appears after traffic would miss the crash-loops it exists to
+/// catch). Called from `telemetry::init` next to
+/// `waddle_xmpp::metrics::init_pod_gauges`; the instruments are held
+/// in the `OnceLock` so their callbacks stay alive for the process
+/// lifetime.
+pub(crate) fn init_process_instruments() {
+    struct ProcessInstruments {
+        _start_time: opentelemetry::metrics::ObservableGauge<i64>,
+        _cpu_time: opentelemetry::metrics::ObservableCounter<f64>,
+        _open_fds: opentelemetry::metrics::ObservableGauge<i64>,
+    }
+    static INSTRUMENTS: OnceLock<ProcessInstruments> = OnceLock::new();
+    INSTRUMENTS.get_or_init(|| ProcessInstruments {
+        _start_time: meter()
+            .i64_observable_gauge("waddle.process.start_time")
+            .with_description(
+                "Unix time the server process started, captured at telemetry init. \
+                 changes(...) > 0 detects a restart from metrics alone (#1435).",
+            )
+            .with_unit("s")
+            .with_callback(|observer| observer.observe(start_time_unix_seconds(), &[]))
+            .build(),
+        _cpu_time: meter()
+            .f64_observable_counter("waddle.process.cpu.time")
+            .with_description(
+                "Total user+system CPU seconds consumed by the server process, \
+                 from /proc/self/stat.",
+            )
+            .with_unit("s")
+            .with_callback(|observer| {
+                if let Some(seconds) = read_cpu_seconds() {
+                    observer.observe(seconds, &[]);
+                }
+            })
+            .build(),
+        _open_fds: meter()
+            .i64_observable_gauge("waddle.process.open_file_descriptors")
+            // UCUM annotation: dropped by Prometheus name normalization,
+            // so the backend series has no unit suffix.
+            .with_unit("{fd}")
+            .with_description(
+                "Open file descriptors held by the server process, from /proc/self/fd.",
+            )
+            .with_callback(|observer| {
+                if let Some(count) = read_open_fd_count() {
+                    observer.observe(count, &[]);
+                }
+            })
+            .build(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_time_is_positive_and_stable() {
+        let first = start_time_unix_seconds();
+        assert!(first > 0, "start time must be a positive unix timestamp");
+        assert_eq!(
+            first,
+            start_time_unix_seconds(),
+            "start time must never move within a process lifetime"
+        );
+    }
+
+    #[test]
+    fn cpu_seconds_parses_a_realistic_stat_line() {
+        // utime = 250 ticks (overall field 14), stime = 150 ticks (15),
+        // 100 ticks/s → 4.0 CPU seconds.
+        let stat = "12345 (waddle-server) S 1 12345 12345 0 -1 4194560 1000 0 5 0 250 150 0 0 20 0 8 0 100000 1000000 500 18446744073709551615 1 1 0 0 0 0 0 0 0 0 0 0 17 3 0 0 0 0 0";
+        assert_eq!(cpu_seconds_from_stat(stat, 100), Some(4.0));
+    }
+
+    #[test]
+    fn cpu_seconds_survives_comm_with_spaces_and_parens() {
+        // comm is attacker/operator-controlled (`exec -a`); parsing must
+        // index after the LAST ')'.
+        let stat = "1 (evil ) comm) S 1 1 1 0 -1 0 0 0 0 0 300 100 0 0 20 0 1 0 1 1 1 1";
+        assert_eq!(cpu_seconds_from_stat(stat, 100), Some(4.0));
+    }
+
+    #[test]
+    fn cpu_seconds_rejects_malformed_input_and_zero_ticks() {
+        assert_eq!(cpu_seconds_from_stat("garbage", 100), None);
+        assert_eq!(cpu_seconds_from_stat("1 (a) S 1 2", 100), None);
+        assert_eq!(cpu_seconds_from_stat("", 100), None);
+        let valid = "1 (a) S 1 1 1 0 -1 0 0 0 0 0 300 100 0 0 20 0 1 0 1 1 1 1";
+        assert_eq!(cpu_seconds_from_stat(valid, 0), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_readers_return_values_on_linux() {
+        assert!(
+            read_cpu_seconds().is_some_and(|seconds| seconds >= 0.0),
+            "a live Linux process must report CPU time"
+        );
+        assert!(
+            read_open_fd_count().is_some_and(|count| count > 0),
+            "a live Linux process must hold open file descriptors"
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn proc_readers_are_none_off_linux() {
+        assert!(read_cpu_seconds().is_none());
+        assert!(read_open_fd_count().is_none());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn init_exports_the_process_instruments_through_the_reader_seam() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        init_process_instruments();
+
+        let names = metrics.metric_names();
+        assert!(
+            names.contains(&"waddle.process.start_time".to_string()),
+            "start time must export eagerly: {names:?}"
+        );
+        assert_eq!(
+            metrics.metric_unit("waddle.process.start_time"),
+            Some("s".to_string()),
+        );
+
+        // The /proc-backed instruments only produce series on Linux.
+        #[cfg(target_os = "linux")]
+        {
+            assert!(
+                names.contains(&"waddle.process.cpu.time".to_string()),
+                "CPU time must export on Linux: {names:?}"
+            );
+            assert!(
+                names.contains(&"waddle.process.open_file_descriptors".to_string()),
+                "open-FD count must export on Linux: {names:?}"
+            );
+        }
+    }
+}

--- a/server/crates/waddle-server/src/server/process_metrics.rs
+++ b/server/crates/waddle-server/src/server/process_metrics.rs
@@ -113,6 +113,10 @@ pub(crate) fn init_process_instruments() {
         _open_fds: opentelemetry::metrics::ObservableGauge<i64>,
     }
     static INSTRUMENTS: OnceLock<ProcessInstruments> = OnceLock::new();
+    // Pin the start timestamp NOW — the observable callback only runs
+    // at the first reader collection (~60 s in), which would otherwise
+    // be the value recorded.
+    let _ = start_time_unix_seconds();
     INSTRUMENTS.get_or_init(|| ProcessInstruments {
         _start_time: meter()
             .i64_observable_gauge("waddle.process.start_time")

--- a/server/crates/waddle-server/src/server/process_metrics.rs
+++ b/server/crates/waddle-server/src/server/process_metrics.rs
@@ -7,11 +7,13 @@
 //! through the OTLP pipeline:
 //!
 //! - `waddle.process.start_time` (unit `s`): unix-epoch seconds
-//!   captured once at telemetry init. Every restart mints a new series
-//!   (`service.instance.id` carries the pod name + pid, and the value
-//!   is constant within a series), so restart detection is
-//!   young-process presence — `time() - waddle_process_start_time_seconds
-//!   < 600` — or series churn, never `changes()` on one series.
+//!   captured once at telemetry init. Restart shape depends on how the
+//!   process died: a deploy or ecdysis re-exec changes the pid-suffixed
+//!   `service.instance.id` (new series), while a kubelet container
+//!   restart keeps hostname and PID 1 (same series, value jumps). The
+//!   query that covers both is young-process presence —
+//!   `time() - waddle_process_start_time_seconds < 600` — not
+//!   `changes()` alone, which the new-series case never satisfies.
 //!   Verify the normalized series name against the live datasource
 //!   before writing alerts; this stack has produced both `_seconds`-
 //!   and raw-UCUM-suffixed names (see `rules/README.md`).
@@ -122,8 +124,10 @@ pub(crate) fn init_process_instruments() {
             .i64_observable_gauge("waddle.process.start_time")
             .with_description(
                 "Unix time the server process started, captured at telemetry init. \
-                 Each restart is a new series (pid-suffixed instance id), so detect \
-                 restarts via time() - value < threshold, not changes() (#1435).",
+                 Deploys/re-execs mint a new series (pid-suffixed instance id); \
+                 in-place container restarts keep the series and jump the value — \
+                 detect restarts via time() - value < threshold, which covers \
+                 both (#1435).",
             )
             .with_unit("s")
             .with_callback(|observer| observer.observe(start_time_unix_seconds(), &[]))

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -382,40 +382,42 @@ mod tests {
         let capture = HttpSpanCapture::default();
         let _subscriber =
             tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
-        let app = Router::new()
-            .route("/health", get(|| async { "ok" }))
-            .layer(axum::middleware::from_fn(attach_http_route_template))
-            .layer(
-                TraceLayer::new_for_http()
-                    .make_span_with(make_request_span)
-                    .on_response(observe_http_response),
+        for probe in PROBE_ROUTE_TEMPLATES {
+            let app = Router::new()
+                .route(probe, get(|| async { "ok" }))
+                .layer(axum::middleware::from_fn(attach_http_route_template))
+                .layer(
+                    TraceLayer::new_for_http()
+                        .make_span_with(make_request_span)
+                        .on_response(observe_http_response),
+                );
+
+            let response = app
+                .oneshot(
+                    Request::builder()
+                        .uri(*probe)
+                        .body(Body::empty())
+                        .expect("request"),
+                )
+                .await
+                .expect("response");
+
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+            let fields = capture.fields.lock().expect("HTTP span capture lock");
+            assert!(
+                fields.is_empty(),
+                "{probe} must not create an http_request span: {fields:?}",
             );
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/health")
-                    .body(Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
-
-        assert_eq!(response.status(), axum::http::StatusCode::OK);
-        let fields = capture.fields.lock().expect("HTTP span capture lock");
-        assert!(
-            fields.is_empty(),
-            "probe request must not create an http_request span: {fields:?}",
-        );
-        drop(fields);
-        assert_eq!(
-            metrics.histogram_count(
-                "http.server.request.duration",
-                &[("route", "/health"), ("status_class", "2xx")],
-            ),
-            Some(1),
-            "suppressing the probe span must not suppress the duration histogram",
-        );
+            drop(fields);
+            assert_eq!(
+                metrics.histogram_count(
+                    "http.server.request.duration",
+                    &[("route", probe), ("status_class", "2xx")],
+                ),
+                Some(1),
+                "suppressing the {probe} span must not suppress the duration histogram",
+            );
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/server/crates/waddle-server/src/server/trace.rs
+++ b/server/crates/waddle-server/src/server/trace.rs
@@ -49,6 +49,39 @@ const HTTP_ROUTE_TEMPLATES: &[&str] = &[
     "/api/files/{slot_id}/{filename}",
 ];
 
+/// Routes whose request spans are pure kube-probe noise (#1438): the
+/// liveness/readiness endpoints and the `/metrics` liveness stub
+/// (#1426), together ~98% of production `http_request` spans. Requests
+/// to these routes get a disabled span; the
+/// `http.server.request.duration` histogram is unaffected because
+/// `observe_http_response` reads the route from the response extension,
+/// not the span.
+const PROBE_ROUTE_TEMPLATES: &[&str] = &[
+    "/health",
+    "/healthz",
+    "/ready",
+    "/readyz",
+    "/metrics",
+    "/api/v1/health",
+];
+
+/// Decide whether a request deserves a `tracing` span at all (#1438).
+///
+/// - No axum `MatchedPath` means no route matched — hostile-scanner
+///   404s (`/enhancecp`, `/azure/.env`, …) that would each mint a root
+///   trace. Not traced.
+/// - A matched probe route is kube-probe noise. Not traced.
+/// - A `MatchedPath` that is missing from `HTTP_ROUTE_TEMPLATES` is a
+///   real route someone forgot to allowlist: keep tracing it (with an
+///   empty `http.route`) rather than silently untracing an endpoint.
+fn should_trace_request(request: &Request<Body>) -> bool {
+    if request.extensions().get::<MatchedPath>().is_none() {
+        return false;
+    }
+    !matched_route_template(request)
+        .is_some_and(|template| PROBE_ROUTE_TEMPLATES.contains(&template))
+}
+
 /// Build the per-request `tracing` span and attach the inbound W3C
 /// trace context (if any) as its OpenTelemetry parent.
 ///
@@ -61,6 +94,9 @@ const HTTP_ROUTE_TEMPLATES: &[&str] = &[
 /// root span instead of being silently re-parented to whatever the
 /// extractor returns for the empty case.
 pub(crate) fn make_request_span(request: &Request<Body>) -> Span {
+    if !should_trace_request(request) {
+        return Span::none();
+    }
     let span = info_span!(
         "http_request",
         method = %request.method(),
@@ -338,6 +374,128 @@ mod tests {
                 .all(|value| !value.contains(sensitive_token)),
             "request span must not expose the raw calendar token: {fields:?}",
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn probe_routes_get_no_request_span_but_keep_the_duration_histogram() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let capture = HttpSpanCapture::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+        let app = Router::new()
+            .route("/health", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(attach_http_route_template))
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(make_request_span)
+                    .on_response(observe_http_response),
+            );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let fields = capture.fields.lock().expect("HTTP span capture lock");
+        assert!(
+            fields.is_empty(),
+            "probe request must not create an http_request span: {fields:?}",
+        );
+        drop(fields);
+        assert_eq!(
+            metrics.histogram_count(
+                "http.server.request.duration",
+                &[("route", "/health"), ("status_class", "2xx")],
+            ),
+            Some(1),
+            "suppressing the probe span must not suppress the duration histogram",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn unrouted_requests_get_no_request_span() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let capture = HttpSpanCapture::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+        let app = Router::new()
+            .route("/api/auth/session", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(attach_http_route_template))
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(make_request_span)
+                    .on_response(observe_http_response),
+            );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/enhancecp")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+        let fields = capture.fields.lock().expect("HTTP span capture lock");
+        assert!(
+            fields.is_empty(),
+            "scanner 404s must not create an http_request span: {fields:?}",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn matched_route_missing_from_the_allowlist_is_still_traced() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let capture = HttpSpanCapture::default();
+        let _subscriber =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+        let app = Router::new()
+            .route("/not/in/the/allowlist", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(attach_http_route_template))
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(make_request_span)
+                    .on_response(observe_http_response),
+            );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/not/in/the/allowlist")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let fields = capture.fields.lock().expect("HTTP span capture lock");
+        assert_eq!(
+            fields.get("uri").map(String::as_str),
+            Some("/not/in/the/allowlist"),
+            "a real route missing from HTTP_ROUTE_TEMPLATES must stay traced",
+        );
+    }
+
+    #[test]
+    fn probe_routes_are_a_subset_of_the_route_allowlist() {
+        // should_trace_request suppresses via matched_route_template,
+        // which only recognizes HTTP_ROUTE_TEMPLATES entries — a probe
+        // route absent from the allowlist would silently stay traced.
+        for probe in PROBE_ROUTE_TEMPLATES {
+            assert!(
+                HTTP_ROUTE_TEMPLATES.contains(probe),
+                "{probe} must be listed in HTTP_ROUTE_TEMPLATES",
+            );
+        }
     }
 
     #[test]

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -17,6 +17,8 @@ use opentelemetry_sdk::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
+mod span_noise;
+
 /// The global tracer provider, stored for shutdown.
 static TRACER_PROVIDER: std::sync::OnceLock<SdkTracerProvider> = std::sync::OnceLock::new();
 
@@ -299,8 +301,10 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Build tracer provider with batch processor. The sampler comes
     // from OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG (default
     // parentbased_traceidratio 1.0 — today's sample-everything
-    // behavior, but now operator-tunable from helm values).
-    let sampler = sampler_from_env();
+    // behavior, but now operator-tunable from helm values), wrapped in
+    // the span-noise filter that drops root kameo actor spans, root
+    // health-check spans, and whole-life actor.lifecycle spans (#1438).
+    let sampler = span_noise::SpanNoiseFilter::new(sampler_from_env());
     let tracer_provider = SdkTracerProvider::builder()
         .with_batch_exporter(trace_exporter)
         .with_sampler(sampler)
@@ -335,6 +339,11 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // pod exports 0 instead of no series (the waddle_connected_users
     // alias reads absent otherwise — Qodo review on PR #1426).
     waddle_xmpp::metrics::init_pod_gauges();
+
+    // Register the process start-time/CPU/FD instruments eagerly so a
+    // fresh pod exports its restart signal on the first OTLP push
+    // (#1435).
+    crate::server::process_metrics::init_process_instruments();
 
     // Build OTLP logs exporter + provider. The tracing bridge below
     // feeds every `tracing::{info,warn,error,debug,trace}!` event into

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -60,17 +60,24 @@ fn has_valid_parent(parent_context: Option<&Context>) -> bool {
     parent_context.is_some_and(|cx| cx.span().span_context().is_valid())
 }
 
-/// A valid parent that was itself dropped. Enforced here — not left to
-/// the delegate — so a suppressed root can never leak orphaned
-/// children when the operator dials a non-parent-based sampler
-/// (`OTEL_TRACES_SAMPLER=always_on` / `traceidratio`): `AlwaysOn`
-/// would re-sample the child of a dropped `actor.handle_message` root
-/// and export it pointing at a parent span that never exports.
-fn has_unsampled_parent(parent_context: Option<&Context>) -> bool {
+/// A valid **local** parent that was itself dropped. Enforced here —
+/// not left to the delegate — so a suppressed root can never leak
+/// orphaned children when the operator dials a non-parent-based
+/// sampler (`OTEL_TRACES_SAMPLER=always_on` / `traceidratio`):
+/// `AlwaysOn` would re-sample the child of a dropped
+/// `actor.handle_message` root and export it pointing at a parent span
+/// that never exports.
+///
+/// Remote parents are excluded: an inbound `traceparent` with flags
+/// `00` says the *caller* chose not to sample, and what happens then
+/// is exactly the delegate sampler's decision to make (`ParentBased`
+/// honors it, `AlwaysOn` deliberately overrides it). Only local
+/// unsampled parents can be this filter's own suppressions.
+fn has_unsampled_local_parent(parent_context: Option<&Context>) -> bool {
     parent_context.is_some_and(|cx| {
         let span = cx.span();
         let span_context = span.span_context();
-        span_context.is_valid() && !span_context.is_sampled()
+        span_context.is_valid() && !span_context.is_sampled() && !span_context.is_remote()
     })
 }
 
@@ -98,7 +105,7 @@ impl ShouldSample for SpanNoiseFilter {
     ) -> SamplingResult {
         if ALWAYS_SUPPRESSED_SPAN_NAMES.contains(&name)
             || (ROOT_SUPPRESSED_SPAN_NAMES.contains(&name) && !has_valid_parent(parent_context))
-            || has_unsampled_parent(parent_context)
+            || has_unsampled_local_parent(parent_context)
         {
             return drop_result(parent_context);
         }
@@ -131,7 +138,7 @@ mod tests {
             .decision
     }
 
-    fn parent_context(sampled: bool) -> Context {
+    fn parent_context_with(sampled: bool, remote: bool) -> Context {
         let flags = if sampled {
             TraceFlags::SAMPLED
         } else {
@@ -141,9 +148,21 @@ mod tests {
             TraceId::from(0xabcdu128),
             SpanId::from(0x1234u64),
             flags,
-            true,
+            remote,
             TraceState::default(),
         ))
+    }
+
+    /// A propagated (remote) parent — the shape `make_request_span`
+    /// attaches from an inbound `traceparent`.
+    fn parent_context(sampled: bool) -> Context {
+        parent_context_with(sampled, true)
+    }
+
+    /// An in-process parent — the shape a span suppressed by this
+    /// filter leaves behind for its children.
+    fn local_parent_context(sampled: bool) -> Context {
+        parent_context_with(sampled, false)
     }
 
     #[test]
@@ -238,11 +257,31 @@ mod tests {
     fn orphans_are_prevented_even_under_non_parent_based_samplers() {
         // With OTEL_TRACES_SAMPLER=always_on the delegate would happily
         // re-sample the child of a suppressed root and export it as an
-        // orphan; the filter must enforce parent consistency itself.
+        // orphan; the filter must enforce consistency for LOCAL
+        // unsampled parents itself.
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        let parent = local_parent_context(false);
+        assert_eq!(
+            sample(&filter, Some(&parent), "db.query"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn remote_unsampled_parents_stay_the_delegates_decision() {
+        // An inbound traceparent with flags 00 is the CALLER's sampling
+        // choice, not one of this filter's suppressions: always_on is
+        // documented to override it, and the filter must not veto that.
         let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
         let parent = parent_context(false);
         assert_eq!(
-            sample(&filter, Some(&parent), "db.query"),
+            sample(&filter, Some(&parent), "http_request"),
+            SamplingDecision::RecordAndSample
+        );
+        // The default parent-based delegate keeps honoring it.
+        let parent_based = SpanNoiseFilter::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)));
+        assert_eq!(
+            sample(&parent_based, Some(&parent), "http_request"),
             SamplingDecision::Drop
         );
     }

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -1,0 +1,311 @@
+//! Span-noise suppression at the sampling layer (#1438).
+//!
+//! Production Tempo ingest was ~95% noise: root `actor.handle_message`
+//! spans minted by kameo for timer/self-check messages (72% of all
+//! spans), kube-probe request spans, and whole-actor-life
+//! `actor.lifecycle` spans that only export on actor death and wreck
+//! duration-based queries. The kameo span families are created inside
+//! the `kameo` crate behind its default `tracing` feature, so they
+//! cannot be suppressed at the instrumentation site — this sampler is
+//! the seam.
+//!
+//! Sampling a span out (rather than filtering at export) kills the
+//! whole noise trace: children inherit the drop through the
+//! parent-based delegate, so no orphaned child spans reach Tempo.
+
+use opentelemetry::{
+    trace::{Link, SpanKind, TraceContextExt, TraceId},
+    Context, KeyValue,
+};
+use opentelemetry_sdk::trace::{Sampler, SamplingDecision, SamplingResult, ShouldSample};
+
+/// Span names dropped only when they would start a new root trace.
+///
+/// - `actor.handle_message`: kameo instruments every actor message;
+///   inside a real dispatch these spans are useful and keep their
+///   parent, but a timer/self-check message with no active parent
+///   context mints a single-span root trace of a few microseconds.
+/// - `health_check`: the DB/pool probe spans. Under a traced request
+///   they stay children; once probe request spans are suppressed at
+///   creation (`server::trace::make_request_span`) they would re-root
+///   here, so root ones are dropped too.
+const ROOT_SUPPRESSED_SPAN_NAMES: &[&str] = &["actor.handle_message", "health_check"];
+
+/// Span names dropped unconditionally.
+///
+/// `actor.lifecycle` spans the actor's entire life (observed up to
+/// 9.6 h in production), is invisible while the actor is alive, is
+/// lost on crash, and skews every duration-based trace query. Actor
+/// restarts are observable through `waddle.process.start_time` and
+/// logs instead.
+const ALWAYS_SUPPRESSED_SPAN_NAMES: &[&str] = &["actor.lifecycle"];
+
+/// Wraps the env-configured sampler and drops the known-noise span
+/// families before delegating every other decision to it.
+#[derive(Clone, Debug)]
+pub(crate) struct SpanNoiseFilter {
+    inner: Sampler,
+}
+
+impl SpanNoiseFilter {
+    pub(crate) fn new(inner: Sampler) -> Self {
+        Self { inner }
+    }
+}
+
+/// A span is a root when there is no parent context or the parent's
+/// span context is invalid (the propagator's empty extraction).
+fn has_valid_parent(parent_context: Option<&Context>) -> bool {
+    parent_context.is_some_and(|cx| cx.span().span_context().is_valid())
+}
+
+/// Mirror the SDK samplers: never set extra attributes, and preserve
+/// the parent's trace state on the way out.
+fn drop_result(parent_context: Option<&Context>) -> SamplingResult {
+    SamplingResult {
+        decision: SamplingDecision::Drop,
+        attributes: Vec::new(),
+        trace_state: parent_context
+            .map(|cx| cx.span().span_context().trace_state().clone())
+            .unwrap_or_default(),
+    }
+}
+
+impl ShouldSample for SpanNoiseFilter {
+    fn should_sample(
+        &self,
+        parent_context: Option<&Context>,
+        trace_id: TraceId,
+        name: &str,
+        span_kind: &SpanKind,
+        attributes: &[KeyValue],
+        links: &[Link],
+    ) -> SamplingResult {
+        if ALWAYS_SUPPRESSED_SPAN_NAMES.contains(&name)
+            || (ROOT_SUPPRESSED_SPAN_NAMES.contains(&name) && !has_valid_parent(parent_context))
+        {
+            return drop_result(parent_context);
+        }
+        self.inner
+            .should_sample(parent_context, trace_id, name, span_kind, attributes, links)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState, TracerProvider as _};
+    use opentelemetry_sdk::error::OTelSdkResult;
+    use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter};
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    fn sample(filter: &SpanNoiseFilter, parent: Option<&Context>, name: &str) -> SamplingDecision {
+        filter
+            .should_sample(
+                parent,
+                TraceId::from(1u128),
+                name,
+                &SpanKind::Internal,
+                &[],
+                &[],
+            )
+            .decision
+    }
+
+    fn parent_context(sampled: bool) -> Context {
+        let flags = if sampled {
+            TraceFlags::SAMPLED
+        } else {
+            TraceFlags::default()
+        };
+        Context::new().with_remote_span_context(SpanContext::new(
+            TraceId::from(0xabcdu128),
+            SpanId::from(0x1234u64),
+            flags,
+            true,
+            TraceState::default(),
+        ))
+    }
+
+    #[test]
+    fn root_actor_handle_message_is_dropped() {
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        assert_eq!(
+            sample(&filter, None, "actor.handle_message"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn invalid_parent_context_still_counts_as_root() {
+        // The W3C propagator extracts an empty (invalid) span context
+        // when no traceparent header is present; that must not count
+        // as a parent.
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        let empty = Context::new();
+        assert_eq!(
+            sample(&filter, Some(&empty), "actor.handle_message"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn parented_actor_handle_message_is_delegated() {
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        let parent = parent_context(true);
+        assert_eq!(
+            sample(&filter, Some(&parent), "actor.handle_message"),
+            SamplingDecision::RecordAndSample
+        );
+    }
+
+    #[test]
+    fn root_health_check_is_dropped_but_parented_is_delegated() {
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        assert_eq!(
+            sample(&filter, None, "health_check"),
+            SamplingDecision::Drop
+        );
+        let parent = parent_context(true);
+        assert_eq!(
+            sample(&filter, Some(&parent), "health_check"),
+            SamplingDecision::RecordAndSample
+        );
+    }
+
+    #[test]
+    fn actor_lifecycle_is_dropped_even_with_sampled_parent() {
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        let parent = parent_context(true);
+        assert_eq!(
+            sample(&filter, Some(&parent), "actor.lifecycle"),
+            SamplingDecision::Drop
+        );
+        assert_eq!(
+            sample(&filter, None, "actor.lifecycle"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn other_spans_delegate_to_the_inner_sampler() {
+        let on = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        assert_eq!(
+            sample(&on, None, "xmpp.stanza.dispatch"),
+            SamplingDecision::RecordAndSample
+        );
+        let off = SpanNoiseFilter::new(Sampler::AlwaysOff);
+        assert_eq!(
+            sample(&off, None, "xmpp.stanza.dispatch"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn children_of_unsampled_parents_stay_dropped_via_parent_based_delegate() {
+        // Production wires ParentBased(...) as the inner sampler, so a
+        // child created under a suppressed (unsampled) parent — e.g. a
+        // handler span inside a suppressed probe request — inherits
+        // the drop.
+        let filter = SpanNoiseFilter::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)));
+        let parent = parent_context(false);
+        assert_eq!(
+            sample(&filter, Some(&parent), "db.query"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[derive(Clone, Debug)]
+    struct CaptureSpanExporter(Arc<Mutex<Vec<SpanData>>>);
+
+    impl SpanExporter for CaptureSpanExporter {
+        async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult {
+            self.0.lock().expect("capture lock").extend(batch);
+            Ok(())
+        }
+    }
+
+    /// End-to-end through the real `tracing` → tracing-opentelemetry →
+    /// SDK pipeline: the production wiring (`SpanNoiseFilter` around a
+    /// parent-based sampler) suppresses a root `actor.handle_message`
+    /// span and its children, while the same span under a real parent
+    /// exports together with that parent.
+    #[test]
+    fn pipeline_drops_root_actor_spans_but_keeps_parented_ones() {
+        let exported = Arc::new(Mutex::new(Vec::new()));
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(CaptureSpanExporter(Arc::clone(&exported)))
+            .with_sampler(SpanNoiseFilter::new(Sampler::ParentBased(Box::new(
+                Sampler::AlwaysOn,
+            ))))
+            .build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("span-noise-test")));
+
+        tracing::subscriber::with_default(subscriber, || {
+            // Timer/self-check shape: a root actor span with a child.
+            let root_actor = tracing::info_span!(parent: None, "actor.handle_message");
+            root_actor.in_scope(|| {
+                tracing::info_span!("db.query").in_scope(|| {});
+            });
+            drop(root_actor);
+
+            // Real-dispatch shape: the same span name under a root
+            // dispatch span must survive.
+            let dispatch = tracing::info_span!(parent: None, "xmpp.stanza.dispatch");
+            dispatch.in_scope(|| {
+                tracing::info_span!("actor.handle_message").in_scope(|| {});
+            });
+            drop(dispatch);
+        });
+
+        let names: Vec<String> = exported
+            .lock()
+            .expect("capture lock")
+            .iter()
+            .map(|span| span.name.to_string())
+            .collect();
+        assert!(
+            names.contains(&"xmpp.stanza.dispatch".to_string()),
+            "real dispatch trace must export: {names:?}"
+        );
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| *name == "actor.handle_message")
+                .count(),
+            1,
+            "only the parented actor span may export: {names:?}"
+        );
+        assert!(
+            !names.contains(&"db.query".to_string()),
+            "children of a suppressed root must not export as orphans: {names:?}"
+        );
+    }
+
+    #[test]
+    fn drop_result_preserves_parent_trace_state() {
+        let trace_state = TraceState::from_key_value([("vendor", "value")]).expect("trace state");
+        let parent = Context::new().with_remote_span_context(SpanContext::new(
+            TraceId::from(0xabcdu128),
+            SpanId::from(0x1234u64),
+            TraceFlags::SAMPLED,
+            true,
+            trace_state.clone(),
+        ));
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        let result = filter.should_sample(
+            Some(&parent),
+            TraceId::from(1u128),
+            "actor.lifecycle",
+            &SpanKind::Internal,
+            &[],
+            &[],
+        );
+        assert_eq!(result.decision, SamplingDecision::Drop);
+        assert_eq!(result.trace_state.get("vendor"), Some("value"));
+    }
+}

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -10,8 +10,9 @@
 //! the seam.
 //!
 //! Sampling a span out (rather than filtering at export) kills the
-//! whole noise trace: children inherit the drop through the
-//! parent-based delegate, so no orphaned child spans reach Tempo.
+//! whole noise trace: the filter drops every span under an unsampled
+//! parent itself, so no orphaned child spans reach Tempo no matter
+//! which `OTEL_TRACES_SAMPLER` the operator dials.
 
 use opentelemetry::{
     trace::{Link, SpanKind, TraceContextExt, TraceId},
@@ -59,6 +60,20 @@ fn has_valid_parent(parent_context: Option<&Context>) -> bool {
     parent_context.is_some_and(|cx| cx.span().span_context().is_valid())
 }
 
+/// A valid parent that was itself dropped. Enforced here — not left to
+/// the delegate — so a suppressed root can never leak orphaned
+/// children when the operator dials a non-parent-based sampler
+/// (`OTEL_TRACES_SAMPLER=always_on` / `traceidratio`): `AlwaysOn`
+/// would re-sample the child of a dropped `actor.handle_message` root
+/// and export it pointing at a parent span that never exports.
+fn has_unsampled_parent(parent_context: Option<&Context>) -> bool {
+    parent_context.is_some_and(|cx| {
+        let span = cx.span();
+        let span_context = span.span_context();
+        span_context.is_valid() && !span_context.is_sampled()
+    })
+}
+
 /// Mirror the SDK samplers: never set extra attributes, and preserve
 /// the parent's trace state on the way out.
 fn drop_result(parent_context: Option<&Context>) -> SamplingResult {
@@ -83,6 +98,7 @@ impl ShouldSample for SpanNoiseFilter {
     ) -> SamplingResult {
         if ALWAYS_SUPPRESSED_SPAN_NAMES.contains(&name)
             || (ROOT_SUPPRESSED_SPAN_NAMES.contains(&name) && !has_valid_parent(parent_context))
+            || has_unsampled_parent(parent_context)
         {
             return drop_result(parent_context);
         }
@@ -211,6 +227,19 @@ mod tests {
         // handler span inside a suppressed probe request — inherits
         // the drop.
         let filter = SpanNoiseFilter::new(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)));
+        let parent = parent_context(false);
+        assert_eq!(
+            sample(&filter, Some(&parent), "db.query"),
+            SamplingDecision::Drop
+        );
+    }
+
+    #[test]
+    fn orphans_are_prevented_even_under_non_parent_based_samplers() {
+        // With OTEL_TRACES_SAMPLER=always_on the delegate would happily
+        // re-sample the child of a suppressed root and export it as an
+        // orphan; the filter must enforce parent consistency itself.
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
         let parent = parent_context(false);
         assert_eq!(
             sample(&filter, Some(&parent), "db.query"),


### PR DESCRIPTION
Implements #1435 and #1438 (production telemetry sweep 2026-07-21). Closes #1435. Closes #1438.

## #1435 — restore process start-time / CPU / FD metrics via OTLP

Since #1330/#1426 reduced `/metrics` to a liveness stub, waddle-server exported no restart/uptime signal; crash-loops were only inferable from ReplicaSet-hash churn.

- New `server/crates/waddle-server/src/server/process_metrics.rs`, registered eagerly from `telemetry::init()` (same pattern as `init_pod_gauges` and the existing RSS gauge), so a fresh pod exports its restart signal on the first OTLP push:
  - `waddle.process.start_time` (gauge, unit `s`): unix-epoch seconds captured once at init. Each restart mints a **new series** (`service.instance.id` carries pod name + pid), so restart detection is young-process presence — `time() - value < threshold` — or series churn, **not** `changes()` on one series (documented on the instrument).
  - `waddle.process.cpu.time` (observable counter, unit `s`): utime+stime from `/proc/self/stat`, parsed after the last `)` so a hostile `comm` can't shift fields.
  - `waddle.process.open_file_descriptors` (gauge, `{fd}`): `/proc/self/fd` entry count.
- `/proc` readers degrade to "no series" off Linux (RSS-gauge precedent). Pure parser + reader-seam tests pin names, units, and export.

## #1438 — cut ~95% trace-ingest noise

Two seams:

1. **`make_request_span` (`server/trace.rs`)** returns a disabled span for kube-probe routes (`/health`, `/healthz`, `/ready`, `/readyz`, `/api/v1/health`, `/metrics` — ~33.8k spans/day, ~98% of `http_request` volume) and for requests with no matched route (hostile-scanner 404s, 466 root traces/day). The `http.server.request.duration` histogram is extension-driven and unchanged (test-pinned). A matched route missing from `HTTP_ROUTE_TEMPLATES` stays traced, and a test pins `PROBE_ROUTE_TEMPLATES ⊆ HTTP_ROUTE_TEMPLATES`.
2. **`SpanNoiseFilter` (`telemetry/span_noise.rs`)** wraps the `OTEL_TRACES_SAMPLER`-configured sampler and drops at sampling time:
   - root `actor.handle_message` spans (kameo timer/self-check handlers; 121.9k/day = 72% of all spans) — parented ones unchanged, proven end-to-end through the real tracing→OTel pipeline;
   - root `health_check` spans (children of suppressed probe requests would otherwise re-root);
   - all `actor.lifecycle` spans (whole-actor-life spans up to 9.6 h that only export on actor death and wreck duration queries);
   - **any span under a valid-but-unsampled parent**, so suppressed roots can never leak orphaned children even under non-parent-based samplers (`always_on`/`traceidratio`).

Both kameo span families are minted inside kameo 0.20 behind its default `tracing` feature, so suppression has to happen at the sampler seam.

## Review-driven hardening

Reviewed by two-axis (standards/spec) agents plus adversarial personas and an independent gpt-5.6-terra codex pass:

- `waddle.db.health_check.failed` counter (`db/pool.rs`) replaces the failure signal the suppressed probe spans used to carry — no silent loss of the DB-health failure signal (#1428 history).
- Orphaned-children sampler gap under `always_on` found and fixed (above).
- Restart-query documentation corrected (`changes()` can never fire across pid-suffixed series).
- Follow-up filed: #1483 — clustering-relay/janitor dispatch needs named root spans so its actor work stays traceable under the new sampler.

## Post-deploy verification owed

Tempo, ~24 h after deploy: total span volume down ~85–95%; `xmpp.stanza.dispatch` / `xmpp.muc.fanout` / real `http_request` volume unchanged. Mimir: `waddle_process_start_time_seconds` (verify normalized name against the live datasource — see `rules/README.md`) present per pod.

Not XMPP wire work — telemetry-only, covered by the operational-telemetry exception; no XEP surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
