### PR TITLE
fix(infra): make Grafana deploy annotation best-effort with bounded retries

### DIFF
--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -146,9 +146,11 @@ schema.#Project & {
 		// 4xx responses, DNS failures, malformed URLs, cert verification
 		// errors — still fails the task (TLS handshake drops, curl 35,
 		// are retried since they are usually mid-handshake network
-		// failures). Retrying the POST can leave duplicate
-		// markers if Grafana committed before an edge error; acceptable
-		// for telemetry.
+		// failures). A hard deadline caps total retry wall time so the
+		// job cannot linger inside the workflow's cancel-in-progress
+		// window. Retrying the POST can duplicate markers — classically
+		// when --max-time aborts client-side after Grafana already
+		// committed the annotation; acceptable for telemetry.
 		deployAnnotation: schema.#Task & {
 			dependsOn: [helmPush, gitopsPush]
 			command: "bash"
@@ -165,6 +167,7 @@ schema.#Project & {
 					  --arg text "waddle infra deploy ${revision}" \
 					  --argjson time "${timestamp_ms}" \
 					  '{text: $text, tags: ["deploy", "waddle"], time: $time}')"
+					retry_deadline="$(( SECONDS + 45 ))"
 					for attempt in 1 2 3 4 5; do
 					  : > "${annotation_response}"
 					  curl_rc=0
@@ -201,11 +204,12 @@ schema.#Project & {
 					        ;;
 					    esac
 					  fi
-					  if [ "${attempt}" -lt 5 ]; then
-					    sleep "$(( 1 << attempt ))"
+					  if [ "${attempt}" -ge 5 ] || [ "${SECONDS}" -ge "${retry_deadline}" ]; then
+					    break
 					  fi
+					  sleep "$(( 1 << attempt ))"
 					done
-					echo "::warning title=Grafana deploy annotation skipped::Grafana unavailable after 5 attempts; no deploy marker for ${revision}."
+					echo "::warning title=Grafana deploy annotation skipped::Grafana unavailable after ${attempt} attempts; no deploy marker for ${revision}."
 					exit 0
 				"""#]
 			inputs: ["gitops/**", "charts/**", "env.cue"]

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -139,10 +139,14 @@ schema.#Project & {
 		// annotation. Flux reconciliation is asynchronous, so this marks the
 		// rollout handoff rather than claiming the pods are already ready.
 		// Sequenced after both pushes so a failed push never gets a marker.
-		// The annotation is best-effort telemetry: transient Grafana errors
-		// (5xx/429, e.g. a cold-starting Cloud instance, or transport
-		// failures) are retried and then tolerated, while 4xx responses
-		// still fail the task because they indicate misconfiguration.
+		// The annotation is best-effort telemetry: transient errors
+		// (408/429/5xx, e.g. a cold-starting Cloud instance, plus
+		// retryable curl transport failures) are retried briefly and then
+		// tolerated with a run-level warning. Misconfiguration — other
+		// 4xx responses, DNS failures, malformed URLs, TLS cert errors —
+		// still fails the task. Retrying the POST can leave duplicate
+		// markers if Grafana committed before an edge error; acceptable
+		// for telemetry.
 		deployAnnotation: schema.#Task & {
 			dependsOn: [helmPush, gitopsPush]
 			command: "bash"
@@ -160,31 +164,47 @@ schema.#Project & {
 					  --argjson time "${timestamp_ms}" \
 					  '{text: $text, tags: ["deploy", "waddle"], time: $time}')"
 					for attempt in 1 2 3 4 5; do
-					  annotation_status="$(curl -sS -o "${annotation_response}" -w '%{http_code}' \
+					  : > "${annotation_response}"
+					  curl_rc=0
+					  annotation_status="$(curl -sS --connect-timeout 5 --max-time 15 \
+					      -o "${annotation_response}" -w '%{http_code}' \
 					      -X POST "${grafana_url}/api/annotations" \
 					      -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
 					      -H 'Content-Type: application/json' \
-					      --data-binary "${annotation_payload}")" || annotation_status="000"
-					  case "${annotation_status}" in
-					    2??)
-					      echo "Grafana deploy annotation posted for ${revision}."
-					      exit 0
-					      ;;
-					    5?? | 429 | 000)
-					      echo "Grafana annotation attempt ${attempt} got HTTP ${annotation_status}:" >&2
-					      cat "${annotation_response}" >&2 || true
-					      if [ "${attempt}" -lt 5 ]; then
-					        sleep "$(( attempt * 10 ))"
-					      fi
-					      ;;
-					    *)
-					      echo "Grafana annotation creation failed with HTTP ${annotation_status}:" >&2
-					      cat "${annotation_response}" >&2
-					      exit 1
-					      ;;
-					  esac
+					      --data-binary "${annotation_payload}")" || curl_rc=$?
+					  if [ "${curl_rc}" -ne 0 ]; then
+					    case "${curl_rc}" in
+					      7 | 28 | 35 | 52 | 56)
+					        echo "Grafana annotation attempt ${attempt} hit transient curl error ${curl_rc}." >&2
+					        ;;
+					      *)
+					        echo "Grafana annotation request failed with curl exit ${curl_rc}; check GRAFANA_CLOUD_URL." >&2
+					        exit 1
+					        ;;
+					    esac
+					  else
+					    case "${annotation_status}" in
+					      2??)
+					        echo "Grafana deploy annotation posted for ${revision}."
+					        exit 0
+					        ;;
+					      408 | 429 | 5??)
+					        echo "Grafana annotation attempt ${attempt} got HTTP ${annotation_status}:" >&2
+					        cat "${annotation_response}" >&2
+					        ;;
+					      *)
+					        echo "Grafana annotation creation failed with HTTP ${annotation_status}:" >&2
+					        cat "${annotation_response}" >&2
+					        exit 1
+					        ;;
+					    esac
+					  fi
+					  if [ "${attempt}" -lt 5 ]; then
+					    sleep "$(( 1 << attempt ))"
+					  fi
 					done
-					echo "Grafana annotation still unavailable after 5 attempts; skipping deploy marker for ${revision}." >&2
+					echo "::warning title=Grafana deploy annotation skipped::Grafana unavailable after 5 attempts; no deploy marker for ${revision}."
+					exit 0
 				"""#]
 			inputs: ["gitops/**", "charts/**", "env.cue"]
 		}

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -169,9 +169,17 @@ schema.#Project & {
 					  '{text: $text, tags: ["deploy", "waddle"], time: $time}')"
 					retry_deadline="$(( SECONDS + 45 ))"
 					for attempt in 1 2 3 4 5; do
+					  remaining="$(( retry_deadline - SECONDS ))"
+					  if [ "${remaining}" -le 0 ]; then
+					    break
+					  fi
+					  max_time=15
+					  if [ "${remaining}" -lt "${max_time}" ]; then
+					    max_time="${remaining}"
+					  fi
 					  : > "${annotation_response}"
 					  curl_rc=0
-					  annotation_status="$(curl -sS --connect-timeout 5 --max-time 15 \
+					  annotation_status="$(curl -sS --connect-timeout 5 --max-time "${max_time}" \
 					      -o "${annotation_response}" -w '%{http_code}' \
 					      -X POST "${grafana_url}/api/annotations" \
 					      -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
@@ -204,10 +212,18 @@ schema.#Project & {
 					        ;;
 					    esac
 					  fi
-					  if [ "${attempt}" -ge 5 ] || [ "${SECONDS}" -ge "${retry_deadline}" ]; then
+					  if [ "${attempt}" -ge 5 ]; then
 					    break
 					  fi
-					  sleep "$(( 1 << attempt ))"
+					  backoff="$(( 1 << attempt ))"
+					  remaining="$(( retry_deadline - SECONDS ))"
+					  if [ "${remaining}" -le 0 ]; then
+					    break
+					  fi
+					  if [ "${backoff}" -gt "${remaining}" ]; then
+					    backoff="${remaining}"
+					  fi
+					  sleep "${backoff}"
 					done
 					echo "::warning title=Grafana deploy annotation skipped::Grafana unavailable after ${attempt} attempts; no deploy marker for ${revision}."
 					exit 0

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -143,8 +143,10 @@ schema.#Project & {
 		// (408/429/5xx, e.g. a cold-starting Cloud instance, plus
 		// retryable curl transport failures) are retried briefly and then
 		// tolerated with a run-level warning. Misconfiguration — other
-		// 4xx responses, DNS failures, malformed URLs, TLS cert errors —
-		// still fails the task. Retrying the POST can leave duplicate
+		// 4xx responses, DNS failures, malformed URLs, cert verification
+		// errors — still fails the task (TLS handshake drops, curl 35,
+		// are retried since they are usually mid-handshake network
+		// failures). Retrying the POST can leave duplicate
 		// markers if Grafana committed before an edge error; acceptable
 		// for telemetry.
 		deployAnnotation: schema.#Task & {
@@ -174,7 +176,7 @@ schema.#Project & {
 					      --data-binary "${annotation_payload}")" || curl_rc=$?
 					  if [ "${curl_rc}" -ne 0 ]; then
 					    case "${curl_rc}" in
-					      7 | 28 | 35 | 52 | 56)
+					      7 | 16 | 18 | 28 | 35 | 52 | 55 | 56 | 92)
 					        echo "Grafana annotation attempt ${attempt} hit transient curl error ${curl_rc}." >&2
 					        ;;
 					      *)

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -139,6 +139,10 @@ schema.#Project & {
 		// annotation. Flux reconciliation is asynchronous, so this marks the
 		// rollout handoff rather than claiming the pods are already ready.
 		// Sequenced after both pushes so a failed push never gets a marker.
+		// The annotation is best-effort telemetry: transient Grafana errors
+		// (5xx/429, e.g. a cold-starting Cloud instance, or transport
+		// failures) are retried and then tolerated, while 4xx responses
+		// still fail the task because they indicate misconfiguration.
 		deployAnnotation: schema.#Task & {
 			dependsOn: [helmPush, gitopsPush]
 			command: "bash"
@@ -151,24 +155,36 @@ schema.#Project & {
 					timestamp_ms="$(( $(date +%s) * 1000 ))"
 					annotation_response="$(mktemp)"
 					trap 'rm -f "${annotation_response}"' EXIT
-					annotation_status="$(jq -n \
+					annotation_payload="$(jq -n \
 					  --arg text "waddle infra deploy ${revision}" \
 					  --argjson time "${timestamp_ms}" \
-					  '{text: $text, tags: ["deploy", "waddle"], time: $time}' \
-					  | curl -sS -o "${annotation_response}" -w '%{http_code}' \
+					  '{text: $text, tags: ["deploy", "waddle"], time: $time}')"
+					for attempt in 1 2 3 4 5; do
+					  annotation_status="$(curl -sS -o "${annotation_response}" -w '%{http_code}' \
 					      -X POST "${grafana_url}/api/annotations" \
 					      -H "Authorization: Bearer ${GRAFANA_CLOUD_DASHBOARDS_TOKEN}" \
 					      -H 'Content-Type: application/json' \
-					      --data-binary @-)"
-					case "${annotation_status}" in
-					  2??) ;;
-					  *)
-					    echo "Grafana annotation creation failed with HTTP ${annotation_status}:" >&2
-					    cat "${annotation_response}" >&2
-					    exit 1
-					    ;;
-					esac
-					echo "Grafana deploy annotation posted for ${revision}."
+					      --data-binary "${annotation_payload}")" || annotation_status="000"
+					  case "${annotation_status}" in
+					    2??)
+					      echo "Grafana deploy annotation posted for ${revision}."
+					      exit 0
+					      ;;
+					    5?? | 429 | 000)
+					      echo "Grafana annotation attempt ${attempt} got HTTP ${annotation_status}:" >&2
+					      cat "${annotation_response}" >&2 || true
+					      if [ "${attempt}" -lt 5 ]; then
+					        sleep "$(( attempt * 10 ))"
+					      fi
+					      ;;
+					    *)
+					      echo "Grafana annotation creation failed with HTTP ${annotation_status}:" >&2
+					      cat "${annotation_response}" >&2
+					      exit 1
+					      ;;
+					  esac
+					done
+					echo "Grafana annotation still unavailable after 5 attempts; skipping deploy marker for ${revision}." >&2
 				"""#]
 			inputs: ["gitops/**", "charts/**", "env.cue"]
 		}


### PR DESCRIPTION
## Problem

Production deployment run [30314437448](https://github.com/waddle-social/waddle/actions/runs/30314437448) (commit `1cad23a2`) was marked failed even though both GitOps artifact pushes succeeded. The `deployAnnotation` task got HTTP 503 (`"Your instance is loading"`) from the Grafana Cloud annotations API while the instance cold-started, and hard-failed the pipeline. The annotation is operational telemetry only; a transient Grafana outage must not fail a deploy whose rollout handoff already succeeded.

## What changed

`deployAnnotation` in `infrastructure/waddle.cloud/env.cue` is now best-effort with bounded retries:

- **Transient errors retry with backoff** (2/4/8/16s): HTTP 408/429/5xx and retryable curl transport errors (`7|16|18|28|35|52|55|56|92` — connection refused, timeouts, mid-transfer drops, HTTP/2 framing/stream errors).
- **Exhausted retries do not fail the deploy**: the task emits a run-level `::warning` annotation (visible in the Actions summary, not buried in a green log) naming the skipped deploy marker and exits 0.
- **Misconfiguration still hard-fails**: other 4xx responses (bad token), and curl exits for DNS failure, malformed URL, or cert verification (60) exit 1 with a `check GRAFANA_CLOUD_URL` pointer.
- **Bounded wall time**: `--connect-timeout 5 --max-time 15` per attempt plus an explicit 45s retry deadline, so the loop cannot linger inside the workflow's `cancel-in-progress` window (which covers the destructive `dashboardsSync` prune).
- The response file is truncated per attempt so stale bodies aren't misattributed in logs, and the duplicate-marker caveat (client timeout after server commit) is documented.

## Verification

- `bash -n`, `shellcheck -s bash`, and `cue fmt --check` clean.
- Behavioral tests against a stubbed curl: cold-start 503→recovery, exhausted 503s (warn + exit 0), 401/403 hard-fail, DNS/curl-6 hard-fail, transient transport codes retry, 408 retry, and deadline cutoff on hanging requests (6s vs ~40s).
- Two adversarial review rounds (shell-correctness and SRE/ops personas); all findings addressed, final shell verdict "no real issues". Reviewer empirically confirmed cuenv streams `::warning` lines unindented so GitHub Actions parses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
