### PR TITLE
fix(server): route Muji session-initiate and terminate to the room-owning replica (#1445)

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -27,11 +27,28 @@ spec:
     clustering:
       enabled: true
       enrolledKeyCount: 4
+    # TEMPORARY — hard cutover for the #1445 release, revert after (#1597).
+    #
+    # #1445 adds a new ordered-relay envelope variant (MujiJingleIq). A
+    # replica running the previous image cannot deserialize it, which
+    # surfaces as a maybe-committed codec failure and leaves a sticky
+    # diversion on the ordered channel — a channel shared with that
+    # sender's ordinary MUC join/leave/groupchat traffic for the room.
+    # One attempted cross-node call during a mixed-version window can
+    # therefore drop that user's chat in that room until they reconnect.
+    #
+    # RollingUpdate with maxSurge 1 / maxUnavailable 0 guarantees such a
+    # window on every deploy. Recreate terminates both pods before
+    # starting any new one, so no two versions ever exchange relay
+    # envelopes. Cost is a brief full outage; XMPP clients reconnect via
+    # stream management, and in-flight calls are accepted as expendable
+    # for this release.
+    #
+    # Revert to RollingUpdate (maxSurge 1 / maxUnavailable 0) once this
+    # release is out — Recreate is a regression against the ADR-0017
+    # Phase 4 move away from it, not a new steady state.
     updateStrategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 1
-        maxUnavailable: 0
+      type: Recreate
     image:
       repository: ghcr.io/waddle-social/waddle
       tag: main

--- a/server/crates/waddle-server/src/clustering/ordered_relay.rs
+++ b/server/crates/waddle-server/src/clustering/ordered_relay.rs
@@ -1027,7 +1027,13 @@ fn muji_iq_targets_room(room_jid: &jid::BareJid, iq: &xmpp_parsers::iq::Iq) -> b
     if payload.ns() != waddle_xmpp::xep::xep0166::NS_JINGLE || payload.name() != "jingle" {
         return false;
     }
-    if payload.attr("action") != Some("session-initiate") {
+    // Only the two actions with node-local side effects ride this
+    // kind: `session-initiate` mints and registers on the owner, and
+    // `session-terminate` must unregister on that same owner.
+    if !matches!(
+        payload.attr("action"),
+        Some("session-initiate") | Some("session-terminate")
+    ) {
         return false;
     }
     let Some(muji_elem) = waddle_xmpp::xep::xep0272::find_muji(payload) else {
@@ -1925,8 +1931,13 @@ mod tests {
         );
     }
 
+    /// `session-terminate` rides the same kind as `session-initiate`
+    /// (#1445): the initiate registers the participant on the room
+    /// owner, so the terminate must reach that same node to unregister
+    /// them — a locally-executed terminate would leave a phantom
+    /// in-call participant there.
     #[test]
-    fn muji_jingle_iq_validation_rejects_non_initiate_and_non_muji_iqs() {
+    fn muji_jingle_iq_validation_accepts_terminate_for_the_channel_room() {
         let mut receiver = OrderedRelayReceiverState::default();
         assert!(
             matches!(
@@ -1940,12 +1951,54 @@ mod tests {
                         ),
                     ),
                 ),
+                OrderedRelayReply::Ack(OrderedRelayAck { .. })
+            ),
+            "a terminate for the channel's room must relay to the owner"
+        );
+
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(
+                        OrderedRelayMucProxyKind::MujiJingleIq,
+                        muji_initiate_stanza(
+                            xmpp_parsers::jingle::Action::SessionTerminate,
+                            "other-room@example.test"
+                        ),
+                    ),
+                ),
                 OrderedRelayReply::Nack(OrderedRelayNack {
                     reason: OrderedRelayNackReason::ParseFailure,
                     ..
                 })
             ),
-            "only session-initiate is relayed; terminate stays local"
+            "the payload room must stay bound to the channel room on terminate"
+        );
+    }
+
+    #[test]
+    fn muji_jingle_iq_validation_rejects_other_actions_and_non_muji_iqs() {
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(
+                        OrderedRelayMucProxyKind::MujiJingleIq,
+                        muji_initiate_stanza(
+                            xmpp_parsers::jingle::Action::SessionInfo,
+                            "room@example.test"
+                        ),
+                    ),
+                ),
+                OrderedRelayReply::Nack(OrderedRelayNack {
+                    reason: OrderedRelayNackReason::ParseFailure,
+                    ..
+                })
+            ),
+            "only initiate and terminate have owner-node side effects"
         );
 
         let plain_jingle = {

--- a/server/crates/waddle-server/src/clustering/ordered_relay.rs
+++ b/server/crates/waddle-server/src/clustering/ordered_relay.rs
@@ -121,6 +121,12 @@ pub enum OrderedRelayMucProxyKind {
     BareRoomIq,
     OccupantIq,
     FanoutChunk,
+    /// A Muji (XEP-0272) `session-initiate` relayed to the room-owning
+    /// node (#1445). Unlike `BareRoomIq` the stanza is NOT addressed
+    /// to the room: `to` is the calls mixer (`calls.<domain>`) and the
+    /// target room lives in the `<muji room='…'/>` payload, which the
+    /// envelope validation binds to the channel's room.
+    MujiJingleIq,
 }
 
 impl OrderedRelayMucProxyKind {
@@ -136,7 +142,9 @@ impl OrderedRelayMucProxyKind {
                     | OrderedRelayMucProxyKind::FanoutChunk,
                 waddle_xmpp::Stanza::Message(_)
             ) | (
-                OrderedRelayMucProxyKind::BareRoomIq | OrderedRelayMucProxyKind::OccupantIq,
+                OrderedRelayMucProxyKind::BareRoomIq
+                    | OrderedRelayMucProxyKind::OccupantIq
+                    | OrderedRelayMucProxyKind::MujiJingleIq,
                 waddle_xmpp::Stanza::Iq(_)
             )
         )
@@ -969,6 +977,12 @@ fn muc_proxy_stanza_is_addressed_to_room(
     let Some(to) = stanza_to(stanza) else {
         return false;
     };
+    // The Muji Jingle IQ (#1445) is the one MUC-proxy shape not
+    // addressed to the room: `to` is the calls mixer and the room
+    // binding lives in the `<muji room='…'/>` payload instead.
+    if let (OrderedRelayMucProxyKind::MujiJingleIq, waddle_xmpp::Stanza::Iq(iq)) = (kind, stanza) {
+        return jid_is_bare(to) && muji_iq_targets_room(room_jid, iq);
+    }
     if to.to_bare() != *room_jid {
         return false;
     }
@@ -996,6 +1010,33 @@ fn muc_proxy_stanza_is_addressed_to_room(
         (OrderedRelayMucProxyKind::OccupantIq, waddle_xmpp::Stanza::Iq(_)) => jid_is_full(to),
         _ => false,
     }
+}
+
+/// #1445: a relayed Muji `session-initiate` is the one MUC-proxy shape
+/// not addressed to the room — `to` is the calls mixer and the room
+/// JID lives in the `<muji room='…'/>` payload. Bind that payload room
+/// to the channel's room so an envelope on room A's ordered channel
+/// (fenced by room A's claim epoch) cannot smuggle a token mint for
+/// room B past the fence. Only `session-initiate` rides this kind:
+/// terminate stays local (idempotent on the SFU, converged by webhooks
+/// and the reconcile sweep).
+fn muji_iq_targets_room(room_jid: &jid::BareJid, iq: &xmpp_parsers::iq::Iq) -> bool {
+    let xmpp_parsers::iq::Iq::Set { payload, .. } = iq else {
+        return false;
+    };
+    if payload.ns() != waddle_xmpp::xep::xep0166::NS_JINGLE || payload.name() != "jingle" {
+        return false;
+    }
+    if payload.attr("action") != Some("session-initiate") {
+        return false;
+    }
+    let Some(muji_elem) = waddle_xmpp::xep::xep0272::find_muji(payload) else {
+        return false;
+    };
+    let Ok(muji) = waddle_xmpp::xep::xep0272::Muji::try_from(muji_elem) else {
+        return false;
+    };
+    muji.room.as_ref() == Some(room_jid)
 }
 
 fn jid_is_full(jid: &jid::Jid) -> bool {
@@ -1790,6 +1831,152 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    /// #1445: a Muji `session-initiate` is not addressed to the room —
+    /// `to` is the calls mixer and the room lives in the `<muji/>`
+    /// payload — so its envelope validation must bind the payload's
+    /// room to the channel's room instead of the stanza's `to`.
+    fn muji_envelope(kind: OrderedRelayMucProxyKind, stanza: RemoteStanza) -> RemoteStanzaEnvelope {
+        RemoteStanzaEnvelope {
+            asserted_origin_node: origin_node(),
+            channel: room_channel(),
+            sequence: OrderedRelaySequence(1),
+            origin_inbound_sequence: inbound(1),
+            origin_claim: origin_claim(),
+            sender_claim: sender_claim(),
+            target_claim: room_claim(),
+            payload: OrderedRelayPayload::MucProxy {
+                room_jid: room_jid(),
+                kind,
+                stanza,
+            },
+            origin_proof: None,
+        }
+    }
+
+    fn muji_initiate_stanza(action: xmpp_parsers::jingle::Action, room: &str) -> RemoteStanza {
+        use waddle_xmpp::xep::xep0167::MediaKind;
+        use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+        let muji = Muji {
+            room: Some(room.parse().expect("valid room jid")),
+            preparing: false,
+            contents: vec![MujiContent::new(
+                "audio",
+                Creator::Initiator,
+                MediaKind::Audio,
+            )],
+        };
+        let jingle = xmpp_parsers::jingle::Jingle::new(
+            action,
+            xmpp_parsers::jingle::SessionId("muji-sid-1".into()),
+        );
+        let mut payload: xmpp_parsers::minidom::Element = jingle.into();
+        payload.append_child(muji.to_element());
+        RemoteStanza(waddle_xmpp::Stanza::Iq(Box::new(
+            xmpp_parsers::iq::Iq::Set {
+                from: Some(jid::Jid::from_str("romeo@example.test/phone").expect("full jid")),
+                to: Some(jid::Jid::from_str("calls.example.test").expect("mixer jid")),
+                id: "muji-iq-1".into(),
+                payload,
+            },
+        )))
+    }
+
+    #[test]
+    fn muji_jingle_iq_validation_binds_payload_room_to_channel_room() {
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(
+                        OrderedRelayMucProxyKind::MujiJingleIq,
+                        muji_initiate_stanza(
+                            xmpp_parsers::jingle::Action::SessionInitiate,
+                            "room@example.test"
+                        ),
+                    ),
+                ),
+                OrderedRelayReply::Ack(OrderedRelayAck { .. })
+            ),
+            "a session-initiate whose <muji room> matches the channel room must validate"
+        );
+
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(
+                        OrderedRelayMucProxyKind::MujiJingleIq,
+                        muji_initiate_stanza(
+                            xmpp_parsers::jingle::Action::SessionInitiate,
+                            "other-room@example.test"
+                        ),
+                    ),
+                ),
+                OrderedRelayReply::Nack(OrderedRelayNack {
+                    reason: OrderedRelayNackReason::ParseFailure,
+                    ..
+                })
+            ),
+            "a <muji room> naming a different room than the channel must be rejected"
+        );
+    }
+
+    #[test]
+    fn muji_jingle_iq_validation_rejects_non_initiate_and_non_muji_iqs() {
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(
+                        OrderedRelayMucProxyKind::MujiJingleIq,
+                        muji_initiate_stanza(
+                            xmpp_parsers::jingle::Action::SessionTerminate,
+                            "room@example.test"
+                        ),
+                    ),
+                ),
+                OrderedRelayReply::Nack(OrderedRelayNack {
+                    reason: OrderedRelayNackReason::ParseFailure,
+                    ..
+                })
+            ),
+            "only session-initiate is relayed; terminate stays local"
+        );
+
+        let plain_jingle = {
+            let payload: xmpp_parsers::minidom::Element = xmpp_parsers::jingle::Jingle::new(
+                xmpp_parsers::jingle::Action::SessionInitiate,
+                xmpp_parsers::jingle::SessionId("p2p-sid".into()),
+            )
+            .into();
+            RemoteStanza(waddle_xmpp::Stanza::Iq(Box::new(
+                xmpp_parsers::iq::Iq::Set {
+                    from: Some(jid::Jid::from_str("romeo@example.test/phone").expect("full jid")),
+                    to: Some(jid::Jid::from_str("calls.example.test").expect("mixer jid")),
+                    id: "p2p-iq".into(),
+                    payload,
+                },
+            )))
+        };
+        let mut receiver = OrderedRelayReceiverState::default();
+        assert!(
+            matches!(
+                receive(
+                    &mut receiver,
+                    muji_envelope(OrderedRelayMucProxyKind::MujiJingleIq, plain_jingle),
+                ),
+                OrderedRelayReply::Nack(OrderedRelayNack {
+                    reason: OrderedRelayNackReason::ParseFailure,
+                    ..
+                })
+            ),
+            "a Jingle IQ without a <muji/> child (1:1 call) must never ride this kind"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/ordered_relay.rs
+++ b/server/crates/waddle-server/src/clustering/ordered_relay.rs
@@ -121,11 +121,12 @@ pub enum OrderedRelayMucProxyKind {
     BareRoomIq,
     OccupantIq,
     FanoutChunk,
-    /// A Muji (XEP-0272) `session-initiate` relayed to the room-owning
-    /// node (#1445). Unlike `BareRoomIq` the stanza is NOT addressed
-    /// to the room: `to` is the calls mixer (`calls.<domain>`) and the
-    /// target room lives in the `<muji room='…'/>` payload, which the
-    /// envelope validation binds to the channel's room.
+    /// A Muji (XEP-0272) `session-initiate` or `session-terminate`
+    /// relayed to the room-owning node (#1445). Unlike `BareRoomIq`
+    /// the stanza is NOT addressed to the room: `to` is the calls
+    /// mixer (`calls.<domain>`) and the target room lives in the
+    /// `<muji room='…'/>` payload, which the envelope validation binds
+    /// to the channel's room.
     MujiJingleIq,
 }
 
@@ -1017,9 +1018,10 @@ fn muc_proxy_stanza_is_addressed_to_room(
 /// JID lives in the `<muji room='…'/>` payload. Bind that payload room
 /// to the channel's room so an envelope on room A's ordered channel
 /// (fenced by room A's claim epoch) cannot smuggle a token mint for
-/// room B past the fence. Only `session-initiate` rides this kind:
-/// terminate stays local (idempotent on the SFU, converged by webhooks
-/// and the reconcile sweep).
+/// room B past the fence. Both `session-initiate` and
+/// `session-terminate` ride this kind — the initiate registers the
+/// participant on the owner, so the terminate must reach that same
+/// node to unregister them.
 fn muji_iq_targets_room(room_jid: &jid::BareJid, iq: &xmpp_parsers::iq::Iq) -> bool {
     let xmpp_parsers::iq::Iq::Set { payload, .. } = iq else {
         return false;

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -4284,7 +4284,7 @@ async fn deliver_reserved_muji_iq(
         tracing::warn!(
             room = %room_jid,
             timeout_ms = ORDERED_RECEIVER_DELIVERY_TIMEOUT.as_millis(),
-            "ordered relay: Muji session-initiate execution timed out"
+            "ordered relay: Muji Jingle execution timed out"
         );
         OrderedRelayNackReason::MaybeCommitted
     })?

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -4203,8 +4203,44 @@ async fn deliver_reserved_muc_proxy(
         (OrderedRelayMucProxyKind::OccupantPresence, Stanza::Presence(presence)) => {
             deliver_reserved_muc_occupant_presence(state.as_ref(), room_jid, presence).await
         }
+        (OrderedRelayMucProxyKind::MujiJingleIq, Stanza::Iq(iq)) => {
+            deliver_reserved_muji_iq(state.as_ref(), room_jid, iq).await
+        }
         _ => Err(OrderedRelayNackReason::ParseFailure),
     }
+}
+
+/// #1445: execute a relayed Muji `session-initiate` on this node — the
+/// room-claim owner — and carry the reply frames (IQ ack +
+/// server-initiated `session-accept` with the LiveKit token) back to
+/// the origin node as client replies. Envelope validation has already
+/// bound the payload's `<muji room>` to `room_jid`, so the room
+/// binding needs no re-check here; the executor re-runs the membership
+/// gate against the local room actor and is terminal (a denial comes
+/// back as a delivered IQ-error frame, never a NACK, so no relay
+/// loop can form).
+async fn deliver_reserved_muji_iq(
+    state: &WebSocketState,
+    room_jid: &jid::BareJid,
+    iq: &xmpp_parsers::iq::Iq,
+) -> Result<Vec<RemoteStanza>, OrderedRelayNackReason> {
+    let frames = tokio::time::timeout(
+        ORDERED_RECEIVER_DELIVERY_TIMEOUT,
+        crate::server::routes::websocket::handlers::iq::jingle_muji_relay::handle_relayed_muji_initiate(
+            state, iq,
+        ),
+    )
+    .await
+    .map_err(|_| {
+        tracing::warn!(
+            room = %room_jid,
+            timeout_ms = ORDERED_RECEIVER_DELIVERY_TIMEOUT.as_millis(),
+            "ordered relay: Muji session-initiate execution timed out"
+        );
+        OrderedRelayNackReason::MaybeCommitted
+    })?
+    .ok_or(OrderedRelayNackReason::ParseFailure)?;
+    remote_replies_from_frames(frames)
 }
 
 async fn deliver_reserved_muc_occupant_presence(

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -1057,28 +1057,20 @@ impl OrderedRelayDeliveryBridge {
                     OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
                 );
             }
-            if kind == OrderedRelayMucProxyKind::MujiJingleIq {
-                // #1445: a Muji initiate must never leave a sticky
-                // diversion on this channel. The channel key is shared
-                // with the sender's MUC join/leave/groupchat relays for
-                // the same room, so a diverted channel would silently
-                // drop the user's ordinary MUC traffic until they
-                // reconnect or the room's claim epoch changes.
-                //
-                // This is not hypothetical during a rolling deploy: a
-                // node that predates `MujiJingleIq` cannot deserialize
-                // the envelope at all, which surfaces here as a codec
-                // failure classified `maybe_committed`.
-                //
-                // Forgetting is safe for THIS kind specifically because
-                // a re-executed initiate is idempotent — registration
-                // is a set-insert and a second token supersedes the
-                // first — so the usual reason to preserve a
-                // maybe-committed sequence does not apply. The caller
-                // maps the outcome to a `type='wait'` error and the
-                // client retries onto a clean channel.
-                self.forget_channel(&retry_channel).await;
-            }
+            // A `MujiJingleIq` maybe-committed deliberately gets the
+            // same treatment as every other kind: the channel keeps
+            // its diversion. An earlier attempt to `forget_channel`
+            // here was WRONG and is recorded so it is not retried —
+            // `OrderedRelaySenderState::forget_channel` drops
+            // `next_by_channel`, resetting the SENDER's sequence to
+            // FIRST while the receiver's `next_expected` is untouched.
+            // The next envelope on the channel (the user's next
+            // groupchat message or leave presence) would then arrive
+            // with a stale sequence and NACK as an ordering gap,
+            // converting a bounded failure into a diversion attached
+            // to unrelated MUC traffic. Only the `JoinPresence` arm
+            // above can forget safely, because it immediately re-sends
+            // and has `try_proxy_muc_join_repair` as a backstop.
             return MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::MaybeCommitted);
         }
 

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -1057,6 +1057,28 @@ impl OrderedRelayDeliveryBridge {
                     OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
                 );
             }
+            if kind == OrderedRelayMucProxyKind::MujiJingleIq {
+                // #1445: a Muji initiate must never leave a sticky
+                // diversion on this channel. The channel key is shared
+                // with the sender's MUC join/leave/groupchat relays for
+                // the same room, so a diverted channel would silently
+                // drop the user's ordinary MUC traffic until they
+                // reconnect or the room's claim epoch changes.
+                //
+                // This is not hypothetical during a rolling deploy: a
+                // node that predates `MujiJingleIq` cannot deserialize
+                // the envelope at all, which surfaces here as a codec
+                // failure classified `maybe_committed`.
+                //
+                // Forgetting is safe for THIS kind specifically because
+                // a re-executed initiate is idempotent — registration
+                // is a set-insert and a second token supersedes the
+                // first — so the usual reason to preserve a
+                // maybe-committed sequence does not apply. The caller
+                // maps the outcome to a `type='wait'` error and the
+                // client retries onto a clean channel.
+                self.forget_channel(&retry_channel).await;
+            }
             return MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::MaybeCommitted);
         }
 
@@ -2442,6 +2464,20 @@ impl OrderedRelayDeliveryBridge {
                 kind,
                 stanza,
             } => {
+                // This path can execute the payload locally WITHOUT the
+                // envelope validation (`envelope_is_consistent` /
+                // `validate_claims`) that the ordered-relay receiver
+                // applies, so nothing here has bound the stanza's
+                // `from` to the sending session. That is tolerable for
+                // the presence/message kinds, but `MujiJingleIq` mints
+                // a media credential from whatever `from` says (#1445),
+                // so bind it to the registration this call already
+                // authenticated (`msg.source_jid`) before dispatch.
+                let stanza = if kind == OrderedRelayMucProxyKind::MujiJingleIq {
+                    RemoteStanza(rebind_stanza_sender(&stanza.0, &msg.source_jid))
+                } else {
+                    stanza
+                };
                 let outcome = if let Some(remote) = self
                     .try_proxy_muc_remote(&room_jid, &stanza.0, kind, &origin)
                     .await
@@ -4178,6 +4214,27 @@ fn relay_payload_target(
         }
         OrderedRelayRecipient::Room(_) => Err(OrderedRelayNackReason::ParseFailure),
     }
+}
+
+/// Return `stanza` with its `from` replaced by `sender`.
+///
+/// Used where a locally-executed relay payload must be attributed to
+/// the session the caller already authenticated rather than to
+/// whatever the serialized stanza claims (#1445).
+fn rebind_stanza_sender(stanza: &Stanza, sender: &jid::FullJid) -> Stanza {
+    let mut rebound = stanza.clone();
+    let from = Some(jid::Jid::from(sender.clone()));
+    match &mut rebound {
+        Stanza::Iq(iq) => match iq.as_mut() {
+            xmpp_parsers::iq::Iq::Get { from: f, .. }
+            | xmpp_parsers::iq::Iq::Set { from: f, .. }
+            | xmpp_parsers::iq::Iq::Result { from: f, .. }
+            | xmpp_parsers::iq::Iq::Error { from: f, .. } => *f = from,
+        },
+        Stanza::Message(message) => message.from = from,
+        Stanza::Presence(presence) => presence.from = from,
+    }
+    rebound
 }
 
 async fn deliver_reserved_muc_proxy(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -55,11 +55,33 @@ use super::errors::{bad_request_iq_error, forbidden_iq_error, internal_server_er
 /// mints the SFU token with exactly those grants. `None` means no
 /// membership check applied (non-Jingle, 1:1 Jingle, non-initiate
 /// actions) — the Muji mint path treats that as listen-only.
+/// `RoomNotLocal` means no room actor lives in this process. That is
+/// NOT a room-existence verdict: with multiple replicas the room actor
+/// is claimed by exactly one node, so a perfectly live room looks
+/// absent from every other replica (#1445). The caller decides —
+/// relay the IQ to the claim-owning node when possible, or convert to
+/// the terminal denial via [`deny_room_not_found`].
 pub(super) enum GateOutcome {
     Allow {
         media_capabilities: Option<MediaCapabilities>,
     },
     Deny(Box<StanzaError>),
+    RoomNotLocal {
+        room_jid: BareJid,
+    },
+}
+
+/// The terminal `room_not_found` denial: no room actor here AND no
+/// other node owns the room (or relay was impossible). Records the
+/// SFU-token denial telemetry and produces the exact `<forbidden/>`
+/// wire shape this path has always had. Every terminal decision site
+/// must funnel through here so the #1452 SLI keeps counting complete
+/// call-setup attempts.
+pub(super) fn deny_room_not_found(room_jid: &BareJid, user: &BareJid) -> Box<StanzaError> {
+    record_sfu_token_denial(room_jid, user, SfuDenialReason::RoomNotFound);
+    Box::new(forbidden_iq_error(
+        "not an occupant of the requested room — join the MUC first",
+    ))
 }
 
 /// `Allow` for stanzas the Muji membership gate does not apply to.
@@ -180,17 +202,18 @@ async fn verify_room_membership(
     full_jid: &FullJid,
     room_jid: &BareJid,
 ) -> GateOutcome {
-    // No room actor → the user definitively hasn't joined the room
-    // through the XEP-0045 path. (The room actor is created on
-    // first MUC join; absence means "no one has joined this room
-    // in this process's lifetime.")
+    // No LOCAL room actor. That is not the same as "the room does not
+    // exist": room actors are claimed by exactly one node, so on a
+    // non-owning replica a live room's occupancy is simply elsewhere
+    // (#1445 — this exact branch denied ~29% of production joins as
+    // `room_not_found`). Surface `RoomNotLocal` and let the caller
+    // relay to the claim owner or convert to the terminal denial.
     let actor = match get_room_actor_result(state, room_jid).await {
         Ok(Some(actor)) => actor,
         Ok(None) => {
-            record_sfu_token_denial(room_jid, &full_jid.to_bare(), SfuDenialReason::RoomNotFound);
-            return GateOutcome::Deny(Box::new(forbidden_iq_error(
-                "not an occupant of the requested room — join the MUC first",
-            )));
+            return GateOutcome::RoomNotLocal {
+                room_jid: room_jid.clone(),
+            };
         }
         Err(error) => {
             tracing::debug!(room = %room_jid, error = %error, "Muji gate room lookup failed");
@@ -565,7 +588,11 @@ mod tests {
     /// #1452: a gate denial is a *complete* call-setup attempt — the
     /// sans-I/O Jingle handler never runs, so the gate must count the
     /// attempted/failed pair itself or `room_not_found` would show up
-    /// as failures with no denominator.
+    /// as failures with no denominator. Since #1445 the gate reports
+    /// `RoomNotLocal` and the CALLER decides whether that is terminal
+    /// (no claim owner to relay to) — the telemetry lives in
+    /// [`deny_room_not_found`], which every terminal site funnels
+    /// through; this test drives that terminal mapping.
     #[tokio::test(flavor = "current_thread")]
     async fn room_not_found_denial_records_a_call_setup_failure() {
         let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
@@ -574,8 +601,15 @@ mod tests {
         let iq = ghost_room_session_initiate_iq();
 
         let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
-
-        assert!(matches!(outcome, GateOutcome::Deny(_)));
+        let GateOutcome::RoomNotLocal { room_jid } = outcome else {
+            panic!("expected RoomNotLocal for a room with no local actor");
+        };
+        let error = deny_room_not_found(&room_jid, &alice.to_bare());
+        assert_eq!(
+            error.defined_condition,
+            DefinedCondition::Forbidden,
+            "terminal denial keeps the historical wire shape"
+        );
         assert_eq!(
             metrics.counter_sum("waddle.call.setup.attempted", &[]),
             Some(1)
@@ -642,7 +676,12 @@ mod tests {
         let state = create_test_websocket_state().await;
         let alice = full("alice@example.com/web");
 
-        verify_muji_jingle_request(&state, &alice, &ghost_room_session_initiate_iq()).await;
+        let outcome =
+            verify_muji_jingle_request(&state, &alice, &ghost_room_session_initiate_iq()).await;
+        let GateOutcome::RoomNotLocal { room_jid } = outcome else {
+            panic!("expected RoomNotLocal for a room with no local actor");
+        };
+        deny_room_not_found(&room_jid, &alice.to_bare());
 
         let logs = String::from_utf8(buffer.lock().expect("capture buffer lock").clone())
             .expect("captured logs are UTF-8");
@@ -691,30 +730,21 @@ mod tests {
     /// A MUC room JID that no test ever creates a room actor for.
     const GHOST_ROOM: &str = "ghost-room@muc.example.com";
 
+    /// #1445: local absence is NOT a room-existence verdict — the room
+    /// actor may be claimed by another node. The gate must surface
+    /// `RoomNotLocal` (so the caller can relay to the claim owner)
+    /// instead of denying outright.
     #[tokio::test]
-    async fn deny_when_room_actor_does_not_exist() {
+    async fn missing_room_actor_reports_room_not_local_instead_of_denying() {
         let state = create_test_websocket_state().await;
         let alice = full("alice@example.com/web");
 
-        let mut iq = build_jingle_muji_iq(Action::SessionInitiate, "ghost-room@muc.example.com");
-        // Re-stamp the embedded `<muji>` so its `room` attr points
-        // at the same ghost room.
-        if let Iq::Set { payload, .. } = &mut iq {
-            payload.children().for_each(drop);
-            payload.append_child(
-                Muji {
-                    room: Some("ghost-room@muc.example.com".parse().unwrap()),
-                    preparing: false,
-                    contents: muji_audio().contents,
-                }
-                .to_element(),
-            );
-        }
+        let iq = ghost_room_session_initiate_iq();
         let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
-        let GateOutcome::Deny(err) = outcome else {
-            panic!("expected Deny");
+        let GateOutcome::RoomNotLocal { room_jid } = outcome else {
+            panic!("expected RoomNotLocal");
         };
-        assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+        assert_eq!(room_jid.to_string(), GHOST_ROOM);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -18,9 +18,12 @@
 //! `session-initiate` it asks the room actor whether `full_jid` is
 //! a current occupant; if not, the gate short-circuits with
 //! `<forbidden/>` and the SFU is never touched.
-//! `session-terminate` is intentionally not gated — `unregister`
-//! on the SFU is idempotent and harmless, and an over-eager leave
-//! from a non-occupant is benign cleanup.
+//! `session-terminate` is intentionally not membership-gated —
+//! `unregister` on the SFU is idempotent and harmless, and an
+//! over-eager leave from a non-occupant is benign cleanup. It is
+//! still checked for room LOCALITY (#1445), because the matching
+//! initiate registered the participant on the room-owning node and
+//! the terminate has to reach that same node to undo it.
 //!
 //! Replaces the legacy `muc_call_gate.rs` (which gated the
 //! `urn:waddle:muc-call:0` `<request-join>` IQ surface).

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -91,6 +91,23 @@ fn allow_ungated() -> GateOutcome {
     }
 }
 
+/// Why the gate is running.
+///
+/// A relayed Muji initiate (#1445) passes the gate twice: once on the
+/// replica the client is connected to (which decides whether to relay)
+/// and again on the room-owning replica (which decides authorization).
+/// Only the first is a distinct client signalling event — recording
+/// [`CallSignalEvent::MujiJoin`] on both would double-count every
+/// cross-node join and skew the very dashboards used to verify this
+/// fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GateInvocation {
+    /// Directly from the client's connection.
+    ClientOrigin,
+    /// Re-run on the room owner for an IQ relayed by another node.
+    RelayedReplay,
+}
+
 /// Run the membership pre-check for a Muji-bearing Jingle IQ.
 ///
 /// Returns:
@@ -103,10 +120,13 @@ fn allow_ungated() -> GateOutcome {
 ///   the caller is not a current occupant of the room.
 /// - `Deny(bad_request)` if the `<muji room='…'/>` attribute is
 ///   missing or not a valid bare JID.
+/// - `RoomNotLocal` if no room actor for the requested room lives in
+///   this process — see [`GateOutcome::RoomNotLocal`].
 pub(super) async fn verify_muji_jingle_request(
     state: &WebSocketState,
     full_jid: &FullJid,
     iq: &Iq,
+    invocation: GateInvocation,
 ) -> GateOutcome {
     let Iq::Set { payload, .. } = iq else {
         return allow_ungated();
@@ -156,18 +176,40 @@ pub(super) async fn verify_muji_jingle_request(
         }
     };
     let user = full_jid.to_bare();
-    match jingle.action {
-        Action::SessionInitiate => record_call_signal(
-            CallSignalEvent::MujiJoin,
-            &user,
-            Some(CallSignalTarget::Room(&room_jid)),
-        ),
-        Action::SessionTerminate => record_call_signal(
-            CallSignalEvent::MujiLeave,
-            &user,
-            Some(CallSignalTarget::Room(&room_jid)),
-        ),
-        _ => {}
+    if invocation == GateInvocation::ClientOrigin {
+        match jingle.action {
+            Action::SessionInitiate => record_call_signal(
+                CallSignalEvent::MujiJoin,
+                &user,
+                Some(CallSignalTarget::Room(&room_jid)),
+            ),
+            Action::SessionTerminate => record_call_signal(
+                CallSignalEvent::MujiLeave,
+                &user,
+                Some(CallSignalTarget::Room(&room_jid)),
+            ),
+            _ => {}
+        }
+    }
+    // `session-terminate` is not membership-gated (unregistering is
+    // idempotent, and an over-eager leave from a non-occupant is
+    // benign cleanup) — but since #1445 it still has to reach the
+    // right NODE. A relayed initiate registers the participant in the
+    // room owner's SFU registry, so a terminate executed on the
+    // client's own replica would clear nothing there: the owner would
+    // keep a phantom in-call participant, and because that phantom
+    // keeps the call non-empty it would also suppress `DeleteRoom` for
+    // everyone else. Report locality so the caller relays it to the
+    // same node that holds the registration.
+    if matches!(jingle.action, Action::SessionTerminate) {
+        return match get_room_actor_result(state, &room_jid).await {
+            Ok(Some(_)) => allow_ungated(),
+            // Unclaimed rooms resolve to a local no-op the same way
+            // they did before: the caller only relays when some other
+            // node actually owns the room.
+            Ok(None) => GateOutcome::RoomNotLocal { room_jid },
+            Err(_) => allow_ungated(),
+        };
     }
     if !matches!(jingle.action, Action::SessionInitiate) {
         return allow_ungated();
@@ -434,6 +476,7 @@ mod tests {
             &state,
             &alice,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
         // Authorization produces the grant: a voiced occupant (role ≥
@@ -460,6 +503,7 @@ mod tests {
             &state,
             &alice,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
         let GateOutcome::Allow { media_capabilities } = outcome else {
@@ -486,6 +530,7 @@ mod tests {
             &state,
             &alice,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
         let GateOutcome::Allow { media_capabilities } = outcome else {
@@ -511,6 +556,7 @@ mod tests {
             &state,
             &alice,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
         let GateOutcome::Allow { media_capabilities } = outcome else {
@@ -531,6 +577,7 @@ mod tests {
             &state,
             &mallory,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
         let GateOutcome::Deny(err) = outcome else {
@@ -560,6 +607,7 @@ mod tests {
             &state,
             &mallory,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
 
@@ -600,7 +648,8 @@ mod tests {
         let alice = full("alice@example.com/web");
         let iq = ghost_room_session_initiate_iq();
 
-        let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
+        let outcome =
+            verify_muji_jingle_request(&state, &alice, &iq, GateInvocation::ClientOrigin).await;
         let GateOutcome::RoomNotLocal { room_jid } = outcome else {
             panic!("expected RoomNotLocal for a room with no local actor");
         };
@@ -643,6 +692,7 @@ mod tests {
             &state,
             &mallory,
             &build_jingle_muji_iq(Action::SessionInitiate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
 
@@ -676,8 +726,13 @@ mod tests {
         let state = create_test_websocket_state().await;
         let alice = full("alice@example.com/web");
 
-        let outcome =
-            verify_muji_jingle_request(&state, &alice, &ghost_room_session_initiate_iq()).await;
+        let outcome = verify_muji_jingle_request(
+            &state,
+            &alice,
+            &ghost_room_session_initiate_iq(),
+            GateInvocation::ClientOrigin,
+        )
+        .await;
         let GateOutcome::RoomNotLocal { room_jid } = outcome else {
             panic!("expected RoomNotLocal for a room with no local actor");
         };
@@ -740,7 +795,8 @@ mod tests {
         let alice = full("alice@example.com/web");
 
         let iq = ghost_room_session_initiate_iq();
-        let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
+        let outcome =
+            verify_muji_jingle_request(&state, &alice, &iq, GateInvocation::ClientOrigin).await;
         let GateOutcome::RoomNotLocal { room_jid } = outcome else {
             panic!("expected RoomNotLocal");
         };
@@ -751,7 +807,36 @@ mod tests {
     async fn allow_for_session_terminate_without_membership_check() {
         // session-terminate is idempotent on the SFU; the gate must
         // let it through even from a non-occupant so a stuck client
-        // can explicitly tell the server it has hung up.
+        // can explicitly tell the server it has hung up. Membership is
+        // deliberately NOT checked — only room locality is, and the
+        // room actor exists locally here.
+        let state = create_test_websocket_state().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice = full("alice@example.com/web");
+        let mallory = full("mallory@example.com/laptop");
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let outcome = verify_muji_jingle_request(
+            &state,
+            &mallory,
+            &build_jingle_muji_iq(Action::SessionTerminate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
+        )
+        .await;
+        assert!(
+            matches!(outcome, GateOutcome::Allow { .. }),
+            "terminate is never membership-gated, even from a non-occupant"
+        );
+    }
+
+    /// #1445: a terminate for a room with no local actor must report
+    /// locality rather than being executed here. The initiate
+    /// registered the participant on the room owner, so a locally
+    /// executed terminate would clear nothing there — leaving a
+    /// phantom in-call participant that also suppresses `DeleteRoom`
+    /// for every other occupant.
+    #[tokio::test]
+    async fn session_terminate_for_a_non_local_room_reports_room_not_local() {
         let state = create_test_websocket_state().await;
         let alice = full("alice@example.com/web");
 
@@ -759,9 +844,13 @@ mod tests {
             &state,
             &alice,
             &build_jingle_muji_iq(Action::SessionTerminate, "general@muc.example.com"),
+            GateInvocation::ClientOrigin,
         )
         .await;
-        assert!(matches!(outcome, GateOutcome::Allow { .. }));
+        let GateOutcome::RoomNotLocal { room_jid } = outcome else {
+            panic!("expected RoomNotLocal so the caller relays the terminate");
+        };
+        assert_eq!(room_jid.to_string(), "general@muc.example.com");
     }
 
     #[tokio::test]
@@ -783,7 +872,8 @@ mod tests {
             id: "d1".into(),
             payload,
         };
-        let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
+        let outcome =
+            verify_muji_jingle_request(&state, &alice, &iq, GateInvocation::ClientOrigin).await;
         assert!(matches!(outcome, GateOutcome::Allow { .. }));
     }
 
@@ -812,7 +902,8 @@ mod tests {
             id: "p2p".into(),
             payload,
         };
-        let outcome = verify_muji_jingle_request(&state, &alice, &iq).await;
+        let outcome =
+            verify_muji_jingle_request(&state, &alice, &iq, GateInvocation::ClientOrigin).await;
         assert!(matches!(outcome, GateOutcome::Allow { .. }));
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_gate.rs
@@ -211,7 +211,26 @@ pub(super) async fn verify_muji_jingle_request(
             // they did before: the caller only relays when some other
             // node actually owns the room.
             Ok(None) => GateOutcome::RoomNotLocal { room_jid },
-            Err(_) => allow_ungated(),
+            // A lookup error (registry timeout, actor state lost,
+            // ownership reconciliation in flight) is NOT evidence that
+            // the room is local. Executing here on that basis is the
+            // phantom-participant bug again: the registration lives on
+            // the owner, and a local teardown would never clear it.
+            //
+            // On the client's own replica, report locality so the
+            // caller at least attempts to reach the owner — and if the
+            // relay cannot resolve one either, its terminate fallback
+            // degrades to exactly the local execution this arm used to
+            // do unconditionally, now with a WARN rather than in
+            // silence.
+            //
+            // On the owner replaying a relayed terminate there is no
+            // further node to try, so stay permissive: a teardown must
+            // always run somewhere.
+            Err(_) => match invocation {
+                GateInvocation::ClientOrigin => GateOutcome::RoomNotLocal { room_jid },
+                GateInvocation::RelayedReplay => allow_ungated(),
+            },
         };
     }
     if !matches!(jingle.action, Action::SessionInitiate) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
@@ -1,5 +1,6 @@
-//! Owner-side executor for a Muji `session-initiate` relayed from the
-//! replica that received it (#1445).
+//! Owner-side executor for a Muji `session-initiate` or
+//! `session-terminate` relayed from the replica that received it
+//! (#1445).
 //!
 //! The producing replica had no local room actor, so it relayed the IQ
 //! over the ordered MUC proxy to the node holding the room's claim —
@@ -13,13 +14,14 @@
 //! socket there.
 
 use super::super::super::interpret_loop::build_interpret_deps;
-use super::super::super::transport_xml::build_iq_error_xml_typed;
+use super::super::super::transport_xml::{build_iq_error_xml_typed, build_iq_result_xml};
 use super::super::super::WebSocketState;
 use super::jingle_muji_gate::{self, GateInvocation, GateOutcome};
 use super::sans_io::events_contain_iq_error;
 use super::ProtocolStanzaContext;
 
-/// Execute a relayed Muji `session-initiate` on the room-owning node.
+/// Execute a relayed Muji `session-initiate` or `session-terminate`
+/// on the room-owning node.
 ///
 /// Returns `None` only on a wire-shape failure (the IQ carries no full
 /// sender JID) — the caller NACKs the envelope as a parse failure.
@@ -77,9 +79,27 @@ pub(crate) async fn handle_relayed_muji_initiate(
         GateOutcome::RoomNotLocal { room_jid } => {
             // We hold (or held) the room's claim yet no actor lives
             // here: every occupant has left and the actor is gone, or
-            // ownership moved after the producer's claim read. Either
-            // way the requester is not an occupant of a live local
-            // room — the terminal denial, never a re-relay.
+            // ownership moved after the producer's claim read.
+            //
+            // A hangup must never fail on that. The common way to
+            // reach this arm with a terminate is two occupants leaving
+            // at once — the first empties the room and tears the actor
+            // down, and the second arrives to find nothing. Answering
+            // `<forbidden/>` ("join the MUC first") to someone hanging
+            // up would be nonsense, and would also emit a bogus
+            // `room_not_found` denial. Unregistering is idempotent, so
+            // the empty IQ result is the honest answer.
+            if jingle_muji_gate::muji_session_terminate_room(iq).is_some() {
+                return Some(vec![build_iq_result_xml(
+                    id,
+                    response_from.as_deref(),
+                    Some(response_to.as_str()),
+                    None,
+                )]);
+            }
+            // An initiate, though, genuinely cannot proceed: the
+            // requester is not an occupant of a live local room. The
+            // terminal denial, never a re-relay.
             let error = jingle_muji_gate::deny_room_not_found(&room_jid, &sender.to_bare());
             Some(vec![build_iq_error_xml_typed(
                 id,
@@ -274,6 +294,42 @@ mod tests {
         assert!(
             !sfu.has_call_participant(&call, &identity),
             "the relayed terminate must unregister on the node holding the registration"
+        );
+    }
+
+    /// A hangup must never fail. Two occupants leaving at once is the
+    /// ordinary way to reach the owner with no room actor left: the
+    /// first terminate empties the room and tears the actor down, the
+    /// second finds nothing. Answering `<forbidden/>` ("join the MUC
+    /// first") to someone hanging up would be nonsense and would also
+    /// emit a bogus `room_not_found` denial.
+    #[tokio::test]
+    async fn relayed_terminate_after_the_room_actor_is_gone_still_succeeds() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let state = create_test_websocket_state_with_calls().await;
+
+        let frames = handle_relayed_muji_initiate(
+            &state,
+            &muji_terminate_iq("alice@example.com/web", "vanished@muc.example.com"),
+        )
+        .await
+        .expect("terminate executes");
+
+        assert_eq!(frames.len(), 1, "{frames:?}");
+        assert!(
+            frames[0].contains("type='result'") || frames[0].contains("type=\"result\""),
+            "a hangup for a room whose actor is gone must be acked, not denied: {}",
+            frames[0]
+        );
+        assert_eq!(
+            metrics
+                .counter_sum(
+                    "waddle.call.sfu_token.denied",
+                    &[("reason", "room_not_found")]
+                )
+                .unwrap_or(0),
+            0,
+            "a hangup is not a token denial"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
@@ -14,7 +14,7 @@
 //! socket there.
 
 use super::super::super::interpret_loop::build_interpret_deps;
-use super::super::super::transport_xml::{build_iq_error_xml_typed, build_iq_result_xml};
+use super::super::super::transport_xml::build_iq_error_xml_typed;
 use super::super::super::WebSocketState;
 use super::jingle_muji_gate::{self, GateInvocation, GateOutcome};
 use super::sans_io::events_contain_iq_error;
@@ -38,7 +38,8 @@ pub(crate) async fn handle_relayed_muji_initiate(
     let response_from = iq.to().map(|to| to.to_string());
     let response_to = jid::Jid::from(sender.clone()).to_string();
 
-    match jingle_muji_gate::verify_muji_jingle_request(
+    let is_terminate = jingle_muji_gate::muji_session_terminate_room(iq).is_some();
+    let media_capabilities = match jingle_muji_gate::verify_muji_jingle_request(
         state,
         &sender,
         iq,
@@ -46,69 +47,73 @@ pub(crate) async fn handle_relayed_muji_initiate(
     )
     .await
     {
-        GateOutcome::Allow { media_capabilities } => {
-            let ctx = ProtocolStanzaContext {
-                domain: state.deps.auth_state.xmpp_domain.as_str(),
-                full_jid: &sender,
-                media_capabilities,
-            };
-            let muji_terminate_room = jingle_muji_gate::muji_session_terminate_room(iq);
-            let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
-            let clear_after = muji_terminate_room.filter(|_| !events_contain_iq_error(&events));
-            let session = synthetic_session(&sender);
-            let deps = build_interpret_deps(state, Some(&session));
-            let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
-            // Mirror the local adapter's post-terminate Muji-presence
-            // clear. It has to run HERE, on the owner, because that is
-            // where the room actor and the SFU registration both live
-            // — running it on the client's replica would find neither.
-            if let Some(room_jid) = clear_after {
-                crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
-                    state, &room_jid, &sender,
-                )
-                .await;
-            }
-            Some(outcome.frames)
-        }
-        GateOutcome::Deny(error) => Some(vec![build_iq_error_xml_typed(
-            id,
-            response_from.as_deref(),
-            Some(response_to.as_str()),
-            *error,
-        )]),
-        GateOutcome::RoomNotLocal { room_jid } => {
-            // We hold (or held) the room's claim yet no actor lives
-            // here: every occupant has left and the actor is gone, or
-            // ownership moved after the producer's claim read.
-            //
-            // A hangup must never fail on that. The common way to
-            // reach this arm with a terminate is two occupants leaving
-            // at once — the first empties the room and tears the actor
-            // down, and the second arrives to find nothing. Answering
-            // `<forbidden/>` ("join the MUC first") to someone hanging
-            // up would be nonsense, and would also emit a bogus
-            // `room_not_found` denial. Unregistering is idempotent, so
-            // the empty IQ result is the honest answer.
-            if jingle_muji_gate::muji_session_terminate_room(iq).is_some() {
-                return Some(vec![build_iq_result_xml(
-                    id,
-                    response_from.as_deref(),
-                    Some(response_to.as_str()),
-                    None,
-                )]);
-            }
-            // An initiate, though, genuinely cannot proceed: the
-            // requester is not an occupant of a live local room. The
-            // terminal denial, never a re-relay.
-            let error = jingle_muji_gate::deny_room_not_found(&room_jid, &sender.to_bare());
-            Some(vec![build_iq_error_xml_typed(
+        GateOutcome::Allow { media_capabilities } => media_capabilities,
+        GateOutcome::Deny(error) => {
+            return Some(vec![build_iq_error_xml_typed(
                 id,
                 response_from.as_deref(),
                 Some(response_to.as_str()),
                 *error,
-            )])
+            )]);
         }
+        // We hold (or held) the room's claim yet no actor lives here:
+        // every occupant has left and the actor is gone, or ownership
+        // moved after the producer's claim read.
+        //
+        // A terminate MUST still execute. The ordinary way to reach
+        // this arm is two occupants leaving at once — the first
+        // empties the room and tears the actor down, the second
+        // arrives to find nothing. The departing participant may well
+        // still hold an SFU registration and a live LiveKit session
+        // here, and only running the handler unregisters them and
+        // fires `RemoveParticipant`. Synthesizing a bare IQ result
+        // instead would tell the client the call ended while leaving
+        // their media session connected until the reconcile sweep
+        // eventually noticed. This mirrors the MUC-leave path, which
+        // deliberately tears the SFU participant down even when the
+        // room actor is already gone (`handlers/presence/muc.rs`).
+        // Terminate is never membership-gated, so executing it with no
+        // derived capabilities is exactly what the local path does.
+        GateOutcome::RoomNotLocal { room_jid } if is_terminate => {
+            let _ = room_jid;
+            None
+        }
+        // An initiate, though, genuinely cannot proceed: the requester
+        // is not an occupant of a live local room. Terminal denial,
+        // never a re-relay.
+        GateOutcome::RoomNotLocal { room_jid } => {
+            let error = jingle_muji_gate::deny_room_not_found(&room_jid, &sender.to_bare());
+            return Some(vec![build_iq_error_xml_typed(
+                id,
+                response_from.as_deref(),
+                Some(response_to.as_str()),
+                *error,
+            )]);
+        }
+    };
+
+    let ctx = ProtocolStanzaContext {
+        domain: state.deps.auth_state.xmpp_domain.as_str(),
+        full_jid: &sender,
+        media_capabilities,
+    };
+    let muji_terminate_room = jingle_muji_gate::muji_session_terminate_room(iq);
+    let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
+    let clear_after = muji_terminate_room.filter(|_| !events_contain_iq_error(&events));
+    let session = synthetic_session(&sender);
+    let deps = build_interpret_deps(state, Some(&session));
+    let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
+    // Mirror the local adapter's post-terminate Muji-presence clear. It
+    // has to run HERE, on the owner, because that is where the room
+    // actor and the SFU registration both live — running it on the
+    // client's replica would find neither.
+    if let Some(room_jid) = clear_after {
+        crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
+            state, &room_jid, &sender,
+        )
+        .await;
     }
+    Some(outcome.frames)
 }
 
 /// Minimal synthetic session for interpret-side owner checks, same
@@ -297,16 +302,34 @@ mod tests {
         );
     }
 
-    /// A hangup must never fail. Two occupants leaving at once is the
-    /// ordinary way to reach the owner with no room actor left: the
-    /// first terminate empties the room and tears the actor down, the
-    /// second finds nothing. Answering `<forbidden/>` ("join the MUC
-    /// first") to someone hanging up would be nonsense and would also
-    /// emit a bogus `room_not_found` denial.
+    /// A hangup must never fail, and must actually tear the media
+    /// session down. Two occupants leaving at once is the ordinary way
+    /// to reach the owner with no room actor left: the first empties
+    /// the room and tears the actor down, the second finds nothing.
+    ///
+    /// The regression this pins: synthesizing a bare IQ result for
+    /// that case told the client the call had ended while never
+    /// running the handler — so the participant kept their SFU
+    /// registration and their live LiveKit session until the reconcile
+    /// sweep eventually noticed. Registration state, not the reply
+    /// shape, is the assertion that matters here.
     #[tokio::test]
-    async fn relayed_terminate_after_the_room_actor_is_gone_still_succeeds() {
-        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    async fn relayed_terminate_tears_down_media_even_when_the_room_actor_is_gone() {
         let state = create_test_websocket_state_with_calls().await;
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+        let sfu = state
+            .deps
+            .protocol
+            .sfu
+            .as_ref()
+            .expect("the calls fixture wires an SFU");
+        // A registration with NO room actor for its room — exactly the
+        // state a departing occupant is left in when the last MUC leave
+        // tore the actor down before their Jingle terminate arrived.
+        let call = waddle_sfu::CallId::new("vanished@muc.example.com").expect("valid call id");
+        let identity = waddle_sfu::Identity::from_jid(alice.clone());
+        sfu.register_call_participant(&call, &identity);
+        assert!(sfu.has_call_participant(&call, &identity));
 
         let frames = handle_relayed_muji_initiate(
             &state,
@@ -315,21 +338,16 @@ mod tests {
         .await
         .expect("terminate executes");
 
-        assert_eq!(frames.len(), 1, "{frames:?}");
         assert!(
-            frames[0].contains("type='result'") || frames[0].contains("type=\"result\""),
-            "a hangup for a room whose actor is gone must be acked, not denied: {}",
-            frames[0]
+            !sfu.has_call_participant(&call, &identity),
+            "the hangup must unregister the participant even with no room actor; \
+             acking without executing would strand their LiveKit session"
         );
-        assert_eq!(
-            metrics
-                .counter_sum(
-                    "waddle.call.sfu_token.denied",
-                    &[("reason", "room_not_found")]
-                )
-                .unwrap_or(0),
-            0,
-            "a hangup is not a token denial"
+        assert!(
+            frames
+                .iter()
+                .any(|f| f.contains("type='result'") || f.contains("type=\"result\"")),
+            "and the client must still be told the hangup succeeded: {frames:?}"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
@@ -15,7 +15,8 @@
 use super::super::super::interpret_loop::build_interpret_deps;
 use super::super::super::transport_xml::build_iq_error_xml_typed;
 use super::super::super::WebSocketState;
-use super::jingle_muji_gate::{self, GateOutcome};
+use super::jingle_muji_gate::{self, GateInvocation, GateOutcome};
+use super::sans_io::events_contain_iq_error;
 use super::ProtocolStanzaContext;
 
 /// Execute a relayed Muji `session-initiate` on the room-owning node.
@@ -35,17 +36,36 @@ pub(crate) async fn handle_relayed_muji_initiate(
     let response_from = iq.to().map(|to| to.to_string());
     let response_to = jid::Jid::from(sender.clone()).to_string();
 
-    match jingle_muji_gate::verify_muji_jingle_request(state, &sender, iq).await {
+    match jingle_muji_gate::verify_muji_jingle_request(
+        state,
+        &sender,
+        iq,
+        GateInvocation::RelayedReplay,
+    )
+    .await
+    {
         GateOutcome::Allow { media_capabilities } => {
             let ctx = ProtocolStanzaContext {
                 domain: state.deps.auth_state.xmpp_domain.as_str(),
                 full_jid: &sender,
                 media_capabilities,
             };
+            let muji_terminate_room = jingle_muji_gate::muji_session_terminate_room(iq);
             let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
+            let clear_after = muji_terminate_room.filter(|_| !events_contain_iq_error(&events));
             let session = synthetic_session(&sender);
             let deps = build_interpret_deps(state, Some(&session));
             let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
+            // Mirror the local adapter's post-terminate Muji-presence
+            // clear. It has to run HERE, on the owner, because that is
+            // where the room actor and the SFU registration both live
+            // — running it on the client's replica would find neither.
+            if let Some(room_jid) = clear_after {
+                crate::server::routes::muc_muji_clear::clear_muji_presence_for_departure(
+                    state, &room_jid, &sender,
+                )
+                .await;
+            }
             Some(outcome.frames)
         }
         GateOutcome::Deny(error) => Some(vec![build_iq_error_xml_typed(
@@ -191,6 +211,69 @@ mod tests {
                 .iter()
                 .any(|f| f.contains("session-accept") && f.contains("<token")),
             "the focus session-accept with an issued token must be among the replies: {frames:?}"
+        );
+    }
+
+    fn muji_terminate_iq(from: &str, room: &str) -> Iq {
+        let jingle = Jingle::new(Action::SessionTerminate, SessionId("relay-sid".into()));
+        let mut elem: xmpp_parsers::minidom::Element = jingle.into();
+        elem.append_child(
+            Muji {
+                room: Some(room.parse().expect("valid room jid")),
+                preparing: false,
+                contents: vec![],
+            }
+            .to_element(),
+        );
+        Iq::Set {
+            from: Some(from.parse().expect("valid from jid")),
+            to: Some("calls.example.com".parse().expect("valid mixer jid")),
+            id: "relay-term-1".into(),
+            payload: elem,
+        }
+    }
+
+    /// #1445: an initiate registers the participant on the ROOM OWNER,
+    /// so the matching terminate has to unregister on that same node.
+    /// Executing it on the client's own replica would clear nothing
+    /// here, leaving a phantom in-call participant that also keeps the
+    /// call non-empty and so suppresses `DeleteRoom` for everyone
+    /// else. Asserted against the owner's SFU registry directly.
+    #[tokio::test]
+    async fn relayed_terminate_unregisters_on_the_owner() {
+        let state = create_test_websocket_state_with_calls().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+        create_room_and_join(&state, &room, "alice", &alice).await;
+        let sfu = state
+            .deps
+            .protocol
+            .sfu
+            .as_ref()
+            .expect("the calls fixture wires an SFU");
+        let call = waddle_sfu::CallId::new(room.to_string()).expect("room JID is a valid call id");
+        let identity = waddle_sfu::Identity::from_jid(alice.clone());
+
+        handle_relayed_muji_initiate(
+            &state,
+            &muji_initiate_iq(Some("alice@example.com/web"), "general@muc.example.com"),
+        )
+        .await
+        .expect("relayed initiate executes");
+        assert!(
+            sfu.has_call_participant(&call, &identity),
+            "the relayed initiate must register the participant on this node"
+        );
+
+        handle_relayed_muji_initiate(
+            &state,
+            &muji_terminate_iq("alice@example.com/web", "general@muc.example.com"),
+        )
+        .await
+        .expect("relayed terminate executes");
+        assert!(
+            !sfu.has_call_participant(&call, &identity),
+            "the relayed terminate must unregister on the node holding the registration"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
@@ -75,7 +75,15 @@ pub(crate) async fn handle_relayed_muji_initiate(
         // Terminate is never membership-gated, so executing it with no
         // derived capabilities is exactly what the local path does.
         GateOutcome::RoomNotLocal { room_jid } if is_terminate => {
-            let _ = room_jid;
+            // Worth a line: "we were relayed a Muji IQ for a room we
+            // hold the claim for, yet no actor lives here" is the most
+            // diagnostic state this whole path can be in.
+            tracing::debug!(
+                room = %room_jid,
+                user = %sender.to_bare(),
+                "relayed Muji terminate arrived after the room actor was gone; \
+                 executing the teardown anyway"
+            );
             None
         }
         // An initiate, though, genuinely cannot proceed: the requester

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/jingle_muji_relay.rs
@@ -1,0 +1,253 @@
+//! Owner-side executor for a Muji `session-initiate` relayed from the
+//! replica that received it (#1445).
+//!
+//! The producing replica had no local room actor, so it relayed the IQ
+//! over the ordered MUC proxy to the node holding the room's claim —
+//! this node. Here the membership gate re-runs against the local room
+//! actor (which holds the occupancy), the LiveKit token is minted with
+//! gate-derived capabilities, and the SFU participant is registered in
+//! THIS process's registry — consolidating call state on the room
+//! owner. The returned frames (the empty IQ ack and the
+//! server-initiated `session-accept` carrying the token) ride back to
+//! the origin node on the relay ACK and are written to the client's
+//! socket there.
+
+use super::super::super::interpret_loop::build_interpret_deps;
+use super::super::super::transport_xml::build_iq_error_xml_typed;
+use super::super::super::WebSocketState;
+use super::jingle_muji_gate::{self, GateOutcome};
+use super::ProtocolStanzaContext;
+
+/// Execute a relayed Muji `session-initiate` on the room-owning node.
+///
+/// Returns `None` only on a wire-shape failure (the IQ carries no full
+/// sender JID) — the caller NACKs the envelope as a parse failure.
+/// Every authorization outcome, including a denial, is `Some(frames)`:
+/// a delivered IQ-error is the correct reply for the client, not a
+/// relay failure, and returning it as frames prevents any re-relay
+/// loop — this executor is terminal.
+pub(crate) async fn handle_relayed_muji_initiate(
+    state: &WebSocketState,
+    iq: &xmpp_parsers::iq::Iq,
+) -> Option<Vec<String>> {
+    let sender = iq.from()?.clone().try_into_full().ok()?;
+    let id = iq.id();
+    let response_from = iq.to().map(|to| to.to_string());
+    let response_to = jid::Jid::from(sender.clone()).to_string();
+
+    match jingle_muji_gate::verify_muji_jingle_request(state, &sender, iq).await {
+        GateOutcome::Allow { media_capabilities } => {
+            let ctx = ProtocolStanzaContext {
+                domain: state.deps.auth_state.xmpp_domain.as_str(),
+                full_jid: &sender,
+                media_capabilities,
+            };
+            let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
+            let session = synthetic_session(&sender);
+            let deps = build_interpret_deps(state, Some(&session));
+            let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
+            Some(outcome.frames)
+        }
+        GateOutcome::Deny(error) => Some(vec![build_iq_error_xml_typed(
+            id,
+            response_from.as_deref(),
+            Some(response_to.as_str()),
+            *error,
+        )]),
+        GateOutcome::RoomNotLocal { room_jid } => {
+            // We hold (or held) the room's claim yet no actor lives
+            // here: every occupant has left and the actor is gone, or
+            // ownership moved after the producer's claim read. Either
+            // way the requester is not an occupant of a live local
+            // room — the terminal denial, never a re-relay.
+            let error = jingle_muji_gate::deny_room_not_found(&room_jid, &sender.to_bare());
+            Some(vec![build_iq_error_xml_typed(
+                id,
+                response_from.as_deref(),
+                Some(response_to.as_str()),
+                *error,
+            )])
+        }
+    }
+}
+
+/// Minimal synthetic session for interpret-side owner checks, same
+/// shape the other reserved MUC-proxy deliveries use.
+fn synthetic_session(sender: &jid::FullJid) -> crate::auth::Session {
+    let bare = sender.to_bare();
+    let localpart = bare
+        .node()
+        .map(|node| node.to_string())
+        .unwrap_or_else(|| bare.to_string());
+    crate::auth::Session::new(
+        bare.to_string().as_str(),
+        localpart.as_str(),
+        localpart.as_str(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_calls;
+    use jid::{BareJid, FullJid};
+    use waddle_xmpp::muc::room_actor::Join;
+    use waddle_xmpp::muc::room_registry_actor::CreateInstantRoom;
+    use waddle_xmpp::xep::xep0167::MediaKind;
+    use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+    use waddle_xmpp_core::{Affiliation, Role};
+    use xmpp_parsers::iq::Iq;
+    use xmpp_parsers::jingle::{
+        Action, Content, ContentId, Creator as JingleCreator, Jingle, SessionId,
+    };
+
+    fn muji_initiate_iq(from: Option<&str>, room: &str) -> Iq {
+        let mut content = Content::new(JingleCreator::Initiator, ContentId("audio".into()));
+        content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+            waddle_xmpp::xep::xep0167::opus_audio_description(),
+        ));
+        content.transport = Some(xmpp_parsers::jingle::Transport::Unknown(
+            waddle_xmpp::xep::xep_waddle_livekit_transport::WaddleLiveKitTransport::Request
+                .to_element(),
+        ));
+        // No `initiator` attribute: XEP-0166 §7.1 makes it optional
+        // and the handler resolves an omitted value to the
+        // authenticated session (a present value must equal the FULL
+        // sender JID, which varies per test case here).
+        let mut jingle = Jingle::new(Action::SessionInitiate, SessionId("relay-sid".into()));
+        jingle.contents.push(content);
+        let mut elem: xmpp_parsers::minidom::Element = jingle.into();
+        elem.append_child(
+            Muji {
+                room: Some(room.parse().expect("valid room jid")),
+                preparing: false,
+                contents: vec![MujiContent::new(
+                    "audio",
+                    Creator::Initiator,
+                    MediaKind::Audio,
+                )],
+            }
+            .to_element(),
+        );
+        Iq::Set {
+            from: from.map(|f| f.parse().expect("valid from jid")),
+            to: Some("calls.example.com".parse().expect("valid mixer jid")),
+            id: "relay-1".into(),
+            payload: elem,
+        }
+    }
+
+    async fn create_room_and_join(
+        state: &crate::server::routes::websocket::WebSocketState,
+        room: &BareJid,
+        nick: &str,
+        jid: &FullJid,
+    ) {
+        let actor = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(CreateInstantRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("create instant room")
+            .actor_ref;
+        actor
+            .ask(Join {
+                nick: nick.to_string(),
+                real_jid: jid.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+    }
+
+    /// The relayed mint on the owner: gate passes against the local
+    /// room actor and the reply frames carry the IQ ack plus the
+    /// focus's `session-accept` with an issued token — exactly what
+    /// rides back to the origin node as client replies.
+    #[tokio::test]
+    async fn occupant_relayed_initiate_mints_and_returns_ack_and_accept() {
+        let state = create_test_websocket_state_with_calls().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let iq = muji_initiate_iq(Some("alice@example.com/web"), "general@muc.example.com");
+        let frames = handle_relayed_muji_initiate(&state, &iq)
+            .await
+            .expect("well-formed relayed IQ executes");
+
+        assert!(
+            frames
+                .iter()
+                .any(|f| f.contains("type='result'") || f.contains("type=\"result\"")),
+            "the IQ ack must be among the replies: {frames:?}"
+        );
+        assert!(
+            frames
+                .iter()
+                .any(|f| f.contains("session-accept") && f.contains("<token")),
+            "the focus session-accept with an issued token must be among the replies: {frames:?}"
+        );
+    }
+
+    /// A non-occupant relayed to the owner is denied as a delivered
+    /// IQ-error frame — never a relay NACK, so no re-relay loop.
+    #[tokio::test]
+    async fn non_occupant_relayed_initiate_returns_forbidden_frame() {
+        let state = create_test_websocket_state_with_calls().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let iq = muji_initiate_iq(
+            Some("mallory@example.com/laptop"),
+            "general@muc.example.com",
+        );
+        let frames = handle_relayed_muji_initiate(&state, &iq)
+            .await
+            .expect("a denial is a delivered reply, not a shape failure");
+
+        assert_eq!(frames.len(), 1, "exactly the IQ error: {frames:?}");
+        assert!(
+            frames[0].contains("<forbidden") && frames[0].contains("relay-1"),
+            "denial must be the forbidden IQ error for the original id: {}",
+            frames[0]
+        );
+    }
+
+    /// Ownership moved (or the room died) after the producer's claim
+    /// read: no local actor here either. Terminal denial, no re-relay.
+    #[tokio::test]
+    async fn missing_room_on_owner_returns_terminal_room_not_found_frame() {
+        let state = create_test_websocket_state_with_calls().await;
+
+        let iq = muji_initiate_iq(Some("alice@example.com/web"), "ghost@muc.example.com");
+        let frames = handle_relayed_muji_initiate(&state, &iq)
+            .await
+            .expect("terminal denial is a delivered reply");
+
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].contains("<forbidden"), "{}", frames[0]);
+    }
+
+    /// No full sender JID is a wire-shape failure: the caller NACKs
+    /// the envelope instead of replying.
+    #[tokio::test]
+    async fn bare_or_missing_sender_is_a_shape_failure() {
+        let state = create_test_websocket_state_with_calls().await;
+
+        let no_from = muji_initiate_iq(None, "general@muc.example.com");
+        assert!(handle_relayed_muji_initiate(&state, &no_from)
+            .await
+            .is_none());
+
+        let bare_from = muji_initiate_iq(Some("alice@example.com"), "general@muc.example.com");
+        assert!(handle_relayed_muji_initiate(&state, &bare_from)
+            .await
+            .is_none());
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -92,6 +92,8 @@ mod extension_forms;
 mod extension_route_items;
 mod full_jid_forward;
 mod jingle_muji_gate;
+#[cfg(feature = "clustering")]
+pub(crate) mod jingle_muji_relay;
 mod last_activity;
 mod link_preview_lookup;
 pub(crate) mod link_preview_player_embed;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -338,17 +338,7 @@ async fn relay_muji_to_room_owner(
             *super::jingle_muji_gate::deny_room_not_found(room_jid, &full_jid.to_bare()),
         )]
     };
-    let retry_later = || {
-        // `record_sfu_token_denial` already records the call-setup
-        // attempted/failed pair via `setup_failure_reason`, so this
-        // must NOT also call `record_call_setup_rejected` — doing both
-        // double-counted every relay failure in exactly the #1452 SLI
-        // this path exists to feed.
-        super::super::super::call_signaling_telemetry::record_sfu_token_denial(
-            room_jid,
-            &full_jid.to_bare(),
-            waddle_xmpp::telemetry::attributes::SfuDenialReason::InternalError,
-        );
+    let relay_error_frames = || {
         vec![build_iq_error_xml_typed(
             reply.id,
             reply.response_from,
@@ -358,6 +348,36 @@ async fn relay_muji_to_room_owner(
                  please retry",
             ),
         )]
+    };
+    // The owner was definitely never reached, so this attempt ended
+    // here and nowhere else: record it, once, as a relay failure.
+    //
+    // NOT as an SFU token denial — the membership gate did not reject
+    // this request, it never ran. Routing relay outages into
+    // `sfu_token.denied` / `membership_check_failed` would make a
+    // clustering incident read as a permissions problem.
+    let relay_failed = || {
+        waddle_xmpp::telemetry::call::record_call_setup_rejected(
+            waddle_xmpp::telemetry::attributes::CallSetupFailureReason::OwnerUnreachable,
+        );
+        relay_error_frames()
+    };
+    // The owner MAY have executed this already and recorded its own
+    // terminal outcome (`setup.ok`, or a failure of its own). Counting
+    // a failure here too would let one client attempt appear as both
+    // succeeded and failed, breaking the exactly-one-terminal-outcome
+    // property `setup.ok / setup.attempted` depends on. An uncounted
+    // ambiguous attempt is the honest treatment of "we don't know";
+    // the log carries the diagnosis.
+    let relay_uncertain = |reason: &'static str| {
+        tracing::warn!(
+            room = %room_jid,
+            user = %full_jid.to_bare(),
+            reason,
+            "Muji relay outcome is uncertain; the room owner may or may not have \
+             executed this request, so no call-setup outcome is recorded for it"
+        );
+        relay_error_frames()
     };
 
     // The relay's envelope validation requires a bare `to` naming the
@@ -432,9 +452,11 @@ async fn relay_muji_to_room_owner(
         // would otherwise return `Some(vec![])`, which the caller
         // treats as terminal — the client's IQ would get no result and
         // no error, and the call would silently never start.
+        // `Delivered` with no frames (`QueuedDetached`) means the owner
+        // took it — outcome unknown to us, and its own.
         MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(_)) => {
             unrelayable_after_relay_failure("delivered_without_replies");
-            unrelayable(&retry_later)
+            unrelayable(&|| relay_uncertain("delivered_without_replies"))
         }
         // No node owns the room (or this one does, with no actor): the
         // local fallback for a terminate genuinely IS a no-op, because
@@ -442,22 +464,28 @@ async fn relay_muji_to_room_owner(
         MucProxyRouteDecision::RoomUnclaimed | MucProxyRouteDecision::LocalRoom => {
             unrelayable(&deny)
         }
+        // Definitely not delivered: the attempt ended here.
         MucProxyRouteDecision::Attempted(
-            OrderedRelayMucProxyOutcome::Unavailable
-            | OrderedRelayMucProxyOutcome::Dropped
-            | OrderedRelayMucProxyOutcome::MaybeCommitted
-            | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
+            OrderedRelayMucProxyOutcome::Unavailable | OrderedRelayMucProxyOutcome::Dropped,
         ) => {
             unrelayable_after_relay_failure("relay_delivery_failed");
-            unrelayable(&retry_later)
+            unrelayable(&relay_failed)
+        }
+        // Ambiguous by construction — the owner may have committed it.
+        MucProxyRouteDecision::Attempted(
+            OrderedRelayMucProxyOutcome::MaybeCommitted
+            | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
+        ) => {
+            unrelayable_after_relay_failure("relay_maybe_committed");
+            unrelayable(&|| relay_uncertain("relay_maybe_committed"))
         }
         MucProxyRouteDecision::RoomClaimUnavailable => {
             unrelayable_after_relay_failure("room_claim_unavailable");
-            unrelayable(&retry_later)
+            unrelayable(&relay_failed)
         }
         MucProxyRouteDecision::OriginUnavailable => {
             unrelayable_after_relay_failure("origin_unavailable");
-            unrelayable(&retry_later)
+            unrelayable(&relay_failed)
         }
     }
 }
@@ -540,6 +568,29 @@ mod tests {
     use xmpp_parsers::iq::Iq;
     use xmpp_parsers::jingle::{Action, Jingle, SessionId};
 
+    fn muji_initiate_iq(room: &str) -> Iq {
+        let jingle = Jingle::new(Action::SessionInitiate, SessionId("i-sid".into()));
+        let mut elem: xmpp_parsers::minidom::Element = jingle.into();
+        elem.append_child(
+            Muji {
+                room: Some(room.parse().expect("valid room jid")),
+                preparing: false,
+                contents: vec![MujiContent::new(
+                    "audio",
+                    Creator::Initiator,
+                    MediaKind::Audio,
+                )],
+            }
+            .to_element(),
+        );
+        Iq::Set {
+            from: Some("alice@example.com/web".parse().expect("valid full jid")),
+            to: Some("calls.example.com".parse().expect("valid mixer jid")),
+            id: "init-1".into(),
+            payload: elem,
+        }
+    }
+
     fn muji_terminate_iq(room: &str) -> Iq {
         let jingle = Jingle::new(Action::SessionTerminate, SessionId("t-sid".into()));
         let mut elem: xmpp_parsers::minidom::Element = jingle.into();
@@ -561,6 +612,59 @@ mod tests {
             id: "term-1".into(),
             payload: elem,
         }
+    }
+
+    /// #1445: a relay failure is not a membership decision. Routing it
+    /// through the SFU token-denial counter classified it as
+    /// `membership_check_failed`, which would make a clustering
+    /// incident read as a permissions problem on the very dashboards
+    /// used to diagnose it. It must land in its own bucket, and must
+    /// not touch `sfu_token.denied` at all — the gate never ran.
+    #[tokio::test(flavor = "current_thread")]
+    async fn definite_relay_failure_is_attributed_to_the_owner_not_the_membership_gate() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let state = create_test_websocket_state_with_calls().await;
+        let alice: jid::FullJid = "alice@example.com/web".parse().unwrap();
+        let room: jid::BareJid = "general@muc.example.com".parse().unwrap();
+        let mut carbons = false;
+        let mut roster = false;
+        let mut blocklist = false;
+        let conn_state = super::IqConnState {
+            carbons_enabled: &mut carbons,
+            roster_interested: &mut roster,
+            blocklist_interested: &mut blocklist,
+            registry_owner: None,
+            state_machine: None,
+            ordered_relay_origin: None,
+        };
+
+        // An INITIATE (not a terminate — those fall back silently) for
+        // a room with no relay substrate: a definite, terminal failure.
+        let outcome = super::relay_muji_to_room_owner(
+            &state,
+            &conn_state,
+            &alice,
+            &muji_initiate_iq("general@muc.example.com"),
+            &room,
+            super::IqReplyAddressing {
+                id: "init-1",
+                response_from: Some("calls.example.com"),
+                response_to: Some("alice@example.com/web"),
+            },
+        )
+        .await;
+        assert!(matches!(outcome, super::MujiRelayOutcome::Frames(_)));
+
+        assert_eq!(
+            metrics
+                .counter_sum(
+                    "waddle.call.setup.failed",
+                    &[("reason", "membership_check_failed")]
+                )
+                .unwrap_or(0),
+            0,
+            "a relay failure must not be blamed on the membership check"
+        );
     }
 
     /// #1445: a cross-node hangup falls back to local execution when

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -289,12 +289,19 @@ async fn relay_muji_to_room_owner(
     // A terminate that cannot be relayed falls back to this node
     // instead of erroring; an initiate that cannot be relayed is a
     // real failure the client must see.
+    //
+    // The error builders are passed as closures and invoked ONLY on
+    // the initiate branch. They have telemetry side effects (a denial
+    // counter, a call-setup failure, a WARN naming the room and user),
+    // and a hangup is neither a token denial nor a call-setup attempt
+    // — evaluating them eagerly would fabricate `room_not_found`
+    // denials on every cross-node teardown.
     let is_terminate = super::jingle_muji_gate::muji_session_terminate_room(iq).is_some();
-    let unrelayable = |frames: Vec<String>| {
+    let unrelayable = |frames: &dyn Fn() -> Vec<String>| {
         if is_terminate {
             MujiRelayOutcome::ProcessLocally
         } else {
-            MujiRelayOutcome::Frames(frames)
+            MujiRelayOutcome::Frames(frames())
         }
     };
 
@@ -307,9 +314,11 @@ async fn relay_muji_to_room_owner(
         )]
     };
     let retry_later = || {
-        waddle_xmpp::telemetry::call::record_call_setup_rejected(
-            waddle_xmpp::telemetry::attributes::CallSetupFailureReason::MembershipCheckFailed,
-        );
+        // `record_sfu_token_denial` already records the call-setup
+        // attempted/failed pair via `setup_failure_reason`, so this
+        // must NOT also call `record_call_setup_rejected` — doing both
+        // double-counted every relay failure in exactly the #1452 SLI
+        // this path exists to feed.
         super::super::super::call_signaling_telemetry::record_sfu_token_denial(
             room_jid,
             &full_jid.to_bare(),
@@ -344,7 +353,7 @@ async fn relay_muji_to_room_owner(
     let room_is_local =
         room_jid.domain().as_str() == format!("muc.{}", state.deps.auth_state.xmpp_domain.as_str());
     if !addressed_to_mixer || !room_is_local {
-        return unrelayable(deny());
+        return unrelayable(&deny);
     }
 
     let bridge = state
@@ -356,7 +365,7 @@ async fn relay_muji_to_room_owner(
     let (Some(bridge), Some(origin)) = (bridge, conn_state.ordered_relay_origin.as_ref()) else {
         // No relay substrate (clustering disabled at runtime): local
         // absence is definitive, exactly the pre-#1445 semantics.
-        return unrelayable(deny());
+        return unrelayable(&deny);
     };
     // Stamp the authenticated full JID as `from` before relaying:
     // clients legitimately omit `from` (the server derives the sender
@@ -397,10 +406,10 @@ async fn relay_muji_to_room_owner(
         // treats as terminal — the client's IQ would get no result and
         // no error, and the call would silently never start.
         MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(_)) => {
-            unrelayable(retry_later())
+            unrelayable(&retry_later)
         }
         MucProxyRouteDecision::RoomUnclaimed | MucProxyRouteDecision::LocalRoom => {
-            unrelayable(deny())
+            unrelayable(&deny)
         }
         MucProxyRouteDecision::Attempted(
             OrderedRelayMucProxyOutcome::Unavailable
@@ -409,7 +418,7 @@ async fn relay_muji_to_room_owner(
             | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
         )
         | MucProxyRouteDecision::RoomClaimUnavailable
-        | MucProxyRouteDecision::OriginUnavailable => unrelayable(retry_later()),
+        | MucProxyRouteDecision::OriginUnavailable => unrelayable(&retry_later),
     }
 }
 
@@ -481,4 +490,100 @@ async fn mirror_remote_carbons_update(
     _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
     _enabled: bool,
 ) {
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_calls;
+    use waddle_xmpp::xep::xep0167::MediaKind;
+    use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+    use xmpp_parsers::iq::Iq;
+    use xmpp_parsers::jingle::{Action, Jingle, SessionId};
+
+    fn muji_terminate_iq(room: &str) -> Iq {
+        let jingle = Jingle::new(Action::SessionTerminate, SessionId("t-sid".into()));
+        let mut elem: xmpp_parsers::minidom::Element = jingle.into();
+        elem.append_child(
+            Muji {
+                room: Some(room.parse().expect("valid room jid")),
+                preparing: false,
+                contents: vec![MujiContent::new(
+                    "audio",
+                    Creator::Initiator,
+                    MediaKind::Audio,
+                )],
+            }
+            .to_element(),
+        );
+        Iq::Set {
+            from: Some("alice@example.com/web".parse().expect("valid full jid")),
+            to: Some("calls.example.com".parse().expect("valid mixer jid")),
+            id: "term-1".into(),
+            payload: elem,
+        }
+    }
+
+    /// #1445: a cross-node hangup falls back to local execution when
+    /// it cannot be relayed, and that fallback must be SILENT. The
+    /// error builders it bypasses carry telemetry side effects — a
+    /// token-denial counter, a call-setup failure, a WARN naming the
+    /// room and user — and a hangup is neither a token denial nor a
+    /// call-setup attempt. Evaluating them eagerly (rather than as
+    /// closures behind the initiate branch) fabricated a
+    /// `room_not_found` denial on every cross-node teardown, including
+    /// every hangup for a non-local room on a single-node deployment.
+    #[tokio::test(flavor = "current_thread")]
+    async fn unrelayable_terminate_records_no_denial_telemetry() {
+        let metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+        let state = create_test_websocket_state_with_calls().await;
+        let alice: jid::FullJid = "alice@example.com/web".parse().unwrap();
+        let room: jid::BareJid = "general@muc.example.com".parse().unwrap();
+        let mut carbons = false;
+        let mut roster = false;
+        let mut blocklist = false;
+        let conn_state = super::IqConnState {
+            carbons_enabled: &mut carbons,
+            roster_interested: &mut roster,
+            blocklist_interested: &mut blocklist,
+            registry_owner: None,
+            state_machine: None,
+            ordered_relay_origin: None,
+        };
+
+        let outcome = super::relay_muji_to_room_owner(
+            &state,
+            &conn_state,
+            &alice,
+            &muji_terminate_iq("general@muc.example.com"),
+            &room,
+            super::IqReplyAddressing {
+                id: "term-1",
+                response_from: Some("calls.example.com"),
+                response_to: Some("alice@example.com/web"),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, super::MujiRelayOutcome::ProcessLocally),
+            "an unrelayable terminate must fall back to local execution"
+        );
+        assert_eq!(
+            metrics
+                .counter_sum(
+                    "waddle.call.sfu_token.denied",
+                    &[("reason", "room_not_found")]
+                )
+                .unwrap_or(0),
+            0,
+            "a hangup must not record a token denial"
+        );
+        assert_eq!(
+            metrics
+                .counter_sum("waddle.call.setup.attempted", &[])
+                .unwrap_or(0),
+            0,
+            "a hangup is not a call-setup attempt"
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -149,6 +149,24 @@ pub(super) async fn handle_sans_io_iq(
                         *stanza_error,
                     )]);
                 }
+                super::jingle_muji_gate::GateOutcome::RoomNotLocal { room_jid } => {
+                    // #1445: no room actor in this process. On a
+                    // clustered deployment the room may be alive on the
+                    // claim-owning node — relay the session-initiate
+                    // there instead of denying a join for a room that
+                    // exists.
+                    let reply = IqReplyAddressing {
+                        id,
+                        response_from,
+                        response_to,
+                    };
+                    return Some(
+                        relay_muji_initiate_or_deny(
+                            state, conn_state, full_jid, iq, &room_jid, reply,
+                        )
+                        .await,
+                    );
+                }
             }
         }
         let ctx = ProtocolStanzaContext {
@@ -196,6 +214,134 @@ pub(super) async fn handle_sans_io_iq(
         return Some(outcome.frames);
     }
     None
+}
+
+/// Resolve a Muji `session-initiate` whose room has no local actor
+/// (#1445): relay it to the room's claim-owning node over the ordered
+/// MUC proxy — the owner runs the gate + mint where the occupancy
+/// lives, and its replies (the IQ ack and the server-initiated
+/// `session-accept` carrying the LiveKit token) ride back on the relay
+/// ACK to be written to this socket. Outcome mapping:
+/// - `Delivered` → the owner's reply frames, verbatim.
+/// - `RoomUnclaimed` → no node owns the room, so it genuinely does not
+///   exist: the terminal `room_not_found` denial (same wire shape and
+///   telemetry as ever).
+/// - everything else (claim unavailable, origin unavailable, relay
+///   dropped/maybe-committed, claim-says-local race) → a `type='wait'`
+///   internal-server-error so the client retries; a duplicate mint on
+///   retry is harmless (set-insert registration, superseding token).
+#[cfg(feature = "clustering")]
+async fn relay_muji_initiate_or_deny(
+    state: &WebSocketState,
+    conn_state: &IqConnState<'_>,
+    full_jid: &FullJid,
+    iq: &xmpp_parsers::iq::Iq,
+    room_jid: &jid::BareJid,
+    reply: IqReplyAddressing<'_>,
+) -> Vec<String> {
+    use crate::clustering::ordered_relay::OrderedRelayMucProxyKind;
+    use crate::clustering::route_bridge::{MucProxyRouteDecision, OrderedRelayMucProxyOutcome};
+
+    let deny = || {
+        vec![build_iq_error_xml_typed(
+            reply.id,
+            reply.response_from,
+            reply.response_to,
+            *super::jingle_muji_gate::deny_room_not_found(room_jid, &full_jid.to_bare()),
+        )]
+    };
+    let retry_later = || {
+        vec![build_iq_error_xml_typed(
+            reply.id,
+            reply.response_from,
+            reply.response_to,
+            internal_server_error_iq_error(
+                "the requested room is owned by another node and could not be reached; \
+                 please retry",
+            ),
+        )]
+    };
+
+    let bridge = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref();
+    let (Some(bridge), Some(origin)) = (bridge, conn_state.ordered_relay_origin.as_ref()) else {
+        // No relay substrate (clustering disabled at runtime): local
+        // absence is definitive, exactly the pre-#1445 semantics.
+        return deny();
+    };
+    // Stamp the authenticated full JID as `from` before relaying:
+    // clients legitimately omit `from` (the server derives the sender
+    // from the bound session), but the envelope's sender-claim
+    // validation and the owner-side executor both read the stanza's
+    // `from`. Unconditional overwrite — a client-supplied `from` is
+    // never trusted.
+    let mut relayed = iq.clone();
+    let stamped_from = Some(jid::Jid::from(full_jid.clone()));
+    match &mut relayed {
+        xmpp_parsers::iq::Iq::Get { from, .. }
+        | xmpp_parsers::iq::Iq::Set { from, .. }
+        | xmpp_parsers::iq::Iq::Result { from, .. }
+        | xmpp_parsers::iq::Iq::Error { from, .. } => *from = stamped_from,
+    }
+    let stanza = waddle_xmpp::Stanza::Iq(Box::new(relayed));
+    match bridge
+        .try_proxy_muc_remote_decision(
+            room_jid,
+            &stanza,
+            OrderedRelayMucProxyKind::MujiJingleIq,
+            origin,
+        )
+        .await
+    {
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(replies)) => {
+            replies
+                .iter()
+                .map(crate::server::routes::websocket::transport_xml::stanza_to_xml)
+                .collect()
+        }
+        MucProxyRouteDecision::RoomUnclaimed => deny(),
+        MucProxyRouteDecision::Attempted(
+            OrderedRelayMucProxyOutcome::Unavailable
+            | OrderedRelayMucProxyOutcome::Dropped
+            | OrderedRelayMucProxyOutcome::MaybeCommitted
+            | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
+        )
+        | MucProxyRouteDecision::LocalRoom
+        | MucProxyRouteDecision::RoomClaimUnavailable
+        | MucProxyRouteDecision::OriginUnavailable => retry_later(),
+    }
+}
+
+/// Non-clustering builds have no other replica that could own the
+/// room, so local absence is definitive — the terminal denial,
+/// byte-identical to the pre-#1445 wire behavior.
+#[cfg(not(feature = "clustering"))]
+async fn relay_muji_initiate_or_deny(
+    _state: &WebSocketState,
+    _conn_state: &IqConnState<'_>,
+    full_jid: &FullJid,
+    _iq: &xmpp_parsers::iq::Iq,
+    room_jid: &jid::BareJid,
+    reply: IqReplyAddressing<'_>,
+) -> Vec<String> {
+    vec![build_iq_error_xml_typed(
+        reply.id,
+        reply.response_from,
+        reply.response_to,
+        *super::jingle_muji_gate::deny_room_not_found(room_jid, &full_jid.to_bare()),
+    )]
+}
+
+/// The (id, from, to) triple every IQ error reply is stamped with —
+/// bundled so the relay helper's signature stays readable.
+struct IqReplyAddressing<'a> {
+    id: &'a str,
+    response_from: Option<&'a str>,
+    response_to: Option<&'a str>,
 }
 
 #[cfg(feature = "clustering")]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn events_contain_iq_error(events: &[waddle_xmpp::protocol::OutboundEvent]) -> bool {
+pub(super) fn events_contain_iq_error(events: &[waddle_xmpp::protocol::OutboundEvent]) -> bool {
     use waddle_xmpp::protocol::OutboundEvent;
     use waddle_xmpp::Stanza;
     events.iter().any(|event| {
@@ -131,7 +131,14 @@ pub(super) async fn handle_sans_io_iq(
         // child — 1:1 Jingle traffic passes through untouched.
         let mut media_capabilities = None;
         if payload_ns == waddle_xmpp::xep::xep0166::NS_JINGLE {
-            match super::jingle_muji_gate::verify_muji_jingle_request(state, full_jid, iq).await {
+            match super::jingle_muji_gate::verify_muji_jingle_request(
+                state,
+                full_jid,
+                iq,
+                super::jingle_muji_gate::GateInvocation::ClientOrigin,
+            )
+            .await
+            {
                 super::jingle_muji_gate::GateOutcome::Allow {
                     media_capabilities: gate_capabilities,
                 } => {
@@ -152,20 +159,27 @@ pub(super) async fn handle_sans_io_iq(
                 super::jingle_muji_gate::GateOutcome::RoomNotLocal { room_jid } => {
                     // #1445: no room actor in this process. On a
                     // clustered deployment the room may be alive on the
-                    // claim-owning node — relay the session-initiate
-                    // there instead of denying a join for a room that
-                    // exists.
+                    // claim-owning node — relay the Muji IQ there
+                    // instead of answering for a room that exists
+                    // elsewhere.
                     let reply = IqReplyAddressing {
                         id,
                         response_from,
                         response_to,
                     };
-                    return Some(
-                        relay_muji_initiate_or_deny(
-                            state, conn_state, full_jid, iq, &room_jid, reply,
-                        )
-                        .await,
-                    );
+                    match relay_muji_to_room_owner(
+                        state, conn_state, full_jid, iq, &room_jid, reply,
+                    )
+                    .await
+                    {
+                        MujiRelayOutcome::Frames(frames) => return Some(frames),
+                        // Terminate could not be relayed. Fall through
+                        // to local dispatch, which is what this path
+                        // did before the relay existed: unregistering
+                        // is idempotent, so a local no-op is strictly
+                        // better than failing the client's hangup.
+                        MujiRelayOutcome::ProcessLocally => {}
+                    }
                 }
             }
         }
@@ -216,31 +230,73 @@ pub(super) async fn handle_sans_io_iq(
     None
 }
 
-/// Resolve a Muji `session-initiate` whose room has no local actor
-/// (#1445): relay it to the room's claim-owning node over the ordered
-/// MUC proxy — the owner runs the gate + mint where the occupancy
-/// lives, and its replies (the IQ ack and the server-initiated
-/// `session-accept` carrying the LiveKit token) ride back on the relay
-/// ACK to be written to this socket. Outcome mapping:
-/// - `Delivered` → the owner's reply frames, verbatim.
-/// - `RoomUnclaimed` → no node owns the room, so it genuinely does not
-///   exist: the terminal `room_not_found` denial (same wire shape and
-///   telemetry as ever).
-/// - everything else (claim unavailable, origin unavailable, relay
-///   dropped/maybe-committed, claim-says-local race) → a `type='wait'`
-///   internal-server-error so the client retries; a duplicate mint on
-///   retry is harmless (set-insert registration, superseding token).
+/// What the caller should do after a relay attempt.
 #[cfg(feature = "clustering")]
-async fn relay_muji_initiate_or_deny(
+enum MujiRelayOutcome {
+    /// Terminal: send these frames to the client.
+    Frames(Vec<String>),
+    /// Non-terminal: handle the IQ on this node after all. Only ever
+    /// returned for `session-terminate`, whose local execution is an
+    /// idempotent no-op and therefore a better answer than an error.
+    ProcessLocally,
+}
+
+/// Resolve a Muji IQ whose room has no local actor (#1445): relay it
+/// to the room's claim-owning node over the ordered MUC proxy — the
+/// owner runs the gate, mint, and registry mutation where the
+/// occupancy lives, and its replies (for an initiate: the IQ ack and
+/// the server-initiated `session-accept` carrying the LiveKit token)
+/// ride back on the relay ACK to be written to this socket.
+///
+/// `session-terminate` is relayed too, and must be: since an initiate
+/// registers the participant on the OWNER, a terminate executed here
+/// would clear nothing there, leaving a phantom in-call participant
+/// that also suppresses `DeleteRoom` for everyone else in the room.
+/// When a terminate cannot be relayed it degrades to local execution
+/// rather than an error.
+///
+/// Outcome mapping for an initiate:
+/// - `Delivered` with frames → the owner's reply frames, verbatim.
+/// - `RoomUnclaimed` and `LocalRoom` → terminal `room_not_found`
+///   denial. `LocalRoom` belongs here, not in the retry bucket: it
+///   means the claim store says THIS node owns the room while the gate
+///   found no local actor, so the room has no occupants and no retry
+///   can change that — the same conclusion the owner-side executor
+///   reaches. Retrying would loop forever against a stale claim row.
+/// - everything else (claim unavailable, origin unavailable, relay
+///   dropped/maybe-committed, or a `Delivered` carrying no frames) → a
+///   `type='wait'` internal-server-error so the client retries; a
+///   duplicate mint on retry is harmless (set-insert registration,
+///   superseding token).
+///
+/// Every terminal arm records call-setup telemetry — `deny` through
+/// [`deny_room_not_found`], `retry_later` explicitly — because a relay
+/// failure is a complete, client-visible call-setup attempt. Leaving
+/// it uncounted would hide exactly the cross-node failure class #1445
+/// exists to fix (#1452).
+#[cfg(feature = "clustering")]
+async fn relay_muji_to_room_owner(
     state: &WebSocketState,
     conn_state: &IqConnState<'_>,
     full_jid: &FullJid,
     iq: &xmpp_parsers::iq::Iq,
     room_jid: &jid::BareJid,
     reply: IqReplyAddressing<'_>,
-) -> Vec<String> {
+) -> MujiRelayOutcome {
     use crate::clustering::ordered_relay::OrderedRelayMucProxyKind;
     use crate::clustering::route_bridge::{MucProxyRouteDecision, OrderedRelayMucProxyOutcome};
+
+    // A terminate that cannot be relayed falls back to this node
+    // instead of erroring; an initiate that cannot be relayed is a
+    // real failure the client must see.
+    let is_terminate = super::jingle_muji_gate::muji_session_terminate_room(iq).is_some();
+    let unrelayable = |frames: Vec<String>| {
+        if is_terminate {
+            MujiRelayOutcome::ProcessLocally
+        } else {
+            MujiRelayOutcome::Frames(frames)
+        }
+    };
 
     let deny = || {
         vec![build_iq_error_xml_typed(
@@ -251,6 +307,14 @@ async fn relay_muji_initiate_or_deny(
         )]
     };
     let retry_later = || {
+        waddle_xmpp::telemetry::call::record_call_setup_rejected(
+            waddle_xmpp::telemetry::attributes::CallSetupFailureReason::MembershipCheckFailed,
+        );
+        super::super::super::call_signaling_telemetry::record_sfu_token_denial(
+            room_jid,
+            &full_jid.to_bare(),
+            waddle_xmpp::telemetry::attributes::SfuDenialReason::InternalError,
+        );
         vec![build_iq_error_xml_typed(
             reply.id,
             reply.response_from,
@@ -262,6 +326,27 @@ async fn relay_muji_initiate_or_deny(
         )]
     };
 
+    // The relay's envelope validation requires a bare `to` naming the
+    // calls mixer; anything else is NACKed as a parse failure by the
+    // receiver, which diverts the shared ordered channel and would
+    // silently break this sender's ordinary MUC traffic for the room.
+    // A client controls `to`, so reject the shape here rather than
+    // letting a malformed (or hostile) one reach the relay at all.
+    // Same for a room outside this server's MUC domain: it can have no
+    // local claim, so relaying it only buys a claim-store lookup.
+    let addressed_to_mixer = iq.to().is_some_and(|to| {
+        to.resource().is_none()
+            && to.to_bare()
+                == waddle_xmpp::protocol::handlers::jingle::calls_mixer_jid(
+                    state.deps.auth_state.xmpp_domain.as_str(),
+                )
+    });
+    let room_is_local =
+        room_jid.domain().as_str() == format!("muc.{}", state.deps.auth_state.xmpp_domain.as_str());
+    if !addressed_to_mixer || !room_is_local {
+        return unrelayable(deny());
+    }
+
     let bridge = state
         .deps
         .app_state
@@ -271,7 +356,7 @@ async fn relay_muji_initiate_or_deny(
     let (Some(bridge), Some(origin)) = (bridge, conn_state.ordered_relay_origin.as_ref()) else {
         // No relay substrate (clustering disabled at runtime): local
         // absence is definitive, exactly the pre-#1445 semantics.
-        return deny();
+        return unrelayable(deny());
     };
     // Stamp the authenticated full JID as `from` before relaying:
     // clients legitimately omit `from` (the server derives the sender
@@ -297,22 +382,34 @@ async fn relay_muji_initiate_or_deny(
         )
         .await
     {
-        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(replies)) => {
-            replies
-                .iter()
-                .map(crate::server::routes::websocket::transport_xml::stanza_to_xml)
-                .collect()
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(replies))
+            if !replies.is_empty() =>
+        {
+            MujiRelayOutcome::Frames(
+                replies
+                    .iter()
+                    .map(crate::server::routes::websocket::transport_xml::stanza_to_xml)
+                    .collect(),
+            )
         }
-        MucProxyRouteDecision::RoomUnclaimed => deny(),
+        // A `Delivered` carrying no frames (e.g. `QueuedDetached`)
+        // would otherwise return `Some(vec![])`, which the caller
+        // treats as terminal — the client's IQ would get no result and
+        // no error, and the call would silently never start.
+        MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(_)) => {
+            unrelayable(retry_later())
+        }
+        MucProxyRouteDecision::RoomUnclaimed | MucProxyRouteDecision::LocalRoom => {
+            unrelayable(deny())
+        }
         MucProxyRouteDecision::Attempted(
             OrderedRelayMucProxyOutcome::Unavailable
             | OrderedRelayMucProxyOutcome::Dropped
             | OrderedRelayMucProxyOutcome::MaybeCommitted
             | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
         )
-        | MucProxyRouteDecision::LocalRoom
         | MucProxyRouteDecision::RoomClaimUnavailable
-        | MucProxyRouteDecision::OriginUnavailable => retry_later(),
+        | MucProxyRouteDecision::OriginUnavailable => unrelayable(retry_later()),
     }
 }
 
@@ -320,20 +417,29 @@ async fn relay_muji_initiate_or_deny(
 /// room, so local absence is definitive — the terminal denial,
 /// byte-identical to the pre-#1445 wire behavior.
 #[cfg(not(feature = "clustering"))]
-async fn relay_muji_initiate_or_deny(
+enum MujiRelayOutcome {
+    Frames(Vec<String>),
+    ProcessLocally,
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn relay_muji_to_room_owner(
     _state: &WebSocketState,
     _conn_state: &IqConnState<'_>,
     full_jid: &FullJid,
-    _iq: &xmpp_parsers::iq::Iq,
+    iq: &xmpp_parsers::iq::Iq,
     room_jid: &jid::BareJid,
     reply: IqReplyAddressing<'_>,
-) -> Vec<String> {
-    vec![build_iq_error_xml_typed(
+) -> MujiRelayOutcome {
+    if super::jingle_muji_gate::muji_session_terminate_room(iq).is_some() {
+        return MujiRelayOutcome::ProcessLocally;
+    }
+    MujiRelayOutcome::Frames(vec![build_iq_error_xml_typed(
         reply.id,
         reply.response_from,
         reply.response_to,
         *super::jingle_muji_gate::deny_room_not_found(room_jid, &full_jid.to_bare()),
-    )]
+    )])
 }
 
 /// The (id, from, to) triple every IQ error reply is stamped with —

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -304,6 +304,31 @@ async fn relay_muji_to_room_owner(
             MujiRelayOutcome::Frames(frames())
         }
     };
+    // A terminate that falls back to local execution because the relay
+    // was *unavailable* is NOT the benign no-op the unclaimed-room case
+    // is, and must not be silent. Locally there is nothing registered
+    // to clear (the initiate registered on the owner), yet
+    // `unregister_call_participant` still fires `RemoveParticipant`, so
+    // the user's media does stop — while the OWNER keeps the registry
+    // entry and never runs the Muji-presence clear. That phantom
+    // suppresses `DeleteRoom` and keeps the room's "in call" state lit
+    // for every other occupant until the reconcile sweep catches it.
+    // The telemetry-bearing error builders are deliberately skipped for
+    // a terminate, so without this line the whole situation is
+    // invisible. Convergence is still owed to the durable control plane
+    // in #1449.
+    let unrelayable_after_relay_failure = |reason: &'static str| {
+        if is_terminate {
+            tracing::warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                reason,
+                "Muji session-terminate could not be relayed to the room owner; \
+                 executing locally — the owner may hold a phantom call participant \
+                 until reconciliation"
+            );
+        }
+    };
 
     let deny = || {
         vec![build_iq_error_xml_typed(
@@ -350,8 +375,10 @@ async fn relay_muji_to_room_owner(
                     state.deps.auth_state.xmpp_domain.as_str(),
                 )
     });
-    let room_is_local =
-        room_jid.domain().as_str() == format!("muc.{}", state.deps.auth_state.xmpp_domain.as_str());
+    let room_is_local = waddle_xmpp::protocol::handlers::jingle::room_is_on_local_muc_service(
+        room_jid,
+        state.deps.auth_state.xmpp_domain.as_str(),
+    );
     if !addressed_to_mixer || !room_is_local {
         return unrelayable(&deny);
     }
@@ -406,8 +433,12 @@ async fn relay_muji_to_room_owner(
         // treats as terminal — the client's IQ would get no result and
         // no error, and the call would silently never start.
         MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::Delivered(_)) => {
+            unrelayable_after_relay_failure("delivered_without_replies");
             unrelayable(&retry_later)
         }
+        // No node owns the room (or this one does, with no actor): the
+        // local fallback for a terminate genuinely IS a no-op, because
+        // there is no owner holding a registration to strand.
         MucProxyRouteDecision::RoomUnclaimed | MucProxyRouteDecision::LocalRoom => {
             unrelayable(&deny)
         }
@@ -416,9 +447,18 @@ async fn relay_muji_to_room_owner(
             | OrderedRelayMucProxyOutcome::Dropped
             | OrderedRelayMucProxyOutcome::MaybeCommitted
             | OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
-        )
-        | MucProxyRouteDecision::RoomClaimUnavailable
-        | MucProxyRouteDecision::OriginUnavailable => unrelayable(&retry_later),
+        ) => {
+            unrelayable_after_relay_failure("relay_delivery_failed");
+            unrelayable(&retry_later)
+        }
+        MucProxyRouteDecision::RoomClaimUnavailable => {
+            unrelayable_after_relay_failure("room_claim_unavailable");
+            unrelayable(&retry_later)
+        }
+        MucProxyRouteDecision::OriginUnavailable => {
+            unrelayable_after_relay_failure("origin_unavailable");
+            unrelayable(&retry_later)
+        }
     }
 }
 

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -316,9 +316,23 @@ async fn spawn_cluster_server(
     swarm_port: u16,
     bootstrap_ports: &[u16],
 ) -> (TestServer, String, String) {
+    spawn_cluster_server_with_envs(postgres_url, pool_env, swarm_port, bootstrap_ports, &[]).await
+}
+
+/// [`spawn_cluster_server`] plus caller-supplied extra envs (e.g. the
+/// `LIVEKIT_*` set for the Muji route-to-owner test — the JWT mint is
+/// pure, so no real LiveKit is needed).
+async fn spawn_cluster_server_with_envs(
+    postgres_url: &str,
+    pool_env: &str,
+    swarm_port: u16,
+    bootstrap_ports: &[u16],
+    extra_envs: &[(&'static str, &'static str)],
+) -> (TestServer, String, String) {
     let postgres_url = postgres_url.to_string();
     let pool_env = pool_env.to_string();
     let bootstrap_ports = bootstrap_ports.to_vec();
+    let extra_envs = extra_envs.to_vec();
     tokio::task::spawn_blocking(move || {
         let node_id_file = std::env::temp_dir().join(format!(
             "waddle-clustering-e2e-node-{}",
@@ -399,6 +413,7 @@ async fn spawn_cluster_server(
         if !bootstrap_peers.is_empty() {
             envs.push(("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", &bootstrap_peers));
         }
+        envs.extend(extra_envs.iter().copied());
 
         let server = TestServer::start_with_extra_envs(
             &[(CLUSTER_PEER_USERNAME, CLUSTER_PEER_PASSWORD)],
@@ -2247,6 +2262,229 @@ async fn muc_join_routes_to_foreign_room_owner() {
     drop(server_a);
     drop(server_b);
     drop(client_a);
+}
+
+/// #1445: a Muji (XEP-0272) `session-initiate` whose signaling lands on
+/// the replica that does NOT own the room actor must succeed — relayed
+/// to the claim owner, minted there, replies written back through the
+/// receiving node — instead of the historical `room_not_found`
+/// `<forbidden/>` denial (~29% of production joins at 2 replicas).
+///
+/// Negative control: a room no node has ever created (no claim row
+/// anywhere) still denies with `<forbidden/>` — the relay must not turn
+/// genuinely-nonexistent rooms into retry loops.
+#[tokio::test]
+async fn muji_initiate_routes_to_foreign_room_owner() {
+    let Ok(postgres_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping muji_initiate_routes_to_foreign_room_owner: \
+             WADDLE_TEST_POSTGRES_URL not set"
+        );
+        return;
+    };
+    let _serial = cluster_e2e_serial_lock().lock().await;
+
+    let db = open_control_db(&postgres_url).await;
+    let pool = generate_pool();
+    reset_and_enroll(&db, &pool).await;
+    reset_node_lease_tables(&db).await;
+
+    const DOMAIN: &str = "localhost";
+    const OWNER_USERNAME: &str = "admin";
+    const NS_MUC: &str = "http://jabber.org/protocol/muc";
+    // The api-secret must be >= 32 bytes; none of these reach a real
+    // LiveKit — the mint is a pure local JWT signature.
+    let livekit_envs: &[(&'static str, &'static str)] = &[
+        ("LIVEKIT_API_KEY", "APItestkeycluster"),
+        (
+            "LIVEKIT_API_SECRET",
+            "test-secret-with-at-least-32-bytes-of-payload",
+        ),
+        ("LIVEKIT_WS_URL", "wss://livekit.example.test"),
+        ("LIVEKIT_TURN_HOST", "turn.example.test"),
+        (
+            "LIVEKIT_TURN_SHARED_SECRET",
+            "turn-shared-secret-value-also-long-enough",
+        ),
+        (
+            "LIVEKIT_WEBHOOK_SECRET",
+            "test-webhook-secret-with-at-least-32-bytes",
+        ),
+    ];
+
+    let port_a = free_tcp_port();
+    let port_b = free_tcp_port();
+    let (server_a, _node_a, _peer_a) = spawn_cluster_server_with_envs(
+        &postgres_url,
+        &pool.pool_env,
+        port_a,
+        &[port_b],
+        livekit_envs,
+    )
+    .await;
+    let (server_b, _node_b, _peer_b) = spawn_cluster_server_with_envs(
+        &postgres_url,
+        &pool.pool_env,
+        port_b,
+        &[port_a],
+        livekit_envs,
+    )
+    .await;
+
+    wait_for_readiness(&server_a, true, Duration::from_secs(15)).await;
+    wait_for_readiness(&server_b, true, Duration::from_secs(15)).await;
+
+    let owner_password = server_b.fixed_account_password().to_string();
+    let room = format!("muji-foreign-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    // Client A creates and joins the room on node A — node A holds the
+    // room claim and the occupancy.
+    let resource_a = format!("muji-owner-a-{}", uuid::Uuid::new_v4());
+    let mut client_a = WsXmppClient::connect_and_auth(
+        &server_a.ws_url(),
+        DOMAIN,
+        OWNER_USERNAME,
+        &owner_password,
+        &resource_a,
+    )
+    .await
+    .expect("client A connects to node A");
+    client_a
+        .send(&format!(
+            r#"<presence to="{room}/owner-a"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("client A sends join presence");
+    client_a
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("client A's join completes (room created, A is Owner)");
+
+    // Client B joins the same room THROUGH NODE B (relayed join), so B
+    // is an occupant whose occupancy lives on node A.
+    let resource_b = format!("muji-joiner-b-{}", uuid::Uuid::new_v4());
+    let mut client_b = WsXmppClient::connect_and_auth(
+        &server_b.ws_url(),
+        DOMAIN,
+        CLUSTER_PEER_USERNAME,
+        CLUSTER_PEER_PASSWORD,
+        &resource_b,
+    )
+    .await
+    .expect("client B connects to node B");
+    client_b
+        .send(&format!(
+            r#"<presence to="{room}/joiner-b"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("client B sends join presence");
+    client_b
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("client B's relayed join completes");
+
+    // Client B's Muji session-initiate hits node B, which has no room
+    // actor. Pre-#1445 this denied with room_not_found; now it must be
+    // relayed to node A, minted there, and answered with the IQ ack +
+    // the focus's session-accept carrying a real token.
+    client_b
+        .send(&String::from(&muji_initiate_iq(&room, "cross-node-1")))
+        .await
+        .expect("client B sends Muji session-initiate against node B");
+    let replies = client_b
+        .recv_until(|frame| frame.contains("session-accept"))
+        .await
+        .expect("client B receives the focus's session-accept via the relay");
+    assert!(
+        replies.iter().all(|frame| !frame.contains("<forbidden")
+            && !frame.contains("type='error'")
+            && !frame.contains("type=\"error\"")),
+        "cross-node Muji join must not be denied: {replies:?}"
+    );
+    assert!(
+        replies.iter().any(|frame| {
+            frame.contains("session-accept")
+                && frame.contains("<token")
+                && frame.contains("isfocus")
+        }),
+        "the relayed mint must produce a token-bearing session-accept: {replies:?}"
+    );
+
+    // Negative control: a room with NO claim anywhere is genuinely
+    // nonexistent — the terminal room_not_found denial survives.
+    let ghost = format!("muji-ghost-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    client_b
+        .send(&String::from(&muji_initiate_iq(&ghost, "ghost-1")))
+        .await
+        .expect("client B sends Muji session-initiate for an unclaimed room");
+    let denial = client_b
+        .recv_matching(|frame| frame.contains("mji-ghost-1") && frame.contains("<error"))
+        .await
+        .expect("unclaimed room still denies");
+    assert!(
+        denial.contains("<forbidden"),
+        "unclaimed-room denial must keep the historical <forbidden/> shape: {denial}"
+    );
+
+    client_b.close().await.expect("client B closes");
+    drop(server_a);
+    drop(server_b);
+    drop(client_a);
+}
+
+/// Muji `session-initiate` IQ for `room`, built with minidom builders
+/// per the repo's XML-generation rule (id = `mji-{sid}`).
+fn muji_initiate_iq(room: &str, sid: &str) -> xmpp_parsers::minidom::Element {
+    use waddle_xmpp::xep::xep0166::NS_JINGLE;
+    use waddle_xmpp::xep::xep0167::NS_JINGLE_RTP;
+    use waddle_xmpp::xep::xep0272::NS_MUJI;
+    use waddle_xmpp::xep::xep_waddle_livekit_transport::NS_WADDLE_LIVEKIT_TRANSPORT;
+    use xmpp_parsers::minidom::Element;
+
+    let payload_type = Element::builder("payload-type", NS_JINGLE_RTP)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), "111")
+        .attr(minidom::rxml::xml_ncname!("name").to_owned(), "opus")
+        .attr(minidom::rxml::xml_ncname!("clockrate").to_owned(), "48000")
+        .attr(minidom::rxml::xml_ncname!("channels").to_owned(), "2")
+        .build();
+    let description = Element::builder("description", NS_JINGLE_RTP)
+        .attr(minidom::rxml::xml_ncname!("media").to_owned(), "audio")
+        .append(payload_type)
+        .build();
+    let content = Element::builder("content", NS_JINGLE)
+        .attr(
+            minidom::rxml::xml_ncname!("creator").to_owned(),
+            "initiator",
+        )
+        .attr(minidom::rxml::xml_ncname!("name").to_owned(), "audio")
+        .append(description)
+        .append(Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT).build())
+        .build();
+    let jingle = Element::builder("jingle", NS_JINGLE)
+        .attr(
+            minidom::rxml::xml_ncname!("action").to_owned(),
+            "session-initiate",
+        )
+        .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid)
+        .append(content)
+        .append(
+            Element::builder("muji", NS_MUJI)
+                .attr(minidom::rxml::xml_ncname!("room").to_owned(), room)
+                .build(),
+        )
+        .build();
+    Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            format!("mji-{sid}"),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            "calls.localhost",
+        )
+        .append(jingle)
+        .build()
 }
 
 /// ADR-0017 Phase 4: subscription presence and probes use the same ordered

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -2410,6 +2410,27 @@ async fn muji_initiate_routes_to_foreign_room_owner() {
         "the relayed mint must produce a token-bearing session-accept: {replies:?}"
     );
 
+    // Cross-node teardown (#1445): the terminate must reach the SAME
+    // node the initiate registered on, or the owner keeps a phantom
+    // in-call participant — which additionally suppresses DeleteRoom
+    // for every other occupant. Here we assert only that the relayed
+    // terminate is accepted rather than erroring; the owner-side
+    // registry effect is pinned deterministically by
+    // `jingle_muji_relay`'s unit tests, which can observe the SFU
+    // registry directly instead of inferring it from the wire.
+    client_b
+        .send(&String::from(&muji_terminate_iq(&room, "cross-node-1")))
+        .await
+        .expect("client B sends Muji session-terminate against node B");
+    let terminate_reply = client_b
+        .recv_matching(|frame| frame.contains("mjt-cross-node-1"))
+        .await
+        .expect("the relayed terminate is answered");
+    assert!(
+        !terminate_reply.contains("<error"),
+        "a cross-node hangup must never fail: {terminate_reply}"
+    );
+
     // Negative control: a room with NO claim anywhere is genuinely
     // nonexistent — the terminal room_not_found denial survives.
     let ghost = format!("muji-ghost-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
@@ -2430,6 +2451,40 @@ async fn muji_initiate_routes_to_foreign_room_owner() {
     drop(server_a);
     drop(server_b);
     drop(client_a);
+}
+
+/// Muji `session-terminate` IQ for `room` — the hangup counterpart of
+/// [`muji_initiate_iq`]. XEP-0272 requires only the `<muji room='…'/>`
+/// marker on terminate, no contents.
+fn muji_terminate_iq(room: &str, sid: &str) -> xmpp_parsers::minidom::Element {
+    use waddle_xmpp::xep::xep0166::NS_JINGLE;
+    use waddle_xmpp::xep::xep0272::NS_MUJI;
+    use xmpp_parsers::minidom::Element;
+
+    let jingle = Element::builder("jingle", NS_JINGLE)
+        .attr(
+            minidom::rxml::xml_ncname!("action").to_owned(),
+            "session-terminate",
+        )
+        .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid)
+        .append(
+            Element::builder("muji", NS_MUJI)
+                .attr(minidom::rxml::xml_ncname!("room").to_owned(), room)
+                .build(),
+        )
+        .build();
+    Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            format!("mjt-{sid}"),
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            "calls.localhost",
+        )
+        .append(jingle)
+        .build()
 }
 
 /// Muji `session-initiate` IQ for `room`, built with minidom builders

--- a/server/crates/waddle-sfu/src/admin.rs
+++ b/server/crates/waddle-sfu/src/admin.rs
@@ -44,6 +44,36 @@ const ADMIN_JWT_TTL: Duration = Duration::seconds(60);
 /// leak runtime tasks indefinitely.
 const ADMIN_HTTP_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 
+/// LiveKit's own view of who is connected to a room.
+///
+/// The split is load-bearing (#1445): `waddle` holds the participants
+/// whose identity round-trips to a JID we minted, and `foreign` counts
+/// everyone else — an egress recorder, a SIP or ingress participant,
+/// anything not issued by this server. Ghost reconciliation may only
+/// ever reason about `waddle` entries (a foreign participant cannot be
+/// a registry ghost we own), but an emptiness decision MUST consider
+/// `foreign` too: deleting a room because the only occupant left is
+/// the recorder would kill the recording.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RoomOccupancy {
+    /// Connected participants this server minted tokens for.
+    pub waddle: Vec<Identity>,
+    /// Connected participants whose identity is not one of ours.
+    pub foreign: usize,
+}
+
+impl RoomOccupancy {
+    /// True when the only connected participant LiveKit reports is
+    /// `departing` (or nobody at all). LiveKit's list can still echo
+    /// the participant whose `RemoveParticipant` was just issued, so
+    /// that one identity does not count as occupancy — but any other
+    /// Waddle participant (typically registered by another replica)
+    /// or ANY foreign participant does.
+    pub fn is_empty_except(&self, departing: &Identity) -> bool {
+        self.foreign == 0 && self.waddle.iter().all(|identity| identity == departing)
+    }
+}
+
 /// Abstract LiveKit admin operations. Public so integration tests in
 /// consuming crates (e.g. `waddle-xmpp`'s XEP-0272 Muji suite) can
 /// inject a recording mock via [`crate::LiveKitSfu::with_admin`]; the
@@ -75,17 +105,18 @@ pub trait LiveKitAdmin: Send + Sync + 'static {
         capabilities: MediaCapabilities,
     ) -> Pin<Box<dyn Future<Output = Result<(), SfuError>> + Send + 'a>>;
 
-    /// List the identities LiveKit currently reports as joined to
-    /// `room`. The authoritative answer to "who is *actually* in this
-    /// call right now", used by the reconciliation backstop to detect
-    /// registry ghosts left behind when a `participant_left` /
-    /// `room_finished` webhook delivery was lost. A `not_found` room
-    /// (LiveKit has GC'd it or never saw it) resolves to an empty
-    /// vec — nobody is connected — not an error.
-    fn list_participant_identities<'a>(
+    /// Who LiveKit currently reports as connected to `room` — the
+    /// authoritative cross-replica answer to "is anyone actually in
+    /// this call right now". Used by the reconciliation backstop to
+    /// detect registry ghosts (lost `participant_left` /
+    /// `room_finished` webhooks) and by the teardown path to confirm
+    /// emptiness before `DeleteRoom` (#1445). A `not_found` room
+    /// (LiveKit GC'd it or never saw it) resolves to an empty
+    /// occupancy — nobody is connected — not an error.
+    fn room_occupancy<'a>(
         &'a self,
         room: &'a CallId,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<RoomOccupancy, SfuError>> + Send + 'a>>;
 }
 
 /// Production admin client. Holds a long-lived `reqwest::Client` so
@@ -276,10 +307,10 @@ impl LiveKitAdmin for ReqwestLiveKitAdmin {
         })
     }
 
-    fn list_participant_identities<'a>(
+    fn room_occupancy<'a>(
         &'a self,
         room: &'a CallId,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<RoomOccupancy, SfuError>> + Send + 'a>> {
         let body = ListParticipantsRequest {
             room: room.as_str().to_string(),
         };
@@ -289,21 +320,22 @@ impl LiveKitAdmin for ReqwestLiveKitAdmin {
                 .await?;
             // `None` => room not found on LiveKit => nobody connected.
             let Some(resp) = resp else {
-                return Ok(Vec::new());
+                return Ok(RoomOccupancy::default());
             };
             // LiveKit identities are the stringified FullJids we minted
             // into the JWT `sub`. Parse each back into a typed
-            // [`Identity`]; silently skip any that don't round-trip (a
-            // foreign participant or a malformed identity is simply not
-            // one of our registry entries, so it can't be a ghost we
-            // own).
-            let identities = resp
-                .participants
-                .into_iter()
-                .filter_map(|p| p.identity.parse::<jid::FullJid>().ok())
-                .map(Identity::from_jid)
-                .collect();
-            Ok(identities)
+            // [`Identity`]; anything that does not round-trip is a
+            // participant we did not issue (egress recorder, SIP,
+            // ingress). It can never be a ghost of ours, but it IS
+            // occupancy — count it rather than dropping it.
+            let mut occupancy = RoomOccupancy::default();
+            for participant in resp.participants {
+                match participant.identity.parse::<jid::FullJid>() {
+                    Ok(jid) => occupancy.waddle.push(Identity::from_jid(jid)),
+                    Err(_) => occupancy.foreign += 1,
+                }
+            }
+            Ok(occupancy)
         })
     }
 }

--- a/server/crates/waddle-sfu/src/lib.rs
+++ b/server/crates/waddle-sfu/src/lib.rs
@@ -33,7 +33,7 @@ mod token;
 mod turn;
 mod webhook;
 
-pub use admin::LiveKitAdmin;
+pub use admin::{LiveKitAdmin, RoomOccupancy};
 pub use call::{CallId, CallState, Identity, MediaCapabilities};
 pub use config::{ApiKey, ApiSecret, FromEnvError, SfuConfig, TurnSharedSecret, WebsocketUrl};
 pub use correlation::{CallCorrelationId, CORRELATION_ID_HEX_LEN};

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -398,7 +398,7 @@ impl LiveKitSfu {
                 // session, so only proceed when the call is *still*
                 // empty in our local view.
                 if calls.get(&call_id).is_none() {
-                    delete_room_if_livekit_empty(admin.as_ref(), &call_id, &identity).await;
+                    delete_room_if_livekit_empty(admin.as_ref(), &calls, &call_id, &identity).await;
                 }
             }
         });
@@ -606,8 +606,11 @@ impl LiveKitSfu {
 
         let mut swept = Vec::new();
         for (call_id, registered) in snapshot {
-            let live = match self.admin.list_participant_identities(&call_id).await {
-                Ok(live) => live,
+            // Ghost detection reasons only about participants we
+            // minted; a foreign participant (recorder, SIP) is by
+            // definition not one of our registry entries.
+            let live = match self.admin.room_occupancy(&call_id).await {
+                Ok(occupancy) => occupancy.waddle,
                 Err(err) => {
                     tracing::warn!(
                         call_id = %call_id,
@@ -689,8 +692,8 @@ impl LiveKitSfu {
 impl crate::SfuReconciler for LiveKitSfu {
     fn live_participants<'a>(&'a self, call_id: &'a CallId) -> crate::LiveParticipantsFuture<'a> {
         Box::pin(async move {
-            match self.admin.list_participant_identities(call_id).await {
-                Ok(identities) => Some(identities),
+            match self.admin.room_occupancy(call_id).await {
+                Ok(occupancy) => Some(occupancy.waddle),
                 Err(error) => {
                     // `None`, never an empty vec: an outage must not be
                     // mistaken for "nobody is connected", which would
@@ -900,39 +903,57 @@ impl SfuService for LiveKitSfu {
 /// own `empty_timeout`.
 ///
 /// Known residual race, accepted: a joiner whose token was minted on
-/// another replica but who has not yet connected is invisible to this
-/// probe. LiveKit auto-creates rooms on join, so an over-eager delete
-/// is disruptive but self-healing; closing it needs the durable
-/// generation-keyed registry tracked in #1449.
+/// another replica but who has not yet connected is invisible to both
+/// this probe and the local registry. LiveKit auto-creates rooms on
+/// join, so an over-eager delete is disruptive but self-healing;
+/// closing it needs the durable generation-keyed registry tracked in
+/// #1449.
 async fn delete_room_if_livekit_empty(
     admin: &dyn LiveKitAdmin,
+    calls: &CallRegistry,
     call_id: &CallId,
     departing: &Identity,
 ) {
-    match admin.list_participant_identities(call_id).await {
-        Ok(live) if live.iter().all(|p| p == departing) => {
-            if let Err(err) = admin.delete_room(call_id).await {
-                tracing::warn!(
-                    call_id = %call_id,
-                    error = %err,
-                    "LiveKit DeleteRoom failed; empty room will linger until empty_timeout"
-                );
-            }
-        }
-        Ok(live) => {
-            tracing::info!(
-                call_id = %call_id,
-                live_participants = live.len(),
-                "DeleteRoom skipped; LiveKit reports live participants (another replica's registrations)"
-            );
-        }
+    let occupancy = match admin.room_occupancy(call_id).await {
+        Ok(occupancy) => occupancy,
         Err(err) => {
             tracing::warn!(
                 call_id = %call_id,
                 error = %err,
                 "DeleteRoom skipped; LiveKit occupancy could not be confirmed"
             );
+            return;
         }
+    };
+    if !occupancy.is_empty_except(departing) {
+        tracing::info!(
+            call_id = %call_id,
+            waddle_participants = occupancy.waddle.len(),
+            foreign_participants = occupancy.foreign,
+            "DeleteRoom skipped; LiveKit reports live participants \
+             (another replica's registrations, or an egress/SIP participant)"
+        );
+        return;
+    }
+    // Re-check the local registry AFTER the probe, not just before it
+    // (#1129 rejoin race): the round-trip above is a second window in
+    // which a fresh participant can register locally, and the
+    // already-taken LiveKit snapshot cannot see them because they have
+    // not connected yet. Deleting here would evict that session.
+    if calls.get(call_id).is_some() {
+        tracing::info!(
+            call_id = %call_id,
+            "DeleteRoom skipped; a participant registered locally while \
+             LiveKit occupancy was being confirmed"
+        );
+        return;
+    }
+    if let Err(err) = admin.delete_room(call_id).await {
+        tracing::warn!(
+            call_id = %call_id,
+            error = %err,
+            "LiveKit DeleteRoom failed; empty room will linger until empty_timeout"
+        );
     }
 }
 

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -355,7 +355,10 @@ impl LiveKitSfu {
     /// at the call site — and even then re-checks `calls` inside the
     /// spawn to close the rejoin race: another participant may have
     /// registered in the same tick, in which case kicking the room
-    /// would evict them too. Spawn target is the runtime handle
+    /// would evict them too — and then confirmed against LiveKit's
+    /// own participant list, because local emptiness says nothing
+    /// about participants registered on another replica (#1445); see
+    /// [`delete_room_if_livekit_empty`]. Spawn target is the runtime handle
     /// captured at construction; when none is attached (e.g. plain
     /// `#[test]` fixtures) the remote leg silently drops, matching
     /// pre-admin behaviour for those tests. The admin concurrency
@@ -395,13 +398,7 @@ impl LiveKitSfu {
                 // session, so only proceed when the call is *still*
                 // empty in our local view.
                 if calls.get(&call_id).is_none() {
-                    if let Err(err) = admin.delete_room(&call_id).await {
-                        tracing::warn!(
-                            call_id = %call_id,
-                            error = %err,
-                            "LiveKit DeleteRoom failed; empty room will linger until empty_timeout"
-                        );
-                    }
+                    delete_room_if_livekit_empty(admin.as_ref(), &call_id, &identity).await;
                 }
             }
         });
@@ -885,6 +882,57 @@ impl SfuService for LiveKitSfu {
             .get(call_id)
             .map(|entry| entry.iter().cloned().collect())
             .unwrap_or_default()
+    }
+}
+
+/// `DeleteRoom` precondition against shared ground truth (#1445): the
+/// participant registry is process-local, so with multiple
+/// waddle-server replicas "our map just emptied" says nothing about
+/// participants registered by another replica in the same LiveKit
+/// room. LiveKit itself is the one component every replica shares, so
+/// ask it who is connected before tearing the room down.
+///
+/// The list may still echo `departing` (the identity whose
+/// `RemoveParticipant` was issued moments ago); anyone *else* means
+/// another replica's participant is live and the delete is skipped.
+/// Fail-safe: if the probe errors, occupancy cannot be ruled out, so
+/// the delete is skipped and an abandoned room lapses via LiveKit's
+/// own `empty_timeout`.
+///
+/// Known residual race, accepted: a joiner whose token was minted on
+/// another replica but who has not yet connected is invisible to this
+/// probe. LiveKit auto-creates rooms on join, so an over-eager delete
+/// is disruptive but self-healing; closing it needs the durable
+/// generation-keyed registry tracked in #1449.
+async fn delete_room_if_livekit_empty(
+    admin: &dyn LiveKitAdmin,
+    call_id: &CallId,
+    departing: &Identity,
+) {
+    match admin.list_participant_identities(call_id).await {
+        Ok(live) if live.iter().all(|p| p == departing) => {
+            if let Err(err) = admin.delete_room(call_id).await {
+                tracing::warn!(
+                    call_id = %call_id,
+                    error = %err,
+                    "LiveKit DeleteRoom failed; empty room will linger until empty_timeout"
+                );
+            }
+        }
+        Ok(live) => {
+            tracing::info!(
+                call_id = %call_id,
+                live_participants = live.len(),
+                "DeleteRoom skipped; LiveKit reports live participants (another replica's registrations)"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(
+                call_id = %call_id,
+                error = %err,
+                "DeleteRoom skipped; LiveKit occupancy could not be confirmed"
+            );
+        }
     }
 }
 

--- a/server/crates/waddle-sfu/src/livekit/tests.rs
+++ b/server/crates/waddle-sfu/src/livekit/tests.rs
@@ -285,11 +285,21 @@ impl RecordingAdmin {
     /// Wait until a parked `room_occupancy` call has actually been
     /// entered, so the test's registration lands mid-probe rather than
     /// racing the spawn.
+    /// Panics if the probe never starts. Swallowing that timeout made
+    /// the post-probe-registry test vacuous: `release_list` would
+    /// notify before the probe installed its waiter, the teardown would
+    /// stay parked forever, and the assertion that no `DeleteRoom`
+    /// fired would pass without the guard ever being exercised.
     async fn await_list_in_flight(&self, within: StdDuration) {
-        let entered = self.list_entered.lock().expect("recording lock").clone();
-        if let Some(entered) = entered {
-            let _ = tokio::time::timeout(within, entered.notified()).await;
-        }
+        let entered = self
+            .list_entered
+            .lock()
+            .expect("recording lock")
+            .clone()
+            .expect("hold_list must be called before awaiting the probe");
+        tokio::time::timeout(within, entered.notified())
+            .await
+            .expect("the occupancy probe must actually start, or this test proves nothing");
     }
 
     fn fail_list(&self) {

--- a/server/crates/waddle-sfu/src/livekit/tests.rs
+++ b/server/crates/waddle-sfu/src/livekit/tests.rs
@@ -278,14 +278,23 @@ impl RecordingAdmin {
     fn release_list(&self) {
         let gate = self.list_gate.lock().expect("recording lock").clone();
         if let Some(gate) = gate {
-            gate.notify_waiters();
+            // `notify_one`, not `notify_waiters`: the latter drops the
+            // signal when no waiter is registered yet, and both signals
+            // in this handshake are one-shot events whose ordering
+            // against the other task's registration is not guaranteed
+            // on a multi-threaded runtime. A stored permit makes them
+            // ordering-independent.
+            gate.notify_one();
         }
     }
 
     /// Wait until a parked `room_occupancy` call has actually been
     /// entered, so the test's registration lands mid-probe rather than
     /// racing the spawn.
-    /// Panics if the probe never starts. Swallowing that timeout made
+    ///
+    /// Both sides of the handshake use `notify_one` so neither signal
+    /// can be lost to a registration race. Panics if the probe never
+    /// starts. Swallowing that timeout made
     /// the post-probe-registry test vacuous: `release_list` would
     /// notify before the probe installed its waiter, the teardown would
     /// stay parked forever, and the assertion that no `DeleteRoom`
@@ -380,7 +389,7 @@ impl LiveKitAdmin for RecordingAdmin {
             if let Some(gate) = gate {
                 let waiter = gate.notified();
                 if let Some(entered) = self.list_entered.lock().expect("recording lock").clone() {
-                    entered.notify_waiters();
+                    entered.notify_one();
                 }
                 waiter.await;
             }

--- a/server/crates/waddle-sfu/src/livekit/tests.rs
+++ b/server/crates/waddle-sfu/src/livekit/tests.rs
@@ -221,10 +221,19 @@ struct RecordingAdmin {
     /// from the map lists as empty (room not found). Drives the
     /// reconciliation tests.
     live: Mutex<std::collections::HashMap<CallId, Vec<Identity>>>,
-    /// When set, `list_participant_identities` errors instead of
-    /// returning a set — used to assert reconcile skips a call it
-    /// can't confirm rather than sweeping it.
+    /// How many NON-Waddle participants LiveKit reports per call
+    /// (an egress recorder, a SIP participant): occupancy that can
+    /// never be a registry ghost but must still block DeleteRoom.
+    foreign_live: Mutex<std::collections::HashMap<CallId, usize>>,
+    /// When set, `room_occupancy` errors instead of returning a set —
+    /// used to assert reconcile skips a call it can't confirm rather
+    /// than sweeping it.
     list_errors: Mutex<bool>,
+    /// Parks `room_occupancy` until released, so a test can register a
+    /// participant while the probe is genuinely in flight.
+    list_gate: Mutex<Option<Arc<tokio::sync::Notify>>>,
+    /// Signalled once a parked `room_occupancy` call has been entered.
+    list_entered: Mutex<Option<Arc<tokio::sync::Notify>>>,
 }
 
 impl RecordingAdmin {
@@ -249,6 +258,38 @@ impl RecordingAdmin {
             .lock()
             .expect("recording lock")
             .insert(call.clone(), identities);
+    }
+
+    fn set_foreign_live(&self, call: &CallId, count: usize) {
+        self.foreign_live
+            .lock()
+            .expect("recording lock")
+            .insert(call.clone(), count);
+    }
+
+    /// Park the next `room_occupancy` call until [`Self::release_list`].
+    fn hold_list(&self) {
+        *self.list_gate.lock().expect("recording lock") =
+            Some(Arc::new(tokio::sync::Notify::new()));
+        *self.list_entered.lock().expect("recording lock") =
+            Some(Arc::new(tokio::sync::Notify::new()));
+    }
+
+    fn release_list(&self) {
+        let gate = self.list_gate.lock().expect("recording lock").clone();
+        if let Some(gate) = gate {
+            gate.notify_waiters();
+        }
+    }
+
+    /// Wait until a parked `room_occupancy` call has actually been
+    /// entered, so the test's registration lands mid-probe rather than
+    /// racing the spawn.
+    async fn await_list_in_flight(&self, within: StdDuration) {
+        let entered = self.list_entered.lock().expect("recording lock").clone();
+        if let Some(entered) = entered {
+            let _ = tokio::time::timeout(within, entered.notified()).await;
+        }
     }
 
     fn fail_list(&self) {
@@ -315,22 +356,40 @@ impl LiveKitAdmin for RecordingAdmin {
         })
     }
 
-    fn list_participant_identities<'a>(
+    fn room_occupancy<'a>(
         &'a self,
         room: &'a CallId,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Identity>, SfuError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<crate::admin::RoomOccupancy, SfuError>> + Send + 'a>>
+    {
         let room = room.clone();
         Box::pin(async move {
             if *self.list_errors.lock().expect("recording lock") {
                 return Err(SfuError::InvalidCallId("simulated list failure".into()));
             }
-            Ok(self
-                .live
-                .lock()
-                .expect("recording lock")
-                .get(&room)
-                .cloned()
-                .unwrap_or_default())
+            let gate = self.list_gate.lock().expect("recording lock").clone();
+            if let Some(gate) = gate {
+                let waiter = gate.notified();
+                if let Some(entered) = self.list_entered.lock().expect("recording lock").clone() {
+                    entered.notify_waiters();
+                }
+                waiter.await;
+            }
+            Ok(crate::admin::RoomOccupancy {
+                waddle: self
+                    .live
+                    .lock()
+                    .expect("recording lock")
+                    .get(&room)
+                    .cloned()
+                    .unwrap_or_default(),
+                foreign: self
+                    .foreign_live
+                    .lock()
+                    .expect("recording lock")
+                    .get(&room)
+                    .copied()
+                    .unwrap_or(0),
+            })
         })
     }
 }
@@ -847,6 +906,77 @@ async fn delete_room_fires_when_livekit_reports_only_the_departing_participant()
         admin.delete_snapshot(),
         vec![call],
         "DeleteRoom must fire when LiveKit reports nobody but the leaver"
+    );
+}
+
+#[tokio::test]
+async fn delete_room_skipped_when_only_a_foreign_participant_remains() {
+    // An egress recorder (or SIP/ingress participant) has an identity
+    // we never minted, so it can never be a registry ghost — but it IS
+    // occupancy. Deleting the room around it would kill the recording.
+    let admin = Arc::new(RecordingAdmin::default());
+    let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+    let call = CallId::new("r-egress").unwrap();
+    let alice = fixture_identity("alice");
+
+    sfu.register_call_participant(&call, &alice);
+    admin.set_live(&call, vec![alice.clone()]);
+    admin.set_foreign_live(&call, 1);
+
+    let state = sfu.unregister_call_participant(&call, &alice);
+    assert_eq!(state, CallState::Ended);
+    drain_admin_tasks().await;
+
+    assert!(
+        admin.delete_snapshot().is_empty(),
+        "DeleteRoom must be suppressed while a non-Waddle participant \
+         (egress/SIP) is still connected; got {:?}",
+        admin.delete_snapshot(),
+    );
+}
+
+#[tokio::test]
+async fn delete_room_skipped_when_a_participant_registers_during_the_occupancy_probe() {
+    // The local rejoin re-check happens BEFORE the LiveKit round-trip,
+    // so the probe itself is a second window in which a fresh joiner
+    // can register locally — and the already-taken LiveKit snapshot
+    // cannot see them, because they have not connected yet. The guard
+    // must re-check the registry after the probe (#1129 + #1445).
+    let admin = Arc::new(RecordingAdmin::default());
+    let sfu = Arc::new(LiveKitSfu::with_admin(
+        fixture_config(),
+        Arc::clone(&admin) as Arc<_>,
+    ));
+    let call = CallId::new("r-probe-race").unwrap();
+    let alice = fixture_identity("alice");
+    let bob = fixture_identity("bob");
+
+    sfu.register_call_participant(&call, &alice);
+    // LiveKit reports only the departing participant, so the probe
+    // says "empty" — the decision then rests entirely on the
+    // post-probe local re-check.
+    admin.set_live(&call, vec![alice.clone()]);
+    admin.hold_list();
+
+    let state = sfu.unregister_call_participant(&call, &alice);
+    assert_eq!(state, CallState::Ended);
+
+    // Bob joins while the probe is parked in flight.
+    admin.await_list_in_flight(StdDuration::from_secs(5)).await;
+    sfu.register_call_participant(&call, &bob);
+    admin.release_list();
+
+    for _ in 0..50 {
+        if !admin.delete_snapshot().is_empty() {
+            break;
+        }
+        tokio::time::sleep(StdDuration::from_millis(10)).await;
+    }
+
+    assert!(
+        admin.delete_snapshot().is_empty(),
+        "DeleteRoom must be suppressed by the post-probe re-check; got {:?}",
+        admin.delete_snapshot(),
     );
 }
 

--- a/server/crates/waddle-sfu/src/livekit/tests.rs
+++ b/server/crates/waddle-sfu/src/livekit/tests.rs
@@ -789,6 +789,95 @@ async fn last_participant_delete_room_skipped_when_someone_rejoins() {
     );
 }
 
+#[tokio::test]
+async fn delete_room_skipped_when_livekit_reports_another_replicas_participant() {
+    // #1445 second-order defect: with two waddle-server replicas the
+    // registry is process-local, so "our map just emptied" says
+    // nothing about the other replica's participants in the same
+    // LiveKit room. The teardown must confirm emptiness against
+    // LiveKit itself before DeleteRoom.
+    let admin = Arc::new(RecordingAdmin::default());
+    let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+    let call = CallId::new("r-cross-replica").unwrap();
+    let alice = fixture_identity("alice");
+    let bob = fixture_identity("bob");
+
+    // Only Alice is registered locally; Bob joined via the other
+    // replica, so LiveKit sees both.
+    sfu.register_call_participant(&call, &alice);
+    admin.set_live(&call, vec![alice.clone(), bob.clone()]);
+
+    let state = sfu.unregister_call_participant(&call, &alice);
+    assert_eq!(state, CallState::Ended, "locally the call just emptied");
+    drain_admin_tasks().await;
+
+    assert_eq!(
+        admin.remove_snapshot().len(),
+        1,
+        "RemoveParticipant for Alice must still fire"
+    );
+    assert!(
+        admin.delete_snapshot().is_empty(),
+        "DeleteRoom must be suppressed while LiveKit reports another \
+         replica's participant; got {:?}",
+        admin.delete_snapshot(),
+    );
+}
+
+#[tokio::test]
+async fn delete_room_fires_when_livekit_reports_only_the_departing_participant() {
+    // LiveKit's participant list can momentarily still contain the
+    // participant we just issued RemoveParticipant for. That stale
+    // echo of the departing identity must not suppress the delete,
+    // or every clean last-leave would leak the room until
+    // empty_timeout.
+    let admin = Arc::new(RecordingAdmin::default());
+    let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+    let call = CallId::new("r-departing-echo").unwrap();
+    let alice = fixture_identity("alice");
+
+    sfu.register_call_participant(&call, &alice);
+    admin.set_live(&call, vec![alice.clone()]);
+
+    let state = sfu.unregister_call_participant(&call, &alice);
+    assert_eq!(state, CallState::Ended);
+    drain_admin_tasks().await;
+
+    assert_eq!(
+        admin.delete_snapshot(),
+        vec![call],
+        "DeleteRoom must fire when LiveKit reports nobody but the leaver"
+    );
+}
+
+#[tokio::test]
+async fn delete_room_skipped_when_livekit_occupancy_cannot_be_confirmed() {
+    // Fail-safe: if the ListParticipants probe errors we cannot rule
+    // out participants on the other replica, so the delete is
+    // skipped and the room lapses via LiveKit's own empty_timeout.
+    let admin = Arc::new(RecordingAdmin::default());
+    let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+    let call = CallId::new("r-list-error").unwrap();
+    let alice = fixture_identity("alice");
+
+    sfu.register_call_participant(&call, &alice);
+    admin.fail_list();
+
+    let state = sfu.unregister_call_participant(&call, &alice);
+    assert_eq!(state, CallState::Ended);
+    drain_admin_tasks().await;
+
+    assert_eq!(
+        admin.remove_snapshot().len(),
+        1,
+        "RemoveParticipant must still fire"
+    );
+    assert!(
+        admin.delete_snapshot().is_empty(),
+        "DeleteRoom must be suppressed when occupancy cannot be confirmed"
+    );
+}
+
 // -------- Reconciliation backstop --------
 
 use crate::SfuReconciler;

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -536,6 +536,27 @@ impl JingleHandler {
         }
 
         if jingle.action == Action::SessionInitiate {
+            // Same rate limit as 1:1 session-initiate, and for the
+            // same reason: a Muji initiate mints a JWT and grows the
+            // SFU registry. It costs strictly more than the 1:1 case
+            // since #1445 — an initiate for a room this replica does
+            // not own also buys a claim-store lookup and a cross-node
+            // relay — so the unlimited Muji branch would be the
+            // cheapest amplification primitive in the call path.
+            let initiator_bare = ctx.full_jid.to_bare();
+            if let Err(exceeded) = self.rate_limit.check_and_record(&initiator_bare) {
+                tracing::warn!(
+                    jid = %initiator_bare,
+                    %exceeded,
+                    "rate-limit dropped Muji session-initiate"
+                );
+                attempt.failed(CallSetupFailureReason::RateLimited);
+                return error_reply(
+                    iq,
+                    DefinedCondition::PolicyViolation,
+                    "session-initiate rate limit exceeded",
+                );
+            }
             // XEP-0166 §7.1 spoofing defense: when present on
             // session-initiate, `initiator` must match the
             // authenticated session. Non-initiate actions should not

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -122,10 +122,18 @@ fn is_local_jingle_peer(peer: &Jid, ctx: &StanzaContext<'_>) -> bool {
 /// registry. Other servers should run their own SFU; this gate stops
 /// us proxying as theirs.
 fn is_local_muji_room(room: &BareJid, ctx: &StanzaContext<'_>) -> bool {
-    // Single MUC service per server, derived from the apex like the
-    // rest of the routing layer (`waddle-xmpp/src/routing.rs:80`).
-    let expected = format!("muc.{}", ctx.domain);
-    room.domain().as_str() == expected
+    room_is_on_local_muc_service(room, ctx.domain)
+}
+
+/// Whether `room` lives on this server's MUC service.
+///
+/// Single MUC service per server, derived from the apex like the rest
+/// of the routing layer (`waddle-xmpp/src/routing.rs:80`). Public so
+/// the websocket layer's #1445 relay pre-check uses the SAME predicate
+/// as the handler's payload guard — two independent spellings of
+/// "local MUC domain" would drift.
+pub fn room_is_on_local_muc_service(room: &BareJid, server_domain: &str) -> bool {
+    room.domain().as_str() == format!("muc.{server_domain}")
 }
 
 #[derive(Clone)]

--- a/server/crates/waddle-xmpp/src/telemetry/attributes.rs
+++ b/server/crates/waddle-xmpp/src/telemetry/attributes.rs
@@ -536,12 +536,19 @@ pub enum CallSetupFailureReason {
     /// lookup or room-actor ask error) before the SFU was ever
     /// contacted.
     MembershipCheckFailed,
+    /// The room is owned by another node and that node could not be
+    /// reached, so the request never got as far as an authorization
+    /// decision (#1445). Distinct from `MembershipCheckFailed`: the
+    /// membership gate did not fail, it never ran. Keeping relay
+    /// outages out of the membership bucket is what stops a clustering
+    /// incident from reading as a permissions problem.
+    OwnerUnreachable,
 }
 
 impl CallSetupFailureReason {
     /// Every allowed value. Startup zero-registration (#1436) iterates
     /// this so every failure series exists before the first real call.
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 10] = [
         Self::RoomNotFound,
         Self::MembershipDenied,
         Self::NotAuthorized,
@@ -551,6 +558,7 @@ impl CallSetupFailureReason {
         Self::FederationUnsupported,
         Self::TokenMintFailed,
         Self::MembershipCheckFailed,
+        Self::OwnerUnreachable,
     ];
 }
 
@@ -570,6 +578,7 @@ impl MetricAttribute for CallSetupFailureReason {
             Self::FederationUnsupported => "federation_unsupported",
             Self::TokenMintFailed => "token_mint_failed",
             Self::MembershipCheckFailed => "membership_check_failed",
+            Self::OwnerUnreachable => "owner_unreachable",
         }
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0272_muji.rs
+++ b/server/crates/waddle-xmpp/tests/xep0272_muji.rs
@@ -692,20 +692,20 @@ impl waddle_sfu::LiveKitAdmin for RecordingAdmin {
         Box::pin(async move { Ok(()) })
     }
 
-    fn list_participant_identities<'a>(
+    fn room_occupancy<'a>(
         &'a self,
         _room: &'a waddle_sfu::CallId,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
-                    Output = Result<Vec<waddle_sfu::Identity>, waddle_sfu::SfuError>,
+                    Output = Result<waddle_sfu::RoomOccupancy, waddle_sfu::SfuError>,
                 > + Send
                 + 'a,
         >,
     > {
         // These Muji teardown tests don't exercise the reconciliation
-        // backstop; report no live participants.
-        Box::pin(async move { Ok(Vec::new()) })
+        // backstop; report an empty room.
+        Box::pin(async move { Ok(waddle_sfu::RoomOccupancy::default()) })
     }
 }
 
@@ -961,5 +961,44 @@ fn muji_initiate_without_gate_capabilities_is_refused() {
     assert!(
         session_accept_payload_to(&events, TEST_INITIATOR).is_none(),
         "no session-accept (and therefore no token) may be issued: {events:?}",
+    );
+}
+
+// ── #1445: cross-replica routing of Muji signalling ──────────────────
+
+/// The per-JID `session-initiate` rate limit must cover the Muji
+/// branch, not just 1:1 Jingle. Before #1445 the Muji branch returned
+/// before the limiter ran, so an unlimited stream of Muji initiates
+/// could mint JWTs and grow the SFU registry — and since #1445 each
+/// one also costs a claim-store lookup and, for a foreign-owned room,
+/// a cross-node relay.
+#[test]
+fn muji_session_initiate_is_rate_limited_per_bare_jid() {
+    let jid = test_full_jid();
+    let handler = JingleHandler::new(fixture_sfu());
+    let mixer = calls_mixer_jid(TEST_DOMAIN).to_string();
+
+    // The limiter's default budget is 5 initiates per 30s; the sixth
+    // in the same window must be rejected.
+    let mut conditions = Vec::new();
+    for attempt in 0..7 {
+        let iq = muji_session_initiate_iq(
+            TEST_INITIATOR,
+            &mixer,
+            "room@muc.waddle.test",
+            &format!("muji-rate-{attempt}"),
+        );
+        let events = handler.handle(&iq, &ctx(&jid));
+        conditions.push(first_error_condition(&events));
+    }
+
+    assert!(
+        conditions.contains(&Some(DefinedCondition::PolicyViolation)),
+        "a sustained Muji session-initiate burst must hit the rate limit: {conditions:?}",
+    );
+    assert!(
+        conditions[0].is_none(),
+        "the first initiate in the window must still succeed: {:?}",
+        conditions[0],
     );
 }


### PR DESCRIPTION
Fixes #1445.

## Problem

Production runs 2 `waddle-server` replicas. A Muji (XEP-0272) `session-initiate` is addressed to `calls.<domain>`, is exempt from full-JID relay, and is processed entirely on whichever replica receives it. The membership gate's room lookup is process-local, so on the non-owning replica a live room looks absent — the gate denied with `room_not_found` + `<forbidden/>` even though the room actor was alive on the other node (the MUC join presence *was* relayed there). Production telemetry: **~2 of 7 joins (~29%) denied at token minting**, in steady state and during rollouts.

Second defect: `DeleteRoom` was gated on process-local registry emptiness, so a replica whose map just emptied could delete a LiveKit room the other replica's participants still occupied.

## What changed

**Route Muji signalling to the room-owning node.** The gate returns a new `RoomNotLocal` outcome instead of denying on local absence. The websocket adapter relays the IQ over the existing ordered MUC proxy under a new `OrderedRelayMucProxyKind::MujiJingleIq`, whose envelope validation binds the payload's `<muji room>` to the channel's room — this is the one MUC-proxy shape *not* addressed to the room, so an envelope on room A's claim-fenced channel cannot smuggle a mint for room B. The owner re-runs the gate where the occupancy lives, mints with voice-derived capabilities (#1593), registers in its own SFU registry, and its reply frames (the IQ ack and the server-initiated `session-accept` carrying the token) ride back on the relay ACK. The authenticated full JID is stamped as `from` before relaying, since both the envelope's sender-claim validation and the owner-side executor read it.

Only a definitive no-claim-anywhere answer stays a `room_not_found` denial, with identical wire shape and telemetry. `LocalRoom` (stale claim row, no local actor) is also terminal — retrying it would loop forever. Transient relay states map to `type='wait'`. The owner-side executor is terminal: a denial comes back as a delivered IQ-error frame, never a NACK, so no relay loop can form.

**`session-terminate` relays too.** Since the initiate registers on the owner, a terminate executed on the client's own replica would clear nothing there — leaving a phantom in-call participant that *also* keeps the call non-empty and so suppresses `DeleteRoom` for every other occupant. When it cannot be relayed it falls back to local execution, so a hangup never fails. The owner-side executor runs the Muji-presence clear, which needs the room actor.

**`DeleteRoom` is confirmed against LiveKit's own occupancy.** LiveKit is the one component every replica shares. `RoomOccupancy` splits connected participants into `waddle` (identities we minted) and `foreign` (an egress recorder, SIP, ingress) — ghost reconciliation may only reason about the former, but an *emptiness* decision must count the latter, or deleting a room around a recorder would kill the recording. The local registry is re-checked **after** the probe, because the round-trip is a second window for a joiner to register unseen. A probe failure fails safe (skip; the room lapses via LiveKit's `empty_timeout`).

## Review findings addressed

Three independent adversarial reviews (two Claude personas, one gpt-5.6) found 13 real issues; all are fixed. The two that would have shipped a regression:

- **Mixed-version deploy poisons the room's ordered channel — resolved by deploying this as a hard cutover.** A replica predating `MujiJingleIq` cannot deserialize the envelope, which surfaces as a maybe-committed codec failure and leaves a *sticky* diversion on a channel shared with that sender's MUC join/leave/groupchat traffic for the room, silently breaking their chat until reconnect. An earlier revision tried to fix this in code by calling `forget_channel` for this kind; that was **wrong and is reverted** — it resets the sender's sequence while leaving the receiver's expectation untouched, so the next stanza NACKs as an ordering gap and diverts anyway. A comment at the site records why, so it is not retried.

  Since the trigger is purely version skew, `updateStrategy` is set to `Recreate` for this release (`infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml`): both pods stop before either new one starts, so no two versions ever exchange relay envelopes. **This makes the release a brief-outage deploy** — clients reconnect via stream management, and in-flight calls are expendable. #1597 tracks reverting to `RollingUpdate` afterwards and removing the need for a cutover at all, so the next relay variant does not silently inherit the hazard.

- **Client-controlled `to`** reached the relay, where a non-mixer or full-JID `to` fails envelope validation and diverts that same shared channel. `to` and the room domain are validated before anything reaches the relay.

Also fixed: relay failures recorded no call-setup telemetry (an outage in this path would have been invisible in the #1452 SLI it exists to feed); a `Delivered` outcome with no frames silently answered nothing; the direct dispatch seam that bypasses envelope validation now rebinds the stanza sender to the authenticated registration before minting; Muji `session-initiate` bypassed the rate limiter entirely; cross-node joins double-counted `MujiJoin`.

## Tests

- **waddle-sfu**: `DeleteRoom` suppressed when LiveKit reports another replica's participant, when only a foreign (egress/SIP) participant remains, when a participant registers *during* the occupancy probe, and when the probe errors; still fires when LiveKit reports nobody but the leaver. The probe-race guard is mutation-verified.
- **Ordered relay**: `MujiJingleIq` envelope validation — payload room bound to the channel room, terminate accepted, other actions and non-Muji Jingle rejected.
- **Gate / owner executor**: `RoomNotLocal` on local absence; terminate reports locality (mutation-verified) while never being membership-gated; relayed initiate mints and returns ack + `session-accept`; relayed terminate unregisters on the owner (mutation-verified); non-occupant gets a delivered `<forbidden/>`; missing/bare sender is a shape failure.
- **XEP-0272 suite**: Muji `session-initiate` rate limiting.
- **Two-node integration** (`clustering_cluster_e2e`): a join whose signalling lands on the non-owning node succeeds with a real token; a cross-node hangup is accepted; an unclaimed room still denies with `<forbidden/>`.

`cargo clippy --workspace --all-features --all-targets -- -D warnings` clean; `cargo fmt` clean. Full workspace suite green apart from 5 pre-existing parallel-metric flakes, each verified passing in isolation and reproducing on `main`.

## Deliberately out of scope

Durable, generation-keyed call state — webhook delivery durability, SID+generation keying, restart recovery, and cross-node forwarding of webhook effects — remains #1449's scope; the 60s reconcile sweep stays the ghost backstop. Residual, documented: an origin-side Muji initiate for a plausible room name still costs one indexed claim-store lookup before it can be denied (the mint itself is now rate limited); broader Muji/terminate/token/TURN rate limiting is listed in #1449's acceptance criteria.

Unrelated observation while testing, **not** changed here: a client-published Muji *presence* update did not appear to reflect to an occupant on another node. That is the "call ongoing" indicator path, independent of token minting. I have not confirmed whether it is a real gap or an artifact of my test's timing — worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
