### PR TITLE
fix(chat): stop media and disconnect LiveKit before awaiting XMPP teardown on hang-up

### DIFF
--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -107,10 +107,11 @@ watch(
       // epoch, and the failure telemetry emitted here must carry the id.
       await correlationAdopted;
       // Media first, protocol second (#1446): release any capture the
-      // partial join grabbed before the bounded wire teardown runs in
-      // the background.
-      await engine.disconnect();
+      // partial join grabbed, with the bounded wire teardown running
+      // concurrently in the background — neither stalls the other.
+      const engineDisconnected = engine.disconnect();
       void tearDownActiveCall(getSender(), "gone").catch(reportCallError);
+      await engineDisconnected.catch(reportCallError);
       reportCallError(err);
       // A connect() failure before a room exists never emits the engine's
       // `disconnected` event, so the disconnected-handler cleanup does not

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -106,8 +106,11 @@ watch(
       // Await the in-flight adoption first: clearing (below) bumps the
       // epoch, and the failure telemetry emitted here must carry the id.
       await correlationAdopted;
-      await tearDownActiveCall(getSender(), "gone");
+      // Media first, protocol second (#1446): release any capture the
+      // partial join grabbed before the bounded wire teardown runs in
+      // the background.
       await engine.disconnect();
+      void tearDownActiveCall(getSender(), "gone").catch(reportCallError);
       reportCallError(err);
       // A connect() failure before a room exists never emits the engine's
       // `disconnected` event, so the disconnected-handler cleanup does not

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -165,13 +165,21 @@ export async function toggleScreenShare(): Promise<void> {
  */
 export async function hangupActiveCall(): Promise<void> {
   const sender = getSender();
-  try {
-    const { engine } = useCallEngine();
-    await engine.disconnect();
-  } catch (err) {
-    reportCallError(err);
-  }
+  const engineDisconnected = (async () => {
+    try {
+      await useCallEngine().engine.disconnect();
+    } catch (err) {
+      reportCallError(err);
+    }
+  })();
+  // Started AFTER the engine disconnect so capture release is
+  // initiated first, but not awaited behind it: the synchronous
+  // prefix flips the call slot to idle immediately, and the bounded
+  // wire teardown proceeds concurrently — a LiveKit disconnect
+  // stalling on a dead network can't pin the UI on the ended call
+  // or delay the terminate stanzas.
   void tearDownActiveCall(sender, "success").catch(reportCallError);
+  await engineDisconnected;
 }
 
 /**

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -155,18 +155,23 @@ export async function toggleScreenShare(): Promise<void> {
 }
 
 /**
- * Graceful hangup. Delegates to `tearDownActiveCall` so the
- * appropriate XEP-0166 / XEP-0272 stanzas go out before the engine
- * disconnects.
+ * Graceful hangup. Media first, protocol second (#1446): stop local
+ * capture and the LiveKit transport immediately, then let
+ * `tearDownActiveCall` send the XEP-0166 / XEP-0272 stanzas in the
+ * background. Hang-up must never wait on an XMPP round-trip to turn
+ * the camera off — a server that never replies would leave the user
+ * live on mic/camera after clicking "hang up". The wire teardown is
+ * bounded and best-effort; its failure never re-opens media.
  */
 export async function hangupActiveCall(): Promise<void> {
-  await tearDownActiveCall(getSender(), "success");
+  const sender = getSender();
   try {
     const { engine } = useCallEngine();
     await engine.disconnect();
   } catch (err) {
     reportCallError(err);
   }
+  void tearDownActiveCall(sender, "success").catch(reportCallError);
 }
 
 /**

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -814,6 +814,10 @@ async function leaveMujiCallPresence(
   const selfNick = s.selfNick;
   if (!selfNick || !updateMujiPresence) return;
   try {
+    // Guard the WIRE too, not just the local wipes: the server's Muji
+    // handlers key on room + occupant, not sid, so a stale leave/
+    // terminate for the old call would tear down the new one.
+    if (roomReoccupiedByNewerCall(s.peer, s.sid)) return;
     await boundedTeardownSend(() =>
       updateMujiPresence(s.peer, selfNick, false, false, false, {
         handRaised: false,
@@ -982,8 +986,15 @@ export async function tearDownActiveCall(
               clearLiveCallParticipants(s.peer);
             }
             try {
+              // Re-checked per attempt: the room can be re-occupied
+              // while the previous attempt sat on its deadline, and the
+              // server-side Muji terminate is room-scoped, not
+              // sid-scoped — sending it late would end the NEW call.
               await boundedTeardownSend(
-                () => sendMujiSessionTerminate(raw, s.peer, s.sid),
+                () =>
+                  roomReoccupiedByNewerCall(s.peer, s.sid)
+                    ? Promise.resolve()
+                    : sendMujiSessionTerminate(raw, s.peer, s.sid),
                 TERMINATE_SEND_ATTEMPTS,
               );
               forgetMucCallSession({
@@ -1004,10 +1015,12 @@ export async function tearDownActiveCall(
           }
           break;
         case "incoming":
+          // The ringtone is media too: silence it before the bounded
+          // reject send, not after — the slot is already idle.
+          incomingCallAlerts?.stop(s.sid);
           try {
             await boundedTeardownSend(() => outboundCalls.reject(sender, s.from, s.sid));
           } finally {
-            incomingCallAlerts?.stop(s.sid);
             clearDmCallActivity(s.from, s.sid);
           }
           break;
@@ -1027,8 +1040,14 @@ export async function tearDownActiveCall(
             await leaveMujiCallPresence(raw, s);
             if (s.activePresencePublished) {
               try {
+                // Same per-attempt room-reoccupation guard as the
+                // active-MUC arm: a late room-scoped terminate would
+                // end the room's NEW call.
                 await boundedTeardownSend(
-                  () => sendMujiSessionTerminate(raw, s.peer, s.sid),
+                  () =>
+                    roomReoccupiedByNewerCall(s.peer, s.sid)
+                      ? Promise.resolve()
+                      : sendMujiSessionTerminate(raw, s.peer, s.sid),
                   TERMINATE_SEND_ATTEMPTS,
                 );
                 forgetMucCallSession({

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -20,6 +20,7 @@ import { clearLiveCallParticipants } from "./muc-call-live-participants";
 import {
   boundedTeardownSend,
   TERMINATE_SEND_ATTEMPTS,
+  type TeardownSendPolicy,
 } from "./call-teardown-transport";
 import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
 import { mediaErrorMessage } from "./call-media-issues";
@@ -36,7 +37,7 @@ import {
   publishDmCallOutcomeAnchor,
   publishDmCallStartedAnchor,
 } from "./dm-call-anchor";
-import { barePeerJid } from "../xmpp/jid";
+import { barePeerJid, parseMucRoomJid, type MucRoomJid } from "../xmpp/jid";
 import { dmCallRoomName } from "./call-correlation";
 import type { IncomingCallAlertController } from "@/shell/audio-alerts";
 import { reportError as reportTelemetryError } from "../telemetry";
@@ -733,11 +734,11 @@ function cancelCallTimers(): void {
  * teardown must then skip every projection wipe that is not scoped to
  * its own sid, or it would erase the new call's participants.
  */
-function roomReoccupiedByNewerCall(roomJid: string, sid: string): boolean {
+function roomReoccupiedByNewerCall(roomJid: MucRoomJid, sid: string): boolean {
   const now = $callState.get();
   return (
     (now.phase === "active" || now.phase === "muc-pending") &&
-    now.peer === roomJid &&
+    parseMucRoomJid(now.peer) === roomJid &&
     now.sid !== sid
   );
 }
@@ -761,7 +762,9 @@ function callSlotReoccupiedByNewerCall(sid: string): boolean {
  */
 async function leaveMujiCallPresence(
   raw: RawIqSender,
-  s: { peer: string; sid: string; selfNick?: string; selfFullJid?: string | null },
+  roomJid: MucRoomJid,
+  s: { sid: string; selfNick?: string; selfFullJid?: string | null },
+  policy: TeardownSendPolicy,
 ): Promise<void> {
   const updateMujiPresence = raw.update_muji_presence;
   const selfNick = s.selfNick;
@@ -769,21 +772,60 @@ async function leaveMujiCallPresence(
   try {
     // Guard the WIRE too, not just the local wipes: the server's Muji
     // handlers key on room + occupant, not sid, so a stale leave/
-    // terminate for the old call would tear down the new one.
-    if (roomReoccupiedByNewerCall(s.peer, s.sid)) return;
-    await boundedTeardownSend(() =>
-      updateMujiPresence(s.peer, selfNick, false, false, false, {
-        handRaised: false,
-        muted: false, // leaving clears all in-call state
-      }));
+    // terminate for the old call would tear down the new one. (The
+    // presence itself cannot be cancelled once queued — no id — but
+    // the driver's FIFO stream order guarantees a queued leave is
+    // delivered BEFORE any later rejoin presence, so late delivery is
+    // ordering-safe.)
+    if (roomReoccupiedByNewerCall(roomJid, s.sid)) return;
+    await boundedTeardownSend(
+      () =>
+        updateMujiPresence(roomJid, selfNick, false, false, false, {
+          handRaised: false,
+          muted: false, // leaving clears all in-call state
+        }),
+      policy,
+    );
   } catch (err) {
     if (!callSlotReoccupiedByNewerCall(s.sid)) reportCallError(err);
   } finally {
-    if (!roomReoccupiedByNewerCall(s.peer, s.sid)) {
-      clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
-      setSelfRaisedHand(s.peer, false);
+    if (!roomReoccupiedByNewerCall(roomJid, s.sid)) {
+      clearMucCallParticipant(roomJid, selfNick, s.selfFullJid);
+      setSelfRaisedHand(roomJid, false);
     }
   }
+}
+
+/**
+ * XEP-0166 session-terminate step shared by the active-MUC and
+ * muc-pending teardown arms. Re-checks room reoccupation per attempt
+ * (the server-side Muji terminate is room-scoped, not sid-scoped —
+ * sending it late would end the room's NEW call), and cancels the
+ * underlying IQ inside the WASM driver on every expired attempt so a
+ * stale terminate cannot linger in the pending/deferred queues after
+ * the JS deadline has moved on.
+ */
+async function terminateMujiSession(
+  raw: RawIqSender,
+  roomJid: MucRoomJid,
+  s: { sid: string; selfFullJid?: string | null },
+  policy: TeardownSendPolicy,
+): Promise<void> {
+  const iqId = crypto.randomUUID();
+  await boundedTeardownSend(
+    () =>
+      roomReoccupiedByNewerCall(roomJid, s.sid)
+        ? Promise.resolve()
+        : sendMujiSessionTerminate(raw, roomJid, s.sid, iqId),
+    {
+      ...policy,
+      attempts: TERMINATE_SEND_ATTEMPTS,
+      onTimeout: () => {
+        void raw.cancel_raw_iq?.(iqId).catch(() => undefined);
+      },
+    },
+  );
+  forgetMucCallSession({ roomJid, selfFullJid: s.selfFullJid, sid: s.sid });
 }
 
 /**
@@ -874,6 +916,7 @@ export function callLifecycleTerminalForTeardown(
 export async function tearDownActiveCall(
   sender: CallWireSender | null,
   reason: "success" | "gone",
+  policy: TeardownSendPolicy = {},
 ): Promise<void> {
   cancelCallTimers();
   const s = $callState.get();
@@ -907,7 +950,7 @@ export async function tearDownActiveCall(
             try {
               const outcome = await boundedTeardownSend(
                 () => outboundCalls.sessionTerminateWithOutcome(sender, s.peer, s.sid, reason),
-                TERMINATE_SEND_ATTEMPTS,
+                { ...policy, attempts: TERMINATE_SEND_ATTEMPTS },
               );
               terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
               if (outcome === "error") {
@@ -923,7 +966,10 @@ export async function tearDownActiveCall(
                 // consistently. A classified orphaned Jingle terminate
                 // means the server has already lost the call registry, so
                 // only the message-level bookend can still route.
-                await boundedTeardownSend(() => outboundCalls.finish(sender, s.peer, s.sid));
+                await boundedTeardownSend(
+                  () => outboundCalls.finish(sender, s.peer, s.sid),
+                  policy,
+                );
               } catch (err) {
                 reportWireError(err);
               }
@@ -941,27 +987,20 @@ export async function tearDownActiveCall(
             // try/catch so a single failure (e.g. a stale wasm
             // bundle) can't swallow the other.
             const raw = sender as RawIqSender;
-            await leaveMujiCallPresence(raw, s);
-            if (!roomReoccupiedByNewerCall(s.peer, s.sid)) {
+            // Parse at the boundary: the wire steps below require a
+            // validated bare room JID; local projection cleanup still
+            // runs even when the slot held something unparseable.
+            const roomJid = parseMucRoomJid(s.peer);
+            if (roomJid) {
+              await leaveMujiCallPresence(raw, roomJid, s, policy);
+            }
+            if (!roomJid || !roomReoccupiedByNewerCall(roomJid, s.sid)) {
               clearLiveCallParticipants(s.peer);
             }
             try {
-              // Re-checked per attempt: the room can be re-occupied
-              // while the previous attempt sat on its deadline, and the
-              // server-side Muji terminate is room-scoped, not
-              // sid-scoped — sending it late would end the NEW call.
-              await boundedTeardownSend(
-                () =>
-                  roomReoccupiedByNewerCall(s.peer, s.sid)
-                    ? Promise.resolve()
-                    : sendMujiSessionTerminate(raw, s.peer, s.sid),
-                TERMINATE_SEND_ATTEMPTS,
-              );
-              forgetMucCallSession({
-                roomJid: s.peer,
-                selfFullJid: s.selfFullJid,
-                sid: s.sid,
-              });
+              if (roomJid) {
+                await terminateMujiSession(raw, roomJid, s, policy);
+              }
             } catch (err) {
               reportWireError(err);
             }
@@ -969,7 +1008,7 @@ export async function tearDownActiveCall(
           break;
         case "outgoing":
           try {
-            await boundedTeardownSend(() => outboundCalls.retract(sender, s.to, s.sid));
+            await boundedTeardownSend(() => outboundCalls.retract(sender, s.to, s.sid), policy);
           } finally {
             clearDmCallActivity(s.to, s.sid);
           }
@@ -979,7 +1018,7 @@ export async function tearDownActiveCall(
           // reject send, not after — the slot is already idle.
           incomingCallAlerts?.stop(s.sid);
           try {
-            await boundedTeardownSend(() => outboundCalls.reject(sender, s.from, s.sid));
+            await boundedTeardownSend(() => outboundCalls.reject(sender, s.from, s.sid), policy);
           } finally {
             clearDmCallActivity(s.from, s.sid);
           }
@@ -997,24 +1036,13 @@ export async function tearDownActiveCall(
           );
           {
             const raw = sender as RawIqSender;
-            await leaveMujiCallPresence(raw, s);
-            if (s.activePresencePublished) {
+            const roomJid = parseMucRoomJid(s.peer);
+            if (roomJid) {
+              await leaveMujiCallPresence(raw, roomJid, s, policy);
+            }
+            if (roomJid && s.activePresencePublished) {
               try {
-                // Same per-attempt room-reoccupation guard as the
-                // active-MUC arm: a late room-scoped terminate would
-                // end the room's NEW call.
-                await boundedTeardownSend(
-                  () =>
-                    roomReoccupiedByNewerCall(s.peer, s.sid)
-                      ? Promise.resolve()
-                      : sendMujiSessionTerminate(raw, s.peer, s.sid),
-                  TERMINATE_SEND_ATTEMPTS,
-                );
-                forgetMucCallSession({
-                  roomJid: s.peer,
-                  selfFullJid: s.selfFullJid,
-                  sid: s.sid,
-                });
+                await terminateMujiSession(raw, roomJid, s, policy);
               } catch (err) {
                 reportWireError(err);
               }
@@ -1060,7 +1088,18 @@ export type RawIqSender = {
     sid: string,
     video: boolean,
   ) => Promise<void>;
-  send_muji_session_terminate?: (room_jid: string, sid: string) => Promise<void>;
+  /**
+   * `iq_id` is caller-supplied so the teardown path can cancel the
+   * still-pending or deferred IQ (`cancel_raw_iq`) when its own
+   * deadline expires.
+   */
+  send_muji_session_terminate?: (
+    room_jid: string,
+    sid: string,
+    iq_id: string,
+  ) => Promise<void>;
+  /** Cancel a pending or deferred raw IQ by its id. */
+  cancel_raw_iq?: (id: string) => Promise<void>;
   update_muji_presence?: (
     room_jid: string,
     nick: string,
@@ -1159,6 +1198,7 @@ async function sendMujiSessionTerminate(
   sender: RawIqSender | CallWireSender,
   roomJid: string,
   sid: string,
+  iqId: string = crypto.randomUUID(),
 ): Promise<void> {
   const rawSender = sender as RawIqSender;
   if (!rawSender.send_muji_session_terminate) {
@@ -1166,7 +1206,7 @@ async function sendMujiSessionTerminate(
       "wasm client does not expose send_muji_session_terminate; rebuild the wasm bundle",
     );
   }
-  await rawSender.send_muji_session_terminate(roomJid, sid);
+  await rawSender.send_muji_session_terminate(roomJid, sid, iqId);
 }
 
 function mucSetupStillPending(

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -724,6 +724,56 @@ function cancelCallTimers(): void {
 }
 
 /**
+ * Deadline for each best-effort teardown stanza (#1446). Teardown wire
+ * sends are peer/mixer notifications — they must never hold the local
+ * call slot (or a caller like `hangupActiveCall`) hostage to a server
+ * that withholds its reply.
+ */
+const TEARDOWN_STANZA_TIMEOUT_MS = 10_000;
+let teardownStanzaTimeoutMs = TEARDOWN_STANZA_TIMEOUT_MS;
+
+export function setTeardownStanzaTimeoutMsForTests(timeoutMs: number): () => void {
+  const previous = teardownStanzaTimeoutMs;
+  teardownStanzaTimeoutMs = timeoutMs;
+  return () => {
+    teardownStanzaTimeoutMs = previous;
+  };
+}
+
+class TeardownSendTimeoutError extends Error {
+  constructor() {
+    super("call teardown stanza timed out");
+  }
+}
+
+/**
+ * Race a teardown wire send against the deadline, retrying exactly once
+ * on timeout. A typed error reply from the server is a definitive
+ * answer and is NOT retried — only silence is. The abandoned attempt's
+ * promise is left to settle in the void; its result no longer matters.
+ */
+async function boundedTeardownSend<T>(send: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      return await Promise.race([
+        send(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new TeardownSendTimeoutError()),
+            teardownStanzaTimeoutMs,
+          );
+        }),
+      ]);
+    } catch (err) {
+      if (!(err instanceof TeardownSendTimeoutError) || attempt >= 1) throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+/**
  * Surface a wire-send failure into the global error slot. Components
  * subscribe via `$lastCallError` to render an inline error row.
  * Auto-clears after `AUTO_CLEAR_MS` so the row doesn't linger past
@@ -816,6 +866,12 @@ export async function tearDownActiveCall(
   const s = $callState.get();
   if (s.phase !== "idle" && s.phase !== "ended") {
     finishCallAttempt(s.sid, callLifecycleTerminalForTeardown(s.phase, reason));
+    // Go idle BEFORE any wire teardown (#1446): the stanzas below are
+    // best-effort notifications to the peer/mixer, and none of them may
+    // keep the local UI pinned on a dead call while a slow or silent
+    // server withholds its IQ replies. Everything after this line works
+    // from the `s` snapshot.
+    $callState.set({ phase: "idle" });
   }
   if (sender) {
     try {
@@ -824,12 +880,8 @@ export async function tearDownActiveCall(
           if (s.kind === "dm") {
             let terminateAllowsFinish = false;
             try {
-              const outcome = await outboundCalls.sessionTerminateWithOutcome(
-                sender,
-                s.peer,
-                s.sid,
-                reason,
-              );
+              const outcome = await boundedTeardownSend(() =>
+                outboundCalls.sessionTerminateWithOutcome(sender, s.peer, s.sid, reason));
               terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
               if (outcome === "error") {
                 reportCallError(new Error("call session terminate failed"));
@@ -844,7 +896,7 @@ export async function tearDownActiveCall(
                 // consistently. A classified orphaned Jingle terminate
                 // means the server has already lost the call registry, so
                 // only the message-level bookend can still route.
-                await outboundCalls.finish(sender, s.peer, s.sid);
+                await boundedTeardownSend(() => outboundCalls.finish(sender, s.peer, s.sid));
               } catch (err) {
                 reportCallError(err);
               }
@@ -862,22 +914,25 @@ export async function tearDownActiveCall(
             // try/catch so a single failure (e.g. a stale wasm
             // bundle) can't swallow the other.
             const raw = sender as RawIqSender;
-            if (s.selfNick && raw.update_muji_presence) {
+            const updateMujiPresence = raw.update_muji_presence;
+            const selfNick = s.selfNick;
+            if (selfNick && updateMujiPresence) {
               try {
-                await raw.update_muji_presence(s.peer, s.selfNick, false, false, false, {
-                  handRaised: false,
-                  muted: false, // leaving clears all in-call state
-                });
+                await boundedTeardownSend(() =>
+                  updateMujiPresence(s.peer, selfNick, false, false, false, {
+                    handRaised: false,
+                    muted: false, // leaving clears all in-call state
+                  }));
               } catch (err) {
                 reportCallError(err);
               } finally {
-                clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
+                clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
                 setSelfRaisedHand(s.peer, false);
               }
             }
             clearLiveCallParticipants(s.peer);
             try {
-              await sendMujiSessionTerminate(raw, s.peer, s.sid);
+              await boundedTeardownSend(() => sendMujiSessionTerminate(raw, s.peer, s.sid));
               forgetMucCallSession({
                 roomJid: s.peer,
                 selfFullJid: s.selfFullJid,
@@ -890,14 +945,14 @@ export async function tearDownActiveCall(
           break;
         case "outgoing":
           try {
-            await outboundCalls.retract(sender, s.to, s.sid);
+            await boundedTeardownSend(() => outboundCalls.retract(sender, s.to, s.sid));
           } finally {
             clearDmCallActivity(s.to, s.sid);
           }
           break;
         case "incoming":
           try {
-            await outboundCalls.reject(sender, s.from, s.sid);
+            await boundedTeardownSend(() => outboundCalls.reject(sender, s.from, s.sid));
           } finally {
             incomingCallAlerts?.stop(s.sid);
             clearDmCallActivity(s.from, s.sid);
@@ -914,25 +969,27 @@ export async function tearDownActiveCall(
             s.selfNick,
             new Error("Muji preparing wait cancelled while clearing call state"),
           );
-          $callState.set({ phase: "idle" });
           {
             const raw = sender as RawIqSender;
-            if (s.selfNick && raw.update_muji_presence) {
+            const updateMujiPresence = raw.update_muji_presence;
+            const selfNick = s.selfNick;
+            if (selfNick && updateMujiPresence) {
               try {
-                await raw.update_muji_presence(s.peer, s.selfNick, false, false, false, {
-                  handRaised: false,
-                  muted: false, // leaving clears all in-call state
-                });
+                await boundedTeardownSend(() =>
+                  updateMujiPresence(s.peer, selfNick, false, false, false, {
+                    handRaised: false,
+                    muted: false, // leaving clears all in-call state
+                  }));
               } catch (err) {
                 reportCallError(err);
               } finally {
-                clearMucCallParticipant(s.peer, s.selfNick, s.selfFullJid);
+                clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
                 setSelfRaisedHand(s.peer, false);
               }
             }
             if (s.activePresencePublished) {
               try {
-                await sendMujiSessionTerminate(raw, s.peer, s.sid);
+                await boundedTeardownSend(() => sendMujiSessionTerminate(raw, s.peer, s.sid));
                 forgetMucCallSession({
                   roomJid: s.peer,
                   selfFullJid: s.selfFullJid,
@@ -951,7 +1008,6 @@ export async function tearDownActiveCall(
       reportCallError(err);
     }
   }
-  $callState.set({ phase: "idle" });
 }
 
 /**

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -17,6 +17,10 @@ import {
   rememberMucCallSession,
 } from "./muc-call-session-cache";
 import { clearLiveCallParticipants } from "./muc-call-live-participants";
+import {
+  boundedTeardownSend,
+  TERMINATE_SEND_ATTEMPTS,
+} from "./call-teardown-transport";
 import { selfRaisedHandFor, setSelfRaisedHand } from "./call-raised-hand";
 import { mediaErrorMessage } from "./call-media-issues";
 import {
@@ -724,68 +728,6 @@ function cancelCallTimers(): void {
 }
 
 /**
- * Deadline for each best-effort teardown stanza (#1446). Teardown wire
- * sends are peer/mixer notifications — they must never hold the local
- * call slot (or a caller like `hangupActiveCall`) hostage to a server
- * that withholds its reply.
- */
-const TEARDOWN_STANZA_TIMEOUT_MS = 10_000;
-let teardownStanzaTimeoutMs = TEARDOWN_STANZA_TIMEOUT_MS;
-
-export function setTeardownStanzaTimeoutMsForTests(timeoutMs: number): () => void {
-  const previous = teardownStanzaTimeoutMs;
-  teardownStanzaTimeoutMs = timeoutMs;
-  return () => {
-    teardownStanzaTimeoutMs = previous;
-  };
-}
-
-class TeardownSendTimeoutError extends Error {
-  constructor() {
-    super("call teardown stanza timed out");
-  }
-}
-
-/**
- * XEP-0166 session-terminate is the one teardown stanza worth a second
- * attempt: it is what ends the call for the peer, and re-sending a sid
- * the peer already forgot is harmless. Presence/retract/reject sends
- * stay single-attempt — a duplicate delivered late is not.
- */
-const TERMINATE_SEND_ATTEMPTS = 2;
-
-/**
- * Race a teardown wire send against the deadline, retrying on timeout
- * up to `attempts` total tries. A typed error reply from the server is
- * a definitive answer and is NOT retried — only silence is. The
- * abandoned attempt's promise is left to settle in the void; its
- * result no longer matters.
- */
-async function boundedTeardownSend<T>(
-  send: () => Promise<T>,
-  attempts: number = 1,
-): Promise<T> {
-  for (let attempt = 1; ; attempt += 1) {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    try {
-      return await Promise.race([
-        send(),
-        new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(
-            () => reject(new TeardownSendTimeoutError()),
-            teardownStanzaTimeoutMs,
-          );
-        }),
-      ]);
-    } catch (err) {
-      if (!(err instanceof TeardownSendTimeoutError) || attempt >= attempts) throw err;
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
-  }
-}
-
-/**
  * Whether a NEWER call has already re-occupied `roomJid` while a
  * backgrounded teardown was still in flight (#1446). The old call's
  * teardown must then skip every projection wipe that is not scoped to
@@ -798,6 +740,17 @@ function roomReoccupiedByNewerCall(roomJid: string, sid: string): boolean {
     now.peer === roomJid &&
     now.sid !== sid
   );
+}
+
+/**
+ * Whether ANY newer call now occupies the single call slot. Late
+ * failures from a superseded teardown must not surface into — or
+ * re-arm the auto-clear timer of — the NEW call's global error slot,
+ * nor be attributed to its correlation id.
+ */
+function callSlotReoccupiedByNewerCall(sid: string): boolean {
+  const now = $callState.get();
+  return now.phase !== "idle" && now.phase !== "ended" && now.sid !== sid;
 }
 
 /**
@@ -824,7 +777,7 @@ async function leaveMujiCallPresence(
         muted: false, // leaving clears all in-call state
       }));
   } catch (err) {
-    reportCallError(err);
+    if (!callSlotReoccupiedByNewerCall(s.sid)) reportCallError(err);
   } finally {
     if (!roomReoccupiedByNewerCall(s.peer, s.sid)) {
       clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
@@ -938,6 +891,13 @@ export async function tearDownActiveCall(
     // from the `s` snapshot.
     $callState.set({ phase: "idle" });
   }
+  // Wire failures below surface through this scoped reporter: the slot
+  // is already idle, so by the time a bounded send fails a NEWER call
+  // may own the global error surface (#1606 review).
+  const reportWireError = (err: unknown): void => {
+    if ("sid" in s && callSlotReoccupiedByNewerCall(s.sid)) return;
+    reportCallError(err);
+  };
   if (sender) {
     try {
       switch (s.phase) {
@@ -951,10 +911,10 @@ export async function tearDownActiveCall(
               );
               terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
               if (outcome === "error") {
-                reportCallError(new Error("call session terminate failed"));
+                reportWireError(new Error("call session terminate failed"));
               }
             } catch (err) {
-              reportCallError(err);
+              reportWireError(err);
             }
             if (terminateAllowsFinish) {
               try {
@@ -965,7 +925,7 @@ export async function tearDownActiveCall(
                 // only the message-level bookend can still route.
                 await boundedTeardownSend(() => outboundCalls.finish(sender, s.peer, s.sid));
               } catch (err) {
-                reportCallError(err);
+                reportWireError(err);
               }
             }
             clearDmCallActivity(s.peer, s.sid);
@@ -1003,7 +963,7 @@ export async function tearDownActiveCall(
                 sid: s.sid,
               });
             } catch (err) {
-              reportCallError(err);
+              reportWireError(err);
             }
           }
           break;
@@ -1056,7 +1016,7 @@ export async function tearDownActiveCall(
                   sid: s.sid,
                 });
               } catch (err) {
-                reportCallError(err);
+                reportWireError(err);
               }
             }
           }
@@ -1065,7 +1025,7 @@ export async function tearDownActiveCall(
           break;
       }
     } catch (err) {
-      reportCallError(err);
+      reportWireError(err);
     }
   }
 }

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -747,13 +747,25 @@ class TeardownSendTimeoutError extends Error {
 }
 
 /**
- * Race a teardown wire send against the deadline, retrying exactly once
- * on timeout. A typed error reply from the server is a definitive
- * answer and is NOT retried — only silence is. The abandoned attempt's
- * promise is left to settle in the void; its result no longer matters.
+ * XEP-0166 session-terminate is the one teardown stanza worth a second
+ * attempt: it is what ends the call for the peer, and re-sending a sid
+ * the peer already forgot is harmless. Presence/retract/reject sends
+ * stay single-attempt — a duplicate delivered late is not.
  */
-async function boundedTeardownSend<T>(send: () => Promise<T>): Promise<T> {
-  for (let attempt = 0; ; attempt += 1) {
+const TERMINATE_SEND_ATTEMPTS = 2;
+
+/**
+ * Race a teardown wire send against the deadline, retrying on timeout
+ * up to `attempts` total tries. A typed error reply from the server is
+ * a definitive answer and is NOT retried — only silence is. The
+ * abandoned attempt's promise is left to settle in the void; its
+ * result no longer matters.
+ */
+async function boundedTeardownSend<T>(
+  send: () => Promise<T>,
+  attempts: number = 1,
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
     let timer: ReturnType<typeof setTimeout> | null = null;
     try {
       return await Promise.race([
@@ -766,9 +778,53 @@ async function boundedTeardownSend<T>(send: () => Promise<T>): Promise<T> {
         }),
       ]);
     } catch (err) {
-      if (!(err instanceof TeardownSendTimeoutError) || attempt >= 1) throw err;
+      if (!(err instanceof TeardownSendTimeoutError) || attempt >= attempts) throw err;
     } finally {
       if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Whether a NEWER call has already re-occupied `roomJid` while a
+ * backgrounded teardown was still in flight (#1446). The old call's
+ * teardown must then skip every projection wipe that is not scoped to
+ * its own sid, or it would erase the new call's participants.
+ */
+function roomReoccupiedByNewerCall(roomJid: string, sid: string): boolean {
+  const now = $callState.get();
+  return (
+    (now.phase === "active" || now.phase === "muc-pending") &&
+    now.peer === roomJid &&
+    now.sid !== sid
+  );
+}
+
+/**
+ * Shared XEP-0272 §Leaving step for both the active-MUC and
+ * muc-pending teardown arms: drop our `<muji/>` presence
+ * advertisement, then clear the local self-participant projections —
+ * unless the room has been re-occupied by a newer call.
+ */
+async function leaveMujiCallPresence(
+  raw: RawIqSender,
+  s: { peer: string; sid: string; selfNick?: string; selfFullJid?: string | null },
+): Promise<void> {
+  const updateMujiPresence = raw.update_muji_presence;
+  const selfNick = s.selfNick;
+  if (!selfNick || !updateMujiPresence) return;
+  try {
+    await boundedTeardownSend(() =>
+      updateMujiPresence(s.peer, selfNick, false, false, false, {
+        handRaised: false,
+        muted: false, // leaving clears all in-call state
+      }));
+  } catch (err) {
+    reportCallError(err);
+  } finally {
+    if (!roomReoccupiedByNewerCall(s.peer, s.sid)) {
+      clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
+      setSelfRaisedHand(s.peer, false);
     }
   }
 }
@@ -864,6 +920,11 @@ export async function tearDownActiveCall(
 ): Promise<void> {
   cancelCallTimers();
   const s = $callState.get();
+  if (s.phase === "ended") {
+    // Normalize a lingering post-call summary slot away, as the old
+    // trailing idle-set always did (logout path).
+    $callState.set({ phase: "idle" });
+  }
   if (s.phase !== "idle" && s.phase !== "ended") {
     finishCallAttempt(s.sid, callLifecycleTerminalForTeardown(s.phase, reason));
     // Go idle BEFORE any wire teardown (#1446): the stanzas below are
@@ -880,8 +941,10 @@ export async function tearDownActiveCall(
           if (s.kind === "dm") {
             let terminateAllowsFinish = false;
             try {
-              const outcome = await boundedTeardownSend(() =>
-                outboundCalls.sessionTerminateWithOutcome(sender, s.peer, s.sid, reason));
+              const outcome = await boundedTeardownSend(
+                () => outboundCalls.sessionTerminateWithOutcome(sender, s.peer, s.sid, reason),
+                TERMINATE_SEND_ATTEMPTS,
+              );
               terminateAllowsFinish = outcome === "ok" || outcome === "orphaned";
               if (outcome === "error") {
                 reportCallError(new Error("call session terminate failed"));
@@ -914,25 +977,15 @@ export async function tearDownActiveCall(
             // try/catch so a single failure (e.g. a stale wasm
             // bundle) can't swallow the other.
             const raw = sender as RawIqSender;
-            const updateMujiPresence = raw.update_muji_presence;
-            const selfNick = s.selfNick;
-            if (selfNick && updateMujiPresence) {
-              try {
-                await boundedTeardownSend(() =>
-                  updateMujiPresence(s.peer, selfNick, false, false, false, {
-                    handRaised: false,
-                    muted: false, // leaving clears all in-call state
-                  }));
-              } catch (err) {
-                reportCallError(err);
-              } finally {
-                clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
-                setSelfRaisedHand(s.peer, false);
-              }
+            await leaveMujiCallPresence(raw, s);
+            if (!roomReoccupiedByNewerCall(s.peer, s.sid)) {
+              clearLiveCallParticipants(s.peer);
             }
-            clearLiveCallParticipants(s.peer);
             try {
-              await boundedTeardownSend(() => sendMujiSessionTerminate(raw, s.peer, s.sid));
+              await boundedTeardownSend(
+                () => sendMujiSessionTerminate(raw, s.peer, s.sid),
+                TERMINATE_SEND_ATTEMPTS,
+              );
               forgetMucCallSession({
                 roomJid: s.peer,
                 selfFullJid: s.selfFullJid,
@@ -971,25 +1024,13 @@ export async function tearDownActiveCall(
           );
           {
             const raw = sender as RawIqSender;
-            const updateMujiPresence = raw.update_muji_presence;
-            const selfNick = s.selfNick;
-            if (selfNick && updateMujiPresence) {
-              try {
-                await boundedTeardownSend(() =>
-                  updateMujiPresence(s.peer, selfNick, false, false, false, {
-                    handRaised: false,
-                    muted: false, // leaving clears all in-call state
-                  }));
-              } catch (err) {
-                reportCallError(err);
-              } finally {
-                clearMucCallParticipant(s.peer, selfNick, s.selfFullJid);
-                setSelfRaisedHand(s.peer, false);
-              }
-            }
+            await leaveMujiCallPresence(raw, s);
             if (s.activePresencePublished) {
               try {
-                await boundedTeardownSend(() => sendMujiSessionTerminate(raw, s.peer, s.sid));
+                await boundedTeardownSend(
+                  () => sendMujiSessionTerminate(raw, s.peer, s.sid),
+                  TERMINATE_SEND_ATTEMPTS,
+                );
                 forgetMucCallSession({
                   roomJid: s.peer,
                   selfFullJid: s.selfFullJid,

--- a/chat/src/lib/calls/call-teardown-transport.ts
+++ b/chat/src/lib/calls/call-teardown-transport.ts
@@ -1,0 +1,64 @@
+/**
+ * Transport policy for best-effort call-teardown stanza sends (#1446),
+ * split out of `call-store` so the deadline/retry machinery lives
+ * apart from call state and lifecycle bookkeeping.
+ *
+ * Teardown wire sends are peer/mixer notifications — they must never
+ * hold the local call slot (or a caller like `hangupActiveCall`)
+ * hostage to a server that withholds its reply.
+ */
+const TEARDOWN_STANZA_TIMEOUT_MS = 10_000;
+let teardownStanzaTimeoutMs = TEARDOWN_STANZA_TIMEOUT_MS;
+
+export function setTeardownStanzaTimeoutMsForTests(timeoutMs: number): () => void {
+  const previous = teardownStanzaTimeoutMs;
+  teardownStanzaTimeoutMs = timeoutMs;
+  return () => {
+    teardownStanzaTimeoutMs = previous;
+  };
+}
+
+class TeardownSendTimeoutError extends Error {
+  constructor() {
+    super("call teardown stanza timed out");
+  }
+}
+
+/**
+ * XEP-0166 session-terminate is the one teardown stanza worth a second
+ * attempt: it is what ends the call for the peer, and re-sending a sid
+ * the peer already forgot is harmless. Presence/retract/reject sends
+ * stay single-attempt — a duplicate delivered late is not.
+ */
+export const TERMINATE_SEND_ATTEMPTS = 2;
+
+/**
+ * Race a teardown wire send against the deadline, retrying on timeout
+ * up to `attempts` total tries. A typed error reply from the server is
+ * a definitive answer and is NOT retried — only silence is. The
+ * abandoned attempt's promise is left to settle in the void; its
+ * result no longer matters.
+ */
+export async function boundedTeardownSend<T>(
+  send: () => Promise<T>,
+  attempts: number = 1,
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      return await Promise.race([
+        send(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new TeardownSendTimeoutError()),
+            teardownStanzaTimeoutMs,
+          );
+        }),
+      ]);
+    } catch (err) {
+      if (!(err instanceof TeardownSendTimeoutError) || attempt >= attempts) throw err;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/chat/src/lib/calls/call-teardown-transport.ts
+++ b/chat/src/lib/calls/call-teardown-transport.ts
@@ -7,22 +7,7 @@
  * hold the local call slot (or a caller like `hangupActiveCall`)
  * hostage to a server that withholds its reply.
  */
-const TEARDOWN_STANZA_TIMEOUT_MS = 10_000;
-let teardownStanzaTimeoutMs = TEARDOWN_STANZA_TIMEOUT_MS;
-
-export function setTeardownStanzaTimeoutMsForTests(timeoutMs: number): () => void {
-  const previous = teardownStanzaTimeoutMs;
-  teardownStanzaTimeoutMs = timeoutMs;
-  return () => {
-    teardownStanzaTimeoutMs = previous;
-  };
-}
-
-class TeardownSendTimeoutError extends Error {
-  constructor() {
-    super("call teardown stanza timed out");
-  }
-}
+const DEFAULT_TEARDOWN_STANZA_TIMEOUT_MS = 10_000;
 
 /**
  * XEP-0166 session-terminate is the one teardown stanza worth a second
@@ -33,29 +18,55 @@ class TeardownSendTimeoutError extends Error {
 export const TERMINATE_SEND_ATTEMPTS = 2;
 
 /**
+ * Explicit per-send policy — passed down from the caller (tests supply
+ * a short deadline directly) instead of living as mutable module
+ * state.
+ */
+export type TeardownSendPolicy = {
+  /** Deadline per attempt. Defaults to {@link DEFAULT_TEARDOWN_STANZA_TIMEOUT_MS}. */
+  stanzaTimeoutMs?: number;
+  /** Total tries; only a timeout triggers another attempt. Defaults to 1. */
+  attempts?: number;
+  /**
+   * Invoked after every expired attempt (before any retry) — the hook
+   * where callers cancel the underlying XMPP operation, so a stale
+   * command cannot linger in the WASM driver's pending/deferred queues
+   * after the JS side has moved on.
+   */
+  onTimeout?: () => void;
+};
+
+class TeardownSendTimeoutError extends Error {
+  constructor() {
+    super("call teardown stanza timed out");
+  }
+}
+
+/**
  * Race a teardown wire send against the deadline, retrying on timeout
  * up to `attempts` total tries. A typed error reply from the server is
  * a definitive answer and is NOT retried — only silence is. The
  * abandoned attempt's promise is left to settle in the void; its
- * result no longer matters.
+ * result no longer matters (`onTimeout` is where the underlying
+ * operation gets cancelled).
  */
 export async function boundedTeardownSend<T>(
   send: () => Promise<T>,
-  attempts: number = 1,
+  policy: TeardownSendPolicy = {},
 ): Promise<T> {
+  const timeoutMs = policy.stanzaTimeoutMs ?? DEFAULT_TEARDOWN_STANZA_TIMEOUT_MS;
+  const attempts = policy.attempts ?? 1;
   for (let attempt = 1; ; attempt += 1) {
     let timer: ReturnType<typeof setTimeout> | null = null;
     try {
       return await Promise.race([
         send(),
         new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(
-            () => reject(new TeardownSendTimeoutError()),
-            teardownStanzaTimeoutMs,
-          );
+          timer = setTimeout(() => reject(new TeardownSendTimeoutError()), timeoutMs);
         }),
       ]);
     } catch (err) {
+      if (err instanceof TeardownSendTimeoutError) policy.onTimeout?.();
       if (!(err instanceof TeardownSendTimeoutError) || attempt >= attempts) throw err;
     } finally {
       if (timer) clearTimeout(timer);

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -137,7 +137,11 @@ export async function leaveRetainedMucCallAction({
           "wasm client does not expose send_muji_session_terminate; rebuild the wasm bundle",
         );
       }
-      await sender.send_muji_session_terminate(cachedSession.roomJid, cachedSession.sid);
+      await sender.send_muji_session_terminate(
+        cachedSession.roomJid,
+        cachedSession.sid,
+        crypto.randomUUID(),
+      );
       forgetMucCallSession({
         roomJid: cachedSession.roomJid,
         selfFullJid,

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -1,6 +1,28 @@
 /** JID and room-address utilities. */
 import type { WaddleSession } from "../server-auth";
 
+declare const mucRoomJidBrand: unique symbol;
+
+/**
+ * A validated bare MUC room JID (`room@service`, no resource). Branded
+ * so call-teardown logic can require parse-at-the-boundary instead of
+ * accepting arbitrary strings; the raw bytes are preserved verbatim
+ * (no case folding) so wire sends are byte-identical to the state the
+ * JID came from.
+ */
+export type MucRoomJid = string & { readonly [mucRoomJidBrand]: true };
+
+/**
+ * Parse a raw room JID at the XMPP boundary. Rejects empty values,
+ * values without an `@`, and full JIDs carrying a resource. Trims
+ * surrounding whitespace but otherwise preserves the raw bytes.
+ */
+export function parseMucRoomJid(raw: string): MucRoomJid | null {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.includes("/") || !trimmed.includes("@")) return null;
+  return trimmed as MucRoomJid;
+}
+
 export function jidDomain(jid: string): string {
   const bareJid = barePeerJid(jid);
   return bareJid.split("@")[1] ?? "localhost";

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -379,6 +379,35 @@ describe("hangupActiveCall media-first ordering (#1446)", () => {
     expect(events).toContain("terminate");
     expect(events.indexOf("terminate")).toBeGreaterThan(events.indexOf("disconnect"));
   });
+
+  test("a stalled LiveKit disconnect cannot pin the call slot or delay the terminate", async () => {
+    const sender = {
+      send_call_session_terminate: mock(async () => undefined),
+    };
+    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    const { engine } = useCallEngine();
+    (engine as unknown as { room: unknown }).room = {
+      off: () => undefined,
+      localParticipant: undefined,
+      disconnect: () => new Promise<void>(() => undefined), // dead network
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+
+    void hangupActiveCall();
+
+    // The slot flips idle synchronously, and the terminate goes out,
+    // even though the engine disconnect never settles.
+    expect($callState.get()).toEqual({ phase: "idle" });
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("device-less call controls", () => {

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -14,6 +14,7 @@ import {
   $callScreenShareEnabled,
   $callScreenShareSupported,
   $callMicEnabled,
+  hangupActiveCall,
   installCallPagehideSuspension,
   refreshScreenShareSupported,
   resetCallControls,
@@ -336,6 +337,47 @@ describe("call page lifecycle controls", () => {
     expect(source).toContain("installCallPagehideSuspension(window)");
     expect(unmountBlock).toContain("void engine.disconnect();");
     expect(unmountBlock).not.toContain("tearDownActiveCall(");
+  });
+});
+
+describe("hangupActiveCall media-first ordering (#1446)", () => {
+  test("releases media and goes idle before any XMPP teardown send, even when the server never replies", async () => {
+    const events: string[] = [];
+    const sender = {
+      send_call_session_terminate: mock(() => {
+        events.push("terminate");
+        return new Promise<void>(() => undefined); // server never replies
+      }),
+    };
+    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    const { engine } = useCallEngine();
+    (engine as unknown as { room: unknown }).room = {
+      off: () => undefined,
+      localParticipant: undefined,
+      disconnect: async () => {
+        events.push("disconnect");
+      },
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: { audio: true, video: true },
+      join,
+      kind: "dm",
+    });
+
+    await hangupActiveCall();
+
+    // Camera/mic/LiveKit are released and the call slot is idle without
+    // waiting on the terminate IQ — the server never replied at all.
+    expect(events[0]).toBe("disconnect");
+    expect($callState.get()).toEqual({ phase: "idle" });
+
+    // The XEP-0166 terminate still goes out afterwards, in the background.
+    for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    expect(events).toContain("terminate");
+    expect(events.indexOf("terminate")).toBeGreaterThan(events.indexOf("disconnect"));
   });
 });
 

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -18,6 +18,10 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import {
+  $mucCallLiveParticipants,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls/muc-call-actions";
 import {
@@ -1081,6 +1085,56 @@ describe("tearDownActiveCall", () => {
       expect($lastCallError.get()).not.toBeNull();
     } finally {
       restore();
+    }
+  });
+
+  test("backgrounded MUC teardown does not wipe a newer call's state in the same room (#1446)", async () => {
+    const restore = setTeardownStanzaTimeoutMsForTests(10);
+    try {
+      const sender = {
+        update_muji_presence: mock(() => new Promise<void>(() => undefined)),
+        send_muji_session_terminate: mock(async () => undefined),
+      };
+      const roomJid = "room@muc.waddle.test";
+      $callState.set({
+        phase: "active",
+        peer: roomJid,
+        sid: "old-sid",
+        media: audioVideo,
+        join: { ...join, room: roomJid },
+        kind: "muc",
+        selfNick: "alice",
+        selfFullJid: "alice@waddle.test/web",
+      });
+
+      const teardown = tearDownActiveCall(
+        sender as unknown as Parameters<typeof tearDownActiveCall>[0],
+        "success",
+      );
+      // While the old teardown is stuck on a silent server, the user
+      // starts a NEW call in the same room.
+      $callState.set({
+        phase: "active",
+        peer: roomJid,
+        sid: "new-sid",
+        media: audioVideo,
+        join: { ...join, room: roomJid },
+        kind: "muc",
+        selfNick: "alice",
+        selfFullJid: "alice@waddle.test/web",
+      });
+      setLiveCallParticipants(roomJid, ["alice@waddle.test/web", "bob@waddle.test/phone"]);
+
+      await teardown;
+
+      // The stale teardown must not erase the new call's projections
+      // or its call slot.
+      expect($mucCallLiveParticipants.get()[roomJid]).toBeDefined();
+      expect($callState.get()).toMatchObject({ phase: "active", sid: "new-sid" });
+    } finally {
+      restore();
+      clearCallState();
+      $mucCallLiveParticipants.set({});
     }
   });
 

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -8,7 +8,6 @@ import {
   type RawIqSender,
   scheduleOutgoingTimeout,
   setSessionAcceptTimeoutMsForTests,
-  setTeardownStanzaTimeoutMsForTests,
   tearDownActiveCall,
 } from "../src/lib/calls/call-store";
 import {
@@ -18,6 +17,7 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
+import { setTeardownStanzaTimeoutMsForTests } from "../src/lib/calls/call-teardown-transport";
 import {
   $mucCallLiveParticipants,
   setLiveCallParticipants,
@@ -1133,6 +1133,9 @@ describe("tearDownActiveCall", () => {
       expect($mucCallLiveParticipants.get()[roomJid]).toBeDefined();
       expect($callState.get()).toMatchObject({ phase: "active", sid: "new-sid" });
       expect(sender.send_muji_session_terminate).not.toHaveBeenCalled();
+      // The old teardown's presence-leave timeout must not surface into
+      // the NEW call's global error slot (#1606 review).
+      expect($lastCallError.get()).toBeNull();
     } finally {
       restore();
       clearCallState();

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -8,6 +8,7 @@ import {
   type RawIqSender,
   scheduleOutgoingTimeout,
   setSessionAcceptTimeoutMsForTests,
+  setTeardownStanzaTimeoutMsForTests,
   tearDownActiveCall,
 } from "../src/lib/calls/call-store";
 import {
@@ -1028,6 +1029,59 @@ describe("tearDownActiveCall", () => {
     expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
     expect(sender.send_call_retract).not.toHaveBeenCalled();
     expect(sender.send_call_reject).not.toHaveBeenCalled();
+  });
+
+  test("goes idle synchronously, before any wire send resolves (#1446)", async () => {
+    const restore = setTeardownStanzaTimeoutMsForTests(10);
+    try {
+      const sender: CallWireSender = {
+        send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
+        send_call_finish: mock(async () => undefined),
+      };
+      $callState.set({
+        phase: "active",
+        peer: "bob@waddle.test/desktop",
+        sid: "c1",
+        media: audioVideo,
+        join,
+        kind: "dm",
+        initiator: "alice@waddle.test/web",
+      });
+      const teardown = tearDownActiveCall(sender, "success");
+      expect($callState.get()).toEqual({ phase: "idle" });
+      await teardown;
+    } finally {
+      restore();
+    }
+  });
+
+  test("wire send that never resolves is bounded: times out, retries once, still completes (#1446)", async () => {
+    const restore = setTeardownStanzaTimeoutMsForTests(10);
+    try {
+      const sender: CallWireSender = {
+        send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
+        send_call_finish: mock(async () => undefined),
+      };
+      $callState.set({
+        phase: "active",
+        peer: "bob@waddle.test/desktop",
+        sid: "c1",
+        media: audioVideo,
+        join,
+        kind: "dm",
+        initiator: "alice@waddle.test/web",
+      });
+
+      await tearDownActiveCall(sender, "success");
+
+      // One retry after the deadline, then give up — a timed-out
+      // terminate is not a confirmed one, so no XEP-0353 finish.
+      expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(2);
+      expect(sender.send_call_finish).not.toHaveBeenCalled();
+      expect($lastCallError.get()).not.toBeNull();
+    } finally {
+      restore();
+    }
   });
 
   test("null sender: still clears state without throwing", async () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -17,7 +17,7 @@ import {
   clearMucCallParticipants,
 } from "../src/lib/calls/muc-call-presence";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
-import { setTeardownStanzaTimeoutMsForTests } from "../src/lib/calls/call-teardown-transport";
+
 import {
   $mucCallLiveParticipants,
   setLiveCallParticipants,
@@ -1036,60 +1036,89 @@ describe("tearDownActiveCall", () => {
   });
 
   test("goes idle synchronously, before any wire send resolves (#1446)", async () => {
-    const restore = setTeardownStanzaTimeoutMsForTests(10);
-    try {
-      const sender: CallWireSender = {
-        send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
-        send_call_finish: mock(async () => undefined),
-      };
-      $callState.set({
-        phase: "active",
-        peer: "bob@waddle.test/desktop",
-        sid: "c1",
-        media: audioVideo,
-        join,
-        kind: "dm",
-        initiator: "alice@waddle.test/web",
-      });
-      const teardown = tearDownActiveCall(sender, "success");
-      expect($callState.get()).toEqual({ phase: "idle" });
-      await teardown;
-    } finally {
-      restore();
-    }
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    const teardown = tearDownActiveCall(sender, "success", { stanzaTimeoutMs: 10 });
+    expect($callState.get()).toEqual({ phase: "idle" });
+    await teardown;
   });
 
   test("wire send that never resolves is bounded: times out, retries once, still completes (#1446)", async () => {
-    const restore = setTeardownStanzaTimeoutMsForTests(10);
-    try {
-      const sender: CallWireSender = {
-        send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
-        send_call_finish: mock(async () => undefined),
-      };
-      $callState.set({
-        phase: "active",
-        peer: "bob@waddle.test/desktop",
-        sid: "c1",
-        media: audioVideo,
-        join,
-        kind: "dm",
-        initiator: "alice@waddle.test/web",
-      });
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(() => new Promise<void>(() => undefined)),
+      send_call_finish: mock(async () => undefined),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
 
-      await tearDownActiveCall(sender, "success");
+    await tearDownActiveCall(sender, "success", { stanzaTimeoutMs: 10 });
 
-      // One retry after the deadline, then give up — a timed-out
-      // terminate is not a confirmed one, so no XEP-0353 finish.
-      expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(2);
-      expect(sender.send_call_finish).not.toHaveBeenCalled();
-      expect($lastCallError.get()).not.toBeNull();
-    } finally {
-      restore();
-    }
+    // One retry after the deadline, then give up — a timed-out
+    // terminate is not a confirmed one, so no XEP-0353 finish.
+    expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(2);
+    expect(sender.send_call_finish).not.toHaveBeenCalled();
+    expect($lastCallError.get()).not.toBeNull();
+  });
+
+  test("MUC terminate timeout cancels the underlying IQ inside the wasm driver (#1606 review)", async () => {
+    // A stale room-scoped terminate must not linger in the driver's
+    // pending/deferred queues once the JS deadline gives up on it: the
+    // send carries a caller-supplied iq id, and every expired attempt
+    // fires cancel_raw_iq for that exact id.
+    const terminateIds: string[] = [];
+    const cancelledIds: string[] = [];
+    const sender = {
+      update_muji_presence: mock(async () => undefined),
+      send_muji_session_terminate: mock((_room: string, _sid: string, iqId: string) => {
+        terminateIds.push(iqId);
+        return new Promise<void>(() => undefined); // mixer never replies
+      }),
+      cancel_raw_iq: mock(async (id: string) => {
+        cancelledIds.push(id);
+      }),
+    };
+    $callState.set({
+      phase: "active",
+      peer: "room@muc.waddle.test",
+      sid: "muc-1",
+      media: audioVideo,
+      join: { ...join, room: "room@muc.waddle.test" },
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/web",
+    });
+
+    await tearDownActiveCall(
+      sender as unknown as Parameters<typeof tearDownActiveCall>[0],
+      "success",
+      { stanzaTimeoutMs: 10 },
+    );
+
+    // Both attempts share one iq id; each expiry cancelled it.
+    expect(terminateIds.length).toBe(2);
+    expect(new Set(terminateIds).size).toBe(1);
+    expect(cancelledIds).toEqual([terminateIds[0], terminateIds[0]]);
   });
 
   test("backgrounded MUC teardown does not wipe a newer call's state in the same room (#1446)", async () => {
-    const restore = setTeardownStanzaTimeoutMsForTests(10);
     try {
       const sender = {
         update_muji_presence: mock(() => new Promise<void>(() => undefined)),
@@ -1110,6 +1139,7 @@ describe("tearDownActiveCall", () => {
       const teardown = tearDownActiveCall(
         sender as unknown as Parameters<typeof tearDownActiveCall>[0],
         "success",
+        { stanzaTimeoutMs: 10 },
       );
       // While the old teardown is stuck on a silent server, the user
       // starts a NEW call in the same room.
@@ -1137,7 +1167,6 @@ describe("tearDownActiveCall", () => {
       // the NEW call's global error slot (#1606 review).
       expect($lastCallError.get()).toBeNull();
     } finally {
-      restore();
       clearCallState();
       $mucCallLiveParticipants.set({});
     }
@@ -1257,7 +1286,7 @@ describe("leaveRetainedMucCallAction", () => {
 
     expect(sent).toEqual([
       ["presence", "chan@muc.test", "alice", false, false, false, { handRaised: false, muted: false }],
-      ["terminate", "chan@muc.test", "muc-recovered-live"],
+      ["terminate", "chan@muc.test", "muc-recovered-live", expect.any(String)],
     ]);
     expect($mucCallParticipants.get()).toEqual({});
     expect(readMucCallSession({
@@ -1307,6 +1336,7 @@ describe("leaveRetainedMucCallAction", () => {
     expect(sender.send_muji_session_terminate).toHaveBeenCalledWith(
       "chan@muc.test",
       "muc-retry-live",
+      expect.any(String),
     );
     expect($mucCallParticipants.get()).toEqual({});
     expect(readMucCallSession({
@@ -2402,6 +2432,7 @@ describe("MUC group call", () => {
     expect(send_muji_session_terminate).toHaveBeenCalledWith(
       "chan@muc.test",
       attemptSid,
+      expect.any(String),
     );
     expect(update_muji_presence).toHaveBeenLastCalledWith(
       "chan@muc.test",
@@ -2634,6 +2665,7 @@ describe("MUC group call", () => {
     expect(send_muji_session_terminate).toHaveBeenCalledWith(
       "chan@muc.test",
       "muc-attempt",
+      expect.any(String),
     );
     expect(update_muji_presence).toHaveBeenCalledTimes(1);
     expect(update_muji_presence).toHaveBeenCalledWith(

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1128,9 +1128,11 @@ describe("tearDownActiveCall", () => {
       await teardown;
 
       // The stale teardown must not erase the new call's projections
-      // or its call slot.
+      // or its call slot — and must not send the room-scoped Muji
+      // terminate, which would end the NEW call server-side.
       expect($mucCallLiveParticipants.get()[roomJid]).toBeDefined();
       expect($callState.get()).toMatchObject({ phase: "active", sid: "new-sid" });
+      expect(sender.send_muji_session_terminate).not.toHaveBeenCalled();
     } finally {
       restore();
       clearCallState();

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -386,9 +386,22 @@ impl WaddleClient {
     ///   </jingle>
     /// </iq>
     /// ```
-    pub fn send_muji_session_terminate(&self, room_jid: String, sid_str: String) -> Promise {
+    /// `iq_id` is caller-supplied (and validated against the
+    /// [`waddle_xmpp_client::request::StanzaId`] invariant) so the JS
+    /// side can cancel the still-pending or deferred IQ via
+    /// [`WaddleClient::cancel_raw_iq`] when its own teardown deadline
+    /// expires — a stale room-scoped terminate must not linger in the
+    /// driver after the room has been re-occupied (#1606 review).
+    pub fn send_muji_session_terminate(
+        &self,
+        room_jid: String,
+        sid_str: String,
+        iq_id: String,
+    ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
+            let iq_id = waddle_xmpp_client::request::StanzaId::new(iq_id)
+                .map_err(|err| js_error(err.to_string()))?;
             let mixer = calls_mixer_jid(stored_full_jid(&inner)?.domain().as_str());
 
             let jingle = build_muji_session_terminate(&room_jid, &sid(sid_str));
@@ -396,7 +409,7 @@ impl WaddleClient {
                 .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
                 .attr(
                     minidom::rxml::xml_ncname!("id").to_owned(),
-                    uuid::Uuid::new_v4().to_string(),
+                    iq_id.as_str().to_string(),
                 )
                 .attr(minidom::rxml::xml_ncname!("to").to_owned(), mixer.as_str())
                 .append(jingle)

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -65,24 +65,35 @@ pub(crate) enum IqReplyWait {
     DeadlineExpired,
 }
 
-/// Race the IQ-reply oneshot against `deadline`. Split from the wasm
-/// entry points (which supply a real `setTimeout` future) so the race
-/// itself is testable on native targets.
-pub(crate) async fn wait_iq_reply_with_deadline<D>(
-    rx: oneshot::Receiver<Result<Element, ClientError>>,
-    deadline: D,
-) -> IqReplyWait
+/// Race a full IQ round trip (queue admission + reply oneshot) against
+/// `deadline`. The whole trip sits inside the race on purpose: a
+/// stalled driver can block the bounded command channel before the
+/// stanza is even accepted, and that wait must count against the
+/// deadline too. Split from the wasm entry points (which supply a real
+/// `setTimeout` future) so the race itself is testable on native
+/// targets.
+pub(crate) async fn wait_iq_reply_with_deadline<F, D>(round_trip: F, deadline: D) -> IqReplyWait
 where
+    F: core::future::Future<Output = IqReplyWait>,
     D: core::future::Future<Output = ()>,
 {
     use futures::future::{select, Either};
+    futures::pin_mut!(round_trip);
     futures::pin_mut!(deadline);
-    match select(rx, deadline).await {
-        Either::Left((reply, _)) => match reply {
-            Ok(reply) => IqReplyWait::Reply(reply),
-            Err(_) => IqReplyWait::Disconnected,
-        },
+    match select(round_trip, deadline).await {
+        Either::Left((outcome, _)) => outcome,
         Either::Right(((), _)) => IqReplyWait::DeadlineExpired,
+    }
+}
+
+/// Map the reply oneshot into an [`IqReplyWait`]: a dropped responder
+/// is the driver's disconnect sweep.
+pub(crate) async fn iq_reply_from_oneshot(
+    rx: oneshot::Receiver<Result<Element, ClientError>>,
+) -> IqReplyWait {
+    match rx.await {
+        Ok(reply) => IqReplyWait::Reply(reply),
+        Err(_) => IqReplyWait::Disconnected,
     }
 }
 
@@ -108,19 +119,27 @@ fn sleep_ms(ms: u32) -> impl core::future::Future<Output = ()> {
 }
 
 /// Send an IQ and await its reply under [`IQ_REPLY_DEADLINE_MS`].
-/// Shared by [`send_iq_command`] and [`send_iq_command_stanza_aware`].
+/// Shared by [`send_iq_command`], [`send_iq_command_stanza_aware`],
+/// and [`send_avatar_iq_command`].
 async fn send_iq_roundtrip(
     inner: &Rc<RefCell<WaddleClientInner>>,
     stanza: Element,
 ) -> Result<Result<Element, ClientError>, JsValue> {
     let mut cmd_tx = command_sender(inner)?;
+    let mut cancel_tx = cmd_tx.clone();
     let iq_id = stanza.attr("id").map(str::to_string);
     let (responder, rx) = oneshot::channel();
-    cmd_tx
-        .send(WasmCommand::SendIq { stanza, responder })
-        .await
-        .map_err(|_| js_error("client is disconnected"))?;
-    match wait_iq_reply_with_deadline(rx, sleep_ms(IQ_REPLY_DEADLINE_MS)).await {
+    let round_trip = async move {
+        if cmd_tx
+            .send(WasmCommand::SendIq { stanza, responder })
+            .await
+            .is_err()
+        {
+            return IqReplyWait::Disconnected;
+        }
+        iq_reply_from_oneshot(rx).await
+    };
+    match wait_iq_reply_with_deadline(round_trip, sleep_ms(IQ_REPLY_DEADLINE_MS)).await {
         IqReplyWait::Reply(reply) => Ok(reply),
         IqReplyWait::Disconnected => Err(js_error("client is disconnected")),
         IqReplyWait::DeadlineExpired => {
@@ -130,7 +149,7 @@ async fn send_iq_roundtrip(
             // to the disconnect sweep instead.
             if let Some(id) = iq_id {
                 let (cancel_responder, _cancel_rx) = oneshot::channel();
-                let _ = cmd_tx.try_send(WasmCommand::CancelIq {
+                let _ = cancel_tx.try_send(WasmCommand::CancelIq {
                     id,
                     responder: cancel_responder,
                 });
@@ -242,14 +261,9 @@ pub(crate) async fn send_avatar_iq_command(
     inner: Rc<RefCell<WaddleClientInner>>,
     stanza: Element,
 ) -> Result<Element, AvatarRequestFailure<JsValue>> {
-    let mut cmd_tx = command_sender(&inner).map_err(AvatarRequestFailure::Other)?;
-    let (responder, rx) = oneshot::channel();
-    cmd_tx
-        .send(WasmCommand::SendIq { stanza, responder })
+    send_iq_roundtrip(&inner, stanza)
         .await
-        .map_err(|_| AvatarRequestFailure::Other(js_error("client is disconnected")))?;
-    rx.await
-        .map_err(|_| AvatarRequestFailure::Other(js_error("client is disconnected")))?
+        .map_err(AvatarRequestFailure::Other)?
         .map_err(|err| match err {
             ClientError::StanzaError(_) => AvatarRequestFailure::StanzaError,
             other => AvatarRequestFailure::Other(js_error(other.to_string())),
@@ -391,7 +405,7 @@ mod tests {
         tx.send(Ok(iq_result_element()))
             .unwrap_or_else(|_| panic!("receiver alive"));
         let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
-            rx,
+            iq_reply_from_oneshot(rx),
             futures::future::pending::<()>(),
         ));
         match outcome {
@@ -405,7 +419,7 @@ mod tests {
         let (tx, rx) = oneshot::channel::<Result<Element, ClientError>>();
         drop(tx);
         let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
-            rx,
+            iq_reply_from_oneshot(rx),
             futures::future::pending::<()>(),
         ));
         assert!(matches!(outcome, IqReplyWait::Disconnected));
@@ -418,7 +432,19 @@ mod tests {
         // promise (and anything awaiting it, like call teardown) forever.
         let (_tx, rx) = oneshot::channel::<Result<Element, ClientError>>();
         let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
-            rx,
+            iq_reply_from_oneshot(rx),
+            futures::future::ready(()),
+        ));
+        assert!(matches!(outcome, IqReplyWait::DeadlineExpired));
+    }
+
+    #[test]
+    fn iq_reply_wait_expires_even_when_queue_admission_stalls() {
+        // The deadline must cover the bounded command-channel send too:
+        // a stalled driver that never accepts the command is the same
+        // user-visible hang as a server that never replies.
+        let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
+            futures::future::pending::<IqReplyWait>(),
             futures::future::ready(()),
         ));
         assert!(matches!(outcome, IqReplyWait::DeadlineExpired));

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -97,25 +97,44 @@ pub(crate) async fn iq_reply_from_oneshot(
     }
 }
 
-/// Resolve after `ms` on the JS event loop. Reads `setTimeout` off the
-/// global scope so it works in both window and worker contexts, and
-/// compiles (unused) on native test targets. If the runtime somehow
-/// lacks a timer API the promise never resolves and the wait degrades
-/// to the pre-deadline behavior.
-fn sleep_ms(ms: u32) -> impl core::future::Future<Output = ()> {
-    use wasm_bindgen::JsCast;
-    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
-        let global = js_sys::global();
-        let set_timeout = js_sys::Reflect::get(&global, &JsValue::from_str("setTimeout"))
-            .ok()
-            .and_then(|value| value.dyn_into::<js_sys::Function>().ok());
-        if let Some(set_timeout) = set_timeout {
-            let _ = set_timeout.call2(&global, &resolve, &JsValue::from_f64(f64::from(ms)));
+/// Resolve after `ms` on the JS event loop, plus a cancel handle that
+/// clears the timer once the race is decided (so a won race doesn't
+/// retain the timer + resolve closure for the rest of the deadline).
+/// Reads `setTimeout`/`clearTimeout` off the global scope so it works
+/// in both window and worker contexts, and compiles (unused) on native
+/// test targets. If the runtime somehow lacks a timer API the promise
+/// never resolves and the wait degrades to the pre-deadline behavior.
+fn sleep_ms(ms: u32) -> (impl core::future::Future<Output = ()>, impl FnOnce()) {
+    let timer_id = Rc::new(std::cell::Cell::new(None::<f64>));
+    let timer_id_for_set = timer_id.clone();
+    let promise = js_sys::Promise::new(&mut move |resolve, _reject| {
+        if let Some(set_timeout) = global_timer_fn("setTimeout") {
+            let scheduled = set_timeout.call2(
+                &js_sys::global(),
+                &resolve,
+                &JsValue::from_f64(f64::from(ms)),
+            );
+            if let Ok(id) = scheduled {
+                timer_id_for_set.set(id.as_f64());
+            }
         }
     });
-    async move {
+    let cancel = move || {
+        if let (Some(id), Some(clear_timeout)) = (timer_id.get(), global_timer_fn("clearTimeout")) {
+            let _ = clear_timeout.call1(&js_sys::global(), &JsValue::from_f64(id));
+        }
+    };
+    let future = async move {
         let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
-    }
+    };
+    (future, cancel)
+}
+
+fn global_timer_fn(name: &str) -> Option<js_sys::Function> {
+    use wasm_bindgen::JsCast;
+    js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str(name))
+        .ok()
+        .and_then(|value| value.dyn_into::<js_sys::Function>().ok())
 }
 
 /// Send an IQ and await its reply under [`IQ_REPLY_DEADLINE_MS`].
@@ -139,7 +158,10 @@ async fn send_iq_roundtrip(
         }
         iq_reply_from_oneshot(rx).await
     };
-    match wait_iq_reply_with_deadline(round_trip, sleep_ms(IQ_REPLY_DEADLINE_MS)).await {
+    let (deadline, cancel_deadline) = sleep_ms(IQ_REPLY_DEADLINE_MS);
+    let outcome = wait_iq_reply_with_deadline(round_trip, deadline).await;
+    cancel_deadline();
+    match outcome {
         IqReplyWait::Reply(reply) => Ok(reply),
         IqReplyWait::Disconnected => Err(js_error("client is disconnected")),
         IqReplyWait::DeadlineExpired => {

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -145,8 +145,12 @@ async fn send_iq_roundtrip(
     stanza: Element,
 ) -> Result<Result<Element, ClientError>, JsValue> {
     let mut cmd_tx = command_sender(inner)?;
-    let mut cancel_tx = cmd_tx.clone();
-    let iq_id = stanza.attr("id").map(str::to_string);
+    let cancel_tx = cmd_tx.clone();
+    // Parsed once into the typed correlation id; an absent/empty id
+    // simply means there is nothing to cancel on expiry.
+    let iq_id = stanza
+        .attr("id")
+        .and_then(|value| waddle_xmpp_client::request::StanzaId::new(value).ok());
     let (responder, rx) = oneshot::channel();
     let round_trip = async move {
         if cmd_tx
@@ -167,16 +171,28 @@ async fn send_iq_roundtrip(
         IqReplyWait::DeadlineExpired => {
             // Free the driver's pending-IQ slot (and any deferred copy of
             // the command) so a reply that limps in later has nowhere to
-            // land. Best-effort: on a full command queue the entry falls
-            // to the disconnect sweep instead.
+            // land. Spawned so a momentarily full command queue delays
+            // the cancellation instead of dropping it — the expired
+            // caller must not block on it either way.
             if let Some(id) = iq_id {
-                let (cancel_responder, _cancel_rx) = oneshot::channel();
-                let _ = cancel_tx.try_send(WasmCommand::CancelIq {
-                    id,
-                    responder: cancel_responder,
+                let mut cancel_tx = cancel_tx;
+                wasm_bindgen_futures::spawn_local(async move {
+                    let (cancel_responder, _cancel_rx) = oneshot::channel();
+                    let _ = cancel_tx
+                        .send(WasmCommand::CancelIq {
+                            id,
+                            responder: cancel_responder,
+                        })
+                        .await;
                 });
             }
-            Err(js_error("iq request timed out"))
+            // Typed until the WASM boundary: callers map this like any
+            // other ClientError (send_iq_command stringifies it in
+            // iq_rejection; the stanza-aware/avatar variants at their
+            // own boundary arms).
+            Ok(Err(ClientError::IqTimeout {
+                timeout: std::time::Duration::from_millis(u64::from(IQ_REPLY_DEADLINE_MS)),
+            }))
         }
     }
 }
@@ -247,6 +263,8 @@ pub(crate) async fn cancel_iq_command(
     inner: Rc<RefCell<WaddleClientInner>>,
     id: String,
 ) -> Result<(), JsValue> {
+    let id = waddle_xmpp_client::request::StanzaId::new(id)
+        .map_err(|err| js_error(err.to_string()))?;
     let mut cmd_tx = command_sender(&inner)?;
     let (responder, rx) = oneshot::channel();
     cmd_tx

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -49,18 +49,103 @@ pub(crate) fn send_failure_outcome(error: &ClientError) -> WaddleSendMessageOutc
     }
 }
 
-pub(crate) async fn send_iq_command(
-    inner: Rc<RefCell<WaddleClientInner>>,
+/// Deadline for a client-initiated IQ round trip (#1446). RFC 6120
+/// requires a reply to every IQ, but a broken or silent server can
+/// simply never send one — and the reply oneshot only resolves on a
+/// matched result or a disconnect sweep. Without a deadline every
+/// caller up the stack (including call teardown) inherits an unbounded
+/// wait.
+pub(crate) const IQ_REPLY_DEADLINE_MS: u32 = 30_000;
+
+/// Outcome of racing the driver's IQ-reply oneshot against a deadline.
+pub(crate) enum IqReplyWait {
+    Reply(Result<Element, ClientError>),
+    /// The driver dropped the responder (disconnect sweep).
+    Disconnected,
+    DeadlineExpired,
+}
+
+/// Race the IQ-reply oneshot against `deadline`. Split from the wasm
+/// entry points (which supply a real `setTimeout` future) so the race
+/// itself is testable on native targets.
+pub(crate) async fn wait_iq_reply_with_deadline<D>(
+    rx: oneshot::Receiver<Result<Element, ClientError>>,
+    deadline: D,
+) -> IqReplyWait
+where
+    D: core::future::Future<Output = ()>,
+{
+    use futures::future::{select, Either};
+    futures::pin_mut!(deadline);
+    match select(rx, deadline).await {
+        Either::Left((reply, _)) => match reply {
+            Ok(reply) => IqReplyWait::Reply(reply),
+            Err(_) => IqReplyWait::Disconnected,
+        },
+        Either::Right(((), _)) => IqReplyWait::DeadlineExpired,
+    }
+}
+
+/// Resolve after `ms` on the JS event loop. Reads `setTimeout` off the
+/// global scope so it works in both window and worker contexts, and
+/// compiles (unused) on native test targets. If the runtime somehow
+/// lacks a timer API the promise never resolves and the wait degrades
+/// to the pre-deadline behavior.
+fn sleep_ms(ms: u32) -> impl core::future::Future<Output = ()> {
+    use wasm_bindgen::JsCast;
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        let global = js_sys::global();
+        let set_timeout = js_sys::Reflect::get(&global, &JsValue::from_str("setTimeout"))
+            .ok()
+            .and_then(|value| value.dyn_into::<js_sys::Function>().ok());
+        if let Some(set_timeout) = set_timeout {
+            let _ = set_timeout.call2(&global, &resolve, &JsValue::from_f64(f64::from(ms)));
+        }
+    });
+    async move {
+        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+    }
+}
+
+/// Send an IQ and await its reply under [`IQ_REPLY_DEADLINE_MS`].
+/// Shared by [`send_iq_command`] and [`send_iq_command_stanza_aware`].
+async fn send_iq_roundtrip(
+    inner: &Rc<RefCell<WaddleClientInner>>,
     stanza: Element,
-) -> Result<Element, JsValue> {
-    let mut cmd_tx = command_sender(&inner)?;
+) -> Result<Result<Element, ClientError>, JsValue> {
+    let mut cmd_tx = command_sender(inner)?;
+    let iq_id = stanza.attr("id").map(str::to_string);
     let (responder, rx) = oneshot::channel();
     cmd_tx
         .send(WasmCommand::SendIq { stanza, responder })
         .await
         .map_err(|_| js_error("client is disconnected"))?;
-    rx.await
-        .map_err(|_| js_error("client is disconnected"))?
+    match wait_iq_reply_with_deadline(rx, sleep_ms(IQ_REPLY_DEADLINE_MS)).await {
+        IqReplyWait::Reply(reply) => Ok(reply),
+        IqReplyWait::Disconnected => Err(js_error("client is disconnected")),
+        IqReplyWait::DeadlineExpired => {
+            // Free the driver's pending-IQ slot (and any deferred copy of
+            // the command) so a reply that limps in later has nowhere to
+            // land. Best-effort: on a full command queue the entry falls
+            // to the disconnect sweep instead.
+            if let Some(id) = iq_id {
+                let (cancel_responder, _cancel_rx) = oneshot::channel();
+                let _ = cmd_tx.try_send(WasmCommand::CancelIq {
+                    id,
+                    responder: cancel_responder,
+                });
+            }
+            Err(js_error("iq request timed out"))
+        }
+    }
+}
+
+pub(crate) async fn send_iq_command(
+    inner: Rc<RefCell<WaddleClientInner>>,
+    stanza: Element,
+) -> Result<Element, JsValue> {
+    send_iq_roundtrip(&inner, stanza)
+        .await?
         .map_err(iq_rejection)
 }
 
@@ -145,13 +230,7 @@ pub(crate) async fn send_iq_command_stanza_aware(
     inner: Rc<RefCell<WaddleClientInner>>,
     stanza: Element,
 ) -> Result<Result<Element, waddle_xmpp_client::StanzaError>, JsValue> {
-    let mut cmd_tx = command_sender(&inner)?;
-    let (responder, rx) = oneshot::channel();
-    cmd_tx
-        .send(WasmCommand::SendIq { stanza, responder })
-        .await
-        .map_err(|_| js_error("client is disconnected"))?;
-    let result = rx.await.map_err(|_| js_error("client is disconnected"))?;
+    let result = send_iq_roundtrip(&inner, stanza).await?;
     match result {
         Ok(elem) => Ok(Ok(elem)),
         Err(ClientError::StanzaError(stanza_err)) => Ok(Err(stanza_err)),
@@ -298,5 +377,50 @@ mod tests {
     #[test]
     fn non_stanza_errors_yield_no_fields() {
         assert!(stanza_error_rejection_fields(&ClientError::Disconnected).is_none());
+    }
+
+    fn iq_result_element() -> Element {
+        Element::builder("iq", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .build()
+    }
+
+    #[test]
+    fn iq_reply_wait_delivers_reply_when_it_beats_the_deadline() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(iq_result_element()))
+            .unwrap_or_else(|_| panic!("receiver alive"));
+        let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
+            rx,
+            futures::future::pending::<()>(),
+        ));
+        match outcome {
+            IqReplyWait::Reply(Ok(elem)) => assert_eq!(elem.name(), "iq"),
+            _ => panic!("reply must win over a pending deadline"),
+        }
+    }
+
+    #[test]
+    fn iq_reply_wait_reports_disconnect_when_responder_is_dropped() {
+        let (tx, rx) = oneshot::channel::<Result<Element, ClientError>>();
+        drop(tx);
+        let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
+            rx,
+            futures::future::pending::<()>(),
+        ));
+        assert!(matches!(outcome, IqReplyWait::Disconnected));
+    }
+
+    #[test]
+    fn iq_reply_wait_expires_instead_of_waiting_forever() {
+        // #1446: the reply oneshot must never be awaited bare — a server
+        // that goes silent after the send would otherwise hang the JS
+        // promise (and anything awaiting it, like call teardown) forever.
+        let (_tx, rx) = oneshot::channel::<Result<Element, ClientError>>();
+        let outcome = futures::executor::block_on(wait_iq_reply_with_deadline(
+            rx,
+            futures::future::ready(()),
+        ));
+        assert!(matches!(outcome, IqReplyWait::DeadlineExpired));
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -263,8 +263,8 @@ pub(crate) async fn cancel_iq_command(
     inner: Rc<RefCell<WaddleClientInner>>,
     id: String,
 ) -> Result<(), JsValue> {
-    let id = waddle_xmpp_client::request::StanzaId::new(id)
-        .map_err(|err| js_error(err.to_string()))?;
+    let id =
+        waddle_xmpp_client::request::StanzaId::new(id).map_err(|err| js_error(err.to_string()))?;
     let mut cmd_tx = command_sender(&inner)?;
     let (responder, rx) = oneshot::channel();
     cmd_tx

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -226,21 +226,24 @@ impl WasmDriverTask {
         stanza: Element,
         responder: oneshot::Sender<DriverResult<Element>>,
     ) -> bool {
-        let id = stanza.attr("id").map(|value| value.to_string());
+        // Enforce the `StanzaId` invariant at tracking time: an IQ whose
+        // id would not round-trip through the typed cancellation path
+        // (`WasmCommand::CancelIq`) must never become a pending entry,
+        // or a reply-less server would leave it uncancellable until the
+        // disconnect sweep. Reject before the stanza reaches the wire —
+        // an untrackable request IQ is a caller bug, not a send.
+        let Some(id) = trackable_iq_id(&stanza) else {
+            let _ = responder.send(Err(ClientError::EmptyStanzaId));
+            return true;
+        };
         match self
             .send_transport_message(TransportMessage::Element(stanza))
             .await
         {
-            Ok(()) => match id {
-                Some(id) => {
-                    self.pending_iqs.insert(id, responder);
-                    true
-                }
-                None => {
-                    let _ = responder.send(Err(ClientError::Disconnected));
-                    false
-                }
-            },
+            Ok(()) => {
+                self.pending_iqs.insert(id, responder);
+                true
+            }
             Err(err) => {
                 self.emit_error(err.to_string()).await;
                 let _ = responder.send(Err(err));
@@ -621,6 +624,19 @@ fn publish_resume_state_snapshot(
     inner.borrow_mut().resume_state = resume_state;
 }
 
+/// The pending-IQ tracking key for a request stanza, holding the same
+/// non-empty invariant as [`waddle_xmpp_client::request::StanzaId`] so
+/// every entry that can become pending is also cancellable through the
+/// typed [`WasmCommand::CancelIq`] path. Absent, empty, or
+/// whitespace-only ids yield `None`.
+fn trackable_iq_id(stanza: &Element) -> Option<String> {
+    stanza
+        .attr("id")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 fn cancel_raw_iq_state(
     pending_iqs: &mut HashMap<String, oneshot::Sender<DriverResult<Element>>>,
     deferred_commands: &mut VecDeque<DeferredWasmCommand>,
@@ -688,6 +704,28 @@ mod tests {
     use super::*;
     use futures::executor::block_on;
     use waddle_xmpp_client::discovery::DISCO_INFO_NS;
+
+    fn iq_with_id(id: Option<&str>) -> Element {
+        let mut builder = Element::builder("iq", "jabber:client");
+        if let Some(id) = id {
+            builder = builder.attr(minidom::rxml::xml_ncname!("id").to_owned(), id);
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn trackable_iq_id_holds_the_stanza_id_invariant() {
+        // Every id that can become a pending entry must round-trip
+        // through the typed CancelIq path (#1606 review): absent,
+        // empty, and whitespace-only ids are untrackable.
+        assert_eq!(
+            trackable_iq_id(&iq_with_id(Some("iq-1"))).as_deref(),
+            Some("iq-1")
+        );
+        assert_eq!(trackable_iq_id(&iq_with_id(None)), None);
+        assert_eq!(trackable_iq_id(&iq_with_id(Some(""))), None);
+        assert_eq!(trackable_iq_id(&iq_with_id(Some("   "))), None);
+    }
 
     fn test_inner() -> Rc<RefCell<WaddleClientInner>> {
         Rc::new(RefCell::new(WaddleClientInner {

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -180,7 +180,7 @@ impl WasmDriverTask {
                     .await
             }
             Some(WasmCommand::CancelIq { id, responder }) => {
-                self.cancel_iq_command(&id);
+                self.cancel_iq_command(id.as_str());
                 let _ = responder.send(Ok(()));
                 true
             }

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -180,7 +180,7 @@ impl WasmDriverTask {
                     .await
             }
             Some(WasmCommand::CancelIq { id, responder }) => {
-                self.cancel_iq_command(id.as_str());
+                self.cancel_iq_command(&id);
                 let _ = responder.send(Ok(()));
                 true
             }
@@ -198,7 +198,7 @@ impl WasmDriverTask {
         }
     }
 
-    fn cancel_iq_command(&mut self, id: &str) {
+    fn cancel_iq_command(&mut self, id: &waddle_xmpp_client::request::StanzaId) {
         cancel_raw_iq_state(&mut self.pending_iqs, &mut self.deferred_commands, id);
     }
 
@@ -478,7 +478,8 @@ impl WasmDriverTask {
                 None
             }
             ClientEvent::IqResult { id, element } => {
-                if let Some(responder) = self.pending_iqs.remove(&id) {
+                let iq_key = waddle_xmpp_client::request::StanzaId::new(id.as_str()).ok();
+                if let Some(responder) = iq_key.and_then(|key| self.pending_iqs.remove(&key)) {
                     let result = if element.attr("type") == Some("result") {
                         Ok(element)
                     } else {
@@ -624,23 +625,24 @@ fn publish_resume_state_snapshot(
     inner.borrow_mut().resume_state = resume_state;
 }
 
-/// The pending-IQ tracking key for a request stanza, holding the same
-/// non-empty invariant as [`waddle_xmpp_client::request::StanzaId`] so
-/// every entry that can become pending is also cancellable through the
-/// typed [`WasmCommand::CancelIq`] path. Absent, empty, or
-/// whitespace-only ids yield `None`.
-fn trackable_iq_id(stanza: &Element) -> Option<String> {
-    stanza
-        .attr("id")
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
+/// The pending-IQ tracking key for a request stanza — the typed
+/// [`waddle_xmpp_client::request::StanzaId`], so every entry that can
+/// become pending is also cancellable through the typed
+/// [`WasmCommand::CancelIq`] path. `StanzaId` preserves the raw id
+/// bytes (validation only rejects empty-after-trim), so tracking,
+/// reply correlation, and cancellation all use the exact wire string.
+/// Absent, empty, or whitespace-only ids yield `None`.
+fn trackable_iq_id(stanza: &Element) -> Option<waddle_xmpp_client::request::StanzaId> {
+    waddle_xmpp_client::request::StanzaId::new(stanza.attr("id")?).ok()
 }
 
 fn cancel_raw_iq_state(
-    pending_iqs: &mut HashMap<String, oneshot::Sender<DriverResult<Element>>>,
+    pending_iqs: &mut HashMap<
+        waddle_xmpp_client::request::StanzaId,
+        oneshot::Sender<DriverResult<Element>>,
+    >,
     deferred_commands: &mut VecDeque<DeferredWasmCommand>,
-    id: &str,
+    id: &waddle_xmpp_client::request::StanzaId,
 ) {
     if let Some(responder) = pending_iqs.remove(id) {
         let _ = responder.send(Err(ClientError::RequestCancelled));
@@ -648,7 +650,7 @@ fn cancel_raw_iq_state(
 
     let mut retained = VecDeque::with_capacity(deferred_commands.len());
     while let Some(command) = deferred_commands.pop_front() {
-        if command.raw_iq_id() == Some(id) {
+        if command.raw_iq_id() == Some(id.as_str()) {
             if let DeferredWasmCommand::Iq { responder, .. } = command {
                 let _ = responder.send(Err(ClientError::RequestCancelled));
             }
@@ -717,14 +719,17 @@ mod tests {
     fn trackable_iq_id_holds_the_stanza_id_invariant() {
         // Every id that can become a pending entry must round-trip
         // through the typed CancelIq path (#1606 review): absent,
-        // empty, and whitespace-only ids are untrackable.
-        assert_eq!(
-            trackable_iq_id(&iq_with_id(Some("iq-1"))).as_deref(),
-            Some("iq-1")
-        );
-        assert_eq!(trackable_iq_id(&iq_with_id(None)), None);
-        assert_eq!(trackable_iq_id(&iq_with_id(Some(""))), None);
-        assert_eq!(trackable_iq_id(&iq_with_id(Some("   "))), None);
+        // empty, and whitespace-only ids are untrackable — and a
+        // trackable id preserves its raw bytes (including surrounding
+        // whitespace) so reply correlation and cancellation always use
+        // the exact wire string.
+        let tracked =
+            |raw: Option<&str>| trackable_iq_id(&iq_with_id(raw)).map(|id| id.as_str().to_string());
+        assert_eq!(tracked(Some("iq-1")).as_deref(), Some("iq-1"));
+        assert_eq!(tracked(Some(" iq-1 ")).as_deref(), Some(" iq-1 "));
+        assert_eq!(tracked(None), None);
+        assert_eq!(tracked(Some("")), None);
+        assert_eq!(tracked(Some("   ")), None);
     }
 
     fn test_inner() -> Rc<RefCell<WaddleClientInner>> {
@@ -1047,19 +1052,21 @@ mod tests {
     #[test]
     fn cancel_raw_iq_removes_sent_pending_responder() {
         let (responder, rx) = oneshot::channel();
-        let mut pending_iqs = HashMap::from([("sent-1".to_string(), responder)]);
+        let sent_id =
+            waddle_xmpp_client::request::StanzaId::new("sent-1").expect("valid stanza id");
+        let mut pending_iqs = HashMap::from([(sent_id.clone(), responder)]);
         let mut deferred_commands = VecDeque::new();
 
-        cancel_raw_iq_state(&mut pending_iqs, &mut deferred_commands, "sent-1");
+        cancel_raw_iq_state(&mut pending_iqs, &mut deferred_commands, &sent_id);
 
-        assert!(!pending_iqs.contains_key("sent-1"));
+        assert!(!pending_iqs.contains_key(&sent_id));
         assert!(matches!(
             block_on(rx).expect("responder should send"),
             Err(ClientError::RequestCancelled)
         ));
 
         let late = iq("sent-1");
-        assert!(pending_iqs.remove("sent-1").is_none());
+        assert!(pending_iqs.remove(&sent_id).is_none());
         drop(late);
     }
 
@@ -1079,7 +1086,11 @@ mod tests {
             },
         ]);
 
-        cancel_raw_iq_state(&mut pending_iqs, &mut deferred_commands, "deferred-1");
+        cancel_raw_iq_state(
+            &mut pending_iqs,
+            &mut deferred_commands,
+            &waddle_xmpp_client::request::StanzaId::new("deferred-1").expect("valid stanza id"),
+        );
 
         assert_eq!(deferred_commands.len(), 1);
         assert_eq!(deferred_commands[0].raw_iq_id(), Some("deferred-2"));

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -301,7 +301,8 @@ pub(crate) struct WasmDriverTask {
     pub(crate) cmd_rx: mpsc::Receiver<WasmCommand>,
     pub(crate) event_tx: mpsc::Sender<DriverEvent>,
     pub(crate) inner: Rc<RefCell<WaddleClientInner>>,
-    pub(crate) pending_iqs: HashMap<String, oneshot::Sender<DriverResult<Element>>>,
+    pub(crate) pending_iqs:
+        HashMap<waddle_xmpp_client::request::StanzaId, oneshot::Sender<DriverResult<Element>>>,
     pub(crate) pending_mam_queries: HashMap<String, PendingMamQuery>,
     pub(crate) pending_inbox_queries: HashMap<String, PendingInboxQuery>,
     pub(crate) deferred_commands: VecDeque<DeferredWasmCommand>,

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -210,7 +210,7 @@ pub(crate) enum WasmCommand {
         responder: oneshot::Sender<DriverResult<InboxPage>>,
     },
     CancelIq {
-        id: String,
+        id: waddle_xmpp_client::request::StanzaId,
         responder: oneshot::Sender<DriverResult<()>>,
     },
     Disconnect {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -383,8 +383,14 @@ export class WaddleClient {
      *   </jingle>
      * </iq>
      * ```
+     * `iq_id` is caller-supplied (and validated against the
+     * [`waddle_xmpp_client::request::StanzaId`] invariant) so the JS
+     * side can cancel the still-pending or deferred IQ via
+     * [`WaddleClient::cancel_raw_iq`] when its own teardown deadline
+     * expires — a stale room-scoped terminate must not linger in the
+     * driver after the room has been re-occupied (#1606 review).
      */
-    send_muji_session_terminate(room_jid: string, sid_str: string): Promise<any>;
+    send_muji_session_terminate(room_jid: string, sid_str: string, iq_id: string): Promise<any>;
     /**
      * Publish the user's own presence (RFC 6121 §4.7). `show` is an RFC
      * 6121 `<show>` value (`away` / `xa` / `dnd` / `chat`) or `None` for

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=e5e1fdf59b71";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=e5e1fdf59b71";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=e5e1fdf59b71";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=7c04d7d7f5b9";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=e5e1fdf59b71";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=7c04d7d7f5b9";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=6213fb33499e";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=7c04d7d7f5b9";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=6213fb33499e";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=a923530ae379";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=6213fb33499e";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=a923530ae379";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=bc5c5c47aec7";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=bc5c5c47aec7";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=bc5c5c47aec7";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=a923530ae379";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=bc5c5c47aec7";


### PR DESCRIPTION
## Problem (#1446)

Clicking **Hang up** could leave camera, microphone, and the LiveKit transport live indefinitely: `hangupActiveCall()` awaited the full XMPP/Jingle teardown before `engine.disconnect()`, the call slot stayed pinned on `active` until every IQ resolved, and the WASM IQ helper waited on a bare oneshot with no deadline. A server that never replies meant media stayed live after the user hung up.

## What changed

**Media first, protocol second** (`chat/src/lib/calls/call-controls.ts`)
- `hangupActiveCall()` now disconnects the LiveKit engine (stopping camera, mic, and the noise-processor capture clone) before any XMPP send, then runs the wire teardown in the background. Its promise resolves once media is released.
- `CallOverlay.vue`'s join-failure rollback got the same ordering.

**Bounded, snapshot-driven teardown** (`chat/src/lib/calls/call-store.ts`)
- `tearDownActiveCall` snapshots state and goes `idle` synchronously; the XEP-0166/0272 stanzas are sent afterwards from the snapshot. An `ended` slot still normalizes to `idle`.
- Every teardown send is raced against a 10s deadline (`setTeardownStanzaTimeoutMsForTests` seam). Only `session-terminate` is retried (once) — a duplicate terminate for a forgotten sid is harmless, while duplicated presence/retract/reject sends are not. Failure never re-opens media.
- Because teardown is now backgrounded, a stale teardown finishing late can no longer stomp a newer call in the same room: `roomReoccupiedByNewerCall` gates both the non-sid-scoped MUC projection wipes (self participant, raised hand, live-participant list) **and the wire sends** — the server's Muji leave/terminate are room-scoped, not sid-scoped, so a late send would have ended the *new* call (the guard is re-checked per retry attempt). The shared XEP-0272 leave step is extracted into `leaveMujiCallPresence` (was duplicated across the `active`/`muc-pending` arms).
- The incoming-call ringtone stops before the bounded reject send — it is media too.

**WASM IQ deadline** (`server/crates/waddle-xmpp-client-wasm/src/commands.rs`)
- `send_iq_command`, `send_iq_command_stanza_aware`, and `send_avatar_iq_command` share a `send_iq_roundtrip` that races the whole round trip — bounded-channel queue admission *and* the reply oneshot — against a 30s `setTimeout` deadline (`wait_iq_reply_with_deadline`, natively tested).
- On expiry the helper fires a best-effort `CancelIq`, which frees the driver's pending-IQ slot **and** drains a deferred copy queued during reconnect, so a hang-up mid-reconnect is bounded too. The deadline timer is cleared once the race is decided. Deferred commands only live as long as their driver (exit drains them into `Disconnected`), so the 30s bound cannot outlive a reconnect backoff — it only fires on a live-but-silent stream, which is the bug being fixed.

## Tests
- bun: hang-up with a never-replying server releases media, goes idle, and still emits the terminate afterwards; teardown goes idle synchronously; timeout retries terminate exactly once and skips XEP-0353 `finish`; a stale MUC teardown leaves a newer same-room call untouched.
- Rust (native): the deadline race — reply wins, disconnect maps, deadline expiry, and expiry with stalled queue admission.

## Known limits (follow-up candidates)
- MAM/inbox query round trips still await unbounded oneshots (different command types; a 30s bound may be too tight for large archive pages).
- TS retries at 10s while the wasm deadline is 30s, so an abandoned first terminate holds a driver pending-IQ slot for up to 30s before its own cancel fires. Benign.

Fixes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
