### PR TITLE
test(server): cover receiver-side room-lane kind binding; fix stale Muji relay comment

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -380,12 +380,14 @@ async fn relay_muji_to_room_owner(
         relay_error_frames()
     };
 
-    // The relay's envelope validation requires a bare `to` naming the
-    // calls mixer; anything else is NACKed as a parse failure by the
-    // receiver, which diverts the shared ordered channel and would
-    // silently break this sender's ordinary MUC traffic for the room.
-    // A client controls `to`, so reject the shape here rather than
-    // letting a malformed (or hostile) one reach the relay at all.
+    // The relay's envelope validation requires a bare `to` (and binds
+    // the `<muji room>` payload to the channel's room); a non-bare
+    // `to` is NACKed as a parse failure by the receiver, which
+    // diverts the Muji signaling lane (#1597) and would silently
+    // break this sender's later Muji IQs for the room. The exact
+    // mixer JID is enforced only here at ingress — a client controls
+    // `to`, so reject the shape here rather than letting a malformed
+    // (or hostile) one reach the relay at all.
     // Same for a room outside this server's MUC domain: it can have no
     // local claim, so relaying it only buys a claim-store lookup.
     let addressed_to_mixer = iq.to().is_some_and(|to| {

--- a/server/crates/waddle-server/tests/clustering_ordered_relay.rs
+++ b/server/crates/waddle-server/tests/clustering_ordered_relay.rs
@@ -1125,3 +1125,105 @@ fn muc_proxy_room_iq_kinds_validate_bare_room_vs_occupant_addressing() {
         })
     ));
 }
+
+fn muji_payload() -> OrderedRelayPayload {
+    use waddle_xmpp::xep::xep0167::MediaKind;
+    use waddle_xmpp::xep::xep0272::{Creator, Muji, MujiContent};
+    let muji = Muji {
+        room: Some(room_jid()),
+        preparing: false,
+        contents: vec![MujiContent::new(
+            "audio",
+            Creator::Initiator,
+            MediaKind::Audio,
+        )],
+    };
+    let jingle = xmpp_parsers::jingle::Jingle::new(
+        xmpp_parsers::jingle::Action::SessionInitiate,
+        xmpp_parsers::jingle::SessionId("muji-sid-1".into()),
+    );
+    let mut payload: xmpp_parsers::minidom::Element = jingle.into();
+    payload.append_child(muji.to_element());
+    let stanza = RemoteStanza(waddle_xmpp::Stanza::Iq(Box::new(
+        xmpp_parsers::iq::Iq::Set {
+            from: Some(jid::Jid::from_str("romeo@example.test/home").expect("full jid")),
+            to: Some(jid::Jid::from_str("calls.example.test").expect("mixer jid")),
+            id: "muji-iq-1".into(),
+            payload,
+        },
+    )));
+    OrderedRelayPayload::MucProxy {
+        room_jid: room_jid(),
+        kind: OrderedRelayMucProxyKind::MujiJingleIq,
+        stanza,
+    }
+}
+
+/// #1597: the receiver enforces the kind→lane binding. A Muji payload
+/// on the MUC stanza lane, or an ordinary MUC payload on the Muji
+/// signaling lane, is an envelope-consistency failure — sender and
+/// receiver can never disagree about which lane a kind orders on. The
+/// valid envelope is accepted first to prove the mismatch cases fail
+/// on the lane alone.
+#[test]
+fn receiver_enforces_room_lane_kind_binding() {
+    let valid_muji = RemoteStanzaEnvelope {
+        asserted_origin_node: origin_node(),
+        channel: muji_room_channel(),
+        sequence: OrderedRelaySequence(1),
+        origin_inbound_sequence: inbound(1),
+        origin_claim: origin_claim(),
+        sender_claim: sender_claim(),
+        target_claim: room_claim(),
+        payload: muji_payload(),
+        origin_proof: None,
+    };
+    let muji_on_muc_lane = RemoteStanzaEnvelope {
+        channel: room_channel(),
+        ..valid_muji.clone()
+    };
+    let groupchat_on_muji_lane = RemoteStanzaEnvelope {
+        payload: OrderedRelayPayload::MucProxy {
+            room_jid: room_jid(),
+            kind: OrderedRelayMucProxyKind::GroupchatMessage,
+            stanza: groupchat_stanza_to("room@example.test"),
+        },
+        ..valid_muji.clone()
+    };
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, valid_muji),
+            OrderedRelayReply::Ack(OrderedRelayAck { .. })
+        ),
+        "a Muji envelope on the Muji signaling lane must validate"
+    );
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, muji_on_muc_lane),
+            OrderedRelayReply::Nack(OrderedRelayNack {
+                reason: OrderedRelayNackReason::ParseFailure,
+                ..
+            })
+        ),
+        "a Muji payload must be rejected on the MUC stanza lane"
+    );
+
+    let mut receiver =
+        waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
+    assert!(
+        matches!(
+            receive(&mut receiver, groupchat_on_muji_lane),
+            OrderedRelayReply::Nack(OrderedRelayNack {
+                reason: OrderedRelayNackReason::ParseFailure,
+                ..
+            })
+        ),
+        "ordinary MUC payloads must be rejected on the Muji signaling lane"
+    );
+}


### PR DESCRIPTION
Follow-up to #1600 (refs #1597) shipping the two pieces of the superseded #1602 that main still lacked:

1. **Receiver-side lane-mismatch test** — `receiver_enforces_room_lane_kind_binding`: a valid Muji envelope on the `MujiSignaling` lane Acks; the same envelope on the `MucStanza` lane, and a groupchat payload on the `MujiSignaling` lane, NACK `ParseFailure`. The enforcement (`ordered_relay.rs` `matches_channel_recipient`, `kind.room_lane() == *lane`) was untested; it is the arm an old-binary sender hits during version skew and the property that keeps sender and receiver lane selection in agreement. The valid case is asserted first so the mismatch cases provably fail on the lane alone.

2. **Stale comment fix in `sans_io.rs`** — the Muji ingress comment claimed envelope validation requires `to` to name the calls mixer (it checks only a bare `to` + the `<muji room>` binding; the exact mixer JID is enforced only at ingress) and that a parse failure diverts the shared ordered channel (since #1600 it diverts the Muji signaling lane).

No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)