### PR TITLE
fix(server): route participant_joined grant reassertion to the room-owning replica (#1594)

### DIFF
--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -829,6 +829,91 @@ impl Message<Demote> for RelayActor {
     }
 }
 
+/// #1594: server-originated request to re-assert one live SFU
+/// participant's media grants on the node holding `room`'s claim.
+///
+/// Sent by a node whose LiveKit `participant_joined` webhook found no
+/// local room actor (the webhook URL is load-balanced, so with more
+/// than one replica most joins land on a non-owning node). The
+/// receiver re-derives the occupant's XEP-0045 voice from its OWN room
+/// actor and pushes the grants — converging a token minted before a
+/// voice change in milliseconds instead of the reconciler's next tick.
+///
+/// Mirrors [`Demote`]'s shape: a small, fully typed payload discovered
+/// via the claim store and asked directly on the owner's relay — not
+/// the ordered MUC proxy, which requires a client-stanza origin a
+/// webhook does not have (and whose ordering an idempotent re-assert
+/// does not need).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayReassertMediaGrants {
+    pub room: jid::BareJid,
+    pub participant: jid::FullJid,
+    /// Sender's W3C trace context (#1485), telemetry only: absent from
+    /// an older node's encoding, defaulted on decode, and never read for
+    /// relay semantics. Stamped at the send seam by [`RelayHandle`].
+    #[serde(default)]
+    pub trace: RelayTraceContext,
+}
+
+/// Reply to [`RelayReassertMediaGrants`]. Only the first two variants
+/// are authoritative; the last two mean "could not determine", which
+/// the asker maps to a LiveKit webhook retry — never to an
+/// authorization decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Reply)]
+pub enum RelayReassertMediaGrantsReply {
+    /// The owner's room actor answered with the occupant's voice and
+    /// the grants were pushed to the SFU.
+    Applied,
+    /// The owner's room actor answered authoritatively that the
+    /// participant is not an occupant; they were evicted from the call.
+    NotOccupantEvicted,
+    /// The receiver holds no room actor for `room` — the asker's claim
+    /// read was stale or the actor is mid-(re)spawn. Terminal on the
+    /// receiver (never re-relayed) so a stale claim cannot bounce a
+    /// webhook around the cluster.
+    NotOwner,
+    /// The receiver could not execute the re-assert (services or state
+    /// unavailable, local lookup flaked).
+    Unavailable,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.reassert_media_grants.v1")]
+impl Message<RelayReassertMediaGrants> for RelayActor {
+    // Delegated for the same reason as [`RelayResumeSteal`]: the
+    // owner-side room-actor ask is bounded but must not head-of-line
+    // block this node's relay mailbox while it resolves.
+    type Reply = kameo::reply::DelegatedReply<RelayReassertMediaGrantsReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayReassertMediaGrants,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let span = relay_dispatch_span("reassert_media_grants", &msg.trace);
+        span.record("entity", tracing::field::display(&msg.room));
+        span.record("jid", tracing::field::display(msg.participant.to_bare()));
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        spawn_in_dispatch_span(ctx, span, async move {
+            use super::route_bridge::LocalMediaGrantReassertion;
+            match bridge
+                .reassert_media_grants_local(&msg.room, &msg.participant)
+                .await
+            {
+                LocalMediaGrantReassertion::Applied => RelayReassertMediaGrantsReply::Applied,
+                LocalMediaGrantReassertion::EvictedNonOccupant => {
+                    RelayReassertMediaGrantsReply::NotOccupantEvicted
+                }
+                LocalMediaGrantReassertion::NoLocalRoomActor => {
+                    RelayReassertMediaGrantsReply::NotOwner
+                }
+                LocalMediaGrantReassertion::Unavailable => {
+                    RelayReassertMediaGrantsReply::Unavailable
+                }
+            }
+        })
+    }
+}
+
 /// Harness fault injection: crash the relay actor (simulating an unexpected
 /// stop, so the supervised respawn + same-name re-registration and the
 /// sender-side stale-ref recovery can be asserted cross-node). Inert unless
@@ -1793,6 +1878,59 @@ impl RelayHandle {
         }
     }
 
+    /// #1594: ask the room's claim owner to re-assert one SFU
+    /// participant's media grants from its authoritative occupant
+    /// state. Idempotent (re-deriving and re-pushing the same grants
+    /// is a no-op), so it shares [`Self::demote`]'s exact stale-ref
+    /// refresh-and-retry-once behaviour and `stop_token`-raced
+    /// cancellation-safety.
+    pub async fn reassert_media_grants(
+        &mut self,
+        room: jid::BareJid,
+        participant: jid::FullJid,
+    ) -> Result<RelayReassertMediaGrantsReply, RelayAskError> {
+        let trace = RelayTraceContext::capture();
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.reassert_media_grants_inner(room, participant, trace) => result,
+        }
+    }
+
+    async fn reassert_media_grants_inner(
+        &mut self,
+        room: jid::BareJid,
+        participant: jid::FullJid,
+        trace: RelayTraceContext,
+    ) -> Result<RelayReassertMediaGrantsReply, RelayAskError> {
+        let message = RelayReassertMediaGrants {
+            room,
+            participant,
+            trace,
+        };
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_stale_ref_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
     async fn demote_inner(
         &mut self,
         entity: Entity,
@@ -2427,6 +2565,58 @@ mod tests {
                 &crate::config::ClusteringMessagingConfig::default(),
             ),
         ))
+    }
+
+    /// #1594: a re-assert ask against a relay whose delivery bridge has
+    /// no wired services (this node's `WebSocketState` is unreachable)
+    /// must answer `Unavailable` — never a fabricated occupancy answer,
+    /// and never a hang.
+    #[tokio::test(flavor = "current_thread")]
+    async fn reassert_media_grants_without_wired_services_answers_unavailable() {
+        // Thread-scoped subscriber, not asserted on: a relay ask on a
+        // subscriber-less thread destabilizes the interest cache the
+        // *_records_the_dispatch_span tests depend on when the tests
+        // overlap (pre-existing test-support limitation, observed
+        // deterministically pairwise).
+        let _spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let actor_ref = spawn_test_relay_actor();
+
+        let reply = actor_ref
+            .ask(RelayReassertMediaGrants {
+                room: "room@muc.example.com".parse().expect("room jid"),
+                participant: "alice@example.com/web".parse().expect("participant jid"),
+                trace: RelayTraceContext::default(),
+            })
+            .await
+            .expect("reassert ask succeeds");
+
+        assert_eq!(reply, RelayReassertMediaGrantsReply::Unavailable);
+    }
+
+    /// #1594: the re-assert handler delegates its reply (the owner-side
+    /// room-actor ask is bounded but slow-able), and delegated work must
+    /// still run under the named relay dispatch root span (#1483).
+    #[tokio::test(flavor = "current_thread")]
+    async fn reassert_media_grants_ask_records_the_dispatch_span() {
+        let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
+        let actor_ref = spawn_test_relay_actor();
+
+        let _reply = actor_ref
+            .ask(RelayReassertMediaGrants {
+                room: "room@muc.example.com".parse().expect("room jid"),
+                participant: "alice@example.com/web".parse().expect("participant jid"),
+                trace: RelayTraceContext::default(),
+            })
+            .await
+            .expect("reassert ask succeeds");
+
+        assert_eq!(
+            spans
+                .recorded_field("clustering.relay.dispatch", "relay.message")
+                .as_deref(),
+            Some("reassert_media_grants"),
+            "reassert handling must run under the named relay dispatch root span"
+        );
     }
 
     /// #1483: an inbound relay ask handled inline (no delegated reply) must

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -5027,7 +5027,7 @@ impl OrderedRelayDeliveryBridge {
         participant: &jid::FullJid,
     ) -> LocalMediaGrantReassertion {
         use crate::server::routes::websocket::muc_call_sfu::{
-            enforce_current_voice_grants, GrantEnforcement,
+            apply_derived_enforcement, derive_current_voice, GrantEnforcement, VoiceDerivation,
         };
         let Some(services) = self.services.get().cloned() else {
             return LocalMediaGrantReassertion::Unavailable;
@@ -5046,6 +5046,33 @@ impl OrderedRelayDeliveryBridge {
         // gate in this module applies); otherwise answer
         // `NoLocalRoomActor` so the asker's retry re-resolves the
         // owner.
+        let me = services.node_identity.current();
+        let gate_epoch = match services
+            .claim_store
+            .current_claim(&room_entity(room_jid))
+            .await
+        {
+            Ok(Some(snapshot)) if snapshot.owner_lease_fresh && snapshot.owner == me => {
+                snapshot.claim_epoch
+            }
+            Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
+            Err(_) => return LocalMediaGrantReassertion::Unavailable,
+        };
+        // Derive first, act second: the room-actor ask can take up to
+        // its reply timeout, during which the claim can be stolen and
+        // the local actor's occupant set superseded. Re-checking the
+        // claim (same epoch, still fresh-and-mine) between the answer
+        // and the SFU effect fences the answer to the claim it was
+        // derived under — the SFU push/evict happens only while this
+        // node's ownership is continuously observable.
+        let derivation = derive_current_voice(state.as_ref(), room_jid, participant).await;
+        match derivation {
+            VoiceDerivation::NoLocalRoomActor => {
+                return LocalMediaGrantReassertion::NoLocalRoomActor
+            }
+            VoiceDerivation::LookupFailed => return LocalMediaGrantReassertion::Unavailable,
+            VoiceDerivation::Occupant(_) | VoiceDerivation::NotOccupant => {}
+        }
         match services
             .claim_store
             .current_claim(&room_entity(room_jid))
@@ -5053,19 +5080,26 @@ impl OrderedRelayDeliveryBridge {
         {
             Ok(Some(snapshot))
                 if snapshot.owner_lease_fresh
-                    && snapshot.owner == services.node_identity.current() => {}
+                    && snapshot.owner == me
+                    && snapshot.claim_epoch == gate_epoch => {}
             Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
             Err(_) => return LocalMediaGrantReassertion::Unavailable,
         }
-        match enforce_current_voice_grants(state.as_ref(), room_jid, participant).await {
+        let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+            // An SFU-less node cannot push grants — "cannot execute
+            // here", never an authorization conclusion.
+            return LocalMediaGrantReassertion::Unavailable;
+        };
+        match apply_derived_enforcement(sfu, room_jid, participant, derivation) {
             GrantEnforcement::Applied => LocalMediaGrantReassertion::Applied,
             GrantEnforcement::EvictedNonOccupant => LocalMediaGrantReassertion::EvictedNonOccupant,
-            GrantEnforcement::NoLocalRoomActor => LocalMediaGrantReassertion::NoLocalRoomActor,
-            // An SFU-less node cannot push grants, and a flaked lookup
-            // proves nothing — both are "cannot execute here".
-            GrantEnforcement::LookupFailed | GrantEnforcement::SfuNotConfigured => {
-                LocalMediaGrantReassertion::Unavailable
-            }
+            // Unreachable: both non-authoritative derivations returned
+            // above, and `apply_derived_enforcement` maps the two
+            // authoritative ones exhaustively to the two arms matched
+            // here.
+            GrantEnforcement::NoLocalRoomActor
+            | GrantEnforcement::LookupFailed
+            | GrantEnforcement::SfuNotConfigured => LocalMediaGrantReassertion::Unavailable,
         }
     }
 }

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -5040,7 +5040,10 @@ impl OrderedRelayDeliveryBridge {
         // stale, and a lingering post-demote actor on this node must
         // not answer authoritatively — evicting from a superseded
         // occupant set is the #1593 breaker class. Execute only while
-        // this node still owns the claim; otherwise answer
+        // this node still owns the claim WITH a fresh lease (an
+        // expired lease means another node may already be stealing
+        // it — the same fresh-and-mine predicate every other receiver
+        // gate in this module applies); otherwise answer
         // `NoLocalRoomActor` so the asker's retry re-resolves the
         // owner.
         match services
@@ -5048,7 +5051,9 @@ impl OrderedRelayDeliveryBridge {
             .current_claim(&room_entity(room_jid))
             .await
         {
-            Ok(Some(snapshot)) if snapshot.owner == services.node_identity.current() => {}
+            Ok(Some(snapshot))
+                if snapshot.owner_lease_fresh
+                    && snapshot.owner == services.node_identity.current() => {}
             Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
             Err(_) => return LocalMediaGrantReassertion::Unavailable,
         }
@@ -5503,6 +5508,149 @@ mod tests {
         assert!(
             recorder.snapshot().is_empty(),
             "an unowned claim must never evict"
+        );
+    }
+
+    /// #1594 receiver-side claim gate, freshness half: a claim row
+    /// still naming this node whose node lease has EXPIRED is not
+    /// authority — another node may already be stealing the claim, so
+    /// a lingering local actor must not answer from its (about to be
+    /// superseded) occupant set. Same fresh-and-mine predicate as
+    /// every other receiver gate in this module.
+    #[tokio::test]
+    async fn reassert_media_grants_local_with_stale_lease_refuses_to_execute() {
+        use crate::server::routes::websocket::tests::{
+            create_test_server_owner_session, create_test_websocket_state_with_sfu, RecordingSfu,
+        };
+        use waddle_xmpp::ownership::{ClaimSnapshot, StalePredicate};
+
+        /// `current_claim` answers "owned by `me`, lease expired";
+        /// nothing else is reachable from the gate under test.
+        struct StaleLeaseClaimStore {
+            me: NodeIdentity,
+        }
+
+        #[async_trait::async_trait]
+        impl waddle_xmpp::ownership::ClaimStore for StaleLeaseClaimStore {
+            async fn ensure_schema(&self) -> Result<(), ClaimError> {
+                Ok(())
+            }
+            async fn acquire(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn ensure_claimed(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn steal_stale(
+                &self,
+                _entity: &Entity,
+                _observed: ClaimEpoch,
+                _staleness: StalePredicate,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn steal_for_resume(
+                &self,
+                _entity: &Entity,
+                _observed: ClaimEpoch,
+                _witness: waddle_xmpp::ownership::ResumeIdentityProof,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn current_claim(
+                &self,
+                _entity: &Entity,
+            ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+                Ok(Some(ClaimSnapshot {
+                    owner: self.me.clone(),
+                    claim_epoch: ClaimEpoch(1),
+                    owner_lease_fresh: false,
+                }))
+            }
+            async fn current_claim_after_pending_writes(
+                &self,
+                _entity: &Entity,
+            ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn fence(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+                _mine: ClaimEpoch,
+            ) -> Result<bool, ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn release(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+                _mine: ClaimEpoch,
+            ) -> Result<(), ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+            async fn release_many(
+                &self,
+                _entities: &[Entity],
+                _me: &NodeIdentity,
+            ) -> Result<(), ClaimError> {
+                unreachable!("gate test only calls current_claim")
+            }
+        }
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+        let room: jid::BareJid = "gate-stale@muc.example.com".parse().expect("room jid");
+        let alice: jid::FullJid = "alice@example.com/web".parse().expect("participant jid");
+        crate::server::routes::websocket::handlers::presence::handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room,
+            &alice,
+            "alice",
+            None,
+            &Some(session),
+        )
+        .await;
+
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let mut services = services_with_claims(
+            origin_identity(),
+            receiver_identity(),
+            receiver_identity(),
+            test_peer_id(),
+        )
+        .await;
+        services.web_socket_state = Arc::downgrade(&state);
+        services.claim_store = Arc::new(StaleLeaseClaimStore {
+            me: receiver_identity(),
+        });
+        bridge.wire(Arc::new(services));
+
+        let outcome = bridge.reassert_media_grants_local(&room, &alice).await;
+
+        assert_eq!(outcome, LocalMediaGrantReassertion::NoLocalRoomActor);
+        assert!(
+            recorder.update_snapshot().is_empty(),
+            "an expired lease must suppress the grant push"
+        );
+        assert!(
+            recorder.snapshot().is_empty(),
+            "an expired lease must never evict"
         );
     }
 

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -4988,6 +4988,15 @@ fn ask_error_maybe_committed(error: &RelayAskError) -> bool {
     )
 }
 
+/// Bound on each receiver-side claim-store read in
+/// [`OrderedRelayDeliveryBridge::reassert_media_grants_local`]. The
+/// executor runs in a delegated relay task that outlives the asker's
+/// webhook timeout, so a stalled control-plane pool would otherwise
+/// keep one pending task alive per LiveKit retry. On elapse the
+/// executor answers `Unavailable` — a retry signal, never an
+/// authorization conclusion.
+const REASSERT_CLAIM_READ_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Owner-side outcome of a #1594 cross-node media-grant re-assert,
 /// executed against THIS node's room map. The relay actor maps these
 /// onto [`super::relay::RelayReassertMediaGrantsReply`] — kept as a
@@ -5047,16 +5056,17 @@ impl OrderedRelayDeliveryBridge {
         // `NoLocalRoomActor` so the asker's retry re-resolves the
         // owner.
         let me = services.node_identity.current();
-        let gate_epoch = match services
-            .claim_store
-            .current_claim(&room_entity(room_jid))
-            .await
+        let gate_epoch = match tokio::time::timeout(
+            REASSERT_CLAIM_READ_TIMEOUT,
+            services.claim_store.current_claim(&room_entity(room_jid)),
+        )
+        .await
         {
-            Ok(Some(snapshot)) if snapshot.owner_lease_fresh && snapshot.owner == me => {
+            Ok(Ok(Some(snapshot))) if snapshot.owner_lease_fresh && snapshot.owner == me => {
                 snapshot.claim_epoch
             }
-            Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
-            Err(_) => return LocalMediaGrantReassertion::Unavailable,
+            Ok(Ok(_)) => return LocalMediaGrantReassertion::NoLocalRoomActor,
+            Ok(Err(_)) | Err(_) => return LocalMediaGrantReassertion::Unavailable,
         };
         // Derive first, act second: the room-actor ask can take up to
         // its reply timeout, during which the claim can be stolen and
@@ -5073,17 +5083,18 @@ impl OrderedRelayDeliveryBridge {
             VoiceDerivation::LookupFailed => return LocalMediaGrantReassertion::Unavailable,
             VoiceDerivation::Occupant(_) | VoiceDerivation::NotOccupant => {}
         }
-        match services
-            .claim_store
-            .current_claim(&room_entity(room_jid))
-            .await
+        match tokio::time::timeout(
+            REASSERT_CLAIM_READ_TIMEOUT,
+            services.claim_store.current_claim(&room_entity(room_jid)),
+        )
+        .await
         {
-            Ok(Some(snapshot))
+            Ok(Ok(Some(snapshot)))
                 if snapshot.owner_lease_fresh
                     && snapshot.owner == me
                     && snapshot.claim_epoch == gate_epoch => {}
-            Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
-            Err(_) => return LocalMediaGrantReassertion::Unavailable,
+            Ok(Ok(_)) => return LocalMediaGrantReassertion::NoLocalRoomActor,
+            Ok(Err(_)) | Err(_) => return LocalMediaGrantReassertion::Unavailable,
         }
         let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
             // An SFU-less node cannot push grants — "cannot execute
@@ -5686,6 +5697,126 @@ mod tests {
             recorder.snapshot().is_empty(),
             "an expired lease must never evict"
         );
+    }
+
+    /// #1594: the receiver-side claim reads are bounded. The executor
+    /// runs in a delegated relay task that outlives the asker's
+    /// webhook timeout, so a stalled claim store (pool exhaustion)
+    /// must resolve to `Unavailable` within the read budget instead
+    /// of accumulating one pending task per LiveKit retry.
+    #[tokio::test]
+    async fn reassert_media_grants_local_bounds_a_stalled_claim_store() {
+        use crate::server::routes::websocket::tests::{
+            create_test_websocket_state_with_sfu, RecordingSfu,
+        };
+        use waddle_xmpp::ownership::{ClaimSnapshot, StalePredicate};
+
+        /// `current_claim` never resolves; nothing else is reachable.
+        struct StalledClaimStore;
+
+        #[async_trait::async_trait]
+        impl waddle_xmpp::ownership::ClaimStore for StalledClaimStore {
+            async fn ensure_schema(&self) -> Result<(), ClaimError> {
+                Ok(())
+            }
+            async fn acquire(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn ensure_claimed(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn steal_stale(
+                &self,
+                _entity: &Entity,
+                _observed: ClaimEpoch,
+                _staleness: StalePredicate,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn steal_for_resume(
+                &self,
+                _entity: &Entity,
+                _observed: ClaimEpoch,
+                _witness: waddle_xmpp::ownership::ResumeIdentityProof,
+                _me: &NodeIdentity,
+            ) -> Result<ClaimEpoch, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn current_claim(
+                &self,
+                _entity: &Entity,
+            ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+                std::future::pending().await
+            }
+            async fn current_claim_after_pending_writes(
+                &self,
+                _entity: &Entity,
+            ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn fence(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+                _mine: ClaimEpoch,
+            ) -> Result<bool, ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn release(
+                &self,
+                _entity: &Entity,
+                _me: &NodeIdentity,
+                _mine: ClaimEpoch,
+            ) -> Result<(), ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+            async fn release_many(
+                &self,
+                _entities: &[Entity],
+                _me: &NodeIdentity,
+            ) -> Result<(), ClaimError> {
+                unreachable!("stall test only calls current_claim")
+            }
+        }
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let mut services = services_with_claims(
+            origin_identity(),
+            receiver_identity(),
+            receiver_identity(),
+            test_peer_id(),
+        )
+        .await;
+        services.web_socket_state = Arc::downgrade(&state);
+        services.claim_store = Arc::new(StalledClaimStore);
+        bridge.wire(Arc::new(services));
+
+        let room: jid::BareJid = "gate-stalled@muc.example.com".parse().expect("room jid");
+        let alice: jid::FullJid = "alice@example.com/web".parse().expect("participant jid");
+        let outcome = tokio::time::timeout(
+            REASSERT_CLAIM_READ_TIMEOUT + Duration::from_secs(3),
+            bridge.reassert_media_grants_local(&room, &alice),
+        )
+        .await
+        .expect("a stalled claim store must not hang the executor");
+
+        assert_eq!(outcome, LocalMediaGrantReassertion::Unavailable);
+        assert!(recorder.update_snapshot().is_empty());
+        assert!(recorder.snapshot().is_empty());
     }
 
     /// #1594 owner-side executor happy path: claim owned by this node

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -4988,6 +4988,66 @@ fn ask_error_maybe_committed(error: &RelayAskError) -> bool {
     )
 }
 
+/// Owner-side outcome of a #1594 cross-node media-grant re-assert,
+/// executed against THIS node's room map. The relay actor maps these
+/// onto [`super::relay::RelayReassertMediaGrantsReply`] — kept as a
+/// separate enum so the bridge (like `ResumeStealBridge`'s
+/// `LocalForcedDetachOutcome`) does not depend on relay wire types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalMediaGrantReassertion {
+    /// A local room actor answered with the occupant's voice and the
+    /// grants were pushed to the SFU.
+    Applied,
+    /// A local room actor answered authoritatively that the
+    /// participant is not an occupant; they were evicted from the call.
+    EvictedNonOccupant,
+    /// No room actor lives in this process — the asker's claim read is
+    /// stale or the actor is mid-(re)spawn. No side effect performed.
+    NoLocalRoomActor,
+    /// This node cannot execute the re-assert right now (services or
+    /// `WebSocketState` unavailable, or the local lookup flaked). No
+    /// authorization conclusion may be drawn from this.
+    Unavailable,
+}
+
+impl OrderedRelayDeliveryBridge {
+    /// Execute a relayed `participant_joined` grant re-assert on this
+    /// node — the receiving side of #1594. Terminal by design: this
+    /// never re-relays, so a stale claim read on the asker cannot
+    /// bounce a webhook around the cluster; a `NoLocalRoomActor`
+    /// answer sends the asker back to LiveKit's retry (which
+    /// re-resolves the claim).
+    ///
+    /// Reuses the exact same enforcement core as the same-node webhook
+    /// path (`muc_call_sfu::enforce_current_voice_grants`), so relayed
+    /// and local enforcement cannot diverge.
+    pub async fn reassert_media_grants_local(
+        &self,
+        room_jid: &jid::BareJid,
+        participant: &jid::FullJid,
+    ) -> LocalMediaGrantReassertion {
+        use crate::server::routes::websocket::muc_call_sfu::{
+            enforce_current_voice_grants, GrantEnforcement,
+        };
+        let Some(services) = self.services.get().cloned() else {
+            return LocalMediaGrantReassertion::Unavailable;
+        };
+        let Some(state) = services.web_socket_state.upgrade() else {
+            return LocalMediaGrantReassertion::Unavailable;
+        };
+        match enforce_current_voice_grants(state.as_ref(), room_jid, participant).await {
+            GrantEnforcement::Applied => LocalMediaGrantReassertion::Applied,
+            GrantEnforcement::EvictedNonOccupant => LocalMediaGrantReassertion::EvictedNonOccupant,
+            GrantEnforcement::NoLocalRoomActor => LocalMediaGrantReassertion::NoLocalRoomActor,
+            // An SFU-less node cannot push grants, and a flaked lookup
+            // proves nothing — both are "cannot execute here".
+            GrantEnforcement::LookupFailed | GrantEnforcement::SfuNotConfigured => {
+                LocalMediaGrantReassertion::Unavailable
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5341,6 +5401,35 @@ mod tests {
             blocking_storage,
             web_socket_state: Weak::new(),
         }
+    }
+
+    /// #1594: the owner-side re-assert executor must degrade to
+    /// `Unavailable` when the bridge is wired but this node's
+    /// `WebSocketState` has been dropped — the asker maps that to a
+    /// LiveKit retry, never to an authorization decision.
+    #[tokio::test]
+    async fn reassert_media_grants_local_without_live_state_is_unavailable() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        ));
+
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room jid");
+        let participant: jid::FullJid = "alice@example.com/web".parse().expect("participant jid");
+        let outcome = bridge
+            .reassert_media_grants_local(&room, &participant)
+            .await;
+
+        assert_eq!(outcome, LocalMediaGrantReassertion::Unavailable);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -5035,6 +5035,23 @@ impl OrderedRelayDeliveryBridge {
         let Some(state) = services.web_socket_state.upgrade() else {
             return LocalMediaGrantReassertion::Unavailable;
         };
+        // Receiver-side claim gate, mirroring what `validate_claims`
+        // does for ordered payloads: the asker's claim read can be
+        // stale, and a lingering post-demote actor on this node must
+        // not answer authoritatively — evicting from a superseded
+        // occupant set is the #1593 breaker class. Execute only while
+        // this node still owns the claim; otherwise answer
+        // `NoLocalRoomActor` so the asker's retry re-resolves the
+        // owner.
+        match services
+            .claim_store
+            .current_claim(&room_entity(room_jid))
+            .await
+        {
+            Ok(Some(snapshot)) if snapshot.owner == services.node_identity.current() => {}
+            Ok(_) => return LocalMediaGrantReassertion::NoLocalRoomActor,
+            Err(_) => return LocalMediaGrantReassertion::Unavailable,
+        }
         match enforce_current_voice_grants(state.as_ref(), room_jid, participant).await {
             GrantEnforcement::Applied => LocalMediaGrantReassertion::Applied,
             GrantEnforcement::EvictedNonOccupant => LocalMediaGrantReassertion::EvictedNonOccupant,
@@ -5430,6 +5447,116 @@ mod tests {
             .await;
 
         assert_eq!(outcome, LocalMediaGrantReassertion::Unavailable);
+    }
+
+    /// #1594 receiver-side claim gate: even with a live local room
+    /// actor holding the participant, a node that does NOT own the
+    /// room's claim must refuse to execute a relayed re-assert — a
+    /// lingering post-demote actor answering from a superseded
+    /// occupant set is the #1593 breaker class. Without the gate this
+    /// setup would answer `Applied` and push a grant.
+    #[tokio::test]
+    async fn reassert_media_grants_local_without_owned_claim_refuses_to_execute() {
+        use crate::server::routes::websocket::tests::{
+            create_test_server_owner_session, create_test_websocket_state_with_sfu, RecordingSfu,
+        };
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+        let room: jid::BareJid = "gate-refused@muc.example.com".parse().expect("room jid");
+        let alice: jid::FullJid = "alice@example.com/web".parse().expect("participant jid");
+        crate::server::routes::websocket::handlers::presence::handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room,
+            &alice,
+            "alice",
+            None,
+            &Some(session),
+        )
+        .await;
+
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        // Claim store knows the fixture entities but NOT this room —
+        // exactly what a deposed/never-owning receiver observes.
+        let mut services = services_with_claims(
+            origin_identity(),
+            receiver_identity(),
+            receiver_identity(),
+            test_peer_id(),
+        )
+        .await;
+        services.web_socket_state = Arc::downgrade(&state);
+        bridge.wire(Arc::new(services));
+
+        let outcome = bridge.reassert_media_grants_local(&room, &alice).await;
+
+        assert_eq!(outcome, LocalMediaGrantReassertion::NoLocalRoomActor);
+        assert!(
+            recorder.update_snapshot().is_empty(),
+            "an unowned claim must suppress the grant push"
+        );
+        assert!(
+            recorder.snapshot().is_empty(),
+            "an unowned claim must never evict"
+        );
+    }
+
+    /// #1594 owner-side executor happy path: claim owned by this node
+    /// plus a live room actor with the seated occupant → the relayed
+    /// re-assert pushes the voice-derived grant, observable on the
+    /// recording SFU.
+    #[tokio::test]
+    async fn reassert_media_grants_local_with_owned_claim_pushes_grants() {
+        use crate::server::routes::websocket::tests::{
+            create_test_server_owner_session, create_test_websocket_state_with_sfu, RecordingSfu,
+        };
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+        let room: jid::BareJid = "gate-owned@muc.example.com".parse().expect("room jid");
+        let alice: jid::FullJid = "alice@example.com/web".parse().expect("participant jid");
+        crate::server::routes::websocket::handlers::presence::handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room,
+            &alice,
+            "alice",
+            None,
+            &Some(session),
+        )
+        .await;
+
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let mut services = services_with_claims(
+            origin_identity(),
+            receiver_identity(),
+            receiver_identity(),
+            test_peer_id(),
+        )
+        .await;
+        services.web_socket_state = Arc::downgrade(&state);
+        services
+            .claim_store
+            .acquire(&room_entity(&room), &receiver_identity())
+            .await
+            .expect("receiver acquires the room claim");
+        bridge.wire(Arc::new(services));
+
+        let outcome = bridge.reassert_media_grants_local(&room, &alice).await;
+
+        assert_eq!(outcome, LocalMediaGrantReassertion::Applied);
+        let updates = recorder.update_snapshot();
+        assert_eq!(updates.len(), 1, "exactly one grant push expected");
+        assert_eq!(updates[0].1.as_livekit_identity(), alice.to_string());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/livekit_grant_relay.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_grant_relay.rs
@@ -1,0 +1,307 @@
+//! #1594 cross-node routing for `participant_joined` media-grant
+//! re-assertion: decide from the room's claim which replica should
+//! enforce, and relay the re-assert to a fresh foreign claim owner.
+//!
+//! Split out of `livekit_webhook.rs` so the HTTP webhook module stays
+//! HTTP-shaped: claim-store reads, relay-ask plumbing, and the
+//! webhook-scoped timeout policy all live here, behind one entry
+//! point ([`reassert_on_claim_owner`]).
+
+use jid::{BareJid, FullJid};
+#[cfg(feature = "clustering")]
+use std::time::Duration as StdDuration;
+#[cfg(feature = "clustering")]
+use tracing::debug;
+use tracing::warn;
+
+use super::livekit_webhook::ReassertOutcome;
+use super::websocket::WebSocketState;
+
+/// Fallback when there is no fresh foreign owner to relay to (no
+/// clustering, room unclaimed, stale owner lease, or the claim is this
+/// node's own): acknowledge the delivery and leave convergence to the
+/// owning node's reconciliation pass, exactly the pre-#1594 behavior.
+/// (A claim-store read *error* is transient and maps to a LiveKit
+/// retry instead — see [`route_from_claim`].)
+fn converge_on_reconcile(room_jid: &BareJid, full_jid: &FullJid) -> ReassertOutcome {
+    warn!(
+        room = %room_jid,
+        user = %full_jid.to_bare(),
+        "no local room actor on this node; media grants for this join \
+         will converge on the owning node's reconciliation pass",
+    );
+    ReassertOutcome::UnenforceableHere
+}
+
+/// #1594: this node has no room actor, so route the re-assert to the
+/// replica holding the room's claim instead of waiting for its
+/// reconciliation tick. Every path that cannot reach a fresh foreign
+/// owner degrades to [`converge_on_reconcile`]; failures where a
+/// LiveKit retry could plausibly land after the cluster settles map
+/// to [`ReassertOutcome::RetryableFailure`].
+/// Where a `participant_joined` re-assert should go, given the room's
+/// claim state as read by the webhook-receiving node. Pure so every
+/// branch is unit-testable without a claim-store double.
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClaimRoute {
+    /// A fresh foreign owner holds the claim — relay the re-assert to
+    /// this node.
+    AskOwner(waddle_xmpp::ownership::NodeIdentity),
+    /// No owner worth relaying to (unclaimed, stale lease, or the
+    /// claim is our own spawn/teardown race) — acknowledge and leave
+    /// it to the reconciler.
+    ConvergeOnReconcile,
+    /// The claim read itself failed transiently — ask LiveKit to
+    /// retry the delivery.
+    RetryLater,
+}
+
+#[cfg(feature = "clustering")]
+fn route_from_claim(
+    claim: Result<
+        Option<waddle_xmpp::ownership::ClaimSnapshot>,
+        waddle_xmpp::ownership::ClaimError,
+    >,
+    me: &waddle_xmpp::ownership::NodeIdentity,
+) -> ClaimRoute {
+    match claim {
+        // Unclaimed room: nobody holds an authoritative occupant set,
+        // so there is no owner to ask and nothing a retry would reach.
+        Ok(None) => ClaimRoute::ConvergeOnReconcile,
+        // The claim's owner stopped renewing its node lease. Relaying
+        // to a possibly-dead node would just time out, and how long
+        // until another node steals the claim is unbounded — don't
+        // burn LiveKit's bounded retries on it.
+        Ok(Some(snapshot)) if !snapshot.owner_lease_fresh => ClaimRoute::ConvergeOnReconcile,
+        // This node owns the claim but has no actor — a startup or
+        // teardown race. The local reconciliation pass covers it.
+        Ok(Some(snapshot)) if snapshot.owner == *me => ClaimRoute::ConvergeOnReconcile,
+        Ok(Some(snapshot)) => ClaimRoute::AskOwner(snapshot.owner),
+        // A store read error is transient (unlike the structural
+        // no-owner cases above): the next LiveKit retry re-reads it.
+        Err(_) => ClaimRoute::RetryLater,
+    }
+}
+
+/// Ask-timeout budget for the webhook-triggered relay hop. Deliberately
+/// much tighter than the clustering defaults (5s mailbox / 20s reply):
+/// LiveKit abandons a webhook delivery after a few seconds and retries,
+/// and a retry that arrives while the previous attempt still holds the
+/// dedupe entry is swallowed as a duplicate — so the whole hop must
+/// resolve well inside LiveKit's own delivery timeout or the retry
+/// budget burns without enforcing anything.
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_MAILBOX_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+/// Deliberately smaller than the receiver's own wedge bounds (two
+/// 5s-capped actor asks + a claim read): a merely-slow owner costs
+/// this asker a timeout → 503 → one LiveKit retry, but the owner
+/// still completes the idempotent re-assert, so the retry confirms
+/// cheaply against a warm path. The alternative — waiting out the
+/// receiver's worst case — would hold the webhook socket past
+/// LiveKit's own delivery timeout, burning the retry anyway.
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_REPLY_TIMEOUT: StdDuration = StdDuration::from_secs(3);
+/// Overall bound on the relay hop. Kademlia name resolution (up to
+/// three lookups with ~2.1s of backoff) and the stale-ref
+/// re-resolve-and-retry both sit OUTSIDE the per-ask timeouts, so a
+/// cold lookup against a just-died-but-fresh-leased owner could
+/// otherwise hold the webhook socket well past LiveKit's delivery
+/// timeout. On elapse the owner may still complete the (idempotent)
+/// re-assert; the LiveKit retry then confirms cheaply.
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_OVERALL_TIMEOUT: StdDuration = StdDuration::from_secs(4);
+/// Bound on the claim-store read that precedes the relay hop — it
+/// runs before [`WEBHOOK_RELAY_OVERALL_TIMEOUT`] starts, so it needs
+/// its own deadline or a stalled control-plane pool holds the webhook
+/// socket indefinitely while the dedupe entry swallows retries.
+#[cfg(feature = "clustering")]
+const WEBHOOK_CLAIM_READ_TIMEOUT: StdDuration = StdDuration::from_secs(2);
+
+#[cfg(feature = "clustering")]
+pub(super) async fn reassert_on_claim_owner(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> ReassertOutcome {
+    use crate::clustering::relay::{RelayHandle, RelayReassertMediaGrantsReply};
+    use crate::clustering::NodeId;
+    use waddle_xmpp::ownership::{Entity, EntityType};
+
+    let handles = &state.deps.app_state.clustering_claims;
+    let (Some((claim_store, node_identity)), Some(stop_token)) =
+        (handles.claim_pair(), handles.stop_token.clone())
+    else {
+        return converge_on_reconcile(room_jid, full_jid);
+    };
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    // Bounded like the relay hop below: this read precedes the relay
+    // deadline, and a stalled control-plane pool must not hold the
+    // webhook socket while the dedupe entry swallows LiveKit's
+    // retries as duplicates.
+    let claim = match tokio::time::timeout(
+        WEBHOOK_CLAIM_READ_TIMEOUT,
+        claim_store.current_claim(&entity),
+    )
+    .await
+    {
+        Ok(claim) => claim,
+        Err(_elapsed) => {
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                "room claim lookup timed out on participant join; \
+                 asking LiveKit to retry",
+            );
+            return ReassertOutcome::RetryableFailure;
+        }
+    };
+    if let Err(error) = &claim {
+        warn!(
+            room = %room_jid,
+            user = %full_jid.to_bare(),
+            error = %error,
+            "room claim lookup failed on participant join; \
+             asking LiveKit to retry",
+        );
+    }
+    let owner = match route_from_claim(claim, &node_identity.current()) {
+        ClaimRoute::AskOwner(owner) => owner,
+        ClaimRoute::ConvergeOnReconcile => return converge_on_reconcile(room_jid, full_jid),
+        ClaimRoute::RetryLater => return ReassertOutcome::RetryableFailure,
+    };
+    let mut relay = RelayHandle::new(NodeId::new(owner.node_id.clone()), stop_token.clone())
+        .with_ask_timeouts(WEBHOOK_RELAY_MAILBOX_TIMEOUT, WEBHOOK_RELAY_REPLY_TIMEOUT);
+    let asked = tokio::time::timeout(
+        WEBHOOK_RELAY_OVERALL_TIMEOUT,
+        relay.reassert_media_grants(room_jid.clone(), full_jid.clone()),
+    )
+    .await;
+    let Ok(result) = asked else {
+        warn!(
+            room = %room_jid,
+            user = %full_jid.to_bare(),
+            owner = %owner.node_id,
+            "cross-node media grant re-assert timed out resolving the owner; \
+             asking LiveKit to retry",
+        );
+        return ReassertOutcome::RetryableFailure;
+    };
+    match result {
+        Ok(RelayReassertMediaGrantsReply::Applied) => {
+            debug!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %owner.node_id,
+                "media grants re-asserted on the room's claim owner",
+            );
+            ReassertOutcome::Handled
+        }
+        Ok(RelayReassertMediaGrantsReply::NotOccupantEvicted) => {
+            // The owner's actor answered authoritatively and evicted;
+            // its own warn line carries the details.
+            ReassertOutcome::Handled
+        }
+        Ok(RelayReassertMediaGrantsReply::NotOwner) => {
+            // The claim moved between our read and the ask (or the
+            // owner's actor is mid-(re)spawn). A retry re-resolves the
+            // claim and reaches the new owner.
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %owner.node_id,
+                "room claim owner had no local room actor; \
+                 asking LiveKit to retry",
+            );
+            ReassertOutcome::RetryableFailure
+        }
+        Ok(RelayReassertMediaGrantsReply::Unavailable) => {
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %owner.node_id,
+                "room claim owner could not re-assert media grants; \
+                 asking LiveKit to retry",
+            );
+            ReassertOutcome::RetryableFailure
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %owner.node_id,
+                error = %error,
+                "cross-node media grant re-assert failed; \
+                 asking LiveKit to retry",
+            );
+            ReassertOutcome::RetryableFailure
+        }
+    }
+}
+
+/// Without the `clustering` feature there is no relay to route
+/// through; keep the pre-#1594 acknowledge-and-reconcile behavior.
+#[cfg(not(feature = "clustering"))]
+pub(super) async fn reassert_on_claim_owner(
+    _state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> ReassertOutcome {
+    converge_on_reconcile(room_jid, full_jid)
+}
+
+#[cfg(test)]
+#[cfg(feature = "clustering")]
+mod tests {
+    use super::*;
+    use waddle_xmpp::ownership::NodeIdentity;
+
+    /// Every branch of the pure claim-routing decision: only a
+    /// FRESH claim held by ANOTHER node is worth a relay ask;
+    /// unclaimed / stale-lease / self-owned all degrade to the
+    /// reconciler, and only a claim-store read error burns a
+    /// LiveKit retry.
+    #[test]
+    fn claim_routing_decides_owner_fallback_and_retry() {
+        use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, ClaimSnapshot};
+        let me = NodeIdentity::new("node-self", "epoch-1");
+        let other = NodeIdentity::new("node-other", "epoch-9");
+        let fresh = |owner: &NodeIdentity| ClaimSnapshot {
+            owner: owner.clone(),
+            claim_epoch: ClaimEpoch(1),
+            owner_lease_fresh: true,
+        };
+
+        assert_eq!(
+            route_from_claim(Ok(None), &me),
+            ClaimRoute::ConvergeOnReconcile,
+            "unclaimed room has no owner to ask"
+        );
+        assert_eq!(
+            route_from_claim(
+                Ok(Some(ClaimSnapshot {
+                    owner_lease_fresh: false,
+                    ..fresh(&other)
+                })),
+                &me
+            ),
+            ClaimRoute::ConvergeOnReconcile,
+            "a stale-leased owner must not be relayed to"
+        );
+        assert_eq!(
+            route_from_claim(Ok(Some(fresh(&me))), &me),
+            ClaimRoute::ConvergeOnReconcile,
+            "a self-owned claim is a local race, not a relay target"
+        );
+        assert_eq!(
+            route_from_claim(Ok(Some(fresh(&other))), &me),
+            ClaimRoute::AskOwner(other.clone()),
+            "a fresh foreign owner gets the relay ask"
+        );
+        assert_eq!(
+            route_from_claim(Err(ClaimError::Poisoned), &me),
+            ClaimRoute::RetryLater,
+            "a transient store error is worth a LiveKit retry"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -414,7 +414,7 @@ async fn process_participant_left(state: &WebSocketState, env: &ParticipantEnvel
 /// Whether a `participant_joined` delivery was fully handled, or could
 /// not be enforced and should be retried by LiveKit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReassertOutcome {
+pub(super) enum ReassertOutcome {
     /// Grants were converged, or no MUC authorization applies to this
     /// participant. Nothing a retry would improve.
     Handled,
@@ -496,230 +496,19 @@ async fn reassert_voice_grants_on_join(
             // Absence of a local actor means "cannot determine"
             // locally; #1594 routes the re-assert to the room's claim
             // owner instead.
-            reassert_on_claim_owner(state, &room_jid, &full_jid).await
+            super::livekit_grant_relay::reassert_on_claim_owner(state, &room_jid, &full_jid).await
         }
         GrantEnforcement::LookupFailed => {
             // The lookup failed transiently, so this node could not
             // resolve the occupant's role. Deliberately NOT an
             // eviction — the participant is probably legitimate — but
             // a stale token goes unenforced on this path, so LiveKit
-            // is asked to retry.
-            warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                "could not resolve MUC voice on participant join; \
-                 asking LiveKit to retry",
-            );
+            // is asked to retry. The shared core already logged the
+            // failure WARN with the underlying error; a second line
+            // here would double-count the event in log-based alerting.
             ReassertOutcome::RetryableFailure
         }
     }
-}
-
-/// Fallback when there is no fresh foreign owner to relay to (no
-/// clustering, room unclaimed, stale owner lease, or the claim is this
-/// node's own): acknowledge the delivery and leave convergence to the
-/// owning node's reconciliation pass, exactly the pre-#1594 behavior.
-/// (A claim-store read *error* is transient and maps to a LiveKit
-/// retry instead — see [`route_from_claim`].)
-fn converge_on_reconcile(room_jid: &BareJid, full_jid: &FullJid) -> ReassertOutcome {
-    warn!(
-        room = %room_jid,
-        user = %full_jid.to_bare(),
-        "no local room actor on this node; media grants for this join \
-         will converge on the owning node's reconciliation pass",
-    );
-    ReassertOutcome::UnenforceableHere
-}
-
-/// #1594: this node has no room actor, so route the re-assert to the
-/// replica holding the room's claim instead of waiting for its
-/// reconciliation tick. Every path that cannot reach a fresh foreign
-/// owner degrades to [`converge_on_reconcile`]; failures where a
-/// LiveKit retry could plausibly land after the cluster settles map
-/// to [`ReassertOutcome::RetryableFailure`].
-/// Where a `participant_joined` re-assert should go, given the room's
-/// claim state as read by the webhook-receiving node. Pure so every
-/// branch is unit-testable without a claim-store double.
-#[cfg(feature = "clustering")]
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ClaimRoute {
-    /// A fresh foreign owner holds the claim — relay the re-assert to
-    /// this node.
-    AskOwner(waddle_xmpp::ownership::NodeIdentity),
-    /// No owner worth relaying to (unclaimed, stale lease, or the
-    /// claim is our own spawn/teardown race) — acknowledge and leave
-    /// it to the reconciler.
-    ConvergeOnReconcile,
-    /// The claim read itself failed transiently — ask LiveKit to
-    /// retry the delivery.
-    RetryLater,
-}
-
-#[cfg(feature = "clustering")]
-fn route_from_claim(
-    claim: Result<
-        Option<waddle_xmpp::ownership::ClaimSnapshot>,
-        waddle_xmpp::ownership::ClaimError,
-    >,
-    me: &waddle_xmpp::ownership::NodeIdentity,
-) -> ClaimRoute {
-    match claim {
-        // Unclaimed room: nobody holds an authoritative occupant set,
-        // so there is no owner to ask and nothing a retry would reach.
-        Ok(None) => ClaimRoute::ConvergeOnReconcile,
-        // The claim's owner stopped renewing its node lease. Relaying
-        // to a possibly-dead node would just time out, and how long
-        // until another node steals the claim is unbounded — don't
-        // burn LiveKit's bounded retries on it.
-        Ok(Some(snapshot)) if !snapshot.owner_lease_fresh => ClaimRoute::ConvergeOnReconcile,
-        // This node owns the claim but has no actor — a startup or
-        // teardown race. The local reconciliation pass covers it.
-        Ok(Some(snapshot)) if snapshot.owner == *me => ClaimRoute::ConvergeOnReconcile,
-        Ok(Some(snapshot)) => ClaimRoute::AskOwner(snapshot.owner),
-        // A store read error is transient (unlike the structural
-        // no-owner cases above): the next LiveKit retry re-reads it.
-        Err(_) => ClaimRoute::RetryLater,
-    }
-}
-
-/// Ask-timeout budget for the webhook-triggered relay hop. Deliberately
-/// much tighter than the clustering defaults (5s mailbox / 20s reply):
-/// LiveKit abandons a webhook delivery after a few seconds and retries,
-/// and a retry that arrives while the previous attempt still holds the
-/// dedupe entry is swallowed as a duplicate — so the whole hop must
-/// resolve well inside LiveKit's own delivery timeout or the retry
-/// budget burns without enforcing anything.
-#[cfg(feature = "clustering")]
-const WEBHOOK_RELAY_MAILBOX_TIMEOUT: StdDuration = StdDuration::from_secs(1);
-/// Deliberately smaller than the receiver's own wedge bounds (two
-/// 5s-capped actor asks + a claim read): a merely-slow owner costs
-/// this asker a timeout → 503 → one LiveKit retry, but the owner
-/// still completes the idempotent re-assert, so the retry confirms
-/// cheaply against a warm path. The alternative — waiting out the
-/// receiver's worst case — would hold the webhook socket past
-/// LiveKit's own delivery timeout, burning the retry anyway.
-#[cfg(feature = "clustering")]
-const WEBHOOK_RELAY_REPLY_TIMEOUT: StdDuration = StdDuration::from_secs(3);
-/// Overall bound on the relay hop. Kademlia name resolution (up to
-/// three lookups with ~2.1s of backoff) and the stale-ref
-/// re-resolve-and-retry both sit OUTSIDE the per-ask timeouts, so a
-/// cold lookup against a just-died-but-fresh-leased owner could
-/// otherwise hold the webhook socket well past LiveKit's delivery
-/// timeout. On elapse the owner may still complete the (idempotent)
-/// re-assert; the LiveKit retry then confirms cheaply.
-#[cfg(feature = "clustering")]
-const WEBHOOK_RELAY_OVERALL_TIMEOUT: StdDuration = StdDuration::from_secs(4);
-
-#[cfg(feature = "clustering")]
-async fn reassert_on_claim_owner(
-    state: &WebSocketState,
-    room_jid: &BareJid,
-    full_jid: &FullJid,
-) -> ReassertOutcome {
-    use crate::clustering::relay::{RelayHandle, RelayReassertMediaGrantsReply};
-    use crate::clustering::NodeId;
-    use waddle_xmpp::ownership::{Entity, EntityType};
-
-    let handles = &state.deps.app_state.clustering_claims;
-    let (Some((claim_store, node_identity)), Some(stop_token)) =
-        (handles.claim_pair(), handles.stop_token.clone())
-    else {
-        return converge_on_reconcile(room_jid, full_jid);
-    };
-    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
-    let claim = claim_store.current_claim(&entity).await;
-    if let Err(error) = &claim {
-        warn!(
-            room = %room_jid,
-            user = %full_jid.to_bare(),
-            error = %error,
-            "room claim lookup failed on participant join; \
-             asking LiveKit to retry",
-        );
-    }
-    let owner = match route_from_claim(claim, &node_identity.current()) {
-        ClaimRoute::AskOwner(owner) => owner,
-        ClaimRoute::ConvergeOnReconcile => return converge_on_reconcile(room_jid, full_jid),
-        ClaimRoute::RetryLater => return ReassertOutcome::RetryableFailure,
-    };
-    let mut relay = RelayHandle::new(NodeId::new(owner.node_id.clone()), stop_token.clone())
-        .with_ask_timeouts(WEBHOOK_RELAY_MAILBOX_TIMEOUT, WEBHOOK_RELAY_REPLY_TIMEOUT);
-    let asked = tokio::time::timeout(
-        WEBHOOK_RELAY_OVERALL_TIMEOUT,
-        relay.reassert_media_grants(room_jid.clone(), full_jid.clone()),
-    )
-    .await;
-    let Ok(result) = asked else {
-        warn!(
-            room = %room_jid,
-            user = %full_jid.to_bare(),
-            owner = %owner.node_id,
-            "cross-node media grant re-assert timed out resolving the owner; \
-             asking LiveKit to retry",
-        );
-        return ReassertOutcome::RetryableFailure;
-    };
-    match result {
-        Ok(RelayReassertMediaGrantsReply::Applied) => {
-            debug!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                owner = %owner.node_id,
-                "media grants re-asserted on the room's claim owner",
-            );
-            ReassertOutcome::Handled
-        }
-        Ok(RelayReassertMediaGrantsReply::NotOccupantEvicted) => {
-            // The owner's actor answered authoritatively and evicted;
-            // its own warn line carries the details.
-            ReassertOutcome::Handled
-        }
-        Ok(RelayReassertMediaGrantsReply::NotOwner) => {
-            // The claim moved between our read and the ask (or the
-            // owner's actor is mid-(re)spawn). A retry re-resolves the
-            // claim and reaches the new owner.
-            warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                owner = %owner.node_id,
-                "room claim owner had no local room actor; \
-                 asking LiveKit to retry",
-            );
-            ReassertOutcome::RetryableFailure
-        }
-        Ok(RelayReassertMediaGrantsReply::Unavailable) => {
-            warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                owner = %owner.node_id,
-                "room claim owner could not re-assert media grants; \
-                 asking LiveKit to retry",
-            );
-            ReassertOutcome::RetryableFailure
-        }
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                owner = %owner.node_id,
-                error = %error,
-                "cross-node media grant re-assert failed; \
-                 asking LiveKit to retry",
-            );
-            ReassertOutcome::RetryableFailure
-        }
-    }
-}
-
-/// Without the `clustering` feature there is no relay to route
-/// through; keep the pre-#1594 acknowledge-and-reconcile behavior.
-#[cfg(not(feature = "clustering"))]
-async fn reassert_on_claim_owner(
-    _state: &WebSocketState,
-    room_jid: &BareJid,
-    full_jid: &FullJid,
-) -> ReassertOutcome {
-    converge_on_reconcile(room_jid, full_jid)
 }
 
 async fn process_participant_left_for_identity(
@@ -1326,55 +1115,6 @@ mod tests {
             assert!(
                 recorder.snapshot().is_empty(),
                 "must never evict on absence"
-            );
-        }
-
-        /// Every branch of the pure claim-routing decision: only a
-        /// FRESH claim held by ANOTHER node is worth a relay ask;
-        /// unclaimed / stale-lease / self-owned all degrade to the
-        /// reconciler, and only a claim-store read error burns a
-        /// LiveKit retry.
-        #[test]
-        fn claim_routing_decides_owner_fallback_and_retry() {
-            use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, ClaimSnapshot};
-            let me = NodeIdentity::new("node-self", "epoch-1");
-            let other = NodeIdentity::new("node-other", "epoch-9");
-            let fresh = |owner: &NodeIdentity| ClaimSnapshot {
-                owner: owner.clone(),
-                claim_epoch: ClaimEpoch(1),
-                owner_lease_fresh: true,
-            };
-
-            assert_eq!(
-                route_from_claim(Ok(None), &me),
-                ClaimRoute::ConvergeOnReconcile,
-                "unclaimed room has no owner to ask"
-            );
-            assert_eq!(
-                route_from_claim(
-                    Ok(Some(ClaimSnapshot {
-                        owner_lease_fresh: false,
-                        ..fresh(&other)
-                    })),
-                    &me
-                ),
-                ClaimRoute::ConvergeOnReconcile,
-                "a stale-leased owner must not be relayed to"
-            );
-            assert_eq!(
-                route_from_claim(Ok(Some(fresh(&me))), &me),
-                ClaimRoute::ConvergeOnReconcile,
-                "a self-owned claim is a local race, not a relay target"
-            );
-            assert_eq!(
-                route_from_claim(Ok(Some(fresh(&other))), &me),
-                ClaimRoute::AskOwner(other.clone()),
-                "a fresh foreign owner gets the relay ask"
-            );
-            assert_eq!(
-                route_from_claim(Err(ClaimError::Poisoned), &me),
-                ClaimRoute::RetryLater,
-                "a transient store error is worth a LiveKit retry"
             );
         }
 

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -461,9 +461,6 @@ async fn reassert_voice_grants_on_join(
     room_name: &str,
     identity: &str,
 ) -> ReassertOutcome {
-    if state.deps.protocol.sfu.is_none() {
-        return ReassertOutcome::Handled;
-    }
     let Ok(full_jid) = identity.parse::<FullJid>() else {
         // Permanent: retrying cannot make this parse.
         warn!(
@@ -518,10 +515,12 @@ async fn reassert_voice_grants_on_join(
     }
 }
 
-/// Fallback when the cross-node re-assert cannot even be attempted
-/// (no clustering, room unclaimed, or the claim store is unreadable):
-/// acknowledge the delivery and leave convergence to the owning
-/// node's reconciliation pass, exactly the pre-#1594 behavior.
+/// Fallback when there is no fresh foreign owner to relay to (no
+/// clustering, room unclaimed, stale owner lease, or the claim is this
+/// node's own): acknowledge the delivery and leave convergence to the
+/// owning node's reconciliation pass, exactly the pre-#1594 behavior.
+/// (A claim-store read *error* is transient and maps to a LiveKit
+/// retry instead — see [`route_from_claim`].)
 fn converge_on_reconcile(room_jid: &BareJid, full_jid: &FullJid) -> ReassertOutcome {
     warn!(
         room = %room_jid,
@@ -538,6 +537,63 @@ fn converge_on_reconcile(room_jid: &BareJid, full_jid: &FullJid) -> ReassertOutc
 /// owner degrades to [`converge_on_reconcile`]; failures where a
 /// LiveKit retry could plausibly land after the cluster settles map
 /// to [`ReassertOutcome::RetryableFailure`].
+/// Where a `participant_joined` re-assert should go, given the room's
+/// claim state as read by the webhook-receiving node. Pure so every
+/// branch is unit-testable without a claim-store double.
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClaimRoute {
+    /// A fresh foreign owner holds the claim — relay the re-assert to
+    /// this node.
+    AskOwner(waddle_xmpp::ownership::NodeIdentity),
+    /// No owner worth relaying to (unclaimed, stale lease, or the
+    /// claim is our own spawn/teardown race) — acknowledge and leave
+    /// it to the reconciler.
+    ConvergeOnReconcile,
+    /// The claim read itself failed transiently — ask LiveKit to
+    /// retry the delivery.
+    RetryLater,
+}
+
+#[cfg(feature = "clustering")]
+fn route_from_claim(
+    claim: Result<
+        Option<waddle_xmpp::ownership::ClaimSnapshot>,
+        waddle_xmpp::ownership::ClaimError,
+    >,
+    me: &waddle_xmpp::ownership::NodeIdentity,
+) -> ClaimRoute {
+    match claim {
+        // Unclaimed room: nobody holds an authoritative occupant set,
+        // so there is no owner to ask and nothing a retry would reach.
+        Ok(None) => ClaimRoute::ConvergeOnReconcile,
+        // The claim's owner stopped renewing its node lease. Relaying
+        // to a possibly-dead node would just time out, and how long
+        // until another node steals the claim is unbounded — don't
+        // burn LiveKit's bounded retries on it.
+        Ok(Some(snapshot)) if !snapshot.owner_lease_fresh => ClaimRoute::ConvergeOnReconcile,
+        // This node owns the claim but has no actor — a startup or
+        // teardown race. The local reconciliation pass covers it.
+        Ok(Some(snapshot)) if snapshot.owner == *me => ClaimRoute::ConvergeOnReconcile,
+        Ok(Some(snapshot)) => ClaimRoute::AskOwner(snapshot.owner),
+        // A store read error is transient (unlike the structural
+        // no-owner cases above): the next LiveKit retry re-reads it.
+        Err(_) => ClaimRoute::RetryLater,
+    }
+}
+
+/// Ask-timeout budget for the webhook-triggered relay hop. Deliberately
+/// much tighter than the clustering defaults (5s mailbox / 20s reply):
+/// LiveKit abandons a webhook delivery after a few seconds and retries,
+/// and a retry that arrives while the previous attempt still holds the
+/// dedupe entry is swallowed as a duplicate — so the whole hop must
+/// resolve well inside LiveKit's own delivery timeout or the retry
+/// budget burns without enforcing anything.
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_MAILBOX_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_REPLY_TIMEOUT: StdDuration = StdDuration::from_secs(3);
+
 #[cfg(feature = "clustering")]
 async fn reassert_on_claim_owner(
     state: &WebSocketState,
@@ -555,41 +611,23 @@ async fn reassert_on_claim_owner(
         return converge_on_reconcile(room_jid, full_jid);
     };
     let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
-    let snapshot = match claim_store.current_claim(&entity).await {
-        Ok(Some(snapshot)) => snapshot,
-        Ok(None) => {
-            // Unclaimed room: nobody holds an authoritative occupant
-            // set, so there is no owner to ask and nothing a retry
-            // would reach.
-            return converge_on_reconcile(room_jid, full_jid);
-        }
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                error = %error,
-                "room claim lookup failed on participant join; \
-                 asking LiveKit to retry",
-            );
-            return ReassertOutcome::RetryableFailure;
-        }
+    let claim = claim_store.current_claim(&entity).await;
+    if let Err(error) = &claim {
+        warn!(
+            room = %room_jid,
+            user = %full_jid.to_bare(),
+            error = %error,
+            "room claim lookup failed on participant join; \
+             asking LiveKit to retry",
+        );
+    }
+    let owner = match route_from_claim(claim, &node_identity.current()) {
+        ClaimRoute::AskOwner(owner) => owner,
+        ClaimRoute::ConvergeOnReconcile => return converge_on_reconcile(room_jid, full_jid),
+        ClaimRoute::RetryLater => return ReassertOutcome::RetryableFailure,
     };
-    if !snapshot.owner_lease_fresh {
-        // The claim's owner stopped renewing its node lease. Relaying
-        // to a possibly-dead node would just time out, and how long
-        // until another node steals the claim is unbounded — don't
-        // burn LiveKit's bounded retries on it.
-        return converge_on_reconcile(room_jid, full_jid);
-    }
-    if snapshot.owner == node_identity.current() {
-        // This node owns the claim but has no actor — a startup or
-        // teardown race. The local reconciliation pass covers it.
-        return converge_on_reconcile(room_jid, full_jid);
-    }
-    let mut relay = RelayHandle::new(
-        NodeId::new(snapshot.owner.node_id.clone()),
-        stop_token.clone(),
-    );
+    let mut relay = RelayHandle::new(NodeId::new(owner.node_id.clone()), stop_token.clone())
+        .with_ask_timeouts(WEBHOOK_RELAY_MAILBOX_TIMEOUT, WEBHOOK_RELAY_REPLY_TIMEOUT);
     match relay
         .reassert_media_grants(room_jid.clone(), full_jid.clone())
         .await
@@ -598,7 +636,7 @@ async fn reassert_on_claim_owner(
             debug!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
-                owner = %snapshot.owner.node_id,
+                owner = %owner.node_id,
                 "media grants re-asserted on the room's claim owner",
             );
             ReassertOutcome::Handled
@@ -615,7 +653,7 @@ async fn reassert_on_claim_owner(
             warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
-                owner = %snapshot.owner.node_id,
+                owner = %owner.node_id,
                 "room claim owner had no local room actor; \
                  asking LiveKit to retry",
             );
@@ -625,7 +663,7 @@ async fn reassert_on_claim_owner(
             warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
-                owner = %snapshot.owner.node_id,
+                owner = %owner.node_id,
                 "room claim owner could not re-assert media grants; \
                  asking LiveKit to retry",
             );
@@ -635,7 +673,7 @@ async fn reassert_on_claim_owner(
             warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
-                owner = %snapshot.owner.node_id,
+                owner = %owner.node_id,
                 error = %error,
                 "cross-node media grant re-assert failed; \
                  asking LiveKit to retry",
@@ -1260,6 +1298,55 @@ mod tests {
             assert!(
                 recorder.snapshot().is_empty(),
                 "must never evict on absence"
+            );
+        }
+
+        /// Every branch of the pure claim-routing decision: only a
+        /// FRESH claim held by ANOTHER node is worth a relay ask;
+        /// unclaimed / stale-lease / self-owned all degrade to the
+        /// reconciler, and only a claim-store read error burns a
+        /// LiveKit retry.
+        #[test]
+        fn claim_routing_decides_owner_fallback_and_retry() {
+            use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, ClaimSnapshot};
+            let me = NodeIdentity::new("node-self", "epoch-1");
+            let other = NodeIdentity::new("node-other", "epoch-9");
+            let fresh = |owner: &NodeIdentity| ClaimSnapshot {
+                owner: owner.clone(),
+                claim_epoch: ClaimEpoch(1),
+                owner_lease_fresh: true,
+            };
+
+            assert_eq!(
+                route_from_claim(Ok(None), &me),
+                ClaimRoute::ConvergeOnReconcile,
+                "unclaimed room has no owner to ask"
+            );
+            assert_eq!(
+                route_from_claim(
+                    Ok(Some(ClaimSnapshot {
+                        owner_lease_fresh: false,
+                        ..fresh(&other)
+                    })),
+                    &me
+                ),
+                ClaimRoute::ConvergeOnReconcile,
+                "a stale-leased owner must not be relayed to"
+            );
+            assert_eq!(
+                route_from_claim(Ok(Some(fresh(&me))), &me),
+                ClaimRoute::ConvergeOnReconcile,
+                "a self-owned claim is a local race, not a relay target"
+            );
+            assert_eq!(
+                route_from_claim(Ok(Some(fresh(&other))), &me),
+                ClaimRoute::AskOwner(other.clone()),
+                "a fresh foreign owner gets the relay ask"
+            );
+            assert_eq!(
+                route_from_claim(Err(ClaimError::Poisoned), &me),
+                ClaimRoute::RetryLater,
+                "a transient store error is worth a LiveKit retry"
             );
         }
 

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -591,8 +591,24 @@ fn route_from_claim(
 /// budget burns without enforcing anything.
 #[cfg(feature = "clustering")]
 const WEBHOOK_RELAY_MAILBOX_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+/// Deliberately smaller than the receiver's own wedge bounds (two
+/// 5s-capped actor asks + a claim read): a merely-slow owner costs
+/// this asker a timeout → 503 → one LiveKit retry, but the owner
+/// still completes the idempotent re-assert, so the retry confirms
+/// cheaply against a warm path. The alternative — waiting out the
+/// receiver's worst case — would hold the webhook socket past
+/// LiveKit's own delivery timeout, burning the retry anyway.
 #[cfg(feature = "clustering")]
 const WEBHOOK_RELAY_REPLY_TIMEOUT: StdDuration = StdDuration::from_secs(3);
+/// Overall bound on the relay hop. Kademlia name resolution (up to
+/// three lookups with ~2.1s of backoff) and the stale-ref
+/// re-resolve-and-retry both sit OUTSIDE the per-ask timeouts, so a
+/// cold lookup against a just-died-but-fresh-leased owner could
+/// otherwise hold the webhook socket well past LiveKit's delivery
+/// timeout. On elapse the owner may still complete the (idempotent)
+/// re-assert; the LiveKit retry then confirms cheaply.
+#[cfg(feature = "clustering")]
+const WEBHOOK_RELAY_OVERALL_TIMEOUT: StdDuration = StdDuration::from_secs(4);
 
 #[cfg(feature = "clustering")]
 async fn reassert_on_claim_owner(
@@ -628,10 +644,22 @@ async fn reassert_on_claim_owner(
     };
     let mut relay = RelayHandle::new(NodeId::new(owner.node_id.clone()), stop_token.clone())
         .with_ask_timeouts(WEBHOOK_RELAY_MAILBOX_TIMEOUT, WEBHOOK_RELAY_REPLY_TIMEOUT);
-    match relay
-        .reassert_media_grants(room_jid.clone(), full_jid.clone())
-        .await
-    {
+    let asked = tokio::time::timeout(
+        WEBHOOK_RELAY_OVERALL_TIMEOUT,
+        relay.reassert_media_grants(room_jid.clone(), full_jid.clone()),
+    )
+    .await;
+    let Ok(result) = asked else {
+        warn!(
+            room = %room_jid,
+            user = %full_jid.to_bare(),
+            owner = %owner.node_id,
+            "cross-node media grant re-assert timed out resolving the owner; \
+             asking LiveKit to retry",
+        );
+        return ReassertOutcome::RetryableFailure;
+    };
+    match result {
         Ok(RelayReassertMediaGrantsReply::Applied) => {
             debug!(
                 room = %room_jid,

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -461,9 +461,9 @@ async fn reassert_voice_grants_on_join(
     room_name: &str,
     identity: &str,
 ) -> ReassertOutcome {
-    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+    if state.deps.protocol.sfu.is_none() {
         return ReassertOutcome::Handled;
-    };
+    }
     let Ok(full_jid) = identity.parse::<FullJid>() else {
         // Permanent: retrying cannot make this parse.
         warn!(
@@ -481,89 +481,179 @@ async fn reassert_voice_grants_on_join(
     let Ok(room_jid) = room_name.parse::<BareJid>() else {
         return ReassertOutcome::Handled;
     };
-    let actor =
-        match crate::server::routes::websocket::get_room_actor_result(state, &room_jid).await {
-            Ok(Some(actor)) => actor,
-            Ok(None) => {
-                // `GetRoom` only consults THIS process's room map, so a
-                // room claimed by another cluster node also answers
-                // `Ok(None)`. Webhooks arrive through one load-balanced
-                // URL across replicas, so this is the common case, NOT
-                // evidence that the participant is unauthorized —
-                // evicting here would eject legitimate occupants from
-                // roughly every join that lands on a non-owning node.
-                // Absence of a local actor means "cannot determine",
-                // which is exactly the `Err` case below.
-                warn!(
-                    room = %room_jid,
-                    user = %full_jid.to_bare(),
-                    "no local room actor on this node; media grants for this join \
-                     will converge on the owning node's reconciliation pass",
-                );
-                return ReassertOutcome::UnenforceableHere;
-            }
-            Err(error) => {
-                // The room lives elsewhere or the lookup failed, so this
-                // node cannot resolve the occupant's role. Deliberately
-                // NOT an eviction — the participant is probably
-                // legitimate and we simply cannot see the room — but a
-                // stale token goes unenforced on this path, so it must
-                // be visible.
-                warn!(
-                    room = %room_jid,
-                    user = %full_jid.to_bare(),
-                    error = %error,
-                    "could not resolve MUC voice on participant join; \
-                     asking LiveKit to retry",
-                );
-                return ReassertOutcome::RetryableFailure;
-            }
-        };
-    match actor
-        .ask(waddle_xmpp::muc::room_actor::GetOccupantVoice {
-            jid: full_jid.clone(),
-        })
-        .await
-    {
-        Ok(Some(voice)) => {
-            debug!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                "re-asserting SFU media grants from current MUC voice on participant join",
-            );
-            crate::server::routes::websocket::muc_call_sfu::apply_voice_grants_via_sfu(
-                sfu, &room_jid, &full_jid, voice,
-            );
-            ReassertOutcome::Handled
+    use crate::server::routes::websocket::muc_call_sfu::{
+        enforce_current_voice_grants, GrantEnforcement,
+    };
+    match enforce_current_voice_grants(state, &room_jid, &full_jid).await {
+        GrantEnforcement::Applied
+        | GrantEnforcement::EvictedNonOccupant
+        | GrantEnforcement::SfuNotConfigured => ReassertOutcome::Handled,
+        GrantEnforcement::NoLocalRoomActor => {
+            // `GetRoom` only consults THIS process's room map, so a
+            // room claimed by another cluster node also answers
+            // `Ok(None)`. Webhooks arrive through one load-balanced
+            // URL across replicas, so this is the common case, NOT
+            // evidence that the participant is unauthorized —
+            // evicting here would eject legitimate occupants from
+            // roughly every join that lands on a non-owning node.
+            // Absence of a local actor means "cannot determine"
+            // locally; #1594 routes the re-assert to the room's claim
+            // owner instead.
+            reassert_on_claim_owner(state, &room_jid, &full_jid).await
         }
-        Ok(None) => {
-            // A LOCAL room actor answered, so it owns this room and its
-            // occupant set is authoritative: this participant joined the
-            // SFU room while not being an occupant of the MUC.
-            // Occupancy is the precondition for call participation, so
-            // this is a stale-token join and must end. (Contrast the
-            // absent-actor case above, which proves nothing.)
+        GrantEnforcement::LookupFailed => {
+            // The lookup failed transiently, so this node could not
+            // resolve the occupant's role. Deliberately NOT an
+            // eviction — the participant is probably legitimate — but
+            // a stale token goes unenforced on this path, so LiveKit
+            // is asked to retry.
             warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
-                "LiveKit participant is not a MUC occupant; evicting from the call",
+                "could not resolve MUC voice on participant join; \
+                 asking LiveKit to retry",
             );
-            crate::server::routes::websocket::muc_call_sfu::unregister_participant_via_sfu(
-                sfu, &room_jid, &full_jid,
-            );
-            ReassertOutcome::Handled
+            ReassertOutcome::RetryableFailure
+        }
+    }
+}
+
+/// Fallback when the cross-node re-assert cannot even be attempted
+/// (no clustering, room unclaimed, or the claim store is unreadable):
+/// acknowledge the delivery and leave convergence to the owning
+/// node's reconciliation pass, exactly the pre-#1594 behavior.
+fn converge_on_reconcile(room_jid: &BareJid, full_jid: &FullJid) -> ReassertOutcome {
+    warn!(
+        room = %room_jid,
+        user = %full_jid.to_bare(),
+        "no local room actor on this node; media grants for this join \
+         will converge on the owning node's reconciliation pass",
+    );
+    ReassertOutcome::UnenforceableHere
+}
+
+/// #1594: this node has no room actor, so route the re-assert to the
+/// replica holding the room's claim instead of waiting for its
+/// reconciliation tick. Every path that cannot reach a fresh foreign
+/// owner degrades to [`converge_on_reconcile`]; failures where a
+/// LiveKit retry could plausibly land after the cluster settles map
+/// to [`ReassertOutcome::RetryableFailure`].
+#[cfg(feature = "clustering")]
+async fn reassert_on_claim_owner(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> ReassertOutcome {
+    use crate::clustering::relay::{RelayHandle, RelayReassertMediaGrantsReply};
+    use crate::clustering::NodeId;
+    use waddle_xmpp::ownership::{Entity, EntityType};
+
+    let handles = &state.deps.app_state.clustering_claims;
+    let (Some((claim_store, node_identity)), Some(stop_token)) =
+        (handles.claim_pair(), handles.stop_token.clone())
+    else {
+        return converge_on_reconcile(room_jid, full_jid);
+    };
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let snapshot = match claim_store.current_claim(&entity).await {
+        Ok(Some(snapshot)) => snapshot,
+        Ok(None) => {
+            // Unclaimed room: nobody holds an authoritative occupant
+            // set, so there is no owner to ask and nothing a retry
+            // would reach.
+            return converge_on_reconcile(room_jid, full_jid);
         }
         Err(error) => {
             warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
                 error = %error,
-                "MUC voice lookup failed on participant join; \
+                "room claim lookup failed on participant join; \
+                 asking LiveKit to retry",
+            );
+            return ReassertOutcome::RetryableFailure;
+        }
+    };
+    if !snapshot.owner_lease_fresh {
+        // The claim's owner stopped renewing its node lease. Relaying
+        // to a possibly-dead node would just time out, and how long
+        // until another node steals the claim is unbounded — don't
+        // burn LiveKit's bounded retries on it.
+        return converge_on_reconcile(room_jid, full_jid);
+    }
+    if snapshot.owner == node_identity.current() {
+        // This node owns the claim but has no actor — a startup or
+        // teardown race. The local reconciliation pass covers it.
+        return converge_on_reconcile(room_jid, full_jid);
+    }
+    let mut relay = RelayHandle::new(
+        NodeId::new(snapshot.owner.node_id.clone()),
+        stop_token.clone(),
+    );
+    match relay
+        .reassert_media_grants(room_jid.clone(), full_jid.clone())
+        .await
+    {
+        Ok(RelayReassertMediaGrantsReply::Applied) => {
+            debug!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %snapshot.owner.node_id,
+                "media grants re-asserted on the room's claim owner",
+            );
+            ReassertOutcome::Handled
+        }
+        Ok(RelayReassertMediaGrantsReply::NotOccupantEvicted) => {
+            // The owner's actor answered authoritatively and evicted;
+            // its own warn line carries the details.
+            ReassertOutcome::Handled
+        }
+        Ok(RelayReassertMediaGrantsReply::NotOwner) => {
+            // The claim moved between our read and the ask (or the
+            // owner's actor is mid-(re)spawn). A retry re-resolves the
+            // claim and reaches the new owner.
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %snapshot.owner.node_id,
+                "room claim owner had no local room actor; \
+                 asking LiveKit to retry",
+            );
+            ReassertOutcome::RetryableFailure
+        }
+        Ok(RelayReassertMediaGrantsReply::Unavailable) => {
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %snapshot.owner.node_id,
+                "room claim owner could not re-assert media grants; \
+                 asking LiveKit to retry",
+            );
+            ReassertOutcome::RetryableFailure
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                owner = %snapshot.owner.node_id,
+                error = %error,
+                "cross-node media grant re-assert failed; \
                  asking LiveKit to retry",
             );
             ReassertOutcome::RetryableFailure
         }
     }
+}
+
+/// Without the `clustering` feature there is no relay to route
+/// through; keep the pre-#1594 acknowledge-and-reconcile behavior.
+#[cfg(not(feature = "clustering"))]
+async fn reassert_on_claim_owner(
+    _state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> ReassertOutcome {
+    converge_on_reconcile(room_jid, full_jid)
 }
 
 async fn process_participant_left_for_identity(
@@ -988,6 +1078,228 @@ mod tests {
         // The oldest entry should now be evicted, so re-observing it
         // returns "fresh".
         assert!(seen.observe(Some("EV_0")));
+    }
+
+    /// Cross-node seam (#1594): the shared enforcement helper must
+    /// distinguish "no actor in this process" from every authoritative
+    /// answer, because the webhook forwards exactly that case to the
+    /// room's claim owner. It must neither push grants nor evict on
+    /// absence — absence is "cannot determine", not authorization
+    /// evidence.
+    #[tokio::test]
+    async fn grant_enforcement_reports_missing_local_room_actor_without_side_effects() {
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let room_jid: BareJid = "claimed-elsewhere@muc.example.com"
+            .parse()
+            .expect("room jid");
+        let full_jid: FullJid = "alice@example.com/web".parse().expect("full jid");
+
+        let outcome = crate::server::routes::websocket::muc_call_sfu::enforce_current_voice_grants(
+            state.as_ref(),
+            &room_jid,
+            &full_jid,
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            crate::server::routes::websocket::muc_call_sfu::GrantEnforcement::NoLocalRoomActor
+        );
+        assert!(
+            recorder.update_snapshot().is_empty(),
+            "no grants may be pushed without an authoritative occupant answer"
+        );
+        assert!(
+            recorder.snapshot().is_empty(),
+            "an absent local actor must never evict"
+        );
+    }
+
+    /// The owner-side executor for a relayed re-assert reuses this
+    /// helper, so it must push the seated occupant's voice-derived
+    /// grants exactly like the same-node webhook path.
+    #[tokio::test]
+    async fn grant_enforcement_pushes_grants_for_seated_occupant() {
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let session = crate::server::routes::websocket::tests::create_test_server_owner_session(
+            state.as_ref(),
+            "alice",
+        )
+        .await;
+        let room_jid: BareJid = "grants-here@muc.example.com".parse().expect("room jid");
+        let alice: FullJid = "alice@example.com/web".parse().expect("full jid");
+        crate::server::routes::websocket::handlers::presence::handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room_jid,
+            &alice,
+            "alice",
+            None,
+            &Some(session),
+        )
+        .await;
+
+        let outcome = crate::server::routes::websocket::muc_call_sfu::enforce_current_voice_grants(
+            state.as_ref(),
+            &room_jid,
+            &alice,
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            crate::server::routes::websocket::muc_call_sfu::GrantEnforcement::Applied
+        );
+        let updates = recorder.update_snapshot();
+        assert_eq!(updates.len(), 1, "exactly one grant push expected");
+        assert_eq!(updates[0].0.as_str(), room_jid.to_string());
+        assert_eq!(updates[0].1.as_livekit_identity(), alice.to_string());
+        assert!(
+            !updates[0].2.is_listen_only(),
+            "a seated occupant with voice must not be downgraded to listen-only"
+        );
+        assert!(
+            recorder.snapshot().is_empty(),
+            "occupants are never evicted"
+        );
+    }
+
+    /// A LOCAL actor answering "not an occupant" is authoritative, so
+    /// the shared helper evicts — same contract as the pre-#1594
+    /// webhook path, now also reachable via the relay.
+    #[tokio::test]
+    async fn grant_enforcement_evicts_non_occupant_when_local_actor_is_authoritative() {
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let session = crate::server::routes::websocket::tests::create_test_server_owner_session(
+            state.as_ref(),
+            "alice",
+        )
+        .await;
+        let room_jid: BareJid = "evictions@muc.example.com".parse().expect("room jid");
+        let alice: FullJid = "alice@example.com/web".parse().expect("full jid");
+        crate::server::routes::websocket::handlers::presence::handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room_jid,
+            &alice,
+            "alice",
+            None,
+            &Some(session),
+        )
+        .await;
+        let bob: FullJid = "bob@example.com/phone".parse().expect("full jid");
+
+        let outcome = crate::server::routes::websocket::muc_call_sfu::enforce_current_voice_grants(
+            state.as_ref(),
+            &room_jid,
+            &bob,
+        )
+        .await;
+
+        assert_eq!(
+            outcome,
+            crate::server::routes::websocket::muc_call_sfu::GrantEnforcement::EvictedNonOccupant
+        );
+        assert!(
+            recorder.update_snapshot().is_empty(),
+            "a non-occupant gets evicted, never granted"
+        );
+        let evictions = recorder.snapshot();
+        assert_eq!(evictions.len(), 1);
+        assert_eq!(evictions[0].1.as_livekit_identity(), bob.to_string());
+    }
+
+    /// #1594 decision tests: what `reassert_voice_grants_on_join` does
+    /// when this node has no room actor, by claim state. The foreign
+    /// fresh-owner happy path needs a second live node and is covered
+    /// by the clustering e2e suite.
+    #[cfg(feature = "clustering")]
+    mod cross_node {
+        use super::*;
+        use crate::clustering::ClusteringHandles;
+        use crate::server::routes::websocket::tests::create_test_websocket_state_with_sfu_and_clustering;
+        use tokio_util::sync::CancellationToken;
+        use waddle_xmpp::ownership::{
+            ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+        };
+
+        fn handles_with(store: Arc<InProcessClaimStore>, me: NodeIdentity) -> ClusteringHandles {
+            ClusteringHandles {
+                claim_store: Some(store),
+                node_identity: Some(SharedNodeIdentity::new(me)),
+                stop_token: Some(CancellationToken::new()),
+                ..ClusteringHandles::default()
+            }
+        }
+
+        /// An unclaimed room has no authoritative occupant set anywhere,
+        /// so there is no owner to ask: acknowledge and leave it to the
+        /// reconciler, exactly the pre-#1594 behavior.
+        #[tokio::test]
+        async fn unclaimed_room_falls_back_to_reconcile() {
+            let recorder = Arc::new(RecordingSfu::default());
+            let me = NodeIdentity::new("node-self", "epoch-1");
+            let state = create_test_websocket_state_with_sfu_and_clustering(
+                recorder.clone(),
+                handles_with(Arc::new(InProcessClaimStore::new()), me),
+            )
+            .await;
+
+            let outcome = reassert_voice_grants_on_join(
+                state.as_ref(),
+                "unclaimed@muc.example.com",
+                "alice@example.com/web",
+            )
+            .await;
+
+            assert_eq!(outcome, ReassertOutcome::UnenforceableHere);
+            assert!(recorder.update_snapshot().is_empty());
+            assert!(
+                recorder.snapshot().is_empty(),
+                "must never evict on absence"
+            );
+        }
+
+        /// A claim owned by THIS node with no local actor is a spawn or
+        /// teardown race; the local reconciliation pass covers it, so
+        /// the delivery is acknowledged rather than bounced to a relay
+        /// ask against ourselves.
+        #[tokio::test]
+        async fn self_owned_claim_without_actor_falls_back_to_reconcile() {
+            let recorder = Arc::new(RecordingSfu::default());
+            let me = NodeIdentity::new("node-self", "epoch-1");
+            let store = Arc::new(InProcessClaimStore::new());
+            let room_jid: BareJid = "self-claimed@muc.example.com".parse().expect("room jid");
+            store
+                .acquire(
+                    &Entity::new(EntityType::RoomActor, room_jid.to_string()),
+                    &me,
+                )
+                .await
+                .expect("acquire room claim");
+            let state = create_test_websocket_state_with_sfu_and_clustering(
+                recorder.clone(),
+                handles_with(store, me),
+            )
+            .await;
+
+            let outcome = reassert_voice_grants_on_join(
+                state.as_ref(),
+                "self-claimed@muc.example.com",
+                "alice@example.com/web",
+            )
+            .await;
+
+            assert_eq!(outcome, ReassertOutcome::UnenforceableHere);
+            assert!(recorder.update_snapshot().is_empty());
+            assert!(
+                recorder.snapshot().is_empty(),
+                "must never evict on absence"
+            );
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod calendar_feed; // Read-only iCalendar projection of xCal community event
 pub mod device; // OAuth Device Flow for CLI
 pub mod extension_webhooks; // Extension webhook ingress
 pub mod interpret; // OutboundEvent effect interpreter for sans-I/O protocol
+mod livekit_grant_relay; // #1594 cross-node routing for participant_joined grant re-assertion
 pub mod livekit_webhook; // LiveKit SFU webhook → MUC Muji-presence bridge
 pub mod muc_muji_clear; // Shared Muji clear + broadcast for SFU/Jingle teardown
 mod sfu_voice_reconcile; // periodic XEP-0045 voice → LiveKit grant convergence

--- a/server/crates/waddle-server/src/server/routes/sfu_voice_reconcile.rs
+++ b/server/crates/waddle-server/src/server/routes/sfu_voice_reconcile.rs
@@ -38,12 +38,13 @@ const ROOM_ACTOR_ASK_TIMEOUT: std::time::Duration = waddle_xmpp::muc::ROOM_REGIS
 ///
 /// This is the backstop that makes stale-token enforcement independent
 /// of which replica received a `participant_joined` webhook. The webhook
-/// path is the fast path, and it asks LiveKit to retry when it lands on
-/// a node that cannot resolve the room — but retries are finite and all
-/// of them could miss the owner. Because a room actor is claimed by
-/// exactly one node, iterating locally-claimed rooms covers every room
-/// exactly once across the cluster, with no cross-node request and no
-/// new relay protocol.
+/// path is the fast path: since #1594 a webhook landing on a non-owning
+/// node relays the re-assert to the room's claim owner
+/// (`RelayReassertMediaGrants`), and asks LiveKit to retry on transient
+/// failures — but the relay needs a fresh claim and a reachable owner,
+/// and retries are finite. Because a room actor is claimed by exactly
+/// one node, iterating locally-claimed rooms covers every room exactly
+/// once across the cluster regardless of any of that.
 ///
 /// Whether a room has a call to converge is decided by asking the SFU
 /// itself (`SfuReconciler::live_participants`), NOT by

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -184,6 +184,11 @@ pub(crate) async fn enforce_current_voice_grants(
         .ask(waddle_xmpp::muc::room_actor::GetOccupantVoice {
             jid: full_jid.clone(),
         })
+        // Bounded for the same reason as the reconciler's identical
+        // ask: a wedged room actor must not park an HTTP webhook
+        // handler — or, on the relayed #1594 path, leak an owner-side
+        // delegated relay task per LiveKit retry.
+        .reply_timeout(waddle_xmpp::muc::ROOM_REGISTRY_REPLY_TIMEOUT)
         .await
     {
         Ok(Some(voice)) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -167,7 +167,16 @@ pub(crate) enum VoiceDerivation {
 }
 
 /// Resolve `full_jid`'s current XEP-0045 voice from THIS process's
-/// room actor. Performs no side effects.
+/// room actor.
+///
+/// Performs no SFU side effects — the state-changing half lives in
+/// [`apply_derived_enforcement`], so the #1594 relayed path can
+/// re-validate its room claim between the two. The failure branches
+/// DO emit their diagnostic WARN here, deliberately: both callers
+/// (the same-node webhook path and the relayed owner-side executor)
+/// need the same error-carrying line, and emitting it once at the
+/// derivation site is what keeps log-based alerting from
+/// double-counting a single transient failure.
 pub(crate) async fn derive_current_voice(
     state: &WebSocketState,
     room_jid: &BareJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -148,28 +148,35 @@ pub(crate) enum GrantEnforcement {
     SfuNotConfigured,
 }
 
-/// Re-derive `full_jid`'s XEP-0045 voice from THIS process's room
-/// actor and converge their live SFU media grants with it — the
-/// shared enforcement core behind both the same-node
-/// `participant_joined` webhook path and the owner side of the #1594
-/// cross-node relay. Keeping both on one function is deliberate: the
-/// relayed path must not be able to diverge from the local one.
-///
-/// Side effects happen only on an authoritative answer: a seated
-/// occupant gets their voice-derived grants pushed, a confirmed
-/// non-occupant is evicted, and every other outcome performs nothing.
-pub(crate) async fn enforce_current_voice_grants(
+/// The side-effect-free half of [`enforce_current_voice_grants`]:
+/// THIS process's room actor's authoritative answer about one live
+/// SFU participant, with no SFU effect performed. Split out so the
+/// #1594 relayed path can re-validate its room claim BETWEEN deriving
+/// the answer and acting on it — binding the (possibly slow) actor
+/// answer to the claim it was derived under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VoiceDerivation {
+    /// A local actor answered with the occupant's current voice.
+    Occupant(Voice),
+    /// A local (authoritative) actor answered "not an occupant".
+    NotOccupant,
+    /// No room actor in this process — cannot determine anything.
+    NoLocalRoomActor,
+    /// The registry or actor lookup failed transiently.
+    LookupFailed,
+}
+
+/// Resolve `full_jid`'s current XEP-0045 voice from THIS process's
+/// room actor. Performs no side effects.
+pub(crate) async fn derive_current_voice(
     state: &WebSocketState,
     room_jid: &BareJid,
     full_jid: &FullJid,
-) -> GrantEnforcement {
-    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
-        return GrantEnforcement::SfuNotConfigured;
-    };
+) -> VoiceDerivation {
     let actor = match crate::server::routes::websocket::get_room_actor_result(state, room_jid).await
     {
         Ok(Some(actor)) => actor,
-        Ok(None) => return GrantEnforcement::NoLocalRoomActor,
+        Ok(None) => return VoiceDerivation::NoLocalRoomActor,
         Err(error) => {
             tracing::warn!(
                 room = %room_jid,
@@ -177,7 +184,7 @@ pub(crate) async fn enforce_current_voice_grants(
                 error = %error,
                 "could not resolve MUC voice for a live call participant",
             );
-            return GrantEnforcement::LookupFailed;
+            return VoiceDerivation::LookupFailed;
         }
     };
     match actor
@@ -191,7 +198,33 @@ pub(crate) async fn enforce_current_voice_grants(
         .reply_timeout(waddle_xmpp::muc::ROOM_REGISTRY_REPLY_TIMEOUT)
         .await
     {
-        Ok(Some(voice)) => {
+        Ok(Some(voice)) => VoiceDerivation::Occupant(voice),
+        Ok(None) => VoiceDerivation::NotOccupant,
+        Err(error) => {
+            tracing::warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                error = %error,
+                "MUC voice lookup failed for a live call participant",
+            );
+            VoiceDerivation::LookupFailed
+        }
+    }
+}
+
+/// The side-effecting half of [`enforce_current_voice_grants`]: act
+/// on an already-derived answer. Side effects happen only on an
+/// authoritative derivation: a seated occupant gets their
+/// voice-derived grants pushed, a confirmed non-occupant is evicted,
+/// and every other derivation performs nothing.
+pub(crate) fn apply_derived_enforcement(
+    sfu: &std::sync::Arc<dyn waddle_sfu::SfuService>,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+    derivation: VoiceDerivation,
+) -> GrantEnforcement {
+    match derivation {
+        VoiceDerivation::Occupant(voice) => {
             tracing::debug!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
@@ -200,13 +233,13 @@ pub(crate) async fn enforce_current_voice_grants(
             apply_voice_grants_via_sfu(sfu, room_jid, full_jid, voice);
             GrantEnforcement::Applied
         }
-        Ok(None) => {
+        VoiceDerivation::NotOccupant => {
             // A LOCAL room actor answered, so it owns this room and its
             // occupant set is authoritative: this participant is in the
             // SFU room while not being an occupant of the MUC.
             // Occupancy is the precondition for call participation, so
             // this is a stale-token join and must end. (Contrast the
-            // absent-actor case above, which proves nothing.)
+            // absent-actor case, which proves nothing.)
             tracing::warn!(
                 room = %room_jid,
                 user = %full_jid.to_bare(),
@@ -215,16 +248,29 @@ pub(crate) async fn enforce_current_voice_grants(
             unregister_participant_via_sfu(sfu, room_jid, full_jid);
             GrantEnforcement::EvictedNonOccupant
         }
-        Err(error) => {
-            tracing::warn!(
-                room = %room_jid,
-                user = %full_jid.to_bare(),
-                error = %error,
-                "MUC voice lookup failed for a live call participant",
-            );
-            GrantEnforcement::LookupFailed
-        }
+        VoiceDerivation::NoLocalRoomActor => GrantEnforcement::NoLocalRoomActor,
+        VoiceDerivation::LookupFailed => GrantEnforcement::LookupFailed,
     }
+}
+
+/// Re-derive `full_jid`'s XEP-0045 voice from THIS process's room
+/// actor and converge their live SFU media grants with it — the
+/// shared enforcement core behind both the same-node
+/// `participant_joined` webhook path and the owner side of the #1594
+/// cross-node relay. Keeping both on one core is deliberate: the
+/// relayed path must not be able to diverge from the local one (it
+/// composes [`derive_current_voice`] and [`apply_derived_enforcement`]
+/// with a claim re-check in between).
+pub(crate) async fn enforce_current_voice_grants(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> GrantEnforcement {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        return GrantEnforcement::SfuNotConfigured;
+    };
+    let derivation = derive_current_voice(state, room_jid, full_jid).await;
+    apply_derived_enforcement(sfu, room_jid, full_jid, derivation)
 }
 
 /// Push every occupant's current XEP-0045 voice to the SFU after a

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -121,6 +121,107 @@ pub(crate) fn converge_voice_changes_via_sfu(
     }
 }
 
+/// What [`enforce_current_voice_grants`] established about one live
+/// SFU participant's authorization, from THIS process's room map.
+///
+/// The distinction between [`Self::NoLocalRoomActor`] and every other
+/// variant is load-bearing for clustering (#1594): only a LOCAL room
+/// actor's answer is authoritative. An absent actor means "the room
+/// may be claimed by another replica", never "not an occupant" —
+/// treating absence as authorization evidence would evict legitimate
+/// occupants from roughly every join that lands on a non-owning node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GrantEnforcement {
+    /// The occupant's current voice was pushed to the SFU.
+    Applied,
+    /// A local (authoritative) actor answered "not an occupant"; the
+    /// participant was evicted from the call.
+    EvictedNonOccupant,
+    /// No room actor in this process — the claim may live on another
+    /// replica. No side effect was performed.
+    NoLocalRoomActor,
+    /// The registry or actor lookup failed transiently. No side effect
+    /// was performed; retrying may succeed.
+    LookupFailed,
+    /// This deployment has no SFU configured; there is nothing to
+    /// enforce against.
+    SfuNotConfigured,
+}
+
+/// Re-derive `full_jid`'s XEP-0045 voice from THIS process's room
+/// actor and converge their live SFU media grants with it — the
+/// shared enforcement core behind both the same-node
+/// `participant_joined` webhook path and the owner side of the #1594
+/// cross-node relay. Keeping both on one function is deliberate: the
+/// relayed path must not be able to diverge from the local one.
+///
+/// Side effects happen only on an authoritative answer: a seated
+/// occupant gets their voice-derived grants pushed, a confirmed
+/// non-occupant is evicted, and every other outcome performs nothing.
+pub(crate) async fn enforce_current_voice_grants(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    full_jid: &FullJid,
+) -> GrantEnforcement {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        return GrantEnforcement::SfuNotConfigured;
+    };
+    let actor = match crate::server::routes::websocket::get_room_actor_result(state, room_jid).await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => return GrantEnforcement::NoLocalRoomActor,
+        Err(error) => {
+            tracing::warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                error = %error,
+                "could not resolve MUC voice for a live call participant",
+            );
+            return GrantEnforcement::LookupFailed;
+        }
+    };
+    match actor
+        .ask(waddle_xmpp::muc::room_actor::GetOccupantVoice {
+            jid: full_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(voice)) => {
+            tracing::debug!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                "re-asserting SFU media grants from current MUC voice",
+            );
+            apply_voice_grants_via_sfu(sfu, room_jid, full_jid, voice);
+            GrantEnforcement::Applied
+        }
+        Ok(None) => {
+            // A LOCAL room actor answered, so it owns this room and its
+            // occupant set is authoritative: this participant is in the
+            // SFU room while not being an occupant of the MUC.
+            // Occupancy is the precondition for call participation, so
+            // this is a stale-token join and must end. (Contrast the
+            // absent-actor case above, which proves nothing.)
+            tracing::warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                "LiveKit participant is not a MUC occupant; evicting from the call",
+            );
+            unregister_participant_via_sfu(sfu, room_jid, full_jid);
+            GrantEnforcement::EvictedNonOccupant
+        }
+        Err(error) => {
+            tracing::warn!(
+                room = %room_jid,
+                user = %full_jid.to_bare(),
+                error = %error,
+                "MUC voice lookup failed for a live call participant",
+            );
+            GrantEnforcement::LookupFailed
+        }
+    }
+}
+
 /// Push every occupant's current XEP-0045 voice to the SFU after a
 /// room-configuration change flipped `moderated`.
 ///

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -190,6 +190,24 @@ pub(crate) async fn create_test_websocket_state_with_sfu(
     .await
 }
 
+/// [`create_test_websocket_state_with_sfu`] plus caller-supplied
+/// clustering handles — used by the #1594 webhook tests, which need
+/// BOTH an observable SFU (the enforcement side effect) and a claim
+/// store (the cross-node routing decision).
+#[cfg(feature = "clustering")]
+pub(crate) async fn create_test_websocket_state_with_sfu_and_clustering(
+    sfu: Arc<dyn waddle_sfu::SfuService>,
+    clustering: crate::clustering::ClusteringHandles,
+) -> Arc<WebSocketState> {
+    create_test_websocket_state_with_extension_manager(
+        empty_extension_manager().await,
+        Some(sfu),
+        Some(clustering),
+        None,
+    )
+    .await
+}
+
 /// Recording fake: captures `(call_id, identity)` separately for each
 /// teardown dispatch — `unregister_call_participant` (the admin-evict
 /// path) into `calls`, `note_participant_left` (the webhook-bridge
@@ -589,7 +607,10 @@ async fn create_test_session(state: &WebSocketState, username: &str) -> Session 
     session
 }
 
-async fn create_test_server_owner_session(state: &WebSocketState, username: &str) -> Session {
+pub(crate) async fn create_test_server_owner_session(
+    state: &WebSocketState,
+    username: &str,
+) -> Session {
     let session = create_test_session(state, username).await;
     state
         .deps

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -2479,7 +2479,6 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
 
     const DOMAIN: &str = "localhost";
     const OWNER_USERNAME: &str = "admin";
-    const NS_MUC: &str = "http://jabber.org/protocol/muc";
     const WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
 
     // Fake LiveKit admin origins, ONE PER NODE. `admin_base_url_from_ws`
@@ -2556,9 +2555,7 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
     .await
     .expect("client A connects to node A");
     client_a
-        .send(&format!(
-            r#"<presence to="{room}/owner-a"><x xmlns="{NS_MUC}"/></presence>"#
-        ))
+        .send(&String::from(&muc_join_presence(&room, "owner-a")))
         .await
         .expect("client A sends join presence");
     client_a
@@ -2580,9 +2577,7 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
     .await
     .expect("client B connects to node B");
     client_b
-        .send(&format!(
-            r#"<presence to="{room}/joiner-b"><x xmlns="{NS_MUC}"/></presence>"#
-        ))
+        .send(&String::from(&muc_join_presence(&room, "joiner-b")))
         .await
         .expect("client B sends join presence");
     client_b
@@ -2668,6 +2663,20 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
     drop(server_a);
     drop(server_b);
     drop(client_a);
+}
+
+/// MUC join `<presence/>` built with the typed XML builder (repo
+/// XML-generation rule: never construct XML with `format!`).
+fn muc_join_presence(room: &str, nick: &str) -> xmpp_parsers::minidom::Element {
+    use xmpp_parsers::minidom::Element;
+    const NS_MUC: &str = "http://jabber.org/protocol/muc";
+    Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            format!("{room}/{nick}"),
+        )
+        .append(Element::builder("x", NS_MUC).build())
+        .build()
 }
 
 /// Signed `Authorization` header for a synthetic LiveKit webhook body,

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -2453,6 +2453,217 @@ async fn muji_initiate_routes_to_foreign_room_owner() {
     drop(client_a);
 }
 
+/// #1594: a `participant_joined` webhook that lands on the replica NOT
+/// holding the room's claim must converge that participant's media
+/// grants immediately — relayed to the claim owner, which re-derives
+/// the occupant's XEP-0045 voice from its authoritative room actor and
+/// pushes it to LiveKit. Observable as the owner's Twirp
+/// `UpdateParticipant` call against the (mocked) LiveKit admin API,
+/// where pre-#1594 the delivery was merely acknowledged and enforcement
+/// waited for the owner's 60s reconciliation tick.
+#[tokio::test]
+async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
+    let Ok(postgres_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping participant_joined_webhook_reasserts_grants_on_foreign_room_owner: \
+             WADDLE_TEST_POSTGRES_URL not set"
+        );
+        return;
+    };
+    let _serial = cluster_e2e_serial_lock().lock().await;
+
+    let db = open_control_db(&postgres_url).await;
+    let pool = generate_pool();
+    reset_and_enroll(&db, &pool).await;
+    reset_node_lease_tables(&db).await;
+
+    const DOMAIN: &str = "localhost";
+    const OWNER_USERNAME: &str = "admin";
+    const NS_MUC: &str = "http://jabber.org/protocol/muc";
+    const WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
+
+    // Fake LiveKit admin origin. `admin_base_url_from_ws` derives the
+    // admin REST base by swapping the `LIVEKIT_WS_URL` scheme
+    // (`ws://` → `http://`) on the same authority, so pointing the WS
+    // URL at this mock lets the test observe which NODE pushed a grant.
+    let livekit_admin = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&livekit_admin)
+        .await;
+    let livekit_ws_url: &'static str = Box::leak(
+        livekit_admin
+            .uri()
+            .replacen("http://", "ws://", 1)
+            .into_boxed_str(),
+    );
+
+    let livekit_envs: &[(&'static str, &'static str)] = &[
+        ("LIVEKIT_API_KEY", "APItestkeycluster"),
+        (
+            "LIVEKIT_API_SECRET",
+            "test-secret-with-at-least-32-bytes-of-payload",
+        ),
+        ("LIVEKIT_WS_URL", livekit_ws_url),
+        ("LIVEKIT_TURN_HOST", "turn.example.test"),
+        (
+            "LIVEKIT_TURN_SHARED_SECRET",
+            "turn-shared-secret-value-also-long-enough",
+        ),
+        ("LIVEKIT_WEBHOOK_SECRET", WEBHOOK_SECRET),
+    ];
+
+    let port_a = free_tcp_port();
+    let port_b = free_tcp_port();
+    let (server_a, _node_a, _peer_a) = spawn_cluster_server_with_envs(
+        &postgres_url,
+        &pool.pool_env,
+        port_a,
+        &[port_b],
+        livekit_envs,
+    )
+    .await;
+    let (server_b, _node_b, _peer_b) = spawn_cluster_server_with_envs(
+        &postgres_url,
+        &pool.pool_env,
+        port_b,
+        &[port_a],
+        livekit_envs,
+    )
+    .await;
+
+    wait_for_readiness(&server_a, true, Duration::from_secs(15)).await;
+    wait_for_readiness(&server_b, true, Duration::from_secs(15)).await;
+
+    let owner_password = server_b.fixed_account_password().to_string();
+    let room = format!("grants-foreign-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    // Client A creates and joins the room on node A — node A holds the
+    // room claim and the authoritative occupancy.
+    let resource_a = format!("grants-owner-a-{}", uuid::Uuid::new_v4());
+    let mut client_a = WsXmppClient::connect_and_auth(
+        &server_a.ws_url(),
+        DOMAIN,
+        OWNER_USERNAME,
+        &owner_password,
+        &resource_a,
+    )
+    .await
+    .expect("client A connects to node A");
+    client_a
+        .send(&format!(
+            r#"<presence to="{room}/owner-a"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("client A sends join presence");
+    client_a
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("client A's join completes (room created, A is Owner)");
+
+    // Client B joins the same room THROUGH NODE B (relayed join), so
+    // B's occupancy — and therefore B's voice — lives on node A while
+    // node B has no room actor.
+    let resource_b = format!("grants-joiner-b-{}", uuid::Uuid::new_v4());
+    let mut client_b = WsXmppClient::connect_and_auth(
+        &server_b.ws_url(),
+        DOMAIN,
+        CLUSTER_PEER_USERNAME,
+        CLUSTER_PEER_PASSWORD,
+        &resource_b,
+    )
+    .await
+    .expect("client B connects to node B");
+    client_b
+        .send(&format!(
+            r#"<presence to="{room}/joiner-b"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("client B sends join presence");
+    client_b
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("client B's relayed join completes");
+
+    // LiveKit reports B's SFU join to node B — the NON-owning replica.
+    // Pre-#1594 this was acknowledged with grants unenforced until the
+    // owner's reconcile tick; now node B must relay the re-assert to
+    // node A synchronously with the delivery.
+    let identity = format!("{CLUSTER_PEER_USERNAME}@{DOMAIN}/{resource_b}");
+    let body = serde_json::to_vec(&serde_json::json!({
+        "id": format!("EV_{}", uuid::Uuid::new_v4()),
+        "event": "participant_joined",
+        "room": { "name": room },
+        "participant": { "identity": identity },
+    }))
+    .expect("webhook body");
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}/api/v1/livekit/webhook",
+            server_b.http_base_url()
+        ))
+        .header("Authorization", livekit_webhook_auth(WEBHOOK_SECRET, &body))
+        .body(body)
+        .send()
+        .await
+        .expect("post LiveKit webhook to the non-owning node");
+    assert!(
+        response.status().is_success(),
+        "a cross-node re-assertable join must be acknowledged, got {}",
+        response.status()
+    );
+
+    // The OWNER (node A) pushes the re-derived grant to LiveKit. The
+    // push is fire-and-forget after the relay reply, so poll briefly.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let requests = livekit_admin.received_requests().await.unwrap_or_default();
+        let update_seen = requests.iter().any(|request| {
+            request.url.path() == "/twirp/livekit.RoomService/UpdateParticipant"
+                && String::from_utf8_lossy(&request.body).contains(&identity)
+        });
+        if update_seen {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the claim owner must push an UpdateParticipant for the relayed \
+             re-assert; admin requests seen: {:?}",
+            requests
+                .iter()
+                .map(|request| request.url.path().to_string())
+                .collect::<Vec<_>>()
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    client_b.close().await.expect("client B closes");
+    drop(server_a);
+    drop(server_b);
+    drop(client_a);
+}
+
+/// Signed `Authorization` header for a synthetic LiveKit webhook body,
+/// matching LiveKit's scheme: a JWT over the body's SHA-256, signed
+/// with the deployment's webhook secret.
+fn livekit_webhook_auth(secret: &str, body: &[u8]) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(body);
+    let claims = serde_json::json!({
+        "sha256": base64::engine::general_purpose::STANDARD.encode(hasher.finalize()),
+        "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+        "iat": chrono::Utc::now().timestamp(),
+    });
+    let token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("sign LiveKit webhook");
+    format!("Bearer {token}")
+}
+
 /// Muji `session-terminate` IQ for `room` — the hangup counterpart of
 /// [`muji_initiate_iq`]. XEP-0272 requires only the `<muji room='…'/>`
 /// marker on terminate, no contents.

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -2482,36 +2482,41 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
     const NS_MUC: &str = "http://jabber.org/protocol/muc";
     const WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
 
-    // Fake LiveKit admin origin. `admin_base_url_from_ws` derives the
-    // admin REST base by swapping the `LIVEKIT_WS_URL` scheme
-    // (`ws://` → `http://`) on the same authority, so pointing the WS
-    // URL at this mock lets the test observe which NODE pushed a grant.
-    let livekit_admin = wiremock::MockServer::start().await;
-    wiremock::Mock::given(wiremock::matchers::method("POST"))
-        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
-        .mount(&livekit_admin)
-        .await;
-    let livekit_ws_url: &'static str = Box::leak(
-        livekit_admin
-            .uri()
-            .replacen("http://", "ws://", 1)
-            .into_boxed_str(),
-    );
+    // Fake LiveKit admin origins, ONE PER NODE. `admin_base_url_from_ws`
+    // derives the admin REST base by swapping the `LIVEKIT_WS_URL`
+    // scheme (`ws://` → `http://`) on the same authority, so giving
+    // each node its own mock attributes every admin call to the node
+    // that made it — the assertion below is "the OWNER pushed", not
+    // "someone pushed".
+    async fn fake_livekit_admin() -> (wiremock::MockServer, &'static str) {
+        let mock = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&mock)
+            .await;
+        let ws_url: &'static str =
+            Box::leak(mock.uri().replacen("http://", "ws://", 1).into_boxed_str());
+        (mock, ws_url)
+    }
+    let (livekit_admin_a, ws_url_a) = fake_livekit_admin().await;
+    let (livekit_admin_b, ws_url_b) = fake_livekit_admin().await;
 
-    let livekit_envs: &[(&'static str, &'static str)] = &[
-        ("LIVEKIT_API_KEY", "APItestkeycluster"),
-        (
-            "LIVEKIT_API_SECRET",
-            "test-secret-with-at-least-32-bytes-of-payload",
-        ),
-        ("LIVEKIT_WS_URL", livekit_ws_url),
-        ("LIVEKIT_TURN_HOST", "turn.example.test"),
-        (
-            "LIVEKIT_TURN_SHARED_SECRET",
-            "turn-shared-secret-value-also-long-enough",
-        ),
-        ("LIVEKIT_WEBHOOK_SECRET", WEBHOOK_SECRET),
-    ];
+    fn livekit_envs(ws_url: &'static str) -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("LIVEKIT_API_KEY", "APItestkeycluster"),
+            (
+                "LIVEKIT_API_SECRET",
+                "test-secret-with-at-least-32-bytes-of-payload",
+            ),
+            ("LIVEKIT_WS_URL", ws_url),
+            ("LIVEKIT_TURN_HOST", "turn.example.test"),
+            (
+                "LIVEKIT_TURN_SHARED_SECRET",
+                "turn-shared-secret-value-also-long-enough",
+            ),
+            ("LIVEKIT_WEBHOOK_SECRET", WEBHOOK_SECRET),
+        ]
+    }
 
     let port_a = free_tcp_port();
     let port_b = free_tcp_port();
@@ -2520,7 +2525,7 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
         &pool.pool_env,
         port_a,
         &[port_b],
-        livekit_envs,
+        &livekit_envs(ws_url_a),
     )
     .await;
     let (server_b, _node_b, _peer_b) = spawn_cluster_server_with_envs(
@@ -2528,7 +2533,7 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
         &pool.pool_env,
         port_b,
         &[port_a],
-        livekit_envs,
+        &livekit_envs(ws_url_b),
     )
     .await;
 
@@ -2615,20 +2620,25 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
 
     // The OWNER (node A) pushes the re-derived grant to LiveKit. The
     // push is fire-and-forget after the relay reply, so poll briefly.
+    // Each node has its own mock, so this attributes the push to node
+    // A structurally, not by timing alone.
+    let is_update_for_identity = |request: &wiremock::Request| {
+        request.url.path() == "/twirp/livekit.RoomService/UpdateParticipant"
+            && String::from_utf8_lossy(&request.body).contains(&identity)
+    };
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        let requests = livekit_admin.received_requests().await.unwrap_or_default();
-        let update_seen = requests.iter().any(|request| {
-            request.url.path() == "/twirp/livekit.RoomService/UpdateParticipant"
-                && String::from_utf8_lossy(&request.body).contains(&identity)
-        });
-        if update_seen {
+        let requests = livekit_admin_a
+            .received_requests()
+            .await
+            .unwrap_or_default();
+        if requests.iter().any(is_update_for_identity) {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "the claim owner must push an UpdateParticipant for the relayed \
-             re-assert; admin requests seen: {:?}",
+            "the claim owner (node A) must push an UpdateParticipant for the \
+             relayed re-assert; node A admin requests seen: {:?}",
             requests
                 .iter()
                 .map(|request| request.url.path().to_string())
@@ -2636,6 +2646,23 @@ async fn participant_joined_webhook_reasserts_grants_on_foreign_room_owner() {
         );
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+
+    // And the non-owning webhook receiver must NOT have pushed it —
+    // node B has no local actor, so an UpdateParticipant from B would
+    // mean the relay was bypassed by some local fallback.
+    let node_b_requests = livekit_admin_b
+        .received_requests()
+        .await
+        .unwrap_or_default();
+    assert!(
+        !node_b_requests.iter().any(is_update_for_identity),
+        "the non-owning node must not push grants for this join; node B \
+         admin requests seen: {:?}",
+        node_b_requests
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
 
     client_b.close().await.expect("client B closes");
     drop(server_a);

--- a/server/crates/waddle-server/tests/xep0045_voice_media_grants_ws.rs
+++ b/server/crates/waddle-server/tests/xep0045_voice_media_grants_ws.rs
@@ -1,0 +1,218 @@
+//! XEP-0045 voice → LiveKit media-grant enforcement (#1593/#1594)
+//! against a live waddle-server with `LIVEKIT_*` envs set.
+//!
+//! Dedicated XEP-0045 suite for the voice-derived media-authorization
+//! behavior: an occupant's §7.5 voice decides their SFU publish
+//! grants, occupancy is the precondition for call participation, and
+//! the `participant_joined` webhook is the enforcement point for
+//! tokens minted before a voice change. The SFU side is observed on a
+//! mock LiveKit admin API (`LIVEKIT_WS_URL` pointed at a local
+//! wiremock; the server derives the admin REST base from it).
+//!
+//! The cross-replica half of #1594 — the same enforcement relayed to
+//! the room's claim owner — needs a two-node cluster and lives in
+//! `clustering_cluster_e2e.rs`
+//! (`participant_joined_webhook_reasserts_grants_on_foreign_room_owner`);
+//! this suite pins the single-node XEP-0045 semantics both paths
+//! share.
+
+use waddle_ws_test_support as ws_common;
+
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::time::{Duration, Instant};
+use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const DOMAIN: &str = "localhost";
+const ALICE: &str = "alice";
+const ALICE_PW: &str = "alice-pw-12345";
+const LIVEKIT_WEBHOOK_SECRET: &str = "test-webhook-secret-with-at-least-32-bytes";
+
+/// LiveKit env set whose admin REST origin is the given mock server.
+fn livekit_envs(ws_url: &'static str) -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("LIVEKIT_API_KEY", "APItestkeyxep0045"),
+        (
+            "LIVEKIT_API_SECRET",
+            "test-secret-with-at-least-32-bytes-of-payload",
+        ),
+        ("LIVEKIT_WS_URL", ws_url),
+        ("LIVEKIT_TURN_HOST", "turn.example.test"),
+        (
+            "LIVEKIT_TURN_SHARED_SECRET",
+            "turn-shared-secret-value-also-long-enough",
+        ),
+        ("LIVEKIT_WEBHOOK_SECRET", LIVEKIT_WEBHOOK_SECRET),
+        // Instant-room creation is owner-gated; the fixture account
+        // must be allowed to create the room it joins.
+        ("WADDLE_SERVER_OWNER_LOCALPARTS", ALICE),
+    ]
+}
+
+async fn fake_livekit_admin() -> (wiremock::MockServer, &'static str) {
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&mock)
+        .await;
+    let ws_url: &'static str =
+        Box::leak(mock.uri().replacen("http://", "ws://", 1).into_boxed_str());
+    (mock, ws_url)
+}
+
+/// MUC join `<presence/>` built with the typed XML builder (repo
+/// XML-generation rule: never construct XML with `format!`).
+fn muc_join_presence(room: &str, nick: &str) -> Element {
+    Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            format!("{room}/{nick}"),
+        )
+        .append(Element::builder("x", NS_MUC).build())
+        .build()
+}
+
+fn livekit_webhook_auth(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    let claims = json!({
+        "sha256": BASE64_STANDARD.encode(hasher.finalize()),
+        "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+        "iat": chrono::Utc::now().timestamp(),
+    });
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(LIVEKIT_WEBHOOK_SECRET.as_bytes()),
+    )
+    .expect("sign LiveKit webhook");
+    format!("Bearer {token}")
+}
+
+async fn post_participant_joined(server: &TestServer, room: &str, identity: &str) {
+    let body = serde_json::to_vec(&json!({
+        "id": format!("EV_{}", uuid::Uuid::new_v4()),
+        "event": "participant_joined",
+        "room": { "name": room },
+        "participant": { "identity": identity },
+    }))
+    .expect("webhook body");
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/livekit/webhook", server.http_base_url()))
+        .header("Authorization", livekit_webhook_auth(&body))
+        .body(body)
+        .send()
+        .await
+        .expect("post LiveKit webhook");
+    assert!(
+        response.status().is_success(),
+        "participant_joined webhook must be acknowledged, got {}",
+        response.status()
+    );
+}
+
+/// Poll the mock admin API until a POST to `path` whose body contains
+/// `needle` arrives, or fail with everything that was seen.
+async fn await_admin_call(mock: &wiremock::MockServer, path: &str, needle: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let requests = mock.received_requests().await.unwrap_or_default();
+        if requests.iter().any(|request| {
+            request.url.path() == path && String::from_utf8_lossy(&request.body).contains(needle)
+        }) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected an admin call to {path} mentioning {needle}; saw: {:?}",
+            requests
+                .iter()
+                .map(|request| request.url.path().to_string())
+                .collect::<Vec<_>>()
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// §7.5-derived enforcement, grant half: a seated occupant with voice
+/// who joins the SFU room gets their voice-derived grants pushed to
+/// LiveKit when the `participant_joined` webhook is processed — the
+/// stale-token enforcement point (a token minted before a voice
+/// change carries the OLD permissions; the webhook re-derivation is
+/// what corrects them).
+#[tokio::test]
+async fn occupant_join_webhook_pushes_voice_derived_grants() {
+    let (mock, ws_url) = fake_livekit_admin().await;
+    let server = TestServer::start_with_extra_envs(&[(ALICE, ALICE_PW)], &livekit_envs(ws_url));
+    let mut alice = WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, ALICE, ALICE_PW, "ax")
+        .await
+        .expect("alice connects");
+
+    let room = format!("voice-grants-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    alice
+        .send(&String::from(&muc_join_presence(&room, "alice")))
+        .await
+        .expect("alice sends join presence");
+    alice
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("alice's join completes");
+
+    let identity = format!("{ALICE}@{DOMAIN}/ax");
+    post_participant_joined(&server, &room, &identity).await;
+
+    await_admin_call(
+        &mock,
+        "/twirp/livekit.RoomService/UpdateParticipant",
+        &identity,
+    )
+    .await;
+}
+
+/// §7.5-derived enforcement, eviction half: occupancy is the
+/// precondition for call participation, so a LiveKit participant the
+/// room's authoritative occupant set does NOT contain is evicted from
+/// the call rather than granted — a voluntary leave followed by a
+/// LiveKit reconnect reaches no other teardown path.
+#[tokio::test]
+async fn non_occupant_join_webhook_evicts_from_the_call() {
+    let (mock, ws_url) = fake_livekit_admin().await;
+    let server = TestServer::start_with_extra_envs(&[(ALICE, ALICE_PW)], &livekit_envs(ws_url));
+    let mut alice = WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, ALICE, ALICE_PW, "ax")
+        .await
+        .expect("alice connects");
+
+    let room = format!("voice-evict-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    alice
+        .send(&String::from(&muc_join_presence(&room, "alice")))
+        .await
+        .expect("alice sends join presence");
+    alice
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("alice's join completes");
+
+    // A full JID that is NOT an occupant of the room: the local actor
+    // answers authoritatively, so this join must end in eviction.
+    let ghost = format!("{ALICE}@{DOMAIN}/never-joined");
+    post_participant_joined(&server, &room, &ghost).await;
+
+    await_admin_call(
+        &mock,
+        "/twirp/livekit.RoomService/RemoveParticipant",
+        &ghost,
+    )
+    .await;
+    let requests = mock.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|request| {
+            request.url.path() == "/twirp/livekit.RoomService/UpdateParticipant"
+                && String::from_utf8_lossy(&request.body).contains(&ghost)
+        }),
+        "a non-occupant must never receive a grant push"
+    );
+}


### PR DESCRIPTION
## Problem

#1593 makes XEP-0045 voice decide LiveKit media grants, and the `participant_joined` webhook is the enforcement point for tokens minted before a voice change. But the webhook URL is load-balanced and `reassert_voice_grants_on_join` consulted only the local room map: with `replicaCount: 2`, a join landing on the non-owning replica was merely acknowledged, leaving enforcement to the owner's 60s reconciliation tick (#1594 — a latency gap; correctness was already backstopped).

## What this does

Routes the re-assert to the room's claim owner as a **typed, unordered relay ask** — `waddle.clustering.relay.reassert_media_grants.v1`, following the `Demote`/`RelayResumeSteal` precedent (the stanza-shaped `MucProxy` path needs a client origin a webhook doesn't have, and ordering buys nothing for an idempotent effect).

- **Shared enforcement core** (`muc_call_sfu::enforce_current_voice_grants`): the same-node webhook path and the relayed owner-side executor run the identical derivation — `GetOccupantVoice` (bounded by the room-registry reply timeout) → `apply_voice_grants_via_sfu` / eviction — so the two paths cannot diverge. Eviction still requires an authoritative **local** actor answer; an absent actor is never authorization evidence (the #1593 near-breaker).
- **Asker side** (`reassert_on_claim_owner`): pure `route_from_claim` decides — fresh foreign owner → relay ask; unclaimed / stale lease / self-owned → the pre-existing acknowledge-and-reconcile fallback; claim-store read error → 503 so LiveKit retries. The relay hop runs under tight ask timeouts (1s mailbox / 3s reply) plus a 4s overall bound covering kademlia resolution, so the webhook socket never outlives LiveKit's delivery timeout.
- **Receiver side** (`OrderedRelayDeliveryBridge::reassert_media_grants_local`): terminal (never re-relays), and claim-gated with the module's standard fresh-and-mine predicate — a lingering post-demote or expired-lease actor answers `NotOwner` instead of acting on a superseded occupant set.
- Reply → HTTP mapping: `Applied`/`NotOccupantEvicted` → 200; `NotOwner`/`Unavailable`/transport error → 503 + dedupe-forget (LiveKit's bounded retries re-resolve the claim); the reconciler remains the backstop and its doc comment is updated.

## Tests

- Unit: shared-core behavior (grant push / eviction / no-side-effect-on-absence), every `route_from_claim` branch, webhook fallbacks (unclaimed, self-owned), relay handler `Unavailable` + dispatch-span coverage, bridge claim-gate (unowned claim refuses, stale lease refuses via a claim-store double, owned claim pushes).
- Cluster e2e (`participant_joined_webhook_reasserts_grants_on_foreign_room_owner`): two real nodes, per-node wiremock LiveKit admin mocks; the signed webhook posted to the **non-owning** node is acknowledged, the **owner's** mock receives the Twirp `UpdateParticipant`, and the non-owner's mock provably does not.
- Verified locally: clippy `--all-features -D warnings` clean, default-feature build clean, touched modules green, e2e green against a throwaway Postgres. (7 full-suite failures are pre-existing parallel-metric flakes, reproduced on clean main.)

## Review

Two-axis review (standards/spec) + three adversarial rounds (distributed-systems, security personas) + an independent `codex review` pass. All confirmed findings fixed in dedicated commits: bounded owner-side ask, webhook-scoped relay timeouts, receiver-side claim gate (incl. lease freshness), overall relay-hop bound, per-node e2e mocks, doc/code consistency.

XEP note: no XMPP wire-shape changes (internal clustering effect + LiveKit webhook), so no new XEP conformance surface.

Closes #1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)