### PR TITLE
obs(server): named root spans keep clustering-relay and janitor traces alive post-#1438 (#1483)

### DIFF
--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -100,6 +100,22 @@ fn relay_dispatch_span(message: &'static str) -> tracing::Span {
     )
 }
 
+/// The single seam through which every delegated relay reply task is
+/// spawned (#1483): binding `ctx.spawn` to the dispatch span here means
+/// a handler cannot delegate work outside its root span without
+/// bypassing this helper — and a test pins that no handler does.
+fn spawn_in_dispatch_span<R, F>(
+    ctx: &mut Context<RelayActor, R>,
+    span: tracing::Span,
+    future: F,
+) -> kameo::reply::DelegatedReply<R::Value>
+where
+    R: Reply + ?Sized,
+    F: std::future::Future<Output = R::Value> + Send + 'static,
+{
+    ctx.spawn(future.instrument(span))
+}
+
 /// Backoff between supervised respawn/re-registration attempts.
 const RESPAWN_BACKOFF: Duration = Duration::from_secs(1);
 
@@ -354,15 +370,11 @@ impl Message<RelayDeliverOrdered> for RelayActor {
         // The reservation must stay inline (mailbox-ordered); only the
         // delegated delivery moves onto the instrumented reply task.
         let reservation = receiver.lock().await.reserve(msg.envelope);
-        ctx.spawn(
-            async move {
-                let reply =
-                    finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
-                record_ordered_relay_reply(&reply);
-                reply
-            }
-            .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            let reply = finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
+            record_ordered_relay_reply(&reply);
+            reply
+        })
     }
 }
 
@@ -409,10 +421,9 @@ impl Message<RelayRegisterRemoteUserResource> for RelayActor {
         let span = relay_dispatch_span("remote_resource_register");
         span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.register_remote_user_resource_on_owner(msg).await }
-                .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.register_remote_user_resource_on_owner(msg).await
+        })
     }
 }
 
@@ -440,10 +451,9 @@ impl Message<RelayUnregisterRemoteUserResource> for RelayActor {
         let span = relay_dispatch_span("remote_resource_unregister");
         span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.unregister_remote_user_resource_on_owner(msg).await }
-                .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.unregister_remote_user_resource_on_owner(msg).await
+        })
     }
 }
 
@@ -479,9 +489,9 @@ impl Message<RelayUpdateRemoteUserResource> for RelayActor {
         let span = relay_dispatch_span("remote_resource_update");
         span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.update_remote_user_resource_on_owner(msg).await }.instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.update_remote_user_resource_on_owner(msg).await
+        })
     }
 }
 
@@ -517,10 +527,9 @@ impl Message<RelayRemoteUserSideEffect> for RelayActor {
         let span = relay_dispatch_span("remote_user_side_effect");
         span.record("jid", tracing::field::display(&msg.source_jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.apply_remote_user_side_effect_on_owner(msg).await }
-                .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.apply_remote_user_side_effect_on_owner(msg).await
+        })
     }
 }
 
@@ -550,9 +559,9 @@ impl Message<RelayRouteRemoteResourceStanza> for RelayActor {
         let span = relay_dispatch_span("remote_resource_route");
         span.record("jid", tracing::field::display(&msg.source_jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.route_remote_resource_stanza_on_owner(msg).await }.instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.route_remote_resource_stanza_on_owner(msg).await
+        })
     }
 }
 
@@ -585,10 +594,9 @@ impl Message<RelayDeliverRemoteResourceFrame> for RelayActor {
         let span = relay_dispatch_span("remote_resource_frame");
         span.record("jid", tracing::field::display(&msg.frame.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move { bridge.deliver_remote_resource_frame_on_socket(msg).await }
-                .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge.deliver_remote_resource_frame_on_socket(msg).await
+        })
     }
 }
 
@@ -625,14 +633,11 @@ impl Message<RelayForceDetachRemoteUserResource> for RelayActor {
         let span = relay_dispatch_span("remote_resource_force_detach");
         span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(
-            async move {
-                bridge
-                    .force_detach_remote_user_resource_on_socket(msg)
-                    .await
-            }
-            .instrument(span),
-        )
+        spawn_in_dispatch_span(ctx, span, async move {
+            bridge
+                .force_detach_remote_user_resource_on_socket(msg)
+                .await
+        })
     }
 }
 
@@ -697,29 +702,26 @@ impl Message<RelayResumeSteal> for RelayActor {
         span.record("stream_id", tracing::field::display(&msg.stream_id));
         span.record("jid", tracing::field::display(&msg.requester_bare_jid));
         let resume_bridge = Arc::clone(&self.resume_bridge);
-        ctx.spawn(
-            async move {
-                match resume_bridge
-                    .request_forced_detach(
-                        &msg.stream_id,
-                        &msg.requester_bare_jid,
-                        LOCAL_FORCE_DETACH_ACK_TIMEOUT,
-                    )
-                    .await
-                {
-                    super::resume_bridge::LocalForcedDetachOutcome::Detached => {
-                        RelayResumeStealReply::Detached
-                    }
-                    super::resume_bridge::LocalForcedDetachOutcome::IdentityMismatch => {
-                        RelayResumeStealReply::IdentityMismatch
-                    }
-                    super::resume_bridge::LocalForcedDetachOutcome::NotLiveLocally => {
-                        RelayResumeStealReply::NotLiveLocally
-                    }
+        spawn_in_dispatch_span(ctx, span, async move {
+            match resume_bridge
+                .request_forced_detach(
+                    &msg.stream_id,
+                    &msg.requester_bare_jid,
+                    LOCAL_FORCE_DETACH_ACK_TIMEOUT,
+                )
+                .await
+            {
+                super::resume_bridge::LocalForcedDetachOutcome::Detached => {
+                    RelayResumeStealReply::Detached
+                }
+                super::resume_bridge::LocalForcedDetachOutcome::IdentityMismatch => {
+                    RelayResumeStealReply::IdentityMismatch
+                }
+                super::resume_bridge::LocalForcedDetachOutcome::NotLiveLocally => {
+                    RelayResumeStealReply::NotLiveLocally
                 }
             }
-            .instrument(span),
-        )
+        })
     }
 }
 
@@ -2430,52 +2432,31 @@ mod tests {
         );
     }
 
-    /// #1483 guard: every delegated relay reply task must carry the
-    /// dispatch span. A `ctx.spawn` whose future is not `.instrument`-ed
-    /// runs the actual delivery — where the actor messages happen —
-    /// outside the root span, silently restoring the #1438 trace loss.
-    /// The field-recording tests above cannot catch that (the span still
-    /// records its fields at creation), so pin it structurally.
+    /// #1483 guard: every delegated relay reply must be spawned through
+    /// `spawn_in_dispatch_span`, the one seam that binds the reply task
+    /// to its dispatch span. A direct `ctx.spawn` in a handler would run
+    /// the delivery — where the actor messages happen — outside the root
+    /// span, silently restoring the #1438 trace loss, and the
+    /// field-recording tests above cannot catch that (the span still
+    /// records its fields at creation). Comment lines are skipped; no
+    /// parsing beyond that is needed, so string/paren contents cannot
+    /// cause false failures.
     #[test]
-    fn every_delegated_relay_reply_task_is_instrumented() {
+    fn delegated_relay_replies_go_through_the_dispatch_span_helper() {
         let source = include_str!("relay.rs");
-        let production: String = source
+        let production = source
             .split("#[cfg(test)]")
             .next()
-            .expect("split always yields a first segment")
+            .expect("split always yields a first segment");
+        let direct_spawns = production
             .lines()
             .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<&str>>()
-            .join("\n");
-        let production = production.as_str();
-        let mut checked = 0usize;
-        for (index, _) in production.match_indices("ctx.spawn(") {
-            let argument_start = index + "ctx.spawn(".len();
-            let mut depth = 1usize;
-            let mut argument_end = argument_start;
-            for (offset, character) in production[argument_start..].char_indices() {
-                match character {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            argument_end = argument_start + offset;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            assert!(
-                production[argument_start..argument_end].contains(".instrument("),
-                "the ctx.spawn at byte {index} delegates a relay reply \
-                 without instrumenting it with the dispatch span"
-            );
-            checked += 1;
-        }
-        assert!(
-            checked >= 8,
-            "expected the delegated relay handlers to be found; got {checked}"
+            .filter(|line| line.contains("ctx.spawn("))
+            .count();
+        assert_eq!(
+            direct_spawns, 1,
+            "ctx.spawn must appear exactly once — inside spawn_in_dispatch_span; \
+             route new delegated replies through that helper"
         );
     }
 }

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -18,7 +18,6 @@
 //! Phase 4 wires DM/MUC/presence routing through this relay. Kademlia still
 //! discovers node relays only; entity ownership remains in Postgres claims.
 
-use super::NodeId;
 use super::codec::RemoteStanza;
 use super::local_claims::RoomLocalClaims;
 use super::metrics;
@@ -33,6 +32,7 @@ use super::route_bridge::{
     RemoteResourceStateSnapshot, RemoteResourceStateUpdate, RemoteUserSideEffect,
 };
 use super::self_fence::LocallyClaimedEntities;
+use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
 use kameo::error::RemoteSendError;
 use kameo::message::{Context, Message};
@@ -40,7 +40,7 @@ use kameo::{Actor, RemoteActor, Reply};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use waddle_xmpp::ownership::{ClaimEpoch, Entity};
@@ -2169,8 +2169,8 @@ mod tests {
 
     #[test]
     fn ask_failures_classify_handler_effect_separately_from_failure_kind() {
-        use RelaySendEffect::{MaybeCommitted, NoEffect};
         use std::convert::Infallible;
+        use RelaySendEffect::{MaybeCommitted, NoEffect};
 
         for (error, expected) in [
             (RemoteSendError::ActorNotRunning, NoEffect),

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 use waddle_xmpp::ownership::{ClaimEpoch, Entity};
 
 /// Bound on this node's own wait for a local force-detach to complete when
@@ -59,6 +60,37 @@ const LOCAL_FORCE_DETACH_ACK_TIMEOUT: Duration = Duration::from_secs(10);
 /// kademlia name (O(1) registrations per node, never per entity).
 pub fn relay_name(node_id: &NodeId) -> String {
     format!("waddle-relay/{node_id}")
+}
+
+/// Named root span for one inbound relay dispatch (#1483).
+///
+/// Every substantive `#[kameo::remote_message]` handler on [`RelayActor`]
+/// runs with no active local span (the receive path has no upstream
+/// instrumentation), so the kameo `actor.handle_message` spans its work
+/// mints would root the trace — exactly the shape the #1438 span-noise
+/// sampler drops. Opening this dedicated root before any actor message is
+/// sent keeps the whole delivery traceable: the actor spans become
+/// parented children and survive the sampler.
+///
+/// `parent: None` is load-bearing: the handler itself executes inside
+/// kameo's own (suppressed) root `actor.handle_message` span, and a child
+/// of a locally-unsampled parent is dropped by the sampler too — this span
+/// must start a fresh root trace.
+///
+/// The span name is documented in `telemetry::span_noise` and must never
+/// be added to its suppression lists.
+fn relay_dispatch_span(message: &'static str) -> tracing::Span {
+    tracing::info_span!(
+        parent: None,
+        "clustering.relay.dispatch",
+        relay.message = message,
+        jid = tracing::field::Empty,
+        stream_id = tracing::field::Empty,
+        channel = tracing::field::Empty,
+        sequence = tracing::field::Empty,
+        origin_node = tracing::field::Empty,
+        entity = tracing::field::Empty,
+    )
 }
 
 /// Backoff between supervised respawn/re-registration attempts.
@@ -303,14 +335,27 @@ impl Message<RelayDeliverOrdered> for RelayActor {
         msg: RelayDeliverOrdered,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("deliver_ordered");
+        span.record("channel", tracing::field::debug(&msg.envelope.channel));
+        span.record("sequence", msg.envelope.sequence.0);
+        span.record(
+            "origin_node",
+            tracing::field::display(&msg.envelope.asserted_origin_node),
+        );
         let receiver = Arc::clone(&self.ordered_receiver);
         let delivery_bridge = Arc::clone(&self.ordered_delivery_bridge);
+        // The reservation must stay inline (mailbox-ordered); only the
+        // delegated delivery moves onto the instrumented reply task.
         let reservation = receiver.lock().await.reserve(msg.envelope);
-        ctx.spawn(async move {
-            let reply = finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
-            record_ordered_relay_reply(&reply);
-            reply
-        })
+        ctx.spawn(
+            async move {
+                let reply =
+                    finish_ordered_reservation(receiver, delivery_bridge, reservation).await;
+                record_ordered_relay_reply(&reply);
+                reply
+            }
+            .instrument(span),
+        )
     }
 }
 
@@ -354,8 +399,13 @@ impl Message<RelayRegisterRemoteUserResource> for RelayActor {
         msg: RelayRegisterRemoteUserResource,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_register");
+        span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.register_remote_user_resource_on_owner(msg).await })
+        ctx.spawn(
+            async move { bridge.register_remote_user_resource_on_owner(msg).await }
+                .instrument(span),
+        )
     }
 }
 
@@ -380,8 +430,13 @@ impl Message<RelayUnregisterRemoteUserResource> for RelayActor {
         msg: RelayUnregisterRemoteUserResource,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_unregister");
+        span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.unregister_remote_user_resource_on_owner(msg).await })
+        ctx.spawn(
+            async move { bridge.unregister_remote_user_resource_on_owner(msg).await }
+                .instrument(span),
+        )
     }
 }
 
@@ -414,8 +469,12 @@ impl Message<RelayUpdateRemoteUserResource> for RelayActor {
         msg: RelayUpdateRemoteUserResource,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_update");
+        span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.update_remote_user_resource_on_owner(msg).await })
+        ctx.spawn(
+            async move { bridge.update_remote_user_resource_on_owner(msg).await }.instrument(span),
+        )
     }
 }
 
@@ -448,8 +507,13 @@ impl Message<RelayRemoteUserSideEffect> for RelayActor {
         msg: RelayRemoteUserSideEffect,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_user_side_effect");
+        span.record("jid", tracing::field::display(&msg.source_jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.apply_remote_user_side_effect_on_owner(msg).await })
+        ctx.spawn(
+            async move { bridge.apply_remote_user_side_effect_on_owner(msg).await }
+                .instrument(span),
+        )
     }
 }
 
@@ -476,8 +540,12 @@ impl Message<RelayRouteRemoteResourceStanza> for RelayActor {
         msg: RelayRouteRemoteResourceStanza,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_route");
+        span.record("jid", tracing::field::display(&msg.source_jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.route_remote_resource_stanza_on_owner(msg).await })
+        ctx.spawn(
+            async move { bridge.route_remote_resource_stanza_on_owner(msg).await }.instrument(span),
+        )
     }
 }
 
@@ -507,8 +575,12 @@ impl Message<RelayDeliverRemoteResourceFrame> for RelayActor {
         msg: RelayDeliverRemoteResourceFrame,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_frame");
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move { bridge.deliver_remote_resource_frame_on_socket(msg).await })
+        ctx.spawn(
+            async move { bridge.deliver_remote_resource_frame_on_socket(msg).await }
+                .instrument(span),
+        )
     }
 }
 
@@ -542,12 +614,17 @@ impl Message<RelayForceDetachRemoteUserResource> for RelayActor {
         msg: RelayForceDetachRemoteUserResource,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("remote_resource_force_detach");
+        span.record("jid", tracing::field::display(&msg.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
-        ctx.spawn(async move {
-            bridge
-                .force_detach_remote_user_resource_on_socket(msg)
-                .await
-        })
+        ctx.spawn(
+            async move {
+                bridge
+                    .force_detach_remote_user_resource_on_socket(msg)
+                    .await
+            }
+            .instrument(span),
+        )
     }
 }
 
@@ -608,27 +685,33 @@ impl Message<RelayResumeSteal> for RelayActor {
         msg: RelayResumeSteal,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let span = relay_dispatch_span("resume_steal");
+        span.record("stream_id", tracing::field::display(&msg.stream_id));
+        span.record("jid", tracing::field::display(&msg.requester_bare_jid));
         let resume_bridge = Arc::clone(&self.resume_bridge);
-        ctx.spawn(async move {
-            match resume_bridge
-                .request_forced_detach(
-                    &msg.stream_id,
-                    &msg.requester_bare_jid,
-                    LOCAL_FORCE_DETACH_ACK_TIMEOUT,
-                )
-                .await
-            {
-                super::resume_bridge::LocalForcedDetachOutcome::Detached => {
-                    RelayResumeStealReply::Detached
-                }
-                super::resume_bridge::LocalForcedDetachOutcome::IdentityMismatch => {
-                    RelayResumeStealReply::IdentityMismatch
-                }
-                super::resume_bridge::LocalForcedDetachOutcome::NotLiveLocally => {
-                    RelayResumeStealReply::NotLiveLocally
+        ctx.spawn(
+            async move {
+                match resume_bridge
+                    .request_forced_detach(
+                        &msg.stream_id,
+                        &msg.requester_bare_jid,
+                        LOCAL_FORCE_DETACH_ACK_TIMEOUT,
+                    )
+                    .await
+                {
+                    super::resume_bridge::LocalForcedDetachOutcome::Detached => {
+                        RelayResumeStealReply::Detached
+                    }
+                    super::resume_bridge::LocalForcedDetachOutcome::IdentityMismatch => {
+                        RelayResumeStealReply::IdentityMismatch
+                    }
+                    super::resume_bridge::LocalForcedDetachOutcome::NotLiveLocally => {
+                        RelayResumeStealReply::NotLiveLocally
+                    }
                 }
             }
-        })
+            .instrument(span),
+        )
     }
 }
 
@@ -666,8 +749,14 @@ impl Message<Demote> for RelayActor {
     type Reply = DemoteReply;
 
     async fn handle(&mut self, msg: Demote, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-        self.room_local_claims.demote(&msg.entity).await;
-        DemoteReply::Acked
+        let span = relay_dispatch_span("demote");
+        span.record("entity", tracing::field::debug(&msg.entity));
+        async {
+            self.room_local_claims.demote(&msg.entity).await;
+            DemoteReply::Acked
+        }
+        .instrument(span)
+        .await
     }
 }
 
@@ -2227,5 +2316,83 @@ mod tests {
             .expect("resume-steal task did not panic")
             .expect("resume-steal ask succeeds");
         assert_eq!(resume_steal_reply, RelayResumeStealReply::Detached);
+    }
+
+    fn spawn_test_relay_actor() -> kameo::actor::ActorRef<RelayActor> {
+        use kameo::actor::Spawn;
+        let resume_bridge = ResumeStealBridge::new();
+        resume_bridge.wire(Arc::new(waddle_xmpp::registry::ConnectionRegistry::new()));
+        RelayActor::spawn(RelayActor::new(
+            NodeId::new("span-test-node".to_string()),
+            false,
+            resume_bridge,
+            RoomLocalClaims::new(),
+            OrderedRelayDeliveryBridge::new(
+                CancellationToken::new(),
+                &crate::config::ClusteringMessagingConfig::default(),
+            ),
+        ))
+    }
+
+    /// #1483: an inbound relay ask handled inline (no delegated reply) must
+    /// open the named `clustering.relay.dispatch` root span, so the actor
+    /// work it triggers is parented and survives the #1438 span-noise
+    /// sampler.
+    #[tokio::test(flavor = "current_thread")]
+    async fn inline_relay_ask_records_the_dispatch_span() {
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let actor_ref = spawn_test_relay_actor();
+
+        let reply = actor_ref
+            .ask(Demote {
+                entity: Entity::new(EntityType::RoomActor, "room@muc.example.com".to_string()),
+                new_epoch: ClaimEpoch(7),
+            })
+            .await
+            .expect("demote ask succeeds");
+        assert_eq!(reply, DemoteReply::Acked);
+
+        assert_eq!(
+            spans
+                .recorded_field("clustering.relay.dispatch", "relay.message")
+                .as_deref(),
+            Some("demote"),
+            "demote handling must run under the named relay dispatch root span"
+        );
+    }
+
+    /// #1483: a delegated-reply relay ask must carry the named dispatch span
+    /// onto the spawned reply task, so the whole delivery — not just the
+    /// mailbox slice — is covered by the root span.
+    #[tokio::test(flavor = "current_thread")]
+    async fn delegated_relay_ask_records_the_dispatch_span() {
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let actor_ref = spawn_test_relay_actor();
+
+        // No live local connection for the stream: the delegated task
+        // resolves quickly with NotLiveLocally.
+        let reply = actor_ref
+            .ask(RelayResumeSteal {
+                stream_id: waddle_xmpp::pending_delivery::SmSessionId::new("span-test-stream"),
+                requester_bare_jid: "alice@example.com".parse().expect("valid bare jid"),
+            })
+            .await
+            .expect("resume-steal ask succeeds");
+        assert_eq!(reply, RelayResumeStealReply::NotLiveLocally);
+
+        assert_eq!(
+            spans
+                .recorded_field("clustering.relay.dispatch", "relay.message")
+                .as_deref(),
+            Some("resume_steal"),
+            "resume-steal handling must run under the named relay dispatch root span"
+        );
+        assert_eq!(
+            spans
+                .recorded_field("clustering.relay.dispatch", "stream_id")
+                .as_deref(),
+            Some("span-test-stream"),
+            "the dispatch span must carry the stream id"
+        );
     }
 }

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -18,6 +18,7 @@
 //! Phase 4 wires DM/MUC/presence routing through this relay. Kademlia still
 //! discovers node relays only; entity ownership remains in Postgres claims.
 
+use super::NodeId;
 use super::codec::RemoteStanza;
 use super::local_claims::RoomLocalClaims;
 use super::metrics;
@@ -32,7 +33,6 @@ use super::route_bridge::{
     RemoteResourceStateSnapshot, RemoteResourceStateUpdate, RemoteUserSideEffect,
 };
 use super::self_fence::LocallyClaimedEntities;
-use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
 use kameo::error::RemoteSendError;
 use kameo::message::{Context, Message};
@@ -40,7 +40,7 @@ use kameo::{Actor, RemoteActor, Reply};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use waddle_xmpp::ownership::{ClaimEpoch, Entity};
@@ -69,8 +69,14 @@ pub fn relay_name(node_id: &NodeId) -> String {
 /// instrumentation), so the kameo `actor.handle_message` spans its work
 /// mints would root the trace — exactly the shape the #1438 span-noise
 /// sampler drops. Opening this dedicated root before any actor message is
-/// sent keeps the whole delivery traceable: the actor spans become
-/// parented children and survive the sampler.
+/// sent keeps the receiving node's half of the delivery traceable: the
+/// actor spans become parented children and survive the sampler. The
+/// sending node's half stays a separate trace — kameo 0.20 remote
+/// messaging carries no W3C trace context, so cross-node causality is
+/// not linked (#1485 tracks propagating context on the relay envelopes).
+///
+/// `otel.kind = "consumer"`: this is the receive side of a cross-node
+/// message, per OTel messaging semantics.
 ///
 /// `parent: None` is load-bearing: the handler itself executes inside
 /// kameo's own (suppressed) root `actor.handle_message` span, and a child
@@ -83,6 +89,7 @@ fn relay_dispatch_span(message: &'static str) -> tracing::Span {
     tracing::info_span!(
         parent: None,
         "clustering.relay.dispatch",
+        otel.kind = "consumer",
         relay.message = message,
         jid = tracing::field::Empty,
         stream_id = tracing::field::Empty,
@@ -576,6 +583,7 @@ impl Message<RelayDeliverRemoteResourceFrame> for RelayActor {
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let span = relay_dispatch_span("remote_resource_frame");
+        span.record("jid", tracing::field::display(&msg.frame.jid));
         let bridge = Arc::clone(&self.ordered_delivery_bridge);
         ctx.spawn(
             async move { bridge.deliver_remote_resource_frame_on_socket(msg).await }
@@ -1172,7 +1180,7 @@ impl RelayHandle {
                 None => {
                     return Err(RelayAskError::NotFound {
                         node_id: self.node_id.clone(),
-                    })
+                    });
                 }
             }
         }
@@ -2161,8 +2169,8 @@ mod tests {
 
     #[test]
     fn ask_failures_classify_handler_effect_separately_from_failure_kind() {
-        use std::convert::Infallible;
         use RelaySendEffect::{MaybeCommitted, NoEffect};
+        use std::convert::Infallible;
 
         for (error, expected) in [
             (RemoteSendError::ActorNotRunning, NoEffect),
@@ -2419,6 +2427,55 @@ mod tests {
             opentelemetry::trace::SpanId::INVALID,
             "the dispatch span must root a fresh trace, not inherit the \
              active (suppressed) actor span as its parent"
+        );
+    }
+
+    /// #1483 guard: every delegated relay reply task must carry the
+    /// dispatch span. A `ctx.spawn` whose future is not `.instrument`-ed
+    /// runs the actual delivery — where the actor messages happen —
+    /// outside the root span, silently restoring the #1438 trace loss.
+    /// The field-recording tests above cannot catch that (the span still
+    /// records its fields at creation), so pin it structurally.
+    #[test]
+    fn every_delegated_relay_reply_task_is_instrumented() {
+        let source = include_str!("relay.rs");
+        let production: String = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("split always yields a first segment")
+            .lines()
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<&str>>()
+            .join("\n");
+        let production = production.as_str();
+        let mut checked = 0usize;
+        for (index, _) in production.match_indices("ctx.spawn(") {
+            let argument_start = index + "ctx.spawn(".len();
+            let mut depth = 1usize;
+            let mut argument_end = argument_start;
+            for (offset, character) in production[argument_start..].char_indices() {
+                match character {
+                    '(' => depth += 1,
+                    ')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            argument_end = argument_start + offset;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            assert!(
+                production[argument_start..argument_end].contains(".instrument("),
+                "the ctx.spawn at byte {index} delegates a relay reply \
+                 without instrumenting it with the dispatch span"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 8,
+            "expected the delegated relay handlers to be found; got {checked}"
         );
     }
 }

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -2395,4 +2395,30 @@ mod tests {
             "the dispatch span must carry the stream id"
         );
     }
+
+    /// #1483: `parent: None` is the load-bearing property — the handlers
+    /// run inside kameo's own suppressed root `actor.handle_message` span,
+    /// and a child of a locally-unsampled parent is dropped by the #1438
+    /// sampler too. Pin that the production constructor starts a fresh
+    /// root even when a span is active.
+    #[tokio::test(flavor = "current_thread")]
+    async fn relay_dispatch_span_is_a_root_even_inside_an_active_span() {
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let outer = tracing::info_span!("actor.handle_message");
+        let dispatch = outer.in_scope(|| relay_dispatch_span("root_check"));
+        drop(dispatch);
+        drop(outer);
+
+        let exported = spans.exported();
+        let dispatch = exported
+            .iter()
+            .find(|span| span.name == "clustering.relay.dispatch")
+            .expect("dispatch span must export");
+        assert_eq!(
+            dispatch.parent_span_id,
+            opentelemetry::trace::SpanId::INVALID,
+            "the dispatch span must root a fresh trace, not inherit the \
+             active (suppressed) actor span as its parent"
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1007,6 +1007,37 @@ mod orphan_sweep_supervision_tests {
         supervisor.shutdown().await;
     }
 
+    /// The worker loops wrap each attempt in an `async` block inside their
+    /// `select!` arms because `select!` evaluates branch expressions
+    /// eagerly — this pins the mechanism: an attempt future the cancel arm
+    /// beats to the first poll must not export a phantom attempt root.
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropped_unpolled_attempt_exports_no_phantom_span() {
+        use tracing::Instrument;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+
+        let sweep_context = opentelemetry::trace::SpanContext::empty_context();
+        let attempt = async {
+            std::future::ready(())
+                .instrument(orphan_work_span("sm_hydration", &sweep_context))
+                .await
+        };
+        drop(attempt);
+
+        assert_eq!(
+            spans.recorded_field("janitor.orphan_work", "lane"),
+            None,
+            "an attempt future dropped before its first poll must never create a span"
+        );
+        assert!(
+            spans
+                .exported()
+                .iter()
+                .all(|span| span.name != "janitor.orphan_work"),
+            "a dropped-unpolled attempt must not export a phantom root"
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn executed_orphan_sweep_records_its_lazy_span() {
         let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
@@ -1626,17 +1657,24 @@ impl OrphanReaperSupervisor {
                 let Some(work) = queue.pop_front() else {
                     continue;
                 };
+                // The async block defers span creation to first poll:
+                // select! evaluates every branch expression eagerly, and a
+                // cancel-arm win would otherwise export a phantom attempt
+                // root for work that never ran.
                 let result = tokio::select! {
                     _ = hydration_cancel.cancelled() => break,
-                    result = tokio::time::timeout(
-                        ORPHAN_WORK_ATTEMPT_TIMEOUT,
-                        hydration_registry.hydrate_reclaimed_typed(
-                            &work.entity,
-                            &work.fence,
-                            work.reservation,
-                        ),
-                    )
-                    .instrument(orphan_work_span("sm_hydration", &work.sweep_context)) => result,
+                    result = async {
+                        tokio::time::timeout(
+                            ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                            hydration_registry.hydrate_reclaimed_typed(
+                                &work.entity,
+                                &work.fence,
+                                work.reservation,
+                            ),
+                        )
+                        .instrument(orphan_work_span("sm_hydration", &work.sweep_context))
+                        .await
+                    } => result,
                 };
                 match result {
                     Ok(Ok(
@@ -1660,15 +1698,18 @@ impl OrphanReaperSupervisor {
                     )) => {
                         let cleanup = tokio::select! {
                             _ = hydration_cancel.cancelled() => break,
-                            result = tokio::time::timeout(
-                                ORPHAN_WORK_ATTEMPT_TIMEOUT,
-                                hydration_registry.release_reclaimed_claim(
-                                    &work.entity,
-                                    &work.fence,
-                                    work.reservation,
-                                ),
-                            )
-                            .instrument(orphan_work_span("sm_hydration", &work.sweep_context)) => result,
+                            result = async {
+                                tokio::time::timeout(
+                                    ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                                    hydration_registry.release_reclaimed_claim(
+                                        &work.entity,
+                                        &work.fence,
+                                        work.reservation,
+                                    ),
+                                )
+                                .instrument(orphan_work_span("sm_hydration", &work.sweep_context))
+                                .await
+                            } => result,
                         };
                         match cleanup {
                             Ok(Ok(_)) => {
@@ -1761,13 +1802,19 @@ impl OrphanReaperSupervisor {
                 let Some(work) = queue.pop_front() else {
                     continue;
                 };
+                // async block: see the hydration lane — select! would
+                // otherwise create (and export) the span even when the
+                // cancel arm wins before this branch is ever polled.
                 let result = tokio::select! {
                     _ = release_cancel.cancelled() => break,
-                    result = tokio::time::timeout(
-                        ORPHANED_ROOM_RELEASE_TIMEOUT,
-                        work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
-                    )
-                    .instrument(orphan_work_span("room_release", &work.sweep_context)) => result,
+                    result = async {
+                        tokio::time::timeout(
+                            ORPHANED_ROOM_RELEASE_TIMEOUT,
+                            work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
+                        )
+                        .instrument(orphan_work_span("room_release", &work.sweep_context))
+                        .await
+                    } => result,
                 };
                 match result {
                     Ok(Ok(_)) => {
@@ -2507,6 +2554,7 @@ impl waddle_xmpp::stream_management::persistence::SmPersistenceStorage
         Option<waddle_xmpp::stream_management::persistence::PersistedSession>,
         waddle_xmpp::stream_management::persistence::SmPersistenceError,
     > {
+        drop(tracing::info_span!("orphan.worker.hydration.test"));
         self.read_started.notify_one();
         std::future::pending().await
     }
@@ -2649,6 +2697,7 @@ impl waddle_xmpp::ownership::ClaimStore for HangingExactReleaseStore {
         _mine: waddle_xmpp::ownership::ClaimEpoch,
     ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, waddle_xmpp::ownership::ClaimError>
     {
+        drop(tracing::info_span!("orphan.worker.release.test"));
         self.release_started.notify_one();
         std::future::pending().await
     }
@@ -2738,6 +2787,7 @@ fn assert_linked_orphan_work_attempt(
     spans: &waddle_xmpp::telemetry::test_support::SpanTestGuard,
     sweep_id: opentelemetry::trace::SpanId,
     lane: &str,
+    work_marker: &str,
 ) {
     let exported = spans.exported();
     let attempt = exported
@@ -2761,6 +2811,19 @@ fn assert_linked_orphan_work_attempt(
             .iter()
             .any(|link| link.span_context.span_id() == sweep_id),
         "the attempt must link back to the sweep that enqueued it"
+    );
+    // The marker span the hanging store mints proves the store call ran
+    // INSIDE an attempt span — not merely that an attempt span exists.
+    let marker = exported
+        .iter()
+        .find(|span| span.name == work_marker)
+        .unwrap_or_else(|| panic!("the {work_marker} marker span must export"));
+    assert!(
+        exported
+            .iter()
+            .any(|span| span.name == "janitor.orphan_work"
+                && span.span_context.span_id() == marker.parent_span_id),
+        "the store call must run inside an attempt span"
     );
 }
 
@@ -2804,7 +2867,12 @@ async fn hydration_worker_attempts_link_to_the_enqueuing_sweep() {
     cancel.cancel();
     supervisor.shutdown().await;
 
-    assert_linked_orphan_work_attempt(&spans, sweep_id, "sm_hydration");
+    assert_linked_orphan_work_attempt(
+        &spans,
+        sweep_id,
+        "sm_hydration",
+        "orphan.worker.hydration.test",
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -3310,7 +3378,12 @@ async fn exact_release_worker_attempts_link_to_the_enqueuing_sweep() {
     cancel.cancel();
     supervisor.shutdown().await;
 
-    assert_linked_orphan_work_attempt(&spans, sweep_id, "room_release");
+    assert_linked_orphan_work_attempt(
+        &spans,
+        sweep_id,
+        "room_release",
+        "orphan.worker.release.test",
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -3,8 +3,21 @@ use crate::server::routes;
 use crate::server::routes::websocket::WebSocketState;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, warn};
-use waddle_xmpp::telemetry::attributes::{Janitor, SweepOutcome};
+use tracing::{debug, error, info, warn, Instrument};
+use waddle_xmpp::telemetry::attributes::{Janitor, MetricAttribute, SweepOutcome};
+
+/// Named root span for one janitor sweep tick (#1483).
+///
+/// Janitor loops run with no active span, so the actor.handle_message
+/// spans their asks mint would root the trace — exactly the shape the
+/// #1438 span-noise sampler drops. One root per sweep (never per actor
+/// message) keeps the sweep's actor work parented and traceable.
+/// `parent: None` guarantees root semantics even if a caller is
+/// instrumented. The span name is documented in `telemetry::span_noise`
+/// and must never be added to its suppression lists.
+fn janitor_sweep_span(janitor: Janitor) -> tracing::Span {
+    tracing::info_span!(parent: None, "janitor.sweep", janitor = janitor.value())
+}
 
 /// Default interval for the auth-state TTL janitor.
 const AUTH_JANITOR_INTERVAL: Duration = Duration::from_secs(60);
@@ -156,14 +169,15 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let mut sweep_failed = false;
-            let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
-                .deps
-                .protocol
-                .sm_session_registry
-                .drain_expired()
-                .await
-            {
+            async {
+                let mut sweep_failed = false;
+                let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .drain_expired()
+                    .await
+                {
                 Ok(sessions) => sessions,
                 Err(err) => {
                     sweep_failed = true;
@@ -562,6 +576,9 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     SweepOutcome::Completed
                 },
             );
+            }
+            .instrument(janitor_sweep_span(Janitor::SmExpiry))
+            .await;
         }
     });
 }
@@ -715,7 +732,8 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     &supervisor.workers.cancel,
                     &supervisor.workers.fatal_fence,
                     ORPHAN_REAPER_SWEEP_TIMEOUT,
-                    run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
+                    run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers)
+                        .instrument(janitor_sweep_span(Janitor::OrphanReaper)),
                 )
                 .await;
                 let mut workers_healthy = supervisor.is_healthy();
@@ -4665,175 +4683,185 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let mut sweep_failed = false;
-            let detached_live: Option<Vec<waddle_xmpp::pending_delivery::SmSessionId>> = state
-                .deps
-                .protocol
-                .sm_session_registry
-                .live_session_ids()
-                .map(|ids| {
-                    ids.into_iter()
-                        .map(waddle_xmpp::pending_delivery::SmSessionId::new)
-                        .collect()
-                });
-            let detached_live = match detached_live {
-                Some(v) => v,
-                None => {
-                    warn!(
-                        "claim-expiry janitor: SM session registry locks poisoned; \
-                         skipping sweep to avoid mass-release"
-                    );
-                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                        Janitor::PendingDeliveryClaim,
-                        SweepOutcome::Failed,
-                    );
-                    continue;
-                }
-            };
-            let active_live = state
-                .deps
-                .protocol
-                .connection_registry
-                .active_sm_stream_ids();
-            let mut live_sessions = detached_live;
-            live_sessions.extend(active_live);
-            // #1124 claim recency floor: only release claims older
-            // than several janitor intervals. Non-SM flushes claim
-            // rows under a synthetic `transient:` session id that is
-            // never in the live-set; without the floor, a janitor
-            // pass overlapping an in-flight flush releases its claims
-            // mid-flight and a second resource re-pushes the same
-            // offline messages. Fresh claims are skipped this pass and
-            // re-examined on later sweeps, so genuinely orphaned
-            // (post-crash) claims are still released — just a few
-            // intervals later.
-            let claim_release_floor_ms = i64::try_from(interval_secs)
-                .unwrap_or(i64::MAX)
-                .saturating_mul(1_000)
-                .saturating_mul(PENDING_CLAIM_RELEASE_FLOOR_INTERVALS);
-            let now_ms = chrono::Utc::now().timestamp_millis();
-            let claimed_before_ms = now_ms.saturating_sub(claim_release_floor_ms);
-            // Adopt claims written without a recency stamp (a
-            // pre-#1124 binary during a rolling deploy) so they age
-            // into release-eligibility instead of being skipped
-            // forever — `list_orphaned_claims` ignores unstamped rows.
-            match state
-                .deps
-                .protocol
-                .pending_delivery_storage
-                .stamp_unstamped_claims(now_ms)
-                .await
-            {
-                Ok(adopted) if adopted > 0 => {
-                    debug!(
-                        adopted,
-                        "claim-expiry janitor: adopted unstamped pending_delivery claims"
-                    );
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(error = %error, "claim-expiry janitor: stamp_unstamped_claims failed");
-                }
-            }
-            match state
-                .deps
-                .protocol
-                .pending_delivery_storage
-                .list_orphaned_claims(&live_sessions, claimed_before_ms)
-                .await
-            {
-                Ok(orphans) if !orphans.is_empty() => {
-                    let candidate_count = orphans.len();
-                    let mut released = 0u64;
-                    let mut skipped_reclaimed = 0u64;
-                    for (row_id, session) in orphans {
-                        match state
-                            .deps
-                            .protocol
-                            .pending_delivery_storage
-                            .release_row_if_session(&row_id, &session)
-                            .await
-                        {
-                            Ok(0) => skipped_reclaimed += 1,
-                            Ok(_) => released += 1,
-                            Err(error) => {
-                                sweep_failed = true;
-                                warn!(
-                                    row_id = %row_id,
-                                    session = %session,
-                                    error = %error,
-                                    "claim-expiry janitor: release_row_if_session failed; row stays \
-                                     claimed and will be retried next sweep"
-                                );
-                            }
-                        }
-                    }
-                    info!(
-                        candidate_count,
-                        released,
-                        skipped_reclaimed,
-                        "claim-expiry janitor: released orphaned pending_delivery claims"
-                    );
-                    waddle_xmpp::telemetry::reliability::add_pending_delivery_orphan_claims_released(released);
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(error = %error, "claim-expiry janitor: list_orphaned_claims failed");
-                }
-            }
-
-            let swept = state
-                .deps
-                .protocol
-                .pending_delivery_storage
-                .sweep_internal_bookkeeping();
-            if swept > 0 {
-                debug!(
-                    swept,
-                    "claim-expiry janitor: pruned idle per-recipient insert locks"
-                );
-            }
-
-            let max_age_days = i64::from(pending_delivery_max_age_days_from_env());
-            let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days);
-            match state
-                .deps
-                .protocol
-                .pending_delivery_storage
-                .delete_older_than(cutoff)
-                .await
-            {
-                Ok(0) => {}
-                Ok(removed) => {
-                    waddle_xmpp::telemetry::reliability::add_pending_delivery_aged_out(removed);
-                    info!(
-                        removed,
-                        cutoff = %cutoff,
-                        max_age_days,
-                        "pending_delivery aging janitor: dropped expired rows"
-                    );
-                }
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(
-                        %error,
-                        "pending_delivery aging janitor: delete_older_than failed; \
-                         will retry on next sweep"
-                    );
-                }
-            }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::PendingDeliveryClaim,
-                if sweep_failed {
-                    SweepOutcome::Failed
-                } else {
-                    SweepOutcome::Completed
-                },
-            );
+            run_pending_delivery_claim_sweep(&state, interval_secs).await;
         }
     });
+}
+
+async fn run_pending_delivery_claim_sweep(state: &WebSocketState, interval_secs: u64) {
+    async {
+        let mut sweep_failed = false;
+        let detached_live: Option<Vec<waddle_xmpp::pending_delivery::SmSessionId>> = state
+            .deps
+            .protocol
+            .sm_session_registry
+            .live_session_ids()
+            .map(|ids| {
+                ids.into_iter()
+                    .map(waddle_xmpp::pending_delivery::SmSessionId::new)
+                    .collect()
+            });
+        let detached_live = match detached_live {
+            Some(v) => v,
+            None => {
+                warn!(
+                    "claim-expiry janitor: SM session registry locks poisoned; \
+                     skipping sweep to avoid mass-release"
+                );
+                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                    Janitor::PendingDeliveryClaim,
+                    SweepOutcome::Failed,
+                );
+                return;
+            }
+        };
+        let active_live = state
+            .deps
+            .protocol
+            .connection_registry
+            .active_sm_stream_ids();
+        let mut live_sessions = detached_live;
+        live_sessions.extend(active_live);
+        // #1124 claim recency floor: only release claims older
+        // than several janitor intervals. Non-SM flushes claim
+        // rows under a synthetic `transient:` session id that is
+        // never in the live-set; without the floor, a janitor
+        // pass overlapping an in-flight flush releases its claims
+        // mid-flight and a second resource re-pushes the same
+        // offline messages. Fresh claims are skipped this pass and
+        // re-examined on later sweeps, so genuinely orphaned
+        // (post-crash) claims are still released — just a few
+        // intervals later.
+        let claim_release_floor_ms = i64::try_from(interval_secs)
+            .unwrap_or(i64::MAX)
+            .saturating_mul(1_000)
+            .saturating_mul(PENDING_CLAIM_RELEASE_FLOOR_INTERVALS);
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let claimed_before_ms = now_ms.saturating_sub(claim_release_floor_ms);
+        // Adopt claims written without a recency stamp (a
+        // pre-#1124 binary during a rolling deploy) so they age
+        // into release-eligibility instead of being skipped
+        // forever — `list_orphaned_claims` ignores unstamped rows.
+        match state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .stamp_unstamped_claims(now_ms)
+            .await
+        {
+            Ok(adopted) if adopted > 0 => {
+                debug!(
+                    adopted,
+                    "claim-expiry janitor: adopted unstamped pending_delivery claims"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(error = %error, "claim-expiry janitor: stamp_unstamped_claims failed");
+            }
+        }
+        match state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .list_orphaned_claims(&live_sessions, claimed_before_ms)
+            .await
+        {
+            Ok(orphans) if !orphans.is_empty() => {
+                let candidate_count = orphans.len();
+                let mut released = 0u64;
+                let mut skipped_reclaimed = 0u64;
+                for (row_id, session) in orphans {
+                    match state
+                        .deps
+                        .protocol
+                        .pending_delivery_storage
+                        .release_row_if_session(&row_id, &session)
+                        .await
+                    {
+                        Ok(0) => skipped_reclaimed += 1,
+                        Ok(_) => released += 1,
+                        Err(error) => {
+                            sweep_failed = true;
+                            warn!(
+                                row_id = %row_id,
+                                session = %session,
+                                error = %error,
+                                "claim-expiry janitor: release_row_if_session failed; row stays \
+                                 claimed and will be retried next sweep"
+                            );
+                        }
+                    }
+                }
+                info!(
+                    candidate_count,
+                    released,
+                    skipped_reclaimed,
+                    "claim-expiry janitor: released orphaned pending_delivery claims"
+                );
+                waddle_xmpp::telemetry::reliability::add_pending_delivery_orphan_claims_released(
+                    released,
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(error = %error, "claim-expiry janitor: list_orphaned_claims failed");
+            }
+        }
+
+        let swept = state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .sweep_internal_bookkeeping();
+        if swept > 0 {
+            debug!(
+                swept,
+                "claim-expiry janitor: pruned idle per-recipient insert locks"
+            );
+        }
+
+        let max_age_days = i64::from(pending_delivery_max_age_days_from_env());
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days);
+        match state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .delete_older_than(cutoff)
+            .await
+        {
+            Ok(0) => {}
+            Ok(removed) => {
+                waddle_xmpp::telemetry::reliability::add_pending_delivery_aged_out(removed);
+                info!(
+                    removed,
+                    cutoff = %cutoff,
+                    max_age_days,
+                    "pending_delivery aging janitor: dropped expired rows"
+                );
+            }
+            Err(error) => {
+                sweep_failed = true;
+                warn!(
+                    %error,
+                    "pending_delivery aging janitor: delete_older_than failed; \
+                     will retry on next sweep"
+                );
+            }
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::PendingDeliveryClaim,
+            if sweep_failed {
+                SweepOutcome::Failed
+            } else {
+                SweepOutcome::Completed
+            },
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::PendingDeliveryClaim))
+    .await;
 }
 
 pub(crate) fn spawn_push_service_publish_job_janitor(websocket_state: &Arc<WebSocketState>) {
@@ -4856,35 +4884,40 @@ pub(crate) fn spawn_push_service_publish_job_janitor(websocket_state: &Arc<WebSo
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let outcome = match state
-                .deps
-                .protocol
-                .push_service
-                .drain_queued_notification_publish_jobs(batch_size)
-                .await
-            {
-                Ok(results) if !results.is_empty() => {
-                    debug!(
-                        drained = results.len(),
-                        "Push Service publish-job janitor drained queued XEP-0357 jobs"
-                    );
-                    SweepOutcome::Completed
-                }
-                Ok(_) => SweepOutcome::Completed,
-                Err(error) => {
-                    warn!(
-                        error = %error,
-                        "Push Service publish-job janitor failed; queued jobs remain durable"
-                    );
-                    SweepOutcome::Failed
-                }
-            };
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::PushPublishJob,
-                outcome,
-            );
+            run_push_service_publish_job_sweep(&state, batch_size).await;
         }
     });
+}
+
+async fn run_push_service_publish_job_sweep(state: &WebSocketState, batch_size: usize) {
+    async {
+        let outcome = match state
+            .deps
+            .protocol
+            .push_service
+            .drain_queued_notification_publish_jobs(batch_size)
+            .await
+        {
+            Ok(results) if !results.is_empty() => {
+                debug!(
+                    drained = results.len(),
+                    "Push Service publish-job janitor drained queued XEP-0357 jobs"
+                );
+                SweepOutcome::Completed
+            }
+            Ok(_) => SweepOutcome::Completed,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "Push Service publish-job janitor failed; queued jobs remain durable"
+                );
+                SweepOutcome::Failed
+            }
+        };
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(Janitor::PushPublishJob, outcome);
+    }
+    .instrument(janitor_sweep_span(Janitor::PushPublishJob))
+    .await;
 }
 
 pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketState>) {
@@ -4929,175 +4962,187 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let mut sweep_failed = false;
-            let first_party_service_jid = match state.deps.service_domains.push.parse() {
-                Ok(jid) => jid,
-                Err(error) => {
-                    warn!(
-                        error = %error,
-                        push_service = %state.deps.service_domains.push,
-                        "Notification outbox janitor cannot parse first-party Push Service JID"
-                    );
-                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                        Janitor::NotificationOutbox,
-                        SweepOutcome::Failed,
-                    );
-                    continue;
-                }
-            };
-            let recovered = routes::interpret::reconcile_xep0357_notification_candidates_for_sweep(
-                state.as_ref(),
-                batch_size,
-            )
-            .await;
-            sweep_failed |= recovered.had_failure;
-            if recovered.completed > 0 {
-                debug!(
-                    recovered = recovered.completed,
-                    "Notification outbox janitor recovered XEP-0357 candidates from pending_delivery"
-                );
-            }
-            let recovered_groupchat =
-                routes::interpret::reconcile_groupchat_notification_candidates_for_sweep(
-                    state.as_ref(),
-                    batch_size,
-                )
+            run_notification_outbox_sweep(&state, batch_size, retention_days, prune_batch_size)
                 .await;
-            sweep_failed |= recovered_groupchat.had_failure;
-            if recovered_groupchat.completed > 0 {
-                debug!(
-                    recovered = recovered_groupchat.completed,
-                    "Notification outbox janitor recovered XEP-0357 groupchat candidates from inbox projections"
-                );
-            }
-            let room_policy =
-                RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
-            let dnd_reader = state.deps.protocol.dnd_reader.as_ref();
-            let activity_reader = state.deps.protocol.notification_activity.as_ref();
-            let deps = crate::notification_outbox::NotificationDrainDeps::new(
-                &room_policy,
-                dnd_reader,
-                activity_reader,
-            );
-            match state
-                .deps
-                .protocol
-                .notification_outbox
-                .drain_pending_candidates_into_outbox(
-                    state.deps.protocol.push_store.as_ref(),
-                    state.deps.protocol.blocking_storage.as_ref(),
-                    state
-                        .deps
-                        .protocol
-                        .notification_settings_projection
-                        .as_ref(),
-                    deps,
-                    &first_party_service_jid,
-                    batch_size,
-                )
-                .await
-            {
-                Ok(processed) if processed > 0 => {
-                    debug!(
-                        processed,
-                        "Notification outbox janitor expanded XEP-0357 candidates into outbox jobs"
-                    );
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(
-                        error = %error,
-                        "Notification outbox janitor failed to process candidates; candidates remain durable"
-                    );
-                }
-            }
-            match state
-                .deps
-                .protocol
-                .notification_outbox
-                .drain_due_outbox_jobs(
-                    state.deps.protocol.push_service.as_ref(),
-                    state.deps.protocol.push_store.as_ref(),
-                    state.deps.protocol.inbox_storage.as_ref(),
-                    state.deps.protocol.blocking_storage.as_ref(),
-                    &first_party_service_jid,
-                    batch_size,
-                )
-                .await
-            {
-                Ok(results) if !results.is_empty() => {
-                    debug!(
-                        drained = results.len(),
-                        "Notification outbox janitor emitted durable XEP-0357 PubSub publish jobs"
-                    );
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(
-                        error = %error,
-                        "Notification outbox janitor failed; outbox jobs remain durable"
-                    );
-                }
-            }
-            let cutoff_ms = crate::time::now_ms()
-                .saturating_sub(i64::from(retention_days) * 24 * 60 * 60 * 1_000);
-            match state
-                .deps
-                .protocol
-                .notification_outbox
-                .prune_completed_before(cutoff_ms, prune_batch_size)
-                .await
-            {
-                Ok(outcome) if outcome.total_deleted() > 0 => {
-                    debug!(
-                        candidates_deleted = outcome.candidates_deleted,
-                        jobs_deleted = outcome.jobs_deleted,
-                        "Notification outbox janitor pruned completed rows"
-                    );
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(
-                        error = %error,
-                        "Notification outbox janitor prune failed; completed rows remain durable"
-                    );
-                }
-            }
-            match state
-                .deps
-                .protocol
-                .inbox_storage
-                .prune_completed_groupchat_notification_recoveries(cutoff_ms, prune_batch_size)
-                .await
-            {
-                Ok(deleted) if deleted > 0 => {
-                    debug!(
-                        deleted,
-                        "Notification outbox janitor pruned completed groupchat notification recovery rows"
-                    );
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    sweep_failed = true;
-                    warn!(
-                        error = %error,
-                        "Notification outbox janitor failed to prune completed groupchat notification recovery rows"
-                    );
-                }
-            }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::NotificationOutbox,
-                if sweep_failed {
-                    SweepOutcome::Failed
-                } else {
-                    SweepOutcome::Completed
-                },
-            );
         }
     });
+}
+
+async fn run_notification_outbox_sweep(
+    state: &WebSocketState,
+    batch_size: usize,
+    retention_days: u32,
+    prune_batch_size: usize,
+) {
+    async {
+        let mut sweep_failed = false;
+        let first_party_service_jid = match state.deps.service_domains.push.parse() {
+            Ok(jid) => jid,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    push_service = %state.deps.service_domains.push,
+                    "Notification outbox janitor cannot parse first-party Push Service JID"
+                );
+                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                    Janitor::NotificationOutbox,
+                    SweepOutcome::Failed,
+                );
+                return;
+            }
+        };
+        let recovered =
+            routes::interpret::reconcile_xep0357_notification_candidates_for_sweep(
+                state, batch_size,
+            )
+            .await;
+        sweep_failed |= recovered.had_failure;
+        if recovered.completed > 0 {
+            debug!(
+                recovered = recovered.completed,
+                "Notification outbox janitor recovered XEP-0357 candidates from pending_delivery"
+            );
+        }
+        let recovered_groupchat =
+            routes::interpret::reconcile_groupchat_notification_candidates_for_sweep(
+                state, batch_size,
+            )
+            .await;
+        sweep_failed |= recovered_groupchat.had_failure;
+        if recovered_groupchat.completed > 0 {
+            debug!(
+                recovered = recovered_groupchat.completed,
+                "Notification outbox janitor recovered XEP-0357 groupchat candidates from inbox projections"
+            );
+        }
+        let room_policy = RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
+        let dnd_reader = state.deps.protocol.dnd_reader.as_ref();
+        let activity_reader = state.deps.protocol.notification_activity.as_ref();
+        let deps = crate::notification_outbox::NotificationDrainDeps::new(
+            &room_policy,
+            dnd_reader,
+            activity_reader,
+        );
+        match state
+            .deps
+            .protocol
+            .notification_outbox
+            .drain_pending_candidates_into_outbox(
+                state.deps.protocol.push_store.as_ref(),
+                state.deps.protocol.blocking_storage.as_ref(),
+                state
+                    .deps
+                    .protocol
+                    .notification_settings_projection
+                    .as_ref(),
+                deps,
+                &first_party_service_jid,
+                batch_size,
+            )
+            .await
+        {
+            Ok(processed) if processed > 0 => {
+                debug!(
+                    processed,
+                    "Notification outbox janitor expanded XEP-0357 candidates into outbox jobs"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(
+                    error = %error,
+                    "Notification outbox janitor failed to process candidates; candidates remain durable"
+                );
+            }
+        }
+        match state
+            .deps
+            .protocol
+            .notification_outbox
+            .drain_due_outbox_jobs(
+                state.deps.protocol.push_service.as_ref(),
+                state.deps.protocol.push_store.as_ref(),
+                state.deps.protocol.inbox_storage.as_ref(),
+                state.deps.protocol.blocking_storage.as_ref(),
+                &first_party_service_jid,
+                batch_size,
+            )
+            .await
+        {
+            Ok(results) if !results.is_empty() => {
+                debug!(
+                    drained = results.len(),
+                    "Notification outbox janitor emitted durable XEP-0357 PubSub publish jobs"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(
+                    error = %error,
+                    "Notification outbox janitor failed; outbox jobs remain durable"
+                );
+            }
+        }
+        let cutoff_ms = crate::time::now_ms()
+            .saturating_sub(i64::from(retention_days) * 24 * 60 * 60 * 1_000);
+        match state
+            .deps
+            .protocol
+            .notification_outbox
+            .prune_completed_before(cutoff_ms, prune_batch_size)
+            .await
+        {
+            Ok(outcome) if outcome.total_deleted() > 0 => {
+                debug!(
+                    candidates_deleted = outcome.candidates_deleted,
+                    jobs_deleted = outcome.jobs_deleted,
+                    "Notification outbox janitor pruned completed rows"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(
+                    error = %error,
+                    "Notification outbox janitor prune failed; completed rows remain durable"
+                );
+            }
+        }
+        match state
+            .deps
+            .protocol
+            .inbox_storage
+            .prune_completed_groupchat_notification_recoveries(cutoff_ms, prune_batch_size)
+            .await
+        {
+            Ok(deleted) if deleted > 0 => {
+                debug!(
+                    deleted,
+                    "Notification outbox janitor pruned completed groupchat notification recovery rows"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                sweep_failed = true;
+                warn!(
+                    error = %error,
+                    "Notification outbox janitor failed to prune completed groupchat notification recovery rows"
+                );
+            }
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::NotificationOutbox,
+            if sweep_failed {
+                SweepOutcome::Failed
+            } else {
+                SweepOutcome::Completed
+            },
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::NotificationOutbox))
+    .await;
 }
 
 /// ADR-0017 Phase 3 Slice 10: feed the SM-session Q6 drain's outcomes into
@@ -5479,48 +5524,56 @@ pub(crate) fn spawn_auth_state_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let counts = match state
-                .deps
-                .auth_state
-                .auth_handshake
-                .sweep_expired(chrono::Utc::now())
-                .await
-            {
-                Ok(counts) => counts,
-                Err(error) => {
-                    warn!(error = %error, "auth janitor: sweep failed; will retry next tick");
-                    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                        Janitor::AuthState,
-                        SweepOutcome::Failed,
-                    );
-                    continue;
-                }
-            };
-            let total = counts.pending_pruned + counts.device_pruned + counts.xmpp_pruned;
-            if total > 0 {
-                info!(
-                    pending_auth_pruned = counts.pending_pruned,
-                    device_auth_pruned = counts.device_pruned,
-                    xmpp_auth_codes_pruned = counts.xmpp_pruned,
-                    pending_auth_remaining = counts.pending_remaining,
-                    device_auth_remaining = counts.device_remaining,
-                    xmpp_auth_codes_remaining = counts.xmpp_remaining,
-                    "auth janitor: pruned expired entries"
-                );
-            } else {
-                debug!(
-                    pending_auth_remaining = counts.pending_remaining,
-                    device_auth_remaining = counts.device_remaining,
-                    xmpp_auth_codes_remaining = counts.xmpp_remaining,
-                    "auth janitor: no expired entries"
-                );
-            }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::AuthState,
-                SweepOutcome::Completed,
-            );
+            run_auth_state_sweep(&state).await;
         }
     });
+}
+
+async fn run_auth_state_sweep(state: &WebSocketState) {
+    async {
+        let counts = match state
+            .deps
+            .auth_state
+            .auth_handshake
+            .sweep_expired(chrono::Utc::now())
+            .await
+        {
+            Ok(counts) => counts,
+            Err(error) => {
+                warn!(error = %error, "auth janitor: sweep failed; will retry next tick");
+                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                    Janitor::AuthState,
+                    SweepOutcome::Failed,
+                );
+                return;
+            }
+        };
+        let total = counts.pending_pruned + counts.device_pruned + counts.xmpp_pruned;
+        if total > 0 {
+            info!(
+                pending_auth_pruned = counts.pending_pruned,
+                device_auth_pruned = counts.device_pruned,
+                xmpp_auth_codes_pruned = counts.xmpp_pruned,
+                pending_auth_remaining = counts.pending_remaining,
+                device_auth_remaining = counts.device_remaining,
+                xmpp_auth_codes_remaining = counts.xmpp_remaining,
+                "auth janitor: pruned expired entries"
+            );
+        } else {
+            debug!(
+                pending_auth_remaining = counts.pending_remaining,
+                device_auth_remaining = counts.device_remaining,
+                xmpp_auth_codes_remaining = counts.xmpp_remaining,
+                "auth janitor: no expired entries"
+            );
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::AuthState,
+            SweepOutcome::Completed,
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::AuthState))
+    .await;
 }
 
 /// Per-sweep counts returned by [`sweep_dormant_rooms_once`].
@@ -5676,29 +5729,33 @@ pub(crate) fn spawn_room_dormancy_janitor(websocket_state: &Arc<WebSocketState>)
 }
 
 async fn run_room_dormancy_sweep(state: &WebSocketState) {
-    let counts = sweep_dormant_rooms_once(state).await;
-    if counts.evicted > 0 {
-        info!(
-            examined = counts.examined,
-            evicted = counts.evicted,
-            remaining = counts.remaining,
-            "room dormancy janitor: evicted dormant rooms"
-        );
-    } else {
-        debug!(
-            examined = counts.examined,
-            remaining = counts.remaining,
-            "room dormancy janitor: no dormant rooms"
+    async {
+        let counts = sweep_dormant_rooms_once(state).await;
+        if counts.evicted > 0 {
+            info!(
+                examined = counts.examined,
+                evicted = counts.evicted,
+                remaining = counts.remaining,
+                "room dormancy janitor: evicted dormant rooms"
+            );
+        } else {
+            debug!(
+                examined = counts.examined,
+                remaining = counts.remaining,
+                "room dormancy janitor: no dormant rooms"
+            );
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::RoomDormancy,
+            if counts.failed {
+                SweepOutcome::Failed
+            } else {
+                SweepOutcome::Completed
+            },
         );
     }
-    waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-        Janitor::RoomDormancy,
-        if counts.failed {
-            SweepOutcome::Failed
-        } else {
-            SweepOutcome::Completed
-        },
-    );
+    .instrument(janitor_sweep_span(Janitor::RoomDormancy))
+    .await;
 }
 
 /// Per-sweep counts returned by [`sweep_empty_user_actors_once`].
@@ -5814,31 +5871,39 @@ pub(crate) fn spawn_user_actor_reaper(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let counts = sweep_empty_user_actors_once(&state).await;
-            if counts.reaped > 0 {
-                info!(
-                    examined = counts.examined,
-                    reaped = counts.reaped,
-                    remaining = counts.remaining,
-                    "user actor reaper: reaped empty UserActors"
-                );
-            } else {
-                debug!(
-                    examined = counts.examined,
-                    remaining = counts.remaining,
-                    "user actor reaper: no empty UserActors"
-                );
-            }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::UserActorReaper,
-                if counts.failed {
-                    SweepOutcome::Failed
-                } else {
-                    SweepOutcome::Completed
-                },
-            );
+            run_user_actor_reaper_sweep(&state).await;
         }
     });
+}
+
+async fn run_user_actor_reaper_sweep(state: &WebSocketState) {
+    async {
+        let counts = sweep_empty_user_actors_once(state).await;
+        if counts.reaped > 0 {
+            info!(
+                examined = counts.examined,
+                reaped = counts.reaped,
+                remaining = counts.remaining,
+                "user actor reaper: reaped empty UserActors"
+            );
+        } else {
+            debug!(
+                examined = counts.examined,
+                remaining = counts.remaining,
+                "user actor reaper: no empty UserActors"
+            );
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::UserActorReaper,
+            if counts.failed {
+                SweepOutcome::Failed
+            } else {
+                SweepOutcome::Completed
+            },
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::UserActorReaper))
+    .await;
 }
 
 #[cfg(test)]
@@ -5876,6 +5941,20 @@ mod room_dormancy_tests {
                 &[("janitor", "room_dormancy"), ("outcome", "completed")],
             ),
             Some(1),
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn room_dormancy_sweep_records_the_janitor_span() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let state = create_test_websocket_state().await;
+
+        run_room_dormancy_sweep(&state).await;
+
+        assert_eq!(
+            spans.recorded_field("janitor.sweep", "janitor").as_deref(),
+            Some("room_dormancy"),
         );
     }
 
@@ -6135,7 +6214,7 @@ mod room_dormancy_tests {
 
 #[cfg(test)]
 mod user_reaper_tests {
-    use super::sweep_empty_user_actors_once;
+    use super::{run_user_actor_reaper_sweep, sweep_empty_user_actors_once};
     use crate::server::routes::websocket::tests::create_test_websocket_state;
     use waddle_xmpp::registry::{
         ConnectionEntry, GetUser, RegisterUserResource, TrySendPeer, UserCount,
@@ -6151,6 +6230,20 @@ mod user_reaper_tests {
         msg.bodies
             .insert(xmpp_parsers::message::Lang::new(), "hi".to_string());
         waddle_xmpp::Stanza::Message(msg)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_actor_reaper_sweep_records_the_janitor_span() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let state = create_test_websocket_state().await;
+
+        run_user_actor_reaper_sweep(&state).await;
+
+        assert_eq!(
+            spans.recorded_field("janitor.sweep", "janitor").as_deref(),
+            Some("user_actor_reaper"),
+        );
     }
 
     /// End-to-end sweep over the actor tree: register a resource, force the
@@ -6338,49 +6431,58 @@ pub(crate) fn spawn_remote_muc_membership_reconciler(websocket_state: &Arc<WebSo
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let candidates = collect_remote_muc_reconcile_candidates(&state).await;
-            if candidates.occupants.is_empty() {
-                waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                    Janitor::RemoteMucMembership,
-                    remote_muc_sweep_outcome(candidates.had_failure),
-                );
-                continue;
-            }
-            info!(
-                candidates = candidates.occupants.len(),
-                "remote MUC reconciler: re-driving unavailable relays for departed occupants"
-            );
-            let mut sweep_failed = candidates.had_failure;
-            for occupant in candidates.occupants {
-                // Re-check liveness IMMEDIATELY before the re-drive
-                // (codex review P1 on PR #1277): the candidate list was
-                // collected before earlier awaited re-drives, and the
-                // same full JID may have reconnected in that gap. A
-                // registered connection means the occupancy is
-                // legitimate again; the membership-generation guards
-                // inside the cleanup protect the map but cannot undo a
-                // relayed remote leave.
-                if state
-                    .deps
-                    .protocol
-                    .connection_registry
-                    .get_entry(&occupant)
-                    .is_some()
-                {
-                    continue;
-                }
-                if routes::websocket::redrive_remote_muc_cleanup(&state, &occupant).await
-                    == routes::websocket::MucCleanupOutcome::Failed
-                {
-                    sweep_failed = true;
-                }
-            }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::RemoteMucMembership,
-                remote_muc_sweep_outcome(sweep_failed),
-            );
+            run_remote_muc_membership_sweep(&state).await;
         }
     });
+}
+
+#[cfg(feature = "clustering")]
+async fn run_remote_muc_membership_sweep(state: &WebSocketState) {
+    async {
+        let candidates = collect_remote_muc_reconcile_candidates(state).await;
+        if candidates.occupants.is_empty() {
+            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+                Janitor::RemoteMucMembership,
+                remote_muc_sweep_outcome(candidates.had_failure),
+            );
+            return;
+        }
+        info!(
+            candidates = candidates.occupants.len(),
+            "remote MUC reconciler: re-driving unavailable relays for departed occupants"
+        );
+        let mut sweep_failed = candidates.had_failure;
+        for occupant in candidates.occupants {
+            // Re-check liveness IMMEDIATELY before the re-drive
+            // (codex review P1 on PR #1277): the candidate list was
+            // collected before earlier awaited re-drives, and the
+            // same full JID may have reconnected in that gap. A
+            // registered connection means the occupancy is
+            // legitimate again; the membership-generation guards
+            // inside the cleanup protect the map but cannot undo a
+            // relayed remote leave.
+            if state
+                .deps
+                .protocol
+                .connection_registry
+                .get_entry(&occupant)
+                .is_some()
+            {
+                continue;
+            }
+            if routes::websocket::redrive_remote_muc_cleanup(state, &occupant).await
+                == routes::websocket::MucCleanupOutcome::Failed
+            {
+                sweep_failed = true;
+            }
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::RemoteMucMembership,
+            remote_muc_sweep_outcome(sweep_failed),
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::RemoteMucMembership))
+    .await;
 }
 
 #[cfg(all(test, feature = "clustering"))]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -169,183 +169,55 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            async {
-                let mut sweep_failed = false;
-                let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
-                    .deps
-                    .protocol
-                    .sm_session_registry
-                    .drain_expired()
-                    .await
-                {
-                Ok(sessions) => sessions,
-                Err(err) => {
-                    sweep_failed = true;
-                    warn!(error = %err, "SM janitor: drain_expired failed");
-                    Vec::new()
-                }
-            };
-            if !drained.is_empty() {
-                info!(
-                    count = drained.len(),
-                    "SM janitor: cleaning up expired detached sessions"
-                );
+            run_sm_expiry_sweep(&state).await;
+        }
+    });
+}
+
+async fn run_sm_expiry_sweep(state: &Arc<WebSocketState>) {
+    async {
+        let mut sweep_failed = false;
+        let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
+            .deps
+            .protocol
+            .sm_session_registry
+            .drain_expired()
+            .await
+        {
+            Ok(sessions) => sessions,
+            Err(err) => {
+                sweep_failed = true;
+                warn!(error = %err, "SM janitor: drain_expired failed");
+                Vec::new()
             }
-            let mut promotion_batch = crate::sm_promotion::PromotionBatchGuard::new(
-                &state.deps.protocol.sm_session_registry,
-                drained,
+        };
+        if !drained.is_empty() {
+            info!(
+                count = drained.len(),
+                "SM janitor: cleaning up expired detached sessions"
             );
-            while let Some(pending_session) = promotion_batch.pop() {
-                let mut promotion_guard = crate::sm_promotion::PromotionSessionGuard::new(
-                    &state.deps.protocol.sm_session_registry,
-                    pending_session,
-                );
-                let session = promotion_guard.session().clone();
-                let blocklist = match state
-                    .deps
-                    .protocol
-                    .blocking_storage
-                    .list_blocked_jid_entries(&session.jid.to_bare())
-                    .await
-                {
-                    Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
-                    Err(error) => {
-                        sweep_failed = true;
-                        waddle_xmpp::telemetry::reliability::increment_sm_promotion_blocklist_failed();
-                        let attempts = match state
-                            .deps
-                            .protocol
-                            .sm_session_registry
-                            .record_promotion_failure(&session.stream_id)
-                            .await
-                        {
-                            Ok(n) => n,
-                            Err(record_error) => {
-                                warn!(
-                                    jid = %session.jid,
-                                    error = %error,
-                                    record_error = %record_error,
-                                    "SM janitor: blocklist load failed and \
-                                     record_promotion_failure also failed; preserving \
-                                     session state for retry"
-                                );
-                                if crate::sm_promotion::reinsert_failed_session_for_retry(
-                                    &state.deps.protocol.sm_session_registry,
-                                    session.clone(),
-                                )
-                                .await
-                                {
-                                    promotion_guard.complete();
-                                }
-                                continue;
-                            }
-                        };
-                        if attempts >= max_promotion_attempts_from_env() {
-                            waddle_xmpp::telemetry::reliability::increment_sm_promotion_dead_lettered();
-                            error!(
-                                jid = %session.jid,
-                                stream_id = %session.stream_id,
-                                attempts,
-                                error = %error,
-                                "SM janitor: blocklist load has repeatedly failed; \
-                                 dead-lettering the durable row to break the retry loop"
-                            );
-                            if state
-                                .deps
-                                .protocol
-                                .sm_session_registry
-                                .confirm_drained(&session.stream_id)
-                                .await
-                            {
-                                promotion_guard.complete();
-                            }
-                            continue;
-                        }
-                        warn!(
-                            jid = %session.jid,
-                            attempts,
-                            error = %error,
-                            "SM janitor: blocklist load failed; SKIPPING promotion to \
-                             preserve fail-closed XEP-0191 policy. Durable SM row will \
-                             be retried on the next janitor pass."
-                        );
-                        // Make the retry promise true: drain_expired scans only
-                        // memory, so the drained session must go back into the
-                        // map for the next tick to see it.
-                        if crate::sm_promotion::reinsert_failed_session_for_retry(
-                            &state.deps.protocol.sm_session_registry,
-                            session.clone(),
-                        )
-                        .await
-                        {
-                            promotion_guard.complete();
-                        }
-                        continue;
-                    }
-                };
-                // Round-2 review R2 + round-3 finding 1: retractions
-                // racing this drain window are invisible to the registry
-                // scrub (the sessions are off both maps); fetch the
-                // recent-tombstone record PER SESSION, immediately
-                // before this session's promotion, so even a retraction
-                // landing mid-batch is still seen.
-                let recent_tombstones = match crate::sm_promotion::recent_tombstones_for_promotion(
-                    &state.deps.protocol.sm_session_registry,
-                    "SM janitor",
-                ) {
-                    Ok(records) => records,
-                    Err(_) => {
-                        sweep_failed = true;
-                        Vec::new()
-                    }
-                };
-                let summary = crate::sm_promotion::promote_session_unacked(
-                    &session,
-                    &state.deps.protocol.connection_registry,
-                    &state.deps.protocol.user_registry,
-                    &state.deps.protocol.pending_delivery_storage,
-                    &blocklist,
-                    state.deps.auth_state.xmpp_domain.as_str(),
-                    &recent_tombstones,
-                )
-                .await;
-                // Finding B (retraction-vs-promotion TOCTOU): a
-                // retraction recorded after the snapshot above raced
-                // this session's promotion — re-scrub the pending rows
-                // it may have just inserted BEFORE confirm_drained.
-                if crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
-                    &state.deps.protocol.sm_session_registry,
-                    &state.deps.protocol.pending_delivery_storage,
-                    &recent_tombstones,
-                    "SM janitor",
-                )
+        }
+        let mut promotion_batch = crate::sm_promotion::PromotionBatchGuard::new(
+            &state.deps.protocol.sm_session_registry,
+            drained,
+        );
+        while let Some(pending_session) = promotion_batch.pop() {
+            let mut promotion_guard = crate::sm_promotion::PromotionSessionGuard::new(
+                &state.deps.protocol.sm_session_registry,
+                pending_session,
+            );
+            let session = promotion_guard.session().clone();
+            let blocklist = match state
+                .deps
+                .protocol
+                .blocking_storage
+                .list_blocked_jid_entries(&session.jid.to_bare())
                 .await
-                    == crate::sm_promotion::PromotionScrubOutcome::Failed
-                {
+            {
+                Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
+                Err(error) => {
                     sweep_failed = true;
-                }
-                if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
-                    > 0
-                    || summary.storage_failed > 0
-                {
-                    info!(
-                        jid = %session.jid,
-                        redelivered = summary.redelivered,
-                        queued = summary.queued,
-                        bounced = summary.bounced,
-                        dropped = summary.dropped,
-                        not_promotable = summary.not_promotable,
-                        unparseable = summary.unparseable,
-                        scrubbed = summary.scrubbed,
-                        storage_failed = summary.storage_failed,
-                        "SM janitor: Q6 promotion completed"
-                    );
-                }
-                if summary.has_storage_failure() {
-                    sweep_failed = true;
-                    waddle_xmpp::telemetry::reliability::add_sm_promotion_storage_failed(
-                        u64::from(summary.storage_failed),
-                    );
+                    waddle_xmpp::telemetry::reliability::increment_sm_promotion_blocklist_failed();
                     let attempts = match state
                         .deps
                         .protocol
@@ -354,17 +226,18 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         .await
                     {
                         Ok(n) => n,
-                        Err(error) => {
+                        Err(record_error) => {
                             warn!(
                                 jid = %session.jid,
-                                %error,
-                                "SM janitor: record_promotion_failure failed; \
-                                 preserving session state for retry"
+                                error = %error,
+                                record_error = %record_error,
+                                "SM janitor: blocklist load failed and \
+                                 record_promotion_failure also failed; preserving \
+                                 session state for retry"
                             );
-                            if crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
+                            if crate::sm_promotion::reinsert_failed_session_for_retry(
                                 &state.deps.protocol.sm_session_registry,
                                 session.clone(),
-                                &summary,
                             )
                             .await
                             {
@@ -379,8 +252,8 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                             jid = %session.jid,
                             stream_id = %session.stream_id,
                             attempts,
-                            storage_failed = summary.storage_failed,
-                            "SM janitor: Q6 promotion repeatedly failed; \
+                            error = %error,
+                            "SM janitor: blocklist load has repeatedly failed; \
                              dead-lettering the durable row to break the retry loop"
                         );
                         if state
@@ -397,14 +270,17 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     warn!(
                         jid = %session.jid,
                         attempts,
-                        storage_failed = summary.storage_failed,
-                        "SM janitor: promotion had storage failures; \
-                         preserving session state for retry"
+                        error = %error,
+                        "SM janitor: blocklist load failed; SKIPPING promotion to \
+                         preserve fail-closed XEP-0191 policy. Durable SM row will \
+                         be retried on the next janitor pass."
                     );
-                    if crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
+                    // Make the retry promise true: drain_expired scans only
+                    // memory, so the drained session must go back into the
+                    // map for the next tick to see it.
+                    if crate::sm_promotion::reinsert_failed_session_for_retry(
                         &state.deps.protocol.sm_session_registry,
                         session.clone(),
-                        &summary,
                     )
                     .await
                     {
@@ -412,175 +288,303 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     }
                     continue;
                 }
-                if state
+            };
+            // Round-2 review R2 + round-3 finding 1: retractions
+            // racing this drain window are invisible to the registry
+            // scrub (the sessions are off both maps); fetch the
+            // recent-tombstone record PER SESSION, immediately
+            // before this session's promotion, so even a retraction
+            // landing mid-batch is still seen.
+            let recent_tombstones = match crate::sm_promotion::recent_tombstones_for_promotion(
+                &state.deps.protocol.sm_session_registry,
+                "SM janitor",
+            ) {
+                Ok(records) => records,
+                Err(_) => {
+                    sweep_failed = true;
+                    Vec::new()
+                }
+            };
+            let summary = crate::sm_promotion::promote_session_unacked(
+                &session,
+                &state.deps.protocol.connection_registry,
+                &state.deps.protocol.user_registry,
+                &state.deps.protocol.pending_delivery_storage,
+                &blocklist,
+                state.deps.auth_state.xmpp_domain.as_str(),
+                &recent_tombstones,
+            )
+            .await;
+            // Finding B (retraction-vs-promotion TOCTOU): a
+            // retraction recorded after the snapshot above raced
+            // this session's promotion — re-scrub the pending rows
+            // it may have just inserted BEFORE confirm_drained.
+            if crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
+                &state.deps.protocol.sm_session_registry,
+                &state.deps.protocol.pending_delivery_storage,
+                &recent_tombstones,
+                "SM janitor",
+            )
+            .await
+                == crate::sm_promotion::PromotionScrubOutcome::Failed
+            {
+                sweep_failed = true;
+            }
+            if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
+                > 0
+                || summary.storage_failed > 0
+            {
+                info!(
+                    jid = %session.jid,
+                    redelivered = summary.redelivered,
+                    queued = summary.queued,
+                    bounced = summary.bounced,
+                    dropped = summary.dropped,
+                    not_promotable = summary.not_promotable,
+                    unparseable = summary.unparseable,
+                    scrubbed = summary.scrubbed,
+                    storage_failed = summary.storage_failed,
+                    "SM janitor: Q6 promotion completed"
+                );
+            }
+            if summary.has_storage_failure() {
+                sweep_failed = true;
+                waddle_xmpp::telemetry::reliability::add_sm_promotion_storage_failed(
+                    u64::from(summary.storage_failed),
+                );
+                let attempts = match state
                     .deps
                     .protocol
                     .sm_session_registry
-                    .confirm_drained(&session.stream_id)
+                    .record_promotion_failure(&session.stream_id)
                     .await
                 {
-                    promotion_guard.complete();
-                } else {
-                    sweep_failed = true;
+                    Ok(n) => n,
+                    Err(error) => {
+                        warn!(
+                            jid = %session.jid,
+                            %error,
+                            "SM janitor: record_promotion_failure failed; \
+                             preserving session state for retry"
+                        );
+                        if crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
+                            &state.deps.protocol.sm_session_registry,
+                            session.clone(),
+                            &summary,
+                        )
+                        .await
+                        {
+                            promotion_guard.complete();
+                        }
+                        continue;
+                    }
+                };
+                if attempts >= max_promotion_attempts_from_env() {
+                    waddle_xmpp::telemetry::reliability::increment_sm_promotion_dead_lettered();
+                    error!(
+                        jid = %session.jid,
+                        stream_id = %session.stream_id,
+                        attempts,
+                        storage_failed = summary.storage_failed,
+                        "SM janitor: Q6 promotion repeatedly failed; \
+                         dead-lettering the durable row to break the retry loop"
+                    );
+                    if state
+                        .deps
+                        .protocol
+                        .sm_session_registry
+                        .confirm_drained(&session.stream_id)
+                        .await
+                    {
+                        promotion_guard.complete();
+                    }
                     continue;
                 }
-                let session_id =
-                    waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone());
-
-                // Same replacement re-check as the unclean-disconnect
-                // path: a fresh bind that superseded this expired
-                // detached session broadcasts its own presence, so a
-                // late unavailable would pin subscribers on offline for
-                // an online JID.
-                if routes::websocket::broadcast_unavailable_if_no_replacement(
-                    &state,
-                    &session.jid,
-                    session.presence_available,
+                warn!(
+                    jid = %session.jid,
+                    attempts,
+                    storage_failed = summary.storage_failed,
+                    "SM janitor: promotion had storage failures; \
+                     preserving session state for retry"
+                );
+                if crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
+                    &state.deps.protocol.sm_session_registry,
+                    session.clone(),
+                    &summary,
                 )
                 .await
-                    == routes::websocket::handlers::presence::TerminatedPresenceBroadcastOutcome::Failed
+                {
+                    promotion_guard.complete();
+                }
+                continue;
+            }
+            if state
+                .deps
+                .protocol
+                .sm_session_registry
+                .confirm_drained(&session.stream_id)
+                .await
+            {
+                promotion_guard.complete();
+            } else {
+                sweep_failed = true;
+                continue;
+            }
+            let session_id =
+                waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone());
+
+            // Same replacement re-check as the unclean-disconnect
+            // path: a fresh bind that superseded this expired
+            // detached session broadcasts its own presence, so a
+            // late unavailable would pin subscribers on offline for
+            // an online JID.
+            if routes::websocket::broadcast_unavailable_if_no_replacement(
+                state,
+                &session.jid,
+                session.presence_available,
+            )
+            .await
+                == routes::websocket::handlers::presence::TerminatedPresenceBroadcastOutcome::Failed
+            {
+                sweep_failed = true;
+            }
+            state
+                .deps
+                .protocol
+                .resumable_sessions
+                .remove(&session.stream_id);
+            // ADR-0017 Phase 1 (Greptile P1 on PR #1177): gate the DashMap
+            // removal on the EXPIRED session's own SM stream id, not a plain
+            // `unregister`. A plain unregister removes whatever currently
+            // holds the full JID — which is a live REPLACEMENT session S2 if
+            // it rebound the same resource after this session (S1) detached.
+            // The removed entry's `carbons_enabled` would then be S2's token,
+            // so the actor mirror below would evict S2's actor-tree entry
+            // too — and under Slice 1 the actor tree is the bare-JID
+            // selection source, so S2 would silently stop receiving
+            // messages. `unregister_if_sm_stream_id` removes only when the
+            // current entry is genuinely S1's (matching published stream id),
+            // so S2 is left untouched.
+            //
+            // For the common case, S1 already had its DashMap + actor
+            // entries pruned at detach time (`cleanup_connection_shutdown`),
+            // so this returns `None` and the mirror is skipped — the actor
+            // entry is already gone, not leaked.
+            let removed_entry = state
+                .deps
+                .protocol
+                .connection_registry
+                .unregister_if_sm_stream_id(
+                    &session.jid,
+                    &waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone()),
+                );
+            // Mirror the (S1-gated) unregister into the actor tree. The
+            // removed entry is guaranteed to be S1's, so its token cannot
+            // evict a replacement.
+            if let Some(entry) = removed_entry {
+                if crate::server::dual_registration::mirror_unregister(
+                    &state.deps.protocol.user_registry,
+                    &session.jid,
+                    Some(std::sync::Arc::clone(&entry.carbons_enabled)),
+                )
+                .await
+                    == crate::server::dual_registration::MirrorUnregisterOutcome::Failed
                 {
                     sweep_failed = true;
                 }
-                state
-                    .deps
-                    .protocol
-                    .resumable_sessions
-                    .remove(&session.stream_id);
-                // ADR-0017 Phase 1 (Greptile P1 on PR #1177): gate the DashMap
-                // removal on the EXPIRED session's own SM stream id, not a plain
-                // `unregister`. A plain unregister removes whatever currently
-                // holds the full JID — which is a live REPLACEMENT session S2 if
-                // it rebound the same resource after this session (S1) detached.
-                // The removed entry's `carbons_enabled` would then be S2's token,
-                // so the actor mirror below would evict S2's actor-tree entry
-                // too — and under Slice 1 the actor tree is the bare-JID
-                // selection source, so S2 would silently stop receiving
-                // messages. `unregister_if_sm_stream_id` removes only when the
-                // current entry is genuinely S1's (matching published stream id),
-                // so S2 is left untouched.
-                //
-                // For the common case, S1 already had its DashMap + actor
-                // entries pruned at detach time (`cleanup_connection_shutdown`),
-                // so this returns `None` and the mirror is skipped — the actor
-                // entry is already gone, not leaked.
-                let removed_entry = state
-                    .deps
-                    .protocol
-                    .connection_registry
-                    .unregister_if_sm_stream_id(
+            }
+            // PR #438 review (Qodo issue #2): the periodic SM expiry
+            // janitor takes its own cleanup path; without this drop
+            // it leaks `resource_to_ver` and `pending` entries for
+            // every detached session that times out. The other
+            // disconnect/expiry paths already call this; mirror it
+            // here so the caps state is bounded across all five
+            // tear-down code paths.
+            state
+                .deps
+                .protocol
+                .caps_resolver
+                .drop_resource(&session.jid);
+            // MUC occupancy is keyed by FULL JID: a live same-JID
+            // replacement session (fresh bind after this expired
+            // session detached) shares the room occupancies, so
+            // evicting them here would kick the replacement out of
+            // its rooms. Skip room cleanup whenever any live
+            // registry entry exists for the JID (same guard as
+            // cleanup_invalidated_detached_session).
+            if state
+                .deps
+                .protocol
+                .connection_registry
+                .get_entry(&session.jid)
+                .is_none()
+            {
+                #[cfg(feature = "clustering")]
+                {
+                    let cleanup_origin =
+                        crate::server::routes::interpret::OrderedRelayRouteOrigin {
+                            kind: crate::server::routes::interpret::OrderedRelayRouteOriginKind::SmSession(
+                                session_id.clone(),
+                            ),
+                            sender_entity: waddle_xmpp::ownership::Entity::new(
+                                waddle_xmpp::ownership::EntityType::UserActor,
+                                session.jid.to_bare().to_string(),
+                            ),
+                            inbound_sequence: 0,
+                            handoff: None,
+                        };
+                    if routes::websocket::cleanup_muc_presence_for_jid_with_origin(
+                        state,
                         &session.jid,
-                        &waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone()),
-                    );
-                // Mirror the (S1-gated) unregister into the actor tree. The
-                // removed entry is guaranteed to be S1's, so its token cannot
-                // evict a replacement.
-                if let Some(entry) = removed_entry {
-                    if crate::server::dual_registration::mirror_unregister(
-                        &state.deps.protocol.user_registry,
-                        &session.jid,
-                        Some(std::sync::Arc::clone(&entry.carbons_enabled)),
+                        cleanup_origin,
                     )
                     .await
-                        == crate::server::dual_registration::MirrorUnregisterOutcome::Failed
+                        == routes::websocket::MucCleanupOutcome::Failed
                     {
                         sweep_failed = true;
                     }
                 }
-                // PR #438 review (Qodo issue #2): the periodic SM expiry
-                // janitor takes its own cleanup path; without this drop
-                // it leaks `resource_to_ver` and `pending` entries for
-                // every detached session that times out. The other
-                // disconnect/expiry paths already call this; mirror it
-                // here so the caps state is bounded across all five
-                // tear-down code paths.
-                state
-                    .deps
-                    .protocol
-                    .caps_resolver
-                    .drop_resource(&session.jid);
-                // MUC occupancy is keyed by FULL JID: a live same-JID
-                // replacement session (fresh bind after this expired
-                // session detached) shares the room occupancies, so
-                // evicting them here would kick the replacement out of
-                // its rooms. Skip room cleanup whenever any live
-                // registry entry exists for the JID (same guard as
-                // cleanup_invalidated_detached_session).
-                if state
-                    .deps
-                    .protocol
-                    .connection_registry
-                    .get_entry(&session.jid)
-                    .is_none()
+                #[cfg(not(feature = "clustering"))]
                 {
-                    #[cfg(feature = "clustering")]
-                    {
-                        let cleanup_origin =
-                            crate::server::routes::interpret::OrderedRelayRouteOrigin {
-                                kind: crate::server::routes::interpret::OrderedRelayRouteOriginKind::SmSession(
-                                    session_id.clone(),
-                                ),
-                                sender_entity: waddle_xmpp::ownership::Entity::new(
-                                    waddle_xmpp::ownership::EntityType::UserActor,
-                                    session.jid.to_bare().to_string(),
-                                ),
-                                inbound_sequence: 0,
-                                handoff: None,
-                            };
-                        if routes::websocket::cleanup_muc_presence_for_jid_with_origin(
-                            &state,
-                            &session.jid,
-                            cleanup_origin,
-                        )
+                    if routes::websocket::cleanup_muc_presence_for_jid(&state, &session.jid)
                         .await
-                            == routes::websocket::MucCleanupOutcome::Failed
-                        {
-                            sweep_failed = true;
-                        }
-                    }
-                    #[cfg(not(feature = "clustering"))]
+                        == routes::websocket::MucCleanupOutcome::Failed
                     {
-                        if routes::websocket::cleanup_muc_presence_for_jid(&state, &session.jid)
-                            .await
-                            == routes::websocket::MucCleanupOutcome::Failed
-                        {
-                            sweep_failed = true;
-                        }
+                        sweep_failed = true;
                     }
                 }
-                if let Err(error) = state
-                    .deps
-                    .protocol
-                    .pending_delivery_storage
-                    .release_claim(&session_id)
-                    .await
-                {
-                    sweep_failed = true;
-                    warn!(
-                        jid = %session.jid,
-                        stream_id = %session.stream_id,
-                        error = %error,
-                        "SM janitor: pending_delivery release_claim failed; \
-                         rows remain claimed and will be released by claim-expiry janitor"
-                    );
-                }
             }
-            if !retry_pending_sm_ownership(&state).await {
+            if let Err(error) = state
+                .deps
+                .protocol
+                .pending_delivery_storage
+                .release_claim(&session_id)
+                .await
+            {
                 sweep_failed = true;
+                warn!(
+                    jid = %session.jid,
+                    stream_id = %session.stream_id,
+                    error = %error,
+                    "SM janitor: pending_delivery release_claim failed; \
+                     rows remain claimed and will be released by claim-expiry janitor"
+                );
             }
-            waddle_xmpp::telemetry::reliability::record_janitor_sweep(
-                Janitor::SmExpiry,
-                if sweep_failed {
-                    SweepOutcome::Failed
-                } else {
-                    SweepOutcome::Completed
-                },
-            );
-            }
-            .instrument(janitor_sweep_span(Janitor::SmExpiry))
-            .await;
         }
-    });
+        if !retry_pending_sm_ownership(state).await {
+            sweep_failed = true;
+        }
+        waddle_xmpp::telemetry::reliability::record_janitor_sweep(
+            Janitor::SmExpiry,
+            if sweep_failed {
+                SweepOutcome::Failed
+            } else {
+                SweepOutcome::Completed
+            },
+        );
+    }
+    .instrument(janitor_sweep_span(Janitor::SmExpiry))
+    .await;
 }
 
 async fn retry_pending_sm_ownership(state: &WebSocketState) -> bool {
@@ -732,8 +736,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     &supervisor.workers.cancel,
                     &supervisor.workers.fatal_fence,
                     ORPHAN_REAPER_SWEEP_TIMEOUT,
-                    run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers)
-                        .instrument(janitor_sweep_span(Janitor::OrphanReaper)),
+                    run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
                 )
                 .await;
                 let mut workers_healthy = supervisor.is_healthy();
@@ -924,6 +927,65 @@ mod orphan_sweep_supervision_tests {
         assert!(!fatal_fence.is_cancelled());
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_unpolled_sweep_does_not_export_a_phantom_span() {
+        let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+        let worker_cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = OrphanReaperSupervisor::new(
+            state.deps.protocol.sm_session_registry.clone(),
+            worker_cancel.clone(),
+        );
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+
+        let outcome = supervise_orphan_reaper_sweep(
+            &cancel,
+            &fatal_fence,
+            Duration::from_secs(1),
+            run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
+        )
+        .await;
+
+        assert_eq!(outcome, OrphanSweepOutcome::Cancelled);
+        assert_eq!(
+            spans.recorded_field("janitor.sweep", "janitor"),
+            None,
+            "a sweep that loses the biased cancellation race must never create a span"
+        );
+        assert!(
+            spans
+                .exported()
+                .iter()
+                .all(|span| span.name != "janitor.sweep"),
+            "a cancelled-before-poll sweep must not export a phantom root"
+        );
+
+        worker_cancel.cancel();
+        supervisor.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn executed_orphan_sweep_records_its_lazy_span() {
+        let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+        let worker_cancel = tokio_util::sync::CancellationToken::new();
+        let supervisor = OrphanReaperSupervisor::new(
+            state.deps.protocol.sm_session_registry.clone(),
+            worker_cancel.clone(),
+        );
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+
+        assert!(run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers).await);
+        assert_eq!(
+            spans.recorded_field("janitor.sweep", "janitor").as_deref(),
+            Some("orphan_reaper"),
+        );
+
+        worker_cancel.cancel();
+        supervisor.shutdown().await;
+    }
+
     #[tokio::test]
     async fn fatal_fence_cancels_a_sweep_before_it_can_make_progress() {
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -1061,6 +1123,7 @@ struct SmHydrationWork {
     entity: waddle_xmpp::ownership::Entity,
     fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
     reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    span: tracing::Span,
 }
 
 #[cfg(feature = "clustering")]
@@ -1081,6 +1144,7 @@ struct ExactReleaseWork {
     entity: waddle_xmpp::ownership::Entity,
     owner: waddle_xmpp::ownership::NodeIdentity,
     epoch: waddle_xmpp::ownership::ClaimEpoch,
+    span: tracing::Span,
 }
 
 #[cfg(feature = "clustering")]
@@ -1206,6 +1270,7 @@ impl OrphanReaperWorkers {
             entity,
             fence,
             reservation,
+            span: tracing::Span::current(),
         };
         let key = Self::hydration_key(&work);
         self.hydration_pending
@@ -1257,6 +1322,7 @@ impl OrphanReaperWorkers {
             entity,
             fence,
             reservation,
+            span: tracing::Span::current(),
         };
         if self
             .hydration_pending
@@ -1524,7 +1590,8 @@ impl OrphanReaperSupervisor {
                             &work.fence,
                             work.reservation,
                         ),
-                    ) => result,
+                    )
+                    .instrument(work.span.clone()) => result,
                 };
                 match result {
                     Ok(Ok(
@@ -1555,7 +1622,8 @@ impl OrphanReaperSupervisor {
                                     &work.fence,
                                     work.reservation,
                                 ),
-                            ) => result,
+                            )
+                            .instrument(work.span.clone()) => result,
                         };
                         match cleanup {
                             Ok(Ok(_)) => {
@@ -1591,6 +1659,7 @@ impl OrphanReaperSupervisor {
                                 work.reservation,
                             ),
                         )
+                        .instrument(work.span.clone())
                         .await;
                         match cleanup {
                             Ok(Ok(_)) => {
@@ -1652,7 +1721,8 @@ impl OrphanReaperSupervisor {
                     result = tokio::time::timeout(
                         ORPHANED_ROOM_RELEASE_TIMEOUT,
                         work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
-                    ) => result,
+                    )
+                    .instrument(work.span.clone()) => result,
                 };
                 match result {
                     Ok(Ok(_)) => {
@@ -1962,6 +2032,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                         entity: claim_fence.entity.clone(),
                         owner: context.me.clone(),
                         epoch: claim_fence.epoch,
+                        span: tracing::Span::current(),
                     })
                     .is_accepted()
                 {
@@ -1979,6 +2050,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                     entity: claim_fence.entity.clone(),
                     owner: context.me.clone(),
                     epoch: claim_fence.epoch,
+                    span: tracing::Span::current(),
                 })
                 .is_accepted()
             {
@@ -2380,6 +2452,7 @@ impl waddle_xmpp::stream_management::persistence::SmPersistenceStorage
         Option<waddle_xmpp::stream_management::persistence::PersistedSession>,
         waddle_xmpp::stream_management::persistence::SmPersistenceError,
     > {
+        drop(tracing::info_span!("orphan.worker.hydration.test"));
         self.read_started.notify_one();
         std::future::pending().await
     }
@@ -2522,6 +2595,7 @@ impl waddle_xmpp::ownership::ClaimStore for HangingExactReleaseStore {
         _mine: waddle_xmpp::ownership::ClaimEpoch,
     ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, waddle_xmpp::ownership::ClaimError>
     {
+        drop(tracing::info_span!("orphan.worker.release.test"));
         self.release_started.notify_one();
         std::future::pending().await
     }
@@ -2601,6 +2675,59 @@ async fn hung_sm_hydration_does_not_block_completed_room_lane() {
     tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
         .await
         .expect("hung hydration worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test(flavor = "current_thread")]
+async fn hydration_worker_uses_the_enqueuing_sweep_span() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = NodeIdentity::new("sweeper", "trace-incarnation");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), SharedNodeIdentity::new(me.clone())),
+    );
+    let entity = Entity::new(EntityType::SmSession, "traced-hydration");
+    let epoch = claim_store.acquire(&entity, &me).await.expect("claim");
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("hydration reservation");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+    let sweep = janitor_sweep_span(Janitor::OrphanReaper);
+
+    assert!(sweep
+        .in_scope(|| supervisor.workers.enqueue_hydration(
+            entity,
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(me, epoch),
+            reservation,
+        ))
+        .is_accepted());
+    drop(sweep);
+    tokio::time::timeout(Duration::from_secs(1), storage.read_started.notified())
+        .await
+        .expect("hydration worker started");
+    cancel.cancel();
+    supervisor.shutdown().await;
+
+    let exported = spans.exported();
+    let root = exported
+        .iter()
+        .find(|span| span.name == "janitor.sweep")
+        .expect("sweep root exported");
+    assert!(
+        exported
+            .iter()
+            .any(|span| span.name == "orphan.worker.hydration.test"
+                && span.parent_span_id == root.span_context.span_id()),
+        "hydration storage work must remain parented to the sweep that enqueued it"
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2753,6 +2880,7 @@ async fn failed_worker_restart_retains_captured_won_work_for_terminal_cleanup() 
             won_epoch,
         ),
         reservation: won_reservation,
+        span: tracing::Span::none(),
     };
     supervisor
         .workers
@@ -2782,6 +2910,7 @@ async fn failed_worker_restart_retains_captured_won_work_for_terminal_cleanup() 
         entity: room_entity.clone(),
         owner: me.clone(),
         epoch: room_epoch,
+        span: tracing::Span::current(),
     };
     supervisor
         .workers
@@ -3059,6 +3188,7 @@ async fn hung_exact_release_worker_is_cancelled_and_joined() {
         entity: Entity::new(EntityType::RoomActor, "cancel@muc.example.com"),
         owner: NodeIdentity::new("sweeper", "incarnation"),
         epoch: waddle_xmpp::ownership::ClaimEpoch(1),
+        span: tracing::Span::current(),
     });
     tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
         .await
@@ -3067,6 +3197,53 @@ async fn hung_exact_release_worker_is_cancelled_and_joined() {
     tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
         .await
         .expect("hung exact-release worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test(flavor = "current_thread")]
+async fn exact_release_worker_uses_the_enqueuing_sweep_span() {
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+
+    let store = Arc::new(HangingExactReleaseStore {
+        inner: waddle_xmpp::ownership::InProcessClaimStore::new(),
+        release_started: tokio::sync::Notify::new(),
+    });
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        cancel.clone(),
+    );
+    let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+    let sweep = janitor_sweep_span(Janitor::OrphanReaper);
+
+    assert!(sweep
+        .in_scope(|| supervisor.workers.enqueue_release(ExactReleaseWork {
+            claim_store: store.clone(),
+            entity: Entity::new(EntityType::RoomActor, "traced-release@muc.example.com"),
+            owner: NodeIdentity::new("sweeper", "trace-incarnation"),
+            epoch: waddle_xmpp::ownership::ClaimEpoch(1),
+            span: tracing::Span::current(),
+        }))
+        .is_accepted());
+    drop(sweep);
+    tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
+        .await
+        .expect("release worker started");
+    cancel.cancel();
+    supervisor.shutdown().await;
+
+    let exported = spans.exported();
+    let root = exported
+        .iter()
+        .find(|span| span.name == "janitor.sweep")
+        .expect("sweep root exported");
+    assert!(
+        exported
+            .iter()
+            .any(|span| span.name == "orphan.worker.release.test"
+                && span.parent_span_id == root.span_context.span_id()),
+        "exact release work must remain parented to the sweep that enqueued it"
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -3129,6 +3306,7 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::SmSession, "existing"),
         fence: SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(1)),
         reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(1),
+        span: tracing::Span::none(),
     };
     hydration_tx
         .try_send(existing.clone())
@@ -3230,12 +3408,14 @@ fn exact_release_keys_are_structural_when_components_contain_colons() {
         entity: Entity::new(EntityType::RoomActor, "room:part"),
         owner: NodeIdentity::new("node", "epoch"),
         epoch: ClaimEpoch(1),
+        span: tracing::Span::none(),
     };
     let right = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
         entity: Entity::new(EntityType::RoomActor, "room"),
         owner: NodeIdentity::new("part:node", "epoch"),
         epoch: ClaimEpoch(1),
+        span: tracing::Span::none(),
     };
 
     assert_ne!(
@@ -3260,6 +3440,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::RoomActor, "existing@muc.example.com"),
         owner: owner.clone(),
         epoch: ClaimEpoch(1),
+        span: tracing::Span::none(),
     };
     release_tx
         .try_send(existing.clone())
@@ -3283,6 +3464,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
         owner,
         epoch: ClaimEpoch(2),
+        span: tracing::Span::none(),
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 
@@ -3331,6 +3513,7 @@ fn closed_release_channel_retains_restart_inventory() {
         entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
         owner: NodeIdentity::new("node", "incarnation"),
         epoch: ClaimEpoch(2),
+        span: tracing::Span::none(),
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 
@@ -3428,695 +3611,699 @@ async fn run_orphan_reaper_sweep_with_workers(
     state: &Arc<WebSocketState>,
     workers: &OrphanReaperWorkers,
 ) -> bool {
-    use waddle_xmpp::ownership::ClaimError;
+    async {
+        use waddle_xmpp::ownership::ClaimError;
 
-    let mut sweep_failed = false;
+        let mut sweep_failed = false;
 
-    let clustering = &state.deps.app_state.clustering_claims;
-    let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
-        return true;
-    };
-    let Some(node_lease) = clustering.node_lease.clone() else {
-        return true;
-    };
-    let Some(lease_ttl) = clustering.lease_ttl else {
-        return true;
-    };
+        let clustering = &state.deps.app_state.clustering_claims;
+        let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
+            return true;
+        };
+        let Some(node_lease) = clustering.node_lease.clone() else {
+            return true;
+        };
+        let Some(lease_ttl) = clustering.lease_ttl else {
+            return true;
+        };
 
-    let me = identity_handle.current();
-    if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "start").await {
-        return false;
-    }
+        let me = identity_handle.current();
+        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "start").await {
+            return false;
+        }
 
-    match node_lease
-        .list_heartbeat_stale_nodes(lease_ttl, STALE_NODE_WATCHDOG_CANDIDATE_LIMIT)
-        .await
-    {
-        Ok(stale_nodes) => {
-            let candidate_count = stale_nodes.len();
-            let mut expired_nodes = 0usize;
-            let mut renewed_nodes = 0usize;
-            let mut failed_nodes = 0usize;
-            for stale_node in stale_nodes {
-                if stale_node == me {
-                    debug!(
-                        node_id = %me.node_id,
-                        node_epoch = %me.node_epoch,
-                        "orphan reaper: stale-node watchdog found this node's own heartbeat stale; aborting sweep"
-                    );
-                    return false;
-                }
-                match node_lease.expire(&stale_node, lease_ttl).await {
-                    Ok(true) => expired_nodes += 1,
-                    Ok(false) => renewed_nodes += 1,
-                    Err(error) => {
-                        failed_nodes += 1;
-                        warn!(
-                            node_id = %stale_node.node_id,
-                            node_epoch = %stale_node.node_epoch,
-                            %error,
-                            "orphan reaper: stale-node watchdog expire failed; retrying next sweep"
+        match node_lease
+            .list_heartbeat_stale_nodes(lease_ttl, STALE_NODE_WATCHDOG_CANDIDATE_LIMIT)
+            .await
+        {
+            Ok(stale_nodes) => {
+                let candidate_count = stale_nodes.len();
+                let mut expired_nodes = 0usize;
+                let mut renewed_nodes = 0usize;
+                let mut failed_nodes = 0usize;
+                for stale_node in stale_nodes {
+                    if stale_node == me {
+                        debug!(
+                            node_id = %me.node_id,
+                            node_epoch = %me.node_epoch,
+                            "orphan reaper: stale-node watchdog found this node's own heartbeat stale; aborting sweep"
                         );
-                    }
-                }
-            }
-            if expired_nodes > 0 {
-                info!(
-                    expired_nodes,
-                    candidate_count,
-                    limit = STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
-                    "orphan reaper: stale-node watchdog committed expired nodes"
-                );
-            }
-            if renewed_nodes > 0 {
-                debug!(
-                    renewed_nodes,
-                    candidate_count,
-                    "orphan reaper: stale-node watchdog candidates renewed before expire"
-                );
-            }
-            if failed_nodes > 0 {
-                sweep_failed = true;
-                warn!(
-                    failed_nodes,
-                    candidate_count,
-                    "orphan reaper: stale-node watchdog failed to expire some candidates"
-                );
-            }
-        }
-        Err(error) => {
-            sweep_failed = true;
-            warn!(%error, "orphan reaper: stale-node watchdog candidate scan failed");
-        }
-    }
-
-    if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "post-watchdog")
-        .await
-    {
-        return false;
-    }
-
-    // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
-    // old-generation node backs off before racing a matching/newer
-    // -generation node for a just-orphaned claim, so each entity moves
-    // approximately once per deploy instead of up to N times. Resolved
-    // once per sweep (not per candidate) — the current generation cannot
-    // meaningfully change mid-sweep, and this keeps the hot per-candidate
-    // loop below to a single extra comparison, no extra Postgres round
-    // trip per candidate.
-    let backoff_delay = match node_lease.current_generation().await {
-        Ok(current_generation) => crate::clustering::drain::rollout_backoff_delay(
-            clustering.pod_template_hash.as_deref(),
-            current_generation.as_deref(),
-        ),
-        Err(error) => {
-            sweep_failed = true;
-            debug!(%error, "orphan reaper: current_generation lookup failed; proceeding without backoff");
-            std::time::Duration::ZERO
-        }
-    };
-
-    let room_registry =
-        waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
-    let mut room_hydrated = 0u64;
-    let mut room_released = 0u64;
-    let mut room_already_live = 0u64;
-    let mut room_pending_retry = 0u64;
-    let mut room_lost_race = 0u64;
-    let mut room_failed = 0u64;
-
-    // Ordinary destroy/dead-actor/eviction releases use the same orphan
-    // reaper cadence, but retry one exact fence per sweep so a slow ownership
-    // backend cannot monopolize the registry mailbox.
-    if let Err(error) = room_registry.retry_pending_room_releases(1).await {
-        sweep_failed = true;
-        debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
-    }
-
-    // Retry epochs won on an earlier sweep before discovering new work.
-    // Each retry is its own bounded registry ask, so a slow store operation
-    // cannot monopolize the registry actor as one large batch handler.
-    match room_registry
-        .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
-        .await
-    {
-        Ok(pending) => {
-            for pending_room in pending {
-                match reconcile_registered_room_or_self_fence(
-                    workers,
-                    &room_registry,
-                    pending_room.room_jid,
-                    pending_room.claim_fence,
-                    pending_room.previous_owner,
-                )
-                .await
-                {
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
-                        room_hydrated += 1;
-                    }
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
-                        room_released += 1;
-                    }
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
-                    ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
-                    ) => {
-                        room_pending_retry += 1;
-                    }
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
-                        room_lost_race += 1;
-                    }
-                    Err(error) => {
-                        debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
                         return false;
                     }
-                }
-            }
-        }
-        Err(error) => {
-            debug!(%error, "orphan reaper: pending RoomActor listing failed");
-            workers.fatal_fence.cancel();
-            return false;
-        }
-    }
-    if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
-        if let Ok(releases) = room_registry.pending_room_release_backlog().await {
-            backlog.depth = backlog.depth.saturating_add(releases.depth);
-            backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
-        }
-        crate::clustering::metrics::record_room_orphan_pending_backlog(
-            backlog.depth,
-            backlog.oldest_age_ms,
-        );
-    }
-
-    // RoomActor counterpart: proactively move a bounded set of claims off
-    // committed-dead owners. Unlike detached SM sessions, a room claim may
-    // have no durable state at all (for example an ephemeral instant room).
-    // The serialized registry adoption below therefore either hydrates the
-    // exact won epoch, observes demand-side creation already did so, or
-    // releases the unusable claim.
-    let (room_candidates, room_page_next_cursor, room_page_has_more, room_scan_succeeded) =
-        match node_lease
-            .list_orphaned_room_actor_claims_page(
-                workers.room_cursor(),
-                ORPHANED_ROOM_CANDIDATE_LIMIT,
-            )
-            .await
-        {
-            Ok(page) => {
-                if page.quarantined > 0 {
-                    debug!(
-                        quarantined = page.quarantined,
-                        "orphan reaper: quarantined malformed stale RoomActor claims"
-                    );
-                }
-                (page.candidates, page.next_cursor, page.has_more, true)
-            }
-            Err(error) => {
-                warn!(%error, "orphan reaper: list_orphaned_room_actor_claims_page failed");
-                (Vec::new(), workers.room_cursor(), false, false)
-            }
-        };
-    let mut room_page_processed = true;
-    for candidate in room_candidates {
-        if workers.cancel.is_cancelled() {
-            return false;
-        }
-        if !workers.has_release_capacity() {
-            room_page_processed = false;
-            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
-            warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
-            break;
-        }
-        let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
-            room_page_processed = false;
-            room_failed += 1;
-            debug!(
-                entity_id = %candidate.entity.id,
-                "orphan reaper: RoomActor claim id is not a bare JID; leaving stale claim for repair"
-            );
-            continue;
-        };
-        match room_registry
-            .reserve_pending_reclaimed_room(room_jid.clone())
-            .await
-        {
-            Ok(true) => {}
-            Ok(false) => {
-                room_page_processed = false;
-                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_adoption");
-                warn!("orphan reaper: pausing RoomActor steals because adoption capacity is exhausted");
-                break;
-            }
-            Err(error) => {
-                room_page_processed = false;
-                room_failed += 1;
-                debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
-                break;
-            }
-        }
-        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
-        {
-            let _ = room_registry
-                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
-                .await;
-            return false;
-        }
-        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
-            room_page_processed = false;
-            let _ = room_registry
-                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
-                .await;
-            room_failed += 1;
-            debug!(
-                entity_id = %candidate.entity.id,
-                %error,
-                "orphan reaper: room owner's expire CAS failed"
-            );
-            continue;
-        }
-        if !backoff_delay.is_zero() {
-            tokio::time::sleep(backoff_delay).await;
-        }
-        if workers.cancel.is_cancelled() {
-            let _ = room_registry
-                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
-                .await;
-            return false;
-        }
-        match node_lease
-            .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
-            .await
-        {
-            Ok(new_epoch) => {
-                let pending_handoff = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
-                    room_jid: room_jid.clone(),
-                    claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
-                        candidate.entity.clone(),
-                        me.clone(),
-                        new_epoch,
-                    ),
-                    previous_owner: candidate.owner.clone(),
-                };
-                // This must remain the first operation after observing the
-                // steal CAS succeed. It is synchronous, so cancellation of
-                // the outer sweep cannot drop the exact won epoch before
-                // terminal shutdown can transfer it into RoomRegistry.
-                workers.remember_room_handoff(pending_handoff.clone());
-                match register_reclaimed_epoch_or_cleanup(
-                    ReclaimedRegistrationContext {
-                        workers,
-                        room_registry: &room_registry,
-                        claim_store: &claim_store,
-                        me: &me,
-                    },
-                    pending_handoff.clone(),
-                )
-                .await
-                {
-                    ReclaimedRegistration::Registered => {}
-                    ReclaimedRegistration::Released => {
-                        room_released += 1;
-                        continue;
-                    }
-                    ReclaimedRegistration::LostRace => {
-                        room_lost_race += 1;
-                        continue;
-                    }
-                    ReclaimedRegistration::CleanupScheduled => {
-                        room_failed += 1;
-                        continue;
-                    }
-                }
-                let reconciliation = reconcile_registered_room_or_self_fence(
-                    workers,
-                    &room_registry,
-                    room_jid.clone(),
-                    pending_handoff.claim_fence,
-                    candidate.owner.clone(),
-                )
-                .await;
-                let notify_previous_owner = !matches!(
-                    reconciliation,
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
-                        | Err(_)
-                );
-                if notify_previous_owner {
-                    if let Some(store) = clustering.muc_durable_store.as_ref() {
-                        if let Err(error) = store
-                            .notify_previous_owner_demoted(
-                                &room_jid,
-                                &candidate.owner.node_id,
-                                &candidate.owner.node_epoch,
-                                new_epoch,
-                            )
-                            .await
-                        {
-                            sweep_failed = true;
-                            debug!(
-                                room = %room_jid,
+                    match node_lease.expire(&stale_node, lease_ttl).await {
+                        Ok(true) => expired_nodes += 1,
+                        Ok(false) => renewed_nodes += 1,
+                        Err(error) => {
+                            failed_nodes += 1;
+                            warn!(
+                                node_id = %stale_node.node_id,
+                                node_epoch = %stale_node.node_epoch,
                                 %error,
-                                "orphan reaper: best-effort room demotion notification failed"
+                                "orphan reaper: stale-node watchdog expire failed; retrying next sweep"
                             );
                         }
                     }
                 }
-                match reconciliation {
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
-                        room_hydrated += 1;
-                    }
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
-                        room_released += 1;
-                    }
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
-                    ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
-                    ) => room_pending_retry += 1,
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
-                        room_lost_race += 1;
-                    }
-                    Err(error) => {
-                        debug!(
-                            room = %room_jid,
-                            %error,
-                            "orphan reaper: reclaimed-room registry adoption ask failed; node self-fenced"
-                        );
-                        return false;
-                    }
+                if expired_nodes > 0 {
+                    info!(
+                        expired_nodes,
+                        candidate_count,
+                        limit = STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
+                        "orphan reaper: stale-node watchdog committed expired nodes"
+                    );
                 }
-            }
-            Err(ClaimError::Conflict) => {
-                room_lost_race += 1;
-                if let Err(error) = room_registry
-                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
-                    .await
-                {
+                if renewed_nodes > 0 {
+                    debug!(
+                        renewed_nodes,
+                        candidate_count,
+                        "orphan reaper: stale-node watchdog candidates renewed before expire"
+                    );
+                }
+                if failed_nodes > 0 {
                     sweep_failed = true;
-                    debug!(room = %room_jid, %error, "orphan reaper: failed to cancel lost-race room adoption reservation");
+                    warn!(
+                        failed_nodes,
+                        candidate_count,
+                        "orphan reaper: stale-node watchdog failed to expire some candidates"
+                    );
                 }
             }
             Err(error) => {
+                sweep_failed = true;
+                warn!(%error, "orphan reaper: stale-node watchdog candidate scan failed");
+            }
+        }
+
+        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "post-watchdog")
+            .await
+        {
+            return false;
+        }
+
+        // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
+        // old-generation node backs off before racing a matching/newer
+        // -generation node for a just-orphaned claim, so each entity moves
+        // approximately once per deploy instead of up to N times. Resolved
+        // once per sweep (not per candidate) — the current generation cannot
+        // meaningfully change mid-sweep, and this keeps the hot per-candidate
+        // loop below to a single extra comparison, no extra Postgres round
+        // trip per candidate.
+        let backoff_delay = match node_lease.current_generation().await {
+            Ok(current_generation) => crate::clustering::drain::rollout_backoff_delay(
+                clustering.pod_template_hash.as_deref(),
+                current_generation.as_deref(),
+            ),
+            Err(error) => {
+                sweep_failed = true;
+                debug!(%error, "orphan reaper: current_generation lookup failed; proceeding without backoff");
+                std::time::Duration::ZERO
+            }
+        };
+
+        let room_registry =
+            waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+        let mut room_hydrated = 0u64;
+        let mut room_released = 0u64;
+        let mut room_already_live = 0u64;
+        let mut room_pending_retry = 0u64;
+        let mut room_lost_race = 0u64;
+        let mut room_failed = 0u64;
+
+        // Ordinary destroy/dead-actor/eviction releases use the same orphan
+        // reaper cadence, but retry one exact fence per sweep so a slow ownership
+        // backend cannot monopolize the registry mailbox.
+        if let Err(error) = room_registry.retry_pending_room_releases(1).await {
+            sweep_failed = true;
+            debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
+        }
+
+        // Retry epochs won on an earlier sweep before discovering new work.
+        // Each retry is its own bounded registry ask, so a slow store operation
+        // cannot monopolize the registry actor as one large batch handler.
+        match room_registry
+            .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
+            .await
+        {
+            Ok(pending) => {
+                for pending_room in pending {
+                    match reconcile_registered_room_or_self_fence(
+                        workers,
+                        &room_registry,
+                        pending_room.room_jid,
+                        pending_room.claim_fence,
+                        pending_room.previous_owner,
+                    )
+                    .await
+                    {
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                            room_hydrated += 1;
+                        }
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                            room_released += 1;
+                        }
+                        Ok(
+                            waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                        ) => room_already_live += 1,
+                        Ok(
+                            waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                        ) => {
+                            room_pending_retry += 1;
+                        }
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                            room_lost_race += 1;
+                        }
+                        Err(error) => {
+                            debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
+                            return false;
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                debug!(%error, "orphan reaper: pending RoomActor listing failed");
+                workers.fatal_fence.cancel();
+                return false;
+            }
+        }
+        if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
+            if let Ok(releases) = room_registry.pending_room_release_backlog().await {
+                backlog.depth = backlog.depth.saturating_add(releases.depth);
+                backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
+            }
+            crate::clustering::metrics::record_room_orphan_pending_backlog(
+                backlog.depth,
+                backlog.oldest_age_ms,
+            );
+        }
+
+        // RoomActor counterpart: proactively move a bounded set of claims off
+        // committed-dead owners. Unlike detached SM sessions, a room claim may
+        // have no durable state at all (for example an ephemeral instant room).
+        // The serialized registry adoption below therefore either hydrates the
+        // exact won epoch, observes demand-side creation already did so, or
+        // releases the unusable claim.
+        let (room_candidates, room_page_next_cursor, room_page_has_more, room_scan_succeeded) =
+            match node_lease
+                .list_orphaned_room_actor_claims_page(
+                    workers.room_cursor(),
+                    ORPHANED_ROOM_CANDIDATE_LIMIT,
+                )
+                .await
+            {
+                Ok(page) => {
+                    if page.quarantined > 0 {
+                        debug!(
+                            quarantined = page.quarantined,
+                            "orphan reaper: quarantined malformed stale RoomActor claims"
+                        );
+                    }
+                    (page.candidates, page.next_cursor, page.has_more, true)
+                }
+                Err(error) => {
+                    warn!(%error, "orphan reaper: list_orphaned_room_actor_claims_page failed");
+                    (Vec::new(), workers.room_cursor(), false, false)
+                }
+            };
+        let mut room_page_processed = true;
+        for candidate in room_candidates {
+            if workers.cancel.is_cancelled() {
+                return false;
+            }
+            if !workers.has_release_capacity() {
+                room_page_processed = false;
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+                warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
+                break;
+            }
+            let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
                 room_page_processed = false;
                 room_failed += 1;
+                debug!(
+                    entity_id = %candidate.entity.id,
+                    "orphan reaper: RoomActor claim id is not a bare JID; leaving stale claim for repair"
+                );
+                continue;
+            };
+            match room_registry
+                .reserve_pending_reclaimed_room(room_jid.clone())
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    room_page_processed = false;
+                    crate::clustering::metrics::record_orphan_work_queue_backpressure("room_adoption");
+                    warn!("orphan reaper: pausing RoomActor steals because adoption capacity is exhausted");
+                    break;
+                }
+                Err(error) => {
+                    room_page_processed = false;
+                    room_failed += 1;
+                    debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
+                    break;
+                }
+            }
+            if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
+            {
                 let _ = room_registry
                     .cancel_pending_reclaimed_room_reservation(room_jid.clone())
                     .await;
+                return false;
+            }
+            if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+                room_page_processed = false;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+                room_failed += 1;
                 debug!(
                     entity_id = %candidate.entity.id,
                     %error,
-                    "orphan reaper: RoomActor claim steal failed"
+                    "orphan reaper: room owner's expire CAS failed"
                 );
+                continue;
             }
-        }
-    }
-    if room_scan_succeeded && room_page_processed {
-        let committed_cursor = if room_page_has_more {
-            room_page_next_cursor
-        } else {
-            None
-        };
-        workers.set_room_cursor(committed_cursor.clone());
-        if let Err(error) = node_lease
-            .persist_orphan_reaper_cursor(
-                crate::clustering::claims::OrphanReaperCursorUpdate::RoomActor(committed_cursor),
-            )
-            .await
-        {
-            sweep_failed = true;
-            warn!(%error, "orphan reaper: failed to persist RoomActor scan cursor");
-        }
-    }
-    if !room_scan_succeeded || room_failed > 0 {
-        sweep_failed = true;
-    }
-    for (outcome, count) in [
-        ("hydrated", room_hydrated),
-        ("released", room_released),
-        ("already_live", room_already_live),
-        ("pending_retry", room_pending_retry),
-        ("lost_race", room_lost_race),
-        ("failed", room_failed),
-    ] {
-        if count > 0 {
-            crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
-        }
-    }
-    let room_reconciled = room_hydrated + room_released + room_already_live;
-    if room_pending_retry > 0 || room_failed > 0 {
-        warn!(
-            hydrated = room_hydrated,
-            released = room_released,
-            already_live = room_already_live,
-            pending_retry = room_pending_retry,
-            lost_race = room_lost_race,
-            failed = room_failed,
-            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
-            "orphan reaper: RoomActor reconciliation completed with pending work"
-        );
-    } else if room_reconciled > 0 {
-        info!(
-            hydrated = room_hydrated,
-            released = room_released,
-            already_live = room_already_live,
-            pending_retry = room_pending_retry,
-            lost_race = room_lost_race,
-            failed = room_failed,
-            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
-            "orphan reaper: reconciled orphaned RoomActor claims"
-        );
-    }
-    let (page, scan_succeeded) = match tokio::time::timeout(
-        ORPHANED_SM_SCAN_TIMEOUT,
-        node_lease.list_orphaned_sm_session_claims_page(
-            workers.sm_cursor(),
-            STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
-        ),
-    )
-    .await
-    {
-        Ok(Ok(page)) => (page, true),
-        Ok(Err(error)) => {
-            debug!(%error, "orphan reaper: SM-session candidate page failed; room lane already completed");
-            (
-                crate::clustering::claims::OrphanedSmSessionClaimPage {
-                    candidates: Vec::new(),
-                    next_cursor: workers.sm_cursor(),
-                    has_more: false,
-                    quarantined: 0,
-                },
-                false,
-            )
-        }
-        Err(_) => {
-            debug!(
-                "orphan reaper: SM-session candidate scan timed out; room lane already completed"
-            );
-            (
-                crate::clustering::claims::OrphanedSmSessionClaimPage {
-                    candidates: Vec::new(),
-                    next_cursor: workers.sm_cursor(),
-                    has_more: false,
-                    quarantined: 0,
-                },
-                false,
-            )
-        }
-    };
-    crate::clustering::metrics::record_sm_orphan_candidate_page(
-        page.candidates.len(),
-        page.has_more,
-        page.quarantined,
-    );
-    let page_has_more = page.has_more;
-    let page_next_cursor = page.next_cursor.clone();
-    let candidates = page.candidates;
-    let mut stolen = 0usize;
-    let mut page_processed = true;
-    for candidate in candidates {
-        let Some(reservation) = state
-            .deps
-            .protocol
-            .sm_session_registry
-            .reserve_reclaimed_claim_capacity(&candidate.entity)
-        else {
-            page_processed = false;
-            break;
-        };
-        if !workers.reserve_hydration(&candidate.entity, &me, reservation) {
-            state
-                .deps
-                .protocol
-                .sm_session_registry
-                .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            warn!("orphan reaper: pausing SM steals because hydration capacity is exhausted");
-            page_processed = false;
-            break;
-        }
-        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-candidate")
-            .await
-        {
-            workers.cancel_hydration_reservation(&candidate.entity);
-            state
-                .deps
-                .protocol
-                .sm_session_registry
-                .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            return false;
-        }
-        // Element 9's ordering requirement: commit the expire CAS on the
-        // dead owner's row FIRST. Idempotent/best-effort — a failure here
-        // just means the steal below is also likely to lose (the owner
-        // row is not yet committed-expired), retried next sweep.
-        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
-            sweep_failed = true;
-            page_processed = false;
-            workers.cancel_hydration_reservation(&candidate.entity);
-            debug!(
-                entity_id = %candidate.entity.id,
-                %error,
-                "orphan reaper: expire on the dead owner's row failed; retrying next sweep"
-            );
-            state
-                .deps
-                .protocol
-                .sm_session_registry
-                .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            continue;
-        }
-        // ADR-0017 Phase 3 Slice 10: a placement heuristic only — never
-        // affects correctness. The reaper-specific stale-owner epoch CAS
-        // remains the sole authority over who actually wins; this only
-        // decides who tries first.
-        if !backoff_delay.is_zero() {
-            tokio::time::sleep(backoff_delay).await;
-        }
-        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-steal")
-            .await
-        {
-            workers.cancel_hydration_reservation(&candidate.entity);
-            state
-                .deps
-                .protocol
-                .sm_session_registry
-                .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-            return false;
-        }
-        match node_lease
-            .steal_orphaned_sm_session_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
-            .await
-        {
-            Ok(new_epoch) => {
-                stolen += 1;
-                match workers.enqueue_reserved_hydration(
-                    candidate.entity,
-                    waddle_xmpp::stream_management::persistence::SmClaimFence::new(
-                        me.clone(),
-                        new_epoch,
-                    ),
-                    reservation,
-                ) {
-                    WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
-                    WorkEnqueueOutcome::RetainedForRestart => debug!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
-                    WorkEnqueueOutcome::RetainedForRedrive => debug!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
-                    WorkEnqueueOutcome::Rejected => debug!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
+            if !backoff_delay.is_zero() {
+                tokio::time::sleep(backoff_delay).await;
+            }
+            if workers.cancel.is_cancelled() {
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+                return false;
+            }
+            match node_lease
+                .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
+                .await
+            {
+                Ok(new_epoch) => {
+                    let pending_handoff = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+                        room_jid: room_jid.clone(),
+                        claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+                            candidate.entity.clone(),
+                            me.clone(),
+                            new_epoch,
+                        ),
+                        previous_owner: candidate.owner.clone(),
+                    };
+                    // This must remain the first operation after observing the
+                    // steal CAS succeed. It is synchronous, so cancellation of
+                    // the outer sweep cannot drop the exact won epoch before
+                    // terminal shutdown can transfer it into RoomRegistry.
+                    workers.remember_room_handoff(pending_handoff.clone());
+                    match register_reclaimed_epoch_or_cleanup(
+                        ReclaimedRegistrationContext {
+                            workers,
+                            room_registry: &room_registry,
+                            claim_store: &claim_store,
+                            me: &me,
+                        },
+                        pending_handoff.clone(),
+                    )
+                    .await
+                    {
+                        ReclaimedRegistration::Registered => {}
+                        ReclaimedRegistration::Released => {
+                            room_released += 1;
+                            continue;
+                        }
+                        ReclaimedRegistration::LostRace => {
+                            room_lost_race += 1;
+                            continue;
+                        }
+                        ReclaimedRegistration::CleanupScheduled => {
+                            room_failed += 1;
+                            continue;
+                        }
+                    }
+                    let reconciliation = reconcile_registered_room_or_self_fence(
+                        workers,
+                        &room_registry,
+                        room_jid.clone(),
+                        pending_handoff.claim_fence,
+                        candidate.owner.clone(),
+                    )
+                    .await;
+                    let notify_previous_owner = !matches!(
+                        reconciliation,
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
+                            | Err(_)
+                    );
+                    if notify_previous_owner {
+                        if let Some(store) = clustering.muc_durable_store.as_ref() {
+                            if let Err(error) = store
+                                .notify_previous_owner_demoted(
+                                    &room_jid,
+                                    &candidate.owner.node_id,
+                                    &candidate.owner.node_epoch,
+                                    new_epoch,
+                                )
+                                .await
+                            {
+                                sweep_failed = true;
+                                debug!(
+                                    room = %room_jid,
+                                    %error,
+                                    "orphan reaper: best-effort room demotion notification failed"
+                                );
+                            }
+                        }
+                    }
+                    match reconciliation {
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                            room_hydrated += 1;
+                        }
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                            room_released += 1;
+                        }
+                        Ok(
+                            waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                        ) => room_already_live += 1,
+                        Ok(
+                            waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                        ) => room_pending_retry += 1,
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                            room_lost_race += 1;
+                        }
+                        Err(error) => {
+                            debug!(
+                                room = %room_jid,
+                                %error,
+                                "orphan reaper: reclaimed-room registry adoption ask failed; node self-fenced"
+                            );
+                            return false;
+                        }
+                    }
+                }
+                Err(ClaimError::Conflict) => {
+                    room_lost_race += 1;
+                    if let Err(error) = room_registry
+                        .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                        .await
+                    {
+                        sweep_failed = true;
+                        debug!(room = %room_jid, %error, "orphan reaper: failed to cancel lost-race room adoption reservation");
+                    }
+                }
+                Err(error) => {
+                    room_page_processed = false;
+                    room_failed += 1;
+                    let _ = room_registry
+                        .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                        .await;
+                    debug!(
+                        entity_id = %candidate.entity.id,
+                        %error,
+                        "orphan reaper: RoomActor claim steal failed"
+                    );
                 }
             }
-            Err(ClaimError::Conflict) => {
-                workers.cancel_hydration_reservation(&candidate.entity);
-                state
-                    .deps
-                    .protocol
-                    .sm_session_registry
-                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-                // Another node (or this same node's own re-registration
-                // reacquisition step, ADR-0017 Phase 3 plan deviation #19)
-                // already reclaimed it, or the "dead" owner actually
-                // renewed concurrently — safe, no-op.
-            }
-            Err(error) => {
+        }
+        if room_scan_succeeded && room_page_processed {
+            let committed_cursor = if room_page_has_more {
+                room_page_next_cursor
+            } else {
+                None
+            };
+            workers.set_room_cursor(committed_cursor.clone());
+            if let Err(error) = node_lease
+                .persist_orphan_reaper_cursor(
+                    crate::clustering::claims::OrphanReaperCursorUpdate::RoomActor(committed_cursor),
+                )
+                .await
+            {
                 sweep_failed = true;
-                page_processed = false;
-                workers.cancel_hydration_reservation(&candidate.entity);
-                state
-                    .deps
-                    .protocol
-                    .sm_session_registry
-                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
-                warn!(
-                    entity_id = %candidate.entity.id,
-                    %error,
-                    "orphan reaper: steal_orphaned_sm_session_claim failed"
-                );
+                warn!(%error, "orphan reaper: failed to persist RoomActor scan cursor");
             }
         }
-    }
-    if scan_succeeded && page_processed {
-        let committed_cursor = if page_has_more {
-            page_next_cursor
-        } else {
-            None
-        };
-        workers.set_sm_cursor(committed_cursor.clone());
-        if let Err(error) = node_lease
-            .persist_orphan_reaper_cursor(
-                crate::clustering::claims::OrphanReaperCursorUpdate::SmSession(committed_cursor),
-            )
-            .await
-        {
+        if !room_scan_succeeded || room_failed > 0 {
             sweep_failed = true;
-            warn!(%error, "orphan reaper: failed to persist SM-session scan cursor");
         }
-    }
-    if !scan_succeeded {
-        sweep_failed = true;
-    }
-    if stolen > 0 {
-        info!(
-            stolen,
-            "orphan reaper: reclaimed orphaned SM-session claims"
-        );
-    }
-
-    // Council-adjudicated FIX 4 (ADR-0017 Phase 3 Slice 8): a
-    // `clustering_isr_tokens` row is never reaped by the ordinary
-    // `consume` path alone (a token issued but never resumed, or whose SM
-    // session this very sweep just reaped above, leaves an otherwise
-    // -permanent orphan). No cascade hook exists from the SM session
-    // claim's own release/reap paths — the SM session registry
-    // (`waddle-xmpp`) has no reason to depend on ISR (`waddle-server`
-    // -local, Postgres-only) at all, the same crate separation
-    // `ClaimStore`/`IsrTokenStore` already keep — so this rides the same
-    // janitor cadence as a bounded, deadline-armed TTL sweep instead.
-    if let Some(isr_token_store) = clustering.isr_token_store() {
-        match tokio::time::timeout(
-            ISR_TOKEN_SWEEP_TIMEOUT,
-            isr_token_store.sweep_expired(ISR_TOKEN_SWEEP_MAX_AGE),
+        for (outcome, count) in [
+            ("hydrated", room_hydrated),
+            ("released", room_released),
+            ("already_live", room_already_live),
+            ("pending_retry", room_pending_retry),
+            ("lost_race", room_lost_race),
+            ("failed", room_failed),
+        ] {
+            if count > 0 {
+                crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
+            }
+        }
+        let room_reconciled = room_hydrated + room_released + room_already_live;
+        if room_pending_retry > 0 || room_failed > 0 {
+            warn!(
+                hydrated = room_hydrated,
+                released = room_released,
+                already_live = room_already_live,
+                pending_retry = room_pending_retry,
+                lost_race = room_lost_race,
+                failed = room_failed,
+                limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+                "orphan reaper: RoomActor reconciliation completed with pending work"
+            );
+        } else if room_reconciled > 0 {
+            info!(
+                hydrated = room_hydrated,
+                released = room_released,
+                already_live = room_already_live,
+                pending_retry = room_pending_retry,
+                lost_race = room_lost_race,
+                failed = room_failed,
+                limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+                "orphan reaper: reconciled orphaned RoomActor claims"
+            );
+        }
+        let (page, scan_succeeded) = match tokio::time::timeout(
+            ORPHANED_SM_SCAN_TIMEOUT,
+            node_lease.list_orphaned_sm_session_claims_page(
+                workers.sm_cursor(),
+                STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
+            ),
         )
         .await
         {
-            Ok(Ok(deleted)) if deleted > 0 => {
-                info!(deleted, "orphan reaper: swept expired ISR tokens");
-            }
-            Ok(Ok(_)) => {}
+            Ok(Ok(page)) => (page, true),
             Ok(Err(error)) => {
-                sweep_failed = true;
-                warn!(%error, "orphan reaper: ISR token sweep failed");
+                debug!(%error, "orphan reaper: SM-session candidate page failed; room lane already completed");
+                (
+                    crate::clustering::claims::OrphanedSmSessionClaimPage {
+                        candidates: Vec::new(),
+                        next_cursor: workers.sm_cursor(),
+                        has_more: false,
+                        quarantined: 0,
+                    },
+                    false,
+                )
             }
-            Err(_timeout) => {
-                sweep_failed = true;
-                warn!(
-                    timeout = ?ISR_TOKEN_SWEEP_TIMEOUT,
-                    "orphan reaper: ISR token sweep timed out"
+            Err(_) => {
+                debug!(
+                    "orphan reaper: SM-session candidate scan timed out; room lane already completed"
                 );
+                (
+                    crate::clustering::claims::OrphanedSmSessionClaimPage {
+                        candidates: Vec::new(),
+                        next_cursor: workers.sm_cursor(),
+                        has_more: false,
+                        quarantined: 0,
+                    },
+                    false,
+                )
+            }
+        };
+        crate::clustering::metrics::record_sm_orphan_candidate_page(
+            page.candidates.len(),
+            page.has_more,
+            page.quarantined,
+        );
+        let page_has_more = page.has_more;
+        let page_next_cursor = page.next_cursor.clone();
+        let candidates = page.candidates;
+        let mut stolen = 0usize;
+        let mut page_processed = true;
+        for candidate in candidates {
+            let Some(reservation) = state
+                .deps
+                .protocol
+                .sm_session_registry
+                .reserve_reclaimed_claim_capacity(&candidate.entity)
+            else {
+                page_processed = false;
+                break;
+            };
+            if !workers.reserve_hydration(&candidate.entity, &me, reservation) {
+                state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                warn!("orphan reaper: pausing SM steals because hydration capacity is exhausted");
+                page_processed = false;
+                break;
+            }
+            if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-candidate")
+                .await
+            {
+                workers.cancel_hydration_reservation(&candidate.entity);
+                state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                return false;
+            }
+            // Element 9's ordering requirement: commit the expire CAS on the
+            // dead owner's row FIRST. Idempotent/best-effort — a failure here
+            // just means the steal below is also likely to lose (the owner
+            // row is not yet committed-expired), retried next sweep.
+            if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+                sweep_failed = true;
+                page_processed = false;
+                workers.cancel_hydration_reservation(&candidate.entity);
+                debug!(
+                    entity_id = %candidate.entity.id,
+                    %error,
+                    "orphan reaper: expire on the dead owner's row failed; retrying next sweep"
+                );
+                state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                continue;
+            }
+            // ADR-0017 Phase 3 Slice 10: a placement heuristic only — never
+            // affects correctness. The reaper-specific stale-owner epoch CAS
+            // remains the sole authority over who actually wins; this only
+            // decides who tries first.
+            if !backoff_delay.is_zero() {
+                tokio::time::sleep(backoff_delay).await;
+            }
+            if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-steal")
+                .await
+            {
+                workers.cancel_hydration_reservation(&candidate.entity);
+                state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                return false;
+            }
+            match node_lease
+                .steal_orphaned_sm_session_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
+                .await
+            {
+                Ok(new_epoch) => {
+                    stolen += 1;
+                    match workers.enqueue_reserved_hydration(
+                        candidate.entity,
+                        waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                            me.clone(),
+                            new_epoch,
+                        ),
+                        reservation,
+                    ) {
+                        WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
+                        WorkEnqueueOutcome::RetainedForRestart => debug!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
+                        WorkEnqueueOutcome::RetainedForRedrive => debug!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
+                        WorkEnqueueOutcome::Rejected => debug!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
+                    }
+                }
+                Err(ClaimError::Conflict) => {
+                    workers.cancel_hydration_reservation(&candidate.entity);
+                    state
+                        .deps
+                        .protocol
+                        .sm_session_registry
+                        .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                    // Another node (or this same node's own re-registration
+                    // reacquisition step, ADR-0017 Phase 3 plan deviation #19)
+                    // already reclaimed it, or the "dead" owner actually
+                    // renewed concurrently — safe, no-op.
+                }
+                Err(error) => {
+                    sweep_failed = true;
+                    page_processed = false;
+                    workers.cancel_hydration_reservation(&candidate.entity);
+                    state
+                        .deps
+                        .protocol
+                        .sm_session_registry
+                        .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+                    warn!(
+                        entity_id = %candidate.entity.id,
+                        %error,
+                        "orphan reaper: steal_orphaned_sm_session_claim failed"
+                    );
+                }
             }
         }
+        if scan_succeeded && page_processed {
+            let committed_cursor = if page_has_more {
+                page_next_cursor
+            } else {
+                None
+            };
+            workers.set_sm_cursor(committed_cursor.clone());
+            if let Err(error) = node_lease
+                .persist_orphan_reaper_cursor(
+                    crate::clustering::claims::OrphanReaperCursorUpdate::SmSession(committed_cursor),
+                )
+                .await
+            {
+                sweep_failed = true;
+                warn!(%error, "orphan reaper: failed to persist SM-session scan cursor");
+            }
+        }
+        if !scan_succeeded {
+            sweep_failed = true;
+        }
+        if stolen > 0 {
+            info!(
+                stolen,
+                "orphan reaper: reclaimed orphaned SM-session claims"
+            );
+        }
+
+        // Council-adjudicated FIX 4 (ADR-0017 Phase 3 Slice 8): a
+        // `clustering_isr_tokens` row is never reaped by the ordinary
+        // `consume` path alone (a token issued but never resumed, or whose SM
+        // session this very sweep just reaped above, leaves an otherwise
+        // -permanent orphan). No cascade hook exists from the SM session
+        // claim's own release/reap paths — the SM session registry
+        // (`waddle-xmpp`) has no reason to depend on ISR (`waddle-server`
+        // -local, Postgres-only) at all, the same crate separation
+        // `ClaimStore`/`IsrTokenStore` already keep — so this rides the same
+        // janitor cadence as a bounded, deadline-armed TTL sweep instead.
+        if let Some(isr_token_store) = clustering.isr_token_store() {
+            match tokio::time::timeout(
+                ISR_TOKEN_SWEEP_TIMEOUT,
+                isr_token_store.sweep_expired(ISR_TOKEN_SWEEP_MAX_AGE),
+            )
+            .await
+            {
+                Ok(Ok(deleted)) if deleted > 0 => {
+                    info!(deleted, "orphan reaper: swept expired ISR tokens");
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => {
+                    sweep_failed = true;
+                    warn!(%error, "orphan reaper: ISR token sweep failed");
+                }
+                Err(_timeout) => {
+                    sweep_failed = true;
+                    warn!(
+                        timeout = ?ISR_TOKEN_SWEEP_TIMEOUT,
+                        "orphan reaper: ISR token sweep timed out"
+                    );
+                }
+            }
+        }
+        !sweep_failed
     }
-    !sweep_failed
+    .instrument(janitor_sweep_span(Janitor::OrphanReaper))
+    .await
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -6268,6 +6455,39 @@ mod user_reaper_tests {
         assert_eq!(
             spans.recorded_field("janitor.sweep", "janitor").as_deref(),
             Some("user_actor_reaper"),
+        );
+    }
+
+    /// #1483 acceptance, production path: the registry asks a real sweep
+    /// makes must export `actor.handle_message` spans parented under the
+    /// exported `janitor.sweep` root — the property the sampler needs to
+    /// keep sweep work traceable. This is the test that fails if the
+    /// sweep body escapes the instrumented scope (e.g. a dropped
+    /// `.instrument` or a wrapper around the wrong future).
+    #[tokio::test(flavor = "current_thread")]
+    async fn user_actor_reaper_actor_children_are_parented_under_the_sweep_root() {
+        let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let state = create_test_websocket_state().await;
+
+        run_user_actor_reaper_sweep(&state).await;
+
+        let exported = spans.exported();
+        let root = exported
+            .iter()
+            .find(|span| span.name == "janitor.sweep")
+            .expect("the sweep root must export once the sweep completes");
+        assert!(
+            exported
+                .iter()
+                .any(|span| span.name == "actor.handle_message"
+                    && span.parent_span_id == root.span_context.span_id()),
+            "the sweep's registry asks must export actor.handle_message \
+             spans parented under the janitor.sweep root; exported: {:?}",
+            exported
+                .iter()
+                .map(|span| span.name.as_ref())
+                .collect::<Vec<&str>>()
         );
     }
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -19,6 +19,47 @@ fn janitor_sweep_span(janitor: Janitor) -> tracing::Span {
     tracing::info_span!(parent: None, "janitor.sweep", janitor = janitor.value())
 }
 
+/// The active span's OTel context, captured at work-enqueue time so a
+/// later attempt can *link* back to the sweep that found the work.
+#[cfg(feature = "clustering")]
+fn current_sweep_context() -> opentelemetry::trace::SpanContext {
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    tracing::Span::current()
+        .context()
+        .span()
+        .span_context()
+        .clone()
+}
+
+/// Root span for one orphan-reaper work-item attempt (#1483).
+///
+/// Worker attempts must NOT run under the enqueuing sweep's live span:
+/// retry queues and pending inventories would hold that root open
+/// indefinitely — unbounded duration, lost on crash, the very
+/// `actor.lifecycle` pathology the #1438 sampler kills. Each attempt
+/// gets its own short-lived root instead, linked (not parented) to the
+/// enqueuing sweep when its context is valid. The span name is
+/// documented in `telemetry::span_noise` and must never be added to its
+/// suppression lists.
+#[cfg(feature = "clustering")]
+fn orphan_work_span(
+    lane: &'static str,
+    sweep_context: &opentelemetry::trace::SpanContext,
+) -> tracing::Span {
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    let span = tracing::info_span!(
+        parent: None,
+        "janitor.orphan_work",
+        janitor = Janitor::OrphanReaper.value(),
+        lane,
+    );
+    if sweep_context.is_valid() {
+        span.add_link(sweep_context.clone());
+    }
+    span
+}
+
 /// Default interval for the auth-state TTL janitor.
 const AUTH_JANITOR_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -1123,7 +1164,10 @@ struct SmHydrationWork {
     entity: waddle_xmpp::ownership::Entity,
     fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
     reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
-    span: tracing::Span,
+    /// The enqueuing sweep's span context, carried for a span *link* on
+    /// each attempt — never a live `Span`, which retry queues and pending
+    /// inventories would hold open indefinitely.
+    sweep_context: opentelemetry::trace::SpanContext,
 }
 
 #[cfg(feature = "clustering")]
@@ -1144,7 +1188,8 @@ struct ExactReleaseWork {
     entity: waddle_xmpp::ownership::Entity,
     owner: waddle_xmpp::ownership::NodeIdentity,
     epoch: waddle_xmpp::ownership::ClaimEpoch,
-    span: tracing::Span,
+    /// See [`SmHydrationWork::sweep_context`].
+    sweep_context: opentelemetry::trace::SpanContext,
 }
 
 #[cfg(feature = "clustering")]
@@ -1270,7 +1315,7 @@ impl OrphanReaperWorkers {
             entity,
             fence,
             reservation,
-            span: tracing::Span::current(),
+            sweep_context: current_sweep_context(),
         };
         let key = Self::hydration_key(&work);
         self.hydration_pending
@@ -1322,7 +1367,7 @@ impl OrphanReaperWorkers {
             entity,
             fence,
             reservation,
-            span: tracing::Span::current(),
+            sweep_context: current_sweep_context(),
         };
         if self
             .hydration_pending
@@ -1591,7 +1636,7 @@ impl OrphanReaperSupervisor {
                             work.reservation,
                         ),
                     )
-                    .instrument(work.span.clone()) => result,
+                    .instrument(orphan_work_span("sm_hydration", &work.sweep_context)) => result,
                 };
                 match result {
                     Ok(Ok(
@@ -1623,7 +1668,7 @@ impl OrphanReaperSupervisor {
                                     work.reservation,
                                 ),
                             )
-                            .instrument(work.span.clone()) => result,
+                            .instrument(orphan_work_span("sm_hydration", &work.sweep_context)) => result,
                         };
                         match cleanup {
                             Ok(Ok(_)) => {
@@ -1659,7 +1704,7 @@ impl OrphanReaperSupervisor {
                                 work.reservation,
                             ),
                         )
-                        .instrument(work.span.clone())
+                        .instrument(orphan_work_span("sm_hydration", &work.sweep_context))
                         .await;
                         match cleanup {
                             Ok(Ok(_)) => {
@@ -1722,7 +1767,7 @@ impl OrphanReaperSupervisor {
                         ORPHANED_ROOM_RELEASE_TIMEOUT,
                         work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
                     )
-                    .instrument(work.span.clone()) => result,
+                    .instrument(orphan_work_span("room_release", &work.sweep_context)) => result,
                 };
                 match result {
                     Ok(Ok(_)) => {
@@ -1819,6 +1864,10 @@ impl OrphanReaperSupervisor {
             next.workers.remember_room_handoff(handoff);
         }
         for work in hydration {
+            // Re-enqueueing re-captures the (empty) ambient context, so a
+            // restarted item loses its sweep link; its attempts still get
+            // their own `janitor.orphan_work` roots, so the work stays
+            // traced.
             if !next
                 .workers
                 .enqueue_hydration(work.entity, work.fence, work.reservation)
@@ -1890,6 +1939,7 @@ impl OrphanReaperSupervisor {
         }
         futures::future::join_all(hydrations.into_iter().map(|work| {
             let registry = self.registry.clone();
+            let span = orphan_work_span("sm_hydration", &work.sweep_context);
             async move {
                 match tokio::time::timeout(
                     ORPHAN_WORK_ATTEMPT_TIMEOUT,
@@ -1918,33 +1968,38 @@ impl OrphanReaperSupervisor {
                     }
                 }
             }
+            .instrument(span)
         }))
         .await;
         crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", 0);
-        futures::future::join_all(releases.into_iter().map(|work| async move {
-            match tokio::time::timeout(
-                ORPHANED_ROOM_RELEASE_TIMEOUT,
-                work.claim_store
-                    .release_exact(&work.entity, &work.owner, work.epoch),
-            )
-            .await
-            {
-                Ok(Ok(_)) => {}
-                Ok(Err(error)) => {
-                    crate::clustering::metrics::record_orphan_terminal_cleanup_failure(
-                        "room_release",
-                        "error",
-                    );
-                    debug!(%error, entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup failed");
-                }
-                Err(_) => {
-                    crate::clustering::metrics::record_orphan_terminal_cleanup_failure(
-                        "room_release",
-                        "timeout",
-                    );
-                    debug!(entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup timed out");
+        futures::future::join_all(releases.into_iter().map(|work| {
+            let span = orphan_work_span("room_release", &work.sweep_context);
+            async move {
+                match tokio::time::timeout(
+                    ORPHANED_ROOM_RELEASE_TIMEOUT,
+                    work.claim_store
+                        .release_exact(&work.entity, &work.owner, work.epoch),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(error)) => {
+                        crate::clustering::metrics::record_orphan_terminal_cleanup_failure(
+                            "room_release",
+                            "error",
+                        );
+                        debug!(%error, entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup failed");
+                    }
+                    Err(_) => {
+                        crate::clustering::metrics::record_orphan_terminal_cleanup_failure(
+                            "room_release",
+                            "timeout",
+                        );
+                        debug!(entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup timed out");
+                    }
                 }
             }
+            .instrument(span)
         }))
         .await;
         crate::clustering::metrics::record_orphan_work_queue_depth("room_release", 0);
@@ -2032,7 +2087,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                         entity: claim_fence.entity.clone(),
                         owner: context.me.clone(),
                         epoch: claim_fence.epoch,
-                        span: tracing::Span::current(),
+                        sweep_context: current_sweep_context(),
                     })
                     .is_accepted()
                 {
@@ -2050,7 +2105,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                     entity: claim_fence.entity.clone(),
                     owner: context.me.clone(),
                     epoch: claim_fence.epoch,
-                    span: tracing::Span::current(),
+                    sweep_context: current_sweep_context(),
                 })
                 .is_accepted()
             {
@@ -2452,7 +2507,6 @@ impl waddle_xmpp::stream_management::persistence::SmPersistenceStorage
         Option<waddle_xmpp::stream_management::persistence::PersistedSession>,
         waddle_xmpp::stream_management::persistence::SmPersistenceError,
     > {
-        drop(tracing::info_span!("orphan.worker.hydration.test"));
         self.read_started.notify_one();
         std::future::pending().await
     }
@@ -2595,7 +2649,6 @@ impl waddle_xmpp::ownership::ClaimStore for HangingExactReleaseStore {
         _mine: waddle_xmpp::ownership::ClaimEpoch,
     ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, waddle_xmpp::ownership::ClaimError>
     {
-        drop(tracing::info_span!("orphan.worker.release.test"));
         self.release_started.notify_one();
         std::future::pending().await
     }
@@ -2677,9 +2730,43 @@ async fn hung_sm_hydration_does_not_block_completed_room_lane() {
         .expect("hung hydration worker must cancel and join");
 }
 
+/// #1483 verify round: worker attempts run under their own short-lived
+/// `janitor.orphan_work` root (never the sweep's live span, which retry
+/// queues would pin open) and carry a *link* back to the enqueuing sweep.
+#[cfg(all(test, feature = "clustering"))]
+fn assert_linked_orphan_work_attempt(
+    spans: &waddle_xmpp::telemetry::test_support::SpanTestGuard,
+    sweep_id: opentelemetry::trace::SpanId,
+    lane: &str,
+) {
+    let exported = spans.exported();
+    let attempt = exported
+        .iter()
+        .find(|span| {
+            span.name == "janitor.orphan_work"
+                && span
+                    .attributes
+                    .iter()
+                    .any(|kv| kv.key.as_str() == "lane" && kv.value.as_str() == lane)
+        })
+        .unwrap_or_else(|| panic!("a {lane} attempt span must export"));
+    assert_eq!(
+        attempt.parent_span_id,
+        opentelemetry::trace::SpanId::INVALID,
+        "attempt spans must be roots, never children of the sweep"
+    );
+    assert!(
+        attempt
+            .links
+            .iter()
+            .any(|link| link.span_context.span_id() == sweep_id),
+        "the attempt must link back to the sweep that enqueued it"
+    );
+}
+
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test(flavor = "current_thread")]
-async fn hydration_worker_uses_the_enqueuing_sweep_span() {
+async fn hydration_worker_attempts_link_to_the_enqueuing_sweep() {
     use waddle_xmpp::ownership::{
         ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
     };
@@ -2701,6 +2788,7 @@ async fn hydration_worker_uses_the_enqueuing_sweep_span() {
     let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
     let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
     let sweep = janitor_sweep_span(Janitor::OrphanReaper);
+    let sweep_id = sweep.in_scope(current_sweep_context).span_id();
 
     assert!(sweep
         .in_scope(|| supervisor.workers.enqueue_hydration(
@@ -2710,24 +2798,13 @@ async fn hydration_worker_uses_the_enqueuing_sweep_span() {
         ))
         .is_accepted());
     drop(sweep);
-    tokio::time::timeout(Duration::from_secs(1), storage.read_started.notified())
+    tokio::time::timeout(Duration::from_secs(5), storage.read_started.notified())
         .await
         .expect("hydration worker started");
     cancel.cancel();
     supervisor.shutdown().await;
 
-    let exported = spans.exported();
-    let root = exported
-        .iter()
-        .find(|span| span.name == "janitor.sweep")
-        .expect("sweep root exported");
-    assert!(
-        exported
-            .iter()
-            .any(|span| span.name == "orphan.worker.hydration.test"
-                && span.parent_span_id == root.span_context.span_id()),
-        "hydration storage work must remain parented to the sweep that enqueued it"
-    );
+    assert_linked_orphan_work_attempt(&spans, sweep_id, "sm_hydration");
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2880,7 +2957,7 @@ async fn failed_worker_restart_retains_captured_won_work_for_terminal_cleanup() 
             won_epoch,
         ),
         reservation: won_reservation,
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     supervisor
         .workers
@@ -2910,7 +2987,7 @@ async fn failed_worker_restart_retains_captured_won_work_for_terminal_cleanup() 
         entity: room_entity.clone(),
         owner: me.clone(),
         epoch: room_epoch,
-        span: tracing::Span::current(),
+        sweep_context: current_sweep_context(),
     };
     supervisor
         .workers
@@ -3188,7 +3265,7 @@ async fn hung_exact_release_worker_is_cancelled_and_joined() {
         entity: Entity::new(EntityType::RoomActor, "cancel@muc.example.com"),
         owner: NodeIdentity::new("sweeper", "incarnation"),
         epoch: waddle_xmpp::ownership::ClaimEpoch(1),
-        span: tracing::Span::current(),
+        sweep_context: current_sweep_context(),
     });
     tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
         .await
@@ -3201,7 +3278,7 @@ async fn hung_exact_release_worker_is_cancelled_and_joined() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test(flavor = "current_thread")]
-async fn exact_release_worker_uses_the_enqueuing_sweep_span() {
+async fn exact_release_worker_attempts_link_to_the_enqueuing_sweep() {
     use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
 
     let store = Arc::new(HangingExactReleaseStore {
@@ -3215,6 +3292,7 @@ async fn exact_release_worker_uses_the_enqueuing_sweep_span() {
     );
     let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
     let sweep = janitor_sweep_span(Janitor::OrphanReaper);
+    let sweep_id = sweep.in_scope(current_sweep_context).span_id();
 
     assert!(sweep
         .in_scope(|| supervisor.workers.enqueue_release(ExactReleaseWork {
@@ -3222,28 +3300,17 @@ async fn exact_release_worker_uses_the_enqueuing_sweep_span() {
             entity: Entity::new(EntityType::RoomActor, "traced-release@muc.example.com"),
             owner: NodeIdentity::new("sweeper", "trace-incarnation"),
             epoch: waddle_xmpp::ownership::ClaimEpoch(1),
-            span: tracing::Span::current(),
+            sweep_context: current_sweep_context(),
         }))
         .is_accepted());
     drop(sweep);
-    tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
+    tokio::time::timeout(Duration::from_secs(5), store.release_started.notified())
         .await
         .expect("release worker started");
     cancel.cancel();
     supervisor.shutdown().await;
 
-    let exported = spans.exported();
-    let root = exported
-        .iter()
-        .find(|span| span.name == "janitor.sweep")
-        .expect("sweep root exported");
-    assert!(
-        exported
-            .iter()
-            .any(|span| span.name == "orphan.worker.release.test"
-                && span.parent_span_id == root.span_context.span_id()),
-        "exact release work must remain parented to the sweep that enqueued it"
-    );
+    assert_linked_orphan_work_attempt(&spans, sweep_id, "room_release");
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -3306,7 +3373,7 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::SmSession, "existing"),
         fence: SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(1)),
         reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(1),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     hydration_tx
         .try_send(existing.clone())
@@ -3408,14 +3475,14 @@ fn exact_release_keys_are_structural_when_components_contain_colons() {
         entity: Entity::new(EntityType::RoomActor, "room:part"),
         owner: NodeIdentity::new("node", "epoch"),
         epoch: ClaimEpoch(1),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     let right = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
         entity: Entity::new(EntityType::RoomActor, "room"),
         owner: NodeIdentity::new("part:node", "epoch"),
         epoch: ClaimEpoch(1),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
 
     assert_ne!(
@@ -3440,7 +3507,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::RoomActor, "existing@muc.example.com"),
         owner: owner.clone(),
         epoch: ClaimEpoch(1),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     release_tx
         .try_send(existing.clone())
@@ -3464,7 +3531,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
         owner,
         epoch: ClaimEpoch(2),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 
@@ -3513,7 +3580,7 @@ fn closed_release_channel_retains_restart_inventory() {
         entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
         owner: NodeIdentity::new("node", "incarnation"),
         epoch: ClaimEpoch(2),
-        span: tracing::Span::none(),
+        sweep_context: opentelemetry::trace::SpanContext::empty_context(),
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1007,10 +1007,16 @@ mod orphan_sweep_supervision_tests {
         supervisor.shutdown().await;
     }
 
-    /// The worker loops wrap each attempt in an `async` block inside their
-    /// `select!` arms because `select!` evaluates branch expressions
-    /// eagerly — this pins the mechanism: an attempt future the cancel arm
-    /// beats to the first poll must not export a phantom attempt root.
+    /// Documents WHY the worker loops wrap each attempt in an `async`
+    /// block inside their `select!` arms: `select!` evaluates branch
+    /// expressions eagerly, and only the block's lazy body keeps a
+    /// cancel-beaten attempt from exporting a phantom root. This test
+    /// pins that language mechanism on a hand-built future — it does NOT
+    /// guard the three worker select sites themselves (no deterministic
+    /// seam exists: a pre-cancelled token exits the loop before the
+    /// attempt select is ever reached). The load-bearing guard is the
+    /// `async` block + comment at each site; do not "simplify" those
+    /// blocks away.
     #[tokio::test(flavor = "current_thread")]
     async fn dropped_unpolled_attempt_exports_no_phantom_span() {
         use tracing::Instrument;

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -5958,6 +5958,31 @@ mod room_dormancy_tests {
         );
     }
 
+    /// #1483: `parent: None` is the load-bearing property — a sweep span
+    /// that inherited an active local span could be dropped along with it
+    /// by the #1438 sampler. Pin that the production constructor starts a
+    /// fresh root even when a span is active.
+    #[tokio::test(flavor = "current_thread")]
+    async fn janitor_sweep_span_is_a_root_even_inside_an_active_span() {
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let outer = tracing::info_span!("actor.handle_message");
+        let sweep = outer.in_scope(|| super::janitor_sweep_span(super::Janitor::RoomDormancy));
+        drop(sweep);
+        drop(outer);
+
+        let exported = spans.exported();
+        let sweep = exported
+            .iter()
+            .find(|span| span.name == "janitor.sweep")
+            .expect("sweep span must export");
+        assert_eq!(
+            sweep.parent_span_id,
+            opentelemetry::trace::SpanId::INVALID,
+            "the sweep span must root a fresh trace, not inherit the \
+             active span as its parent"
+        );
+    }
+
     #[tokio::test]
     async fn sweep_evicts_dormant_persistent_rooms() {
         let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -412,19 +412,19 @@ mod tests {
             .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("span-noise-test")));
 
         tracing::subscriber::with_default(subscriber, || {
-            for root_name in ["clustering.relay.dispatch", "janitor.sweep"] {
-                // `parent: None` mirrors the production spans: the relay
-                // spans are minted inside kameo's own suppressed root.
-                let root = if root_name == "clustering.relay.dispatch" {
-                    tracing::info_span!(parent: None, "clustering.relay.dispatch")
-                } else {
-                    tracing::info_span!(parent: None, "janitor.sweep")
-                };
-                root.in_scope(|| {
-                    tracing::info_span!("actor.handle_message").in_scope(|| {});
-                });
-                drop(root);
-            }
+            // `parent: None` mirrors the production spans: the relay spans
+            // are minted inside kameo's own suppressed root.
+            let relay = tracing::info_span!(parent: None, "clustering.relay.dispatch");
+            relay.in_scope(|| {
+                tracing::info_span!("actor.handle_message").in_scope(|| {});
+            });
+            drop(relay);
+
+            let sweep = tracing::info_span!(parent: None, "janitor.sweep");
+            sweep.in_scope(|| {
+                tracing::info_span!("actor.handle_message").in_scope(|| {});
+            });
+            drop(sweep);
         });
 
         let spans = exported.lock().expect("capture lock").clone();

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -28,6 +28,10 @@
 //! - `janitor.sweep` — one per janitor sweep tick
 //!   (`server::session_janitors::janitor_sweep_span`), carrying the
 //!   canonical `janitor` attribute value.
+//! - `janitor.orphan_work` — one per orphan-reaper work-item attempt
+//!   (`server::session_janitors::orphan_work_span`), linked — not
+//!   parented — to the enqueuing sweep so retry queues can never hold
+//!   a sweep root open.
 //!
 //! Pre-existing named roots (`xmpp.stanza.dispatch`, `xmpp.muc.fanout`,
 //! `http_request`, `clustering.shutdown_drain`, ...) pass through the
@@ -264,7 +268,11 @@ mod tests {
     /// and they must never appear on a suppression list.
     #[test]
     fn dedicated_root_span_names_are_never_suppressed() {
-        const DEDICATED_ROOT_SPAN_NAMES: &[&str] = &["clustering.relay.dispatch", "janitor.sweep"];
+        const DEDICATED_ROOT_SPAN_NAMES: &[&str] = &[
+            "clustering.relay.dispatch",
+            "janitor.sweep",
+            "janitor.orphan_work",
+        ];
         let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
         for name in DEDICATED_ROOT_SPAN_NAMES {
             assert!(

--- a/server/crates/waddle-server/src/telemetry/span_noise.rs
+++ b/server/crates/waddle-server/src/telemetry/span_noise.rs
@@ -13,6 +13,25 @@
 //! whole noise trace: the filter drops every span under an unsampled
 //! parent itself, so no orphaned child spans reach Tempo no matter
 //! which `OTEL_TRACES_SAMPLER` the operator dials.
+//!
+//! # Dedicated root spans (#1483)
+//!
+//! Dispatch paths that do real work with no upstream span open a named
+//! root of their own so their `actor.handle_message` children are
+//! parented and survive this filter. These names are load-bearing and
+//! MUST NEVER be added to the suppression lists below:
+//!
+//! - `clustering.relay.dispatch` — one per inbound clustering relay
+//!   message (`clustering::relay::relay_dispatch_span`); covers
+//!   remote-relayed stanza delivery, cross-node resume steals, and
+//!   remote-resource bookkeeping.
+//! - `janitor.sweep` — one per janitor sweep tick
+//!   (`server::session_janitors::janitor_sweep_span`), carrying the
+//!   canonical `janitor` attribute value.
+//!
+//! Pre-existing named roots (`xmpp.stanza.dispatch`, `xmpp.muc.fanout`,
+//! `http_request`, `clustering.shutdown_drain`, ...) pass through the
+//! same way: anything not on the lists delegates to the inner sampler.
 
 use opentelemetry::{
     trace::{Link, SpanKind, TraceContextExt, TraceId},
@@ -239,6 +258,28 @@ mod tests {
         );
     }
 
+    /// #1483: the dedicated dispatch/sweep roots exist precisely so work
+    /// that used to root at a suppressed `actor.handle_message` stays
+    /// traceable — the filter must pass them straight to the delegate
+    /// and they must never appear on a suppression list.
+    #[test]
+    fn dedicated_root_span_names_are_never_suppressed() {
+        const DEDICATED_ROOT_SPAN_NAMES: &[&str] = &["clustering.relay.dispatch", "janitor.sweep"];
+        let filter = SpanNoiseFilter::new(Sampler::AlwaysOn);
+        for name in DEDICATED_ROOT_SPAN_NAMES {
+            assert!(
+                !ROOT_SUPPRESSED_SPAN_NAMES.contains(name)
+                    && !ALWAYS_SUPPRESSED_SPAN_NAMES.contains(name),
+                "{name} is a dedicated root span and must never be suppressed"
+            );
+            assert_eq!(
+                sample(&filter, None, name),
+                SamplingDecision::RecordAndSample,
+                "root {name} must delegate to the inner sampler"
+            );
+        }
+    }
+
     #[test]
     fn children_of_unsampled_parents_stay_dropped_via_parent_based_delegate() {
         // Production wires ParentBased(...) as the inner sampler, so a
@@ -351,6 +392,61 @@ mod tests {
         assert!(
             !names.contains(&"db.query".to_string()),
             "children of a suppressed root must not export as orphans: {names:?}"
+        );
+    }
+
+    /// #1483 acceptance: the dedicated relay/janitor roots export through
+    /// the production sampler wiring, and the `actor.handle_message` work
+    /// under them is parented — it survives instead of being dropped as a
+    /// root the way it was before those paths opened named roots.
+    #[test]
+    fn pipeline_exports_dedicated_roots_with_parented_actor_children() {
+        let exported = Arc::new(Mutex::new(Vec::new()));
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(CaptureSpanExporter(Arc::clone(&exported)))
+            .with_sampler(SpanNoiseFilter::new(Sampler::ParentBased(Box::new(
+                Sampler::AlwaysOn,
+            ))))
+            .build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("span-noise-test")));
+
+        tracing::subscriber::with_default(subscriber, || {
+            for root_name in ["clustering.relay.dispatch", "janitor.sweep"] {
+                // `parent: None` mirrors the production spans: the relay
+                // spans are minted inside kameo's own suppressed root.
+                let root = if root_name == "clustering.relay.dispatch" {
+                    tracing::info_span!(parent: None, "clustering.relay.dispatch")
+                } else {
+                    tracing::info_span!(parent: None, "janitor.sweep")
+                };
+                root.in_scope(|| {
+                    tracing::info_span!("actor.handle_message").in_scope(|| {});
+                });
+                drop(root);
+            }
+        });
+
+        let spans = exported.lock().expect("capture lock").clone();
+        let names: Vec<&str> = spans.iter().map(|span| span.name.as_ref()).collect();
+        for root_name in ["clustering.relay.dispatch", "janitor.sweep"] {
+            let root = spans
+                .iter()
+                .find(|span| span.name == root_name)
+                .unwrap_or_else(|| panic!("{root_name} must export: {names:?}"));
+            assert!(
+                spans.iter().any(|span| span.name == "actor.handle_message"
+                    && span.parent_span_id == root.span_context.span_id()),
+                "actor work under {root_name} must export parented to it: {names:?}"
+            );
+        }
+        assert_eq!(
+            names
+                .iter()
+                .filter(|name| **name == "actor.handle_message")
+                .count(),
+            2,
+            "exactly the two parented actor spans may export: {names:?}"
         );
     }
 


### PR DESCRIPTION
Implements #1483. The #1438 span-noise sampler (PR #1482) drops root `actor.handle_message` spans; dispatch paths that do real work with no upstream span — clustering relay receive and janitor sweeps — therefore lost their whole traces. This PR gives both paths dedicated named root spans so their actor work stays traceable.

## What changed

### `clustering/relay.rs` — `clustering.relay.dispatch`
Every substantive `#[kameo::remote_message]` handler on `RelayActor` opens a named root span (field `relay.message` = message kind, plus `jid` / `stream_id` / `channel` / `sequence` / `origin_node` / `entity` where applicable) and instruments it onto the delegated `ctx.spawn` reply future, so the full delivery — including all `actor.handle_message` children — is parented and survives the sampler. Covered: `deliver_ordered`, `resume_steal`, `remote_resource_register/unregister/update/route/frame/force_detach`, `remote_user_side_effect`, `demote`. Excluded as substrate: `ping`, `echo_stanza`, and the fault-injection messages.

`parent: None` is load-bearing: handlers execute inside kameo's own (suppressed) root `actor.handle_message` span, and the sampler also drops children of locally-unsampled parents — a defaulted parent would kill the new span too. This is documented on the constructor and pinned by tests.

`swarm.rs` (named in the issue) needed no spans: it is libp2p discovery/event plumbing; kameo remote dispatch terminates in the `relay.rs` handlers, which is where the actor messages originate.

### `server/session_janitors.rs` — `janitor.sweep`
Every janitor sweep tick (all nine `Janitor` variants) runs under one root span per sweep — never per actor message — carrying the canonical `janitor` attribute value. Inline tick bodies were extracted into private `run_*_sweep` fns (loop-level `continue` → `return`; behavior, logging, and `record_janitor_sweep` outcomes unchanged); the orphan-reaper's sweep future is instrumented inside its supervision/timeout wrapper; the very large SM-expiry body is wrapped in place.

### Orphan-reaper deep tracing — `janitor.orphan_work`
The orphan-reaper sweep mostly *enqueues*; the real claim work (hydration CAS, exact releases) runs in long-lived worker tasks. Carrying the sweep's live span there would let retry queues pin the sweep root open indefinitely (the `actor.lifecycle` pathology #1438 killed), so work items carry the enqueuing sweep's `SpanContext` instead, and every worker attempt — including shutdown-terminal re-drives — opens its own short-lived root `janitor.orphan_work` (fields `janitor`, `lane`) with an OTel **link** back to the sweep. The sweep span itself opens lazily inside the sweep fn, so shutdown-cancelled, never-polled sweeps export nothing.

### `telemetry/span_noise.rs` — documentation + guards
Module docs now list the dedicated root-span names that must never be added to the suppression lists, with a guard test enforcing it.

## Volume note
`deliver_ordered` and `remote_resource_frame` mint one sampled root per relayed stanza/frame (plus their now-parented actor children) at the default `parentbased_traceidratio` ratio 1.0 — a deliberate partial give-back of the #1438 saving on the clustered data path; dial the ratio if busy-cluster ingest grows. Janitor sweeps add ~1 span per tick (5s–5min cadences, ≈0.4/s/pod). Post-deploy checks owed: both new root names present with parented children, p99/max duration sanity, ingest delta.

## Follow-ups filed
- #1485 — propagate W3C trace context across relay envelopes so cross-node deliveries form one trace (today the receiving node's half is a separate trace; documented on the span constructor).
- #1486 — pre-existing `hung_exact_release_worker_is_cancelled_and_joined` flake (1s budget races `ORPHANED_ROOM_RELEASE_TIMEOUT` under load).

## Tests
- Relay: dispatch span recorded for inline (`demote`) and delegated (`resume_steal`) handlers, including span fields.
- Janitors: sweep span recorded for room-dormancy and user-actor-reaper sweeps.
- Root-ness pinned: removing `parent: None` from either production constructor now fails a test (span must root a fresh trace even inside an active suppressed span).
- Structural guard: every delegated `ctx.spawn` reply task in relay.rs must be `.instrument`-ed (kills the dropped-instrument mutant field-recording tests can't see).
- Orphan workers: attempt roots export with links to the enqueuing sweep (both lanes); a real registry ask's `actor.handle_message` exports parented under the user-reaper sweep root; cancelled-unpolled orphan sweeps export no phantom span.
- Sampler pipeline: both dedicated roots export through the production sampler wiring with their `actor.handle_message` children parented; suppression guard test for the names.

## Verification
- `cargo test -p waddle-server --all-features`: 2028+ passed; the only failures are the known pre-existing parallel-metric flakes (each passes in isolation and reproduces on `main`).
- `cargo clippy -p waddle-server --all-features --all-targets`: clean (`-D warnings`).
- `cargo fmt`: clean.
- Reviewed two-axis (standards + spec vs issue #1483), two adversarial persona rounds, an independent gpt-5.6-terra review, and a dedicated verification round on each round's fixes.

No XMPP wire changes — telemetry only, so no XEP conformance surface is touched.

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
