### PR TITLE
fix(server): give Muji IQs their own ordered-relay side-band lane (#1597)

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -27,22 +27,18 @@ spec:
     clustering:
       enabled: true
       enrolledKeyCount: 4
-    # TEMPORARY — hard cutover for the #1445 release, revert after (#1597).
+    # TEMPORARY — one final hard cutover for the #1597 release, revert
+    # right after it is deployed.
     #
-    # #1445 adds a new ordered-relay envelope variant (MujiJingleIq). A
-    # replica running the previous image cannot deserialize it, which
-    # surfaces as a maybe-committed codec failure and leaves a sticky
-    # diversion on the ordered channel — a channel shared with that
-    # sender's ordinary MUC join/leave/groupchat traffic for the room.
-    # One attempted cross-node call during a mixed-version window can
-    # therefore drop that user's chat in that room until they reconnect.
-    #
-    # RollingUpdate with maxSurge 1 / maxUnavailable 0 guarantees such a
-    # window on every deploy. Recreate terminates both pods before
-    # starting any new one, so no two versions ever exchange relay
-    # envelopes. Cost is a brief full outage; XMPP clients reconnect via
-    # stream management, and in-flight calls are accepted as expendable
-    # for this release.
+    # #1597 moves Muji IQs onto their own ordered-relay side-band lane
+    # (RoomSideBand). During a mixed-version window an old-binary
+    # sender still puts Muji on the shared room lane, which the new
+    # receiver rejects — diverting the OLD sender's shared lane and
+    # silently dropping that user's chat in the room (the exact #1445
+    # failure). One last Recreate deploy removes that window. Once
+    # every replica runs the side-band lane, mixed-version relay
+    # poisoning is bounded to the new feature's own lane, and rolling
+    # deploys become safe for future relay variants too.
     #
     # Revert to RollingUpdate (maxSurge 1 / maxUnavailable 0) once this
     # release is out — Recreate is a regression against the ADR-0017

--- a/server/crates/waddle-server/src/clustering/ordered_relay.rs
+++ b/server/crates/waddle-server/src/clustering/ordered_relay.rs
@@ -42,6 +42,27 @@ pub enum OrderedRelayRecipient {
     BareJid(jid::BareJid),
     FullJid(jid::FullJid),
     Room(jid::BareJid),
+    /// Side-band lane for room-bound payloads that are not ordinary
+    /// MUC stanza traffic (#1597). The recipient participates in the
+    /// channel key, so side-band kinds get their own sequence space
+    /// and their own diversion: a poisoned side-band lane (e.g. a
+    /// peer that cannot decode a newly added payload variant during
+    /// version skew) cannot drop the same sender's join/leave/
+    /// groupchat traffic for the room.
+    RoomSideBand(jid::BareJid),
+}
+
+impl OrderedRelayRecipient {
+    /// The one lane-selection point for MUC-proxy channels: every
+    /// channel carrying an `OrderedRelayPayload::MucProxy` must derive
+    /// its recipient here so sender and receiver agree on the lane.
+    pub fn for_muc_proxy(room_jid: jid::BareJid, kind: OrderedRelayMucProxyKind) -> Self {
+        if kind.is_side_band() {
+            Self::RoomSideBand(room_jid)
+        } else {
+            Self::Room(room_jid)
+        }
+    }
 }
 
 /// Typed origin key for ordered-relay channels.
@@ -126,11 +147,23 @@ pub enum OrderedRelayMucProxyKind {
     /// the stanza is NOT addressed to the room: `to` is the calls
     /// mixer (`calls.<domain>`) and the target room lives in the
     /// `<muji room='…'/>` payload, which the envelope validation binds
-    /// to the channel's room.
+    /// to the channel's room. Rides the `RoomSideBand` lane (#1597),
+    /// so a diversion on it cannot stall the sender's ordinary MUC
+    /// traffic for the room.
     MujiJingleIq,
 }
 
 impl OrderedRelayMucProxyKind {
+    /// Kinds that ride the `RoomSideBand` lane instead of the shared
+    /// room lane (#1597). Any future kind whose payload an old binary
+    /// may not decode belongs here, so a mixed-version window bounds
+    /// the resulting diversion to the side-band lane (all side-band
+    /// kinds share it — such a window can stall existing side-band
+    /// traffic like Muji call signaling, but never room chat).
+    pub fn is_side_band(self) -> bool {
+        matches!(self, OrderedRelayMucProxyKind::MujiJingleIq)
+    }
+
     fn matches_stanza(self, stanza: &waddle_xmpp::Stanza) -> bool {
         matches!(
             (self, stanza),
@@ -211,10 +244,18 @@ impl OrderedRelayPayload {
                 | OrderedRelayPayload::Presence { recipient, .. },
                 OrderedRelayRecipient::FullJid(full),
             ) => recipient == &jid::Jid::from(full.clone()),
+            // The lane split (#1597) is enforced here: a MUC-proxy
+            // payload is only consistent with the lane its kind rides,
+            // so sender and receiver can never disagree about which
+            // channel a kind orders on.
             (
-                OrderedRelayPayload::MucProxy { room_jid, .. },
+                OrderedRelayPayload::MucProxy { room_jid, kind, .. },
                 OrderedRelayRecipient::Room(channel_room),
-            ) => room_jid == channel_room,
+            ) => !kind.is_side_band() && room_jid == channel_room,
+            (
+                OrderedRelayPayload::MucProxy { room_jid, kind, .. },
+                OrderedRelayRecipient::RoomSideBand(channel_room),
+            ) => kind.is_side_band() && room_jid == channel_room,
             _ => false,
         }
     }
@@ -1848,7 +1889,10 @@ mod tests {
     fn muji_envelope(kind: OrderedRelayMucProxyKind, stanza: RemoteStanza) -> RemoteStanzaEnvelope {
         RemoteStanzaEnvelope {
             asserted_origin_node: origin_node(),
-            channel: room_channel(),
+            channel: OrderedRelayChannel {
+                recipient: OrderedRelayRecipient::for_muc_proxy(room_jid(), kind),
+                ..room_channel()
+            },
             sequence: OrderedRelaySequence(1),
             origin_inbound_sequence: inbound(1),
             origin_claim: origin_claim(),

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -958,7 +958,7 @@ impl OrderedRelayDeliveryBridge {
         };
         let channel = OrderedRelayChannel {
             origin: channel_origin,
-            recipient: OrderedRelayRecipient::Room(room_jid.clone()),
+            recipient: OrderedRelayRecipient::for_muc_proxy(room_jid.clone(), kind),
             target_epoch: target_snapshot.claim_epoch,
         };
         let retry_channel = channel.clone();
@@ -1059,18 +1059,20 @@ impl OrderedRelayDeliveryBridge {
             }
             // A `MujiJingleIq` maybe-committed deliberately gets the
             // same treatment as every other kind: the channel keeps
-            // its diversion. An earlier attempt to `forget_channel`
-            // here was WRONG and is recorded so it is not retried —
+            // its diversion. Since #1597 that diversion lands on the
+            // Muji side-band lane, so it stalls only this sender's
+            // later Muji IQs for the room, never their chat. An
+            // earlier attempt to `forget_channel` here was WRONG and
+            // is recorded so it is not retried —
             // `OrderedRelaySenderState::forget_channel` drops
             // `next_by_channel`, resetting the SENDER's sequence to
             // FIRST while the receiver's `next_expected` is untouched.
-            // The next envelope on the channel (the user's next
-            // groupchat message or leave presence) would then arrive
-            // with a stale sequence and NACK as an ordering gap,
-            // converting a bounded failure into a diversion attached
-            // to unrelated MUC traffic. Only the `JoinPresence` arm
-            // above can forget safely, because it immediately re-sends
-            // and has `try_proxy_muc_join_repair` as a backstop.
+            // The next envelope on the channel would then arrive with
+            // a stale sequence and NACK as an ordering gap, restoring
+            // the diversion it tried to clear. Only the `JoinPresence`
+            // arm above can forget safely, because it immediately
+            // re-sends and has `try_proxy_muc_join_repair` as a
+            // backstop.
             return MucProxyRouteDecision::Attempted(OrderedRelayMucProxyOutcome::MaybeCommitted);
         }
 
@@ -2947,7 +2949,10 @@ impl OrderedRelayDeliveryBridge {
         };
         let channel = OrderedRelayChannel {
             origin: OrderedRelayOrigin::Entity(repair_origin_entity.clone()),
-            recipient: OrderedRelayRecipient::Room(room_jid.clone()),
+            recipient: OrderedRelayRecipient::for_muc_proxy(
+                room_jid.clone(),
+                OrderedRelayMucProxyKind::JoinPresence,
+            ),
             target_epoch: target_snapshot.claim_epoch,
         };
         let seed = RemoteDeliverySeed {
@@ -4204,7 +4209,9 @@ fn relay_payload_target(
         OrderedRelayRecipient::FullJid(_) | OrderedRelayRecipient::BareJid(_) => {
             Err(OrderedRelayNackReason::ParseFailure)
         }
-        OrderedRelayRecipient::Room(_) => Err(OrderedRelayNackReason::ParseFailure),
+        OrderedRelayRecipient::Room(_) | OrderedRelayRecipient::RoomSideBand(_) => {
+            Err(OrderedRelayNackReason::ParseFailure)
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -380,12 +380,14 @@ async fn relay_muji_to_room_owner(
         relay_error_frames()
     };
 
-    // The relay's envelope validation requires a bare `to` naming the
-    // calls mixer; anything else is NACKed as a parse failure by the
-    // receiver, which diverts the shared ordered channel and would
-    // silently break this sender's ordinary MUC traffic for the room.
-    // A client controls `to`, so reject the shape here rather than
-    // letting a malformed (or hostile) one reach the relay at all.
+    // The relay's envelope validation requires a bare `to` (and binds
+    // the `<muji room>` payload to the channel's room); a non-bare
+    // `to` is NACKed as a parse failure by the receiver, which
+    // diverts the Muji side-band lane (#1597) and would silently
+    // break this sender's later Muji IQs for the room. The exact
+    // mixer JID is enforced only here at ingress — a client controls
+    // `to`, so reject the shape here rather than letting a malformed
+    // (or hostile) one reach the relay at all.
     // Same for a room outside this server's MUC domain: it can have no
     // local claim, so relaying it only buys a claim-store lookup.
     let addressed_to_mixer = iq.to().is_some_and(|to| {

--- a/server/crates/waddle-server/tests/clustering_ordered_relay.rs
+++ b/server/crates/waddle-server/tests/clustering_ordered_relay.rs
@@ -1049,3 +1049,168 @@ fn muc_proxy_room_iq_kinds_validate_bare_room_vs_occupant_addressing() {
         })
     ));
 }
+
+fn muji_payload() -> OrderedRelayPayload {
+    use waddle_xmpp::xep::xep0167::MediaKind;
+    use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+    let muji = Muji {
+        room: Some(room_jid()),
+        preparing: false,
+        contents: vec![MujiContent::new(
+            "audio",
+            Creator::Initiator,
+            MediaKind::Audio,
+        )],
+    };
+    let jingle = xmpp_parsers::jingle::Jingle::new(
+        xmpp_parsers::jingle::Action::SessionInitiate,
+        xmpp_parsers::jingle::SessionId("muji-sid-1".into()),
+    );
+    let mut payload: xmpp_parsers::minidom::Element = jingle.into();
+    payload.append_child(muji.to_element());
+    let stanza = RemoteStanza(waddle_xmpp::Stanza::Iq(Box::new(
+        xmpp_parsers::iq::Iq::Set {
+            from: Some(jid::Jid::from_str("romeo@example.test/home").expect("full jid")),
+            to: Some(jid::Jid::from_str("calls.example.test").expect("mixer jid")),
+            id: "muji-iq-1".into(),
+            payload,
+        },
+    )));
+    OrderedRelayPayload::MucProxy {
+        room_jid: room_jid(),
+        kind: OrderedRelayMucProxyKind::MujiJingleIq,
+        stanza,
+    }
+}
+
+fn groupchat_payload() -> OrderedRelayPayload {
+    OrderedRelayPayload::MucProxy {
+        room_jid: room_jid(),
+        kind: OrderedRelayMucProxyKind::GroupchatMessage,
+        stanza: groupchat_stanza_to("room@example.test"),
+    }
+}
+
+fn side_band_channel() -> OrderedRelayChannel {
+    OrderedRelayChannel {
+        origin: OrderedRelayOrigin::SmSession(SmSessionId::new("stream-1")),
+        recipient: OrderedRelayRecipient::for_muc_proxy(
+            room_jid(),
+            OrderedRelayMucProxyKind::MujiJingleIq,
+        ),
+        target_epoch: ClaimEpoch(11),
+    }
+}
+
+/// #1597: Muji IQs ride their own side-band lane so a diversion there
+/// (e.g. a peer that cannot decode the variant during version skew)
+/// cannot drop the same sender's ordinary MUC traffic for the room.
+#[test]
+fn muji_side_band_diversion_leaves_room_lane_deliverable() {
+    let mut state = OrderedRelaySenderState::default();
+    let muji_channel = side_band_channel();
+    let room_channel = room_channel();
+    assert_ne!(
+        muji_channel, room_channel,
+        "the Muji lane must be a distinct ordering scope from the room lane"
+    );
+    assert_eq!(
+        OrderedRelayRecipient::for_muc_proxy(
+            room_jid(),
+            OrderedRelayMucProxyKind::GroupchatMessage
+        ),
+        OrderedRelayRecipient::Room(room_jid()),
+        "ordinary MUC kinds must stay on the shared room lane"
+    );
+
+    state.divert(OrderedRelayDiversion {
+        channel: muji_channel.clone(),
+        reason: OrderedRelayDiversionReason::Unreachable,
+    });
+
+    let muji_result = state.next_envelope(
+        origin_node(),
+        muji_channel,
+        inbound(1),
+        claims_for_target(room_claim()),
+        muji_payload(),
+    );
+    assert!(
+        muji_result.is_err(),
+        "the diverted Muji lane stays diverted"
+    );
+
+    let groupchat = state
+        .next_envelope(
+            origin_node(),
+            room_channel,
+            inbound(2),
+            claims_for_target(room_claim()),
+            groupchat_payload(),
+        )
+        .expect("groupchat on the room lane is unaffected by the Muji diversion");
+    assert_eq!(groupchat.sequence, OrderedRelaySequence(1));
+}
+
+/// #1597: the receiver enforces the lane split. A Muji payload on the
+/// shared room lane, or an ordinary MUC payload on the side-band
+/// lane, is an envelope-consistency failure — sender and receiver can
+/// never disagree about which lane a kind rides.
+#[test]
+fn receiver_enforces_muji_side_band_lane_split() {
+    let valid_side_band = RemoteStanzaEnvelope {
+        asserted_origin_node: origin_node(),
+        channel: side_band_channel(),
+        sequence: OrderedRelaySequence(1),
+        origin_inbound_sequence: inbound(1),
+        origin_claim: origin_claim(),
+        sender_claim: sender_claim(),
+        target_claim: room_claim(),
+        payload: muji_payload(),
+        origin_proof: None,
+    };
+    let muji_on_room_lane = RemoteStanzaEnvelope {
+        channel: room_channel(),
+        ..valid_side_band.clone()
+    };
+    let groupchat_on_side_band = RemoteStanzaEnvelope {
+        payload: groupchat_payload(),
+        ..valid_side_band.clone()
+    };
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, valid_side_band),
+            OrderedRelayReply::Ack(OrderedRelayAck { .. })
+        ),
+        "a Muji envelope on the side-band lane must validate"
+    );
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, muji_on_room_lane),
+            OrderedRelayReply::Nack(OrderedRelayNack {
+                reason: OrderedRelayNackReason::ParseFailure,
+                ..
+            })
+        ),
+        "a Muji payload must be rejected on the shared room lane"
+    );
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, groupchat_on_side_band),
+            OrderedRelayReply::Nack(OrderedRelayNack {
+                reason: OrderedRelayNackReason::ParseFailure,
+                ..
+            })
+        ),
+        "ordinary MUC payloads must be rejected on the side-band lane"
+    );
+}


### PR DESCRIPTION
Implements #1597 Task 2 (the lane split). Task 1 (the RollingUpdate revert) is #1603, gated on this release being deployed — see the rollout section below for why it cannot ride along here.

## What

`OrderedRelayMucProxyKind::MujiJingleIq` envelopes move off the shared per-room ordered-relay lane onto a dedicated `OrderedRelayRecipient::RoomSideBand` lane:

- **New recipient variant** `RoomSideBand(BareJid)` participates in the channel key, so side-band kinds get their own sequence space and their own diversion. A poisoned Muji lane (e.g. a peer that cannot decode a future new variant during version skew) can no longer take the sender's ordinary MUC join/leave/groupchat traffic down with it.
- **Single lane-selection point**: `OrderedRelayRecipient::for_muc_proxy(room, kind)` + `OrderedRelayMucProxyKind::is_side_band()`. Both MUC-proxy channel-construction sites (main path and join repair) derive the recipient there; future side-band kinds opt in via `is_side_band`.
- **Receiver-side enforcement**: envelope consistency (`matches_channel_recipient`) rejects a side-band kind on the room lane and vice versa, so sender and receiver can never disagree about which lane a kind orders on.
- Claim mapping is unchanged: side-band envelopes still target the `RoomActor` claim, so the room claim epoch keeps fencing the LiveKit mint.

Approach chosen per the issue's option 1 (suggested independently by both P1 reviewers on #1596). Option 2 (making kameo codec failures non-poisoning) was deliberately not taken: `RemoteSendError::DeserializeMessage` arises both receiver-side before the handler runs and sender-side when decoding the reply after the handler ran; the two are indistinguishable at the sender, so reclassifying them as no-effect risks duplicating committed effects.

## Rollout — this release still needs one final Recreate cutover

During a mixed-version window an **old**-binary sender still puts Muji on the shared room lane, which the **new** receiver rejects as an envelope-consistency failure — diverting the old sender's shared lane and silently dropping their chat in that room (the exact #1445 failure). The HelmRelease therefore keeps `Recreate` here, with the comment updated to this release's rationale. #1603 flips it back to `RollingUpdate` once this image is deployed on all replicas; from then on, mixed-version relay poisoning is bounded to the new feature's own lane and future relay variants need no cutover.

Known bounded cost, accepted: a cross-node Muji call attempt that hits a diverted side-band lane stays diverted until the client reconnects or the room claim epoch changes — calls in that room fail for that session, chat is unaffected.

## Tests

- `muji_side_band_diversion_leaves_room_lane_deliverable` — sender lane isolation.
- `receiver_enforces_muji_side_band_lane_split` — bidirectional receiver enforcement.
- Existing in-crate Muji validation tests moved onto the side-band lane via the shared constructor.
- Cross-node e2e `muji_initiate_routes_to_foreign_room_owner` passes against Postgres.
- Full `--features clustering` suite: 2105 lib + all integration tests pass; the 6 remaining failures are the known parallel-metric flake class (all pass single-threaded, reproduce on unmodified main).

## Review

Two-axis review (standards + spec) plus two adversarial personas (distributed-systems, SRE). All converged on one HIGH finding — the rollout hazard above — resolved by splitting the strategy revert into #1603. All other attack angles (cross-lane receiver state, claim mapping, forget/retry lane preservation, initiate/terminate ordering, serde compatibility of existing variants, signing-view coverage) verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
