### PR TITLE
fix(infra): flip waddle-server to RollingUpdate now that the v2 relay release is deployed

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -27,23 +27,19 @@ spec:
     clustering:
       enabled: true
       enrolledKeyCount: 4
-    # TEMPORARY — one final hard cutover, for the #1597 release itself.
-    #
-    # #1597 versions the ordered-relay envelope message id
-    # (deliver_ordered.v2) so that from that release onward an old
-    # replica fails a new-format ask with UnknownMessage — provably
-    # uncommitted — and the sender rolls back instead of installing a
-    # sticky diversion. That makes every FUTURE deploy safe under
-    # RollingUpdate. Deploying the v2 release itself is the one
-    # remaining unsafe window: an old replica sending .v1 to a new
-    # replica gets UnknownMessage but still runs its OLD code, which
-    # diverts the shared MUC channel. Recreate closes that window.
-    #
-    # Flip to RollingUpdate (maxSurge 1 / maxUnavailable 0) once the
-    # #1597 server release is deployed — tracked as #1601. Recreate is
-    # a regression against ADR-0017 Phase 4, not a steady state.
+    # Zero-downtime rollouts (ADR-0017 Phase 4). Safe under mixed
+    # versions because the ordered-relay envelope message id is
+    # versioned (deliver_ordered.vN, #1597/#1600): an old replica
+    # rejects a newer envelope pre-handler and the sender rolls back
+    # the sequence instead of poisoning the shared channel. Any
+    # envelope or reply-type change MUST bump the version (see
+    # server/CLAUDE.md) — that invariant is what keeps this strategy
+    # sound.
     updateStrategy:
-      type: Recreate
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
     image:
       repository: ghcr.io/waddle-social/waddle
       tag: main


### PR DESCRIPTION
Closes #1601. Completes Task 1 of #1597 (ADR-0017 Phase 4 — `Recreate` must not become steady state).

## What

Flip the `waddle-server` HelmRelease back to zero-downtime rollouts:

```yaml
updateStrategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 1
    maxUnavailable: 0
```

and replace the TEMPORARY `Recreate` comment block with a durable note explaining why RollingUpdate is now sound (the versioned ordered-relay envelope invariant from #1597/#1600 and the `server/CLAUDE.md` version-bump hard rule).

## Deploy gate — verified before merging

#1601 requires the #1597 v2 relay release (PR #1600, `deliver_ordered.v2` + `UnsupportedEnvelope` rollback) to be running on **all** production replicas first — deploying v2 itself was the last unsafe mixed-version window, and Flux applies HelmRelease values on git cadence (minutes) while it detects images on OCI cadence (~12h), so merging early would have made the v2 rollout itself go rolling.

Verified against production (Teleport, `waddle` namespace):

- Both `waddle-server` replicas run image digest `sha256:e5db83e8…`, restarted ~12h ago (the Recreate cutover already happened).
- The GHCR manifest list tagged `sha-0811713` / `main` (= the #1600 merge commit `0811713c`) references exactly that digest.

## Safety checks

- Chart template (`server/charts/waddle-server/templates/deployment.yaml`) consumes `updateStrategy.rollingUpdate` verbatim when type is `RollingUpdate`; rendered locally against chart 0.4.2 (the version prod's `0.4.x` constraint resolves to) with the prod values from this HelmRelease — output is the exact strategy block above.
- Keypool validation: requiredKeys = replicaCount (2) + maxSurge (1) + keypairHeadroom (1) = 4 = `clustering.enrolledKeyCount`; maxSurge already defaulted to 1 under `Recreate`, so this flip does not tighten the gate.
- The RWO-PVC RollingUpdate guard cannot fire: `persistence.enabled: false` in these values.

No chart change, so no `Chart.yaml` version bump is needed — this is a gitops values change Flux applies directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
