### PR TITLE
fix(server): fence clustered admission and websocket lifecycle

### DIFF
--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -266,6 +266,6 @@ This chart supports two extra env mechanisms:
 ## Probes
 
 - Liveness probe: `GET /health`
-- Readiness probe: `GET /api/v1/health`
+- Readiness probe: `GET /ready`
 
 Both are configurable via `probes.*`.

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -251,7 +251,7 @@ probes:
     timeoutSeconds: 2
     failureThreshold: 3
   readiness:
-    path: /api/v1/health
+    path: /ready
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 2

--- a/server/crates/waddle-ecdysis/src/shutdown.rs
+++ b/server/crates/waddle-ecdysis/src/shutdown.rs
@@ -89,6 +89,11 @@ impl ShutdownHandle {
         self.connection_count.load(Ordering::SeqCst)
     }
 
+    /// Canonical absolute drain budget configured for this process.
+    pub fn drain_timeout(&self) -> Duration {
+        self.drain_timeout
+    }
+
     /// Wait until every [`ConnectionGuard`] has dropped, bounded by the
     /// drain timeout.
     ///

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -159,40 +159,124 @@ pub(crate) fn keypair_slot_table_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-/// Shared client-facing HTTP readiness signal for the clustering control
-/// plane (ADR-0017 element 4, Phase 3 Slice 2): flipped to not-ready the
-/// instant a node self-fences (node-lease heartbeat CAS returns zero rows,
-/// or Postgres is unreachable past the lease deadline) and back to ready
-/// only once the node has re-registered under a fresh `node_id`/
-/// `node_epoch` and satisfied the re-acquisition hysteresis gate. Cloning
-/// shares the same underlying flag (cheap `Arc` clone).
+/// Critical local services whose unexpected death makes clustered ownership
+/// unsafe. These are typed operational causes, not XMPP payloads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CriticalNodeFailure {
+    RoomRegistryTerminated,
+    UserRegistryTerminated,
+}
+
+/// The single authority for client admission on this node.
 ///
-/// Unconditionally compiled (no `clustering` feature gate) so `AppState`
-/// and the `/ready`/`/readyz` handlers can hold one field regardless of
-/// build: a non-clustering deployment (or a `clustering`-feature build with
-/// `clustering.enabled = false`) never flips it, so it stays ready forever
-/// — today's behavior, unchanged.
+/// A physical WebSocket remains local, but it may be admitted only while the
+/// node can safely own the logical work behind it. Keeping readiness and the
+/// upgrade gate on this same state prevents a fenced node from becoming
+/// `/ready`-healthy while still accepting a new socket.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NodeAdmission {
+    Starting,
+    Serving,
+    Draining,
+    FencedRecovering,
+    Failed(CriticalNodeFailure),
+}
+
+/// A successful, point-in-time admission decision for one socket upgrade.
+/// The Ecdysis connection guard still owns the connection lifetime; this
+/// permit proves the node was serving immediately before the upgrade began.
+#[derive(Clone, Copy, Debug)]
+pub struct NodeAdmissionPermit;
+
+/// Why an HTTP/XMPP connection was not admitted.
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum NodeAdmissionError {
+    #[error("node is not accepting connections: {0:?}")]
+    NotServing(NodeAdmission),
+}
+
+/// Cloneable lifecycle state shared by readiness, socket admission, and the
+/// clustered fencing workers. `fatal_fence` is retained as the bridge to the
+/// existing bounded claim-drain machinery; its terminal state is represented
+/// here rather than by a separate readiness boolean.
 #[derive(Clone)]
-pub struct ClusteringReadiness {
-    ready: std::sync::Arc<std::sync::atomic::AtomicBool>,
+pub struct NodeLifecycle {
+    admission: std::sync::Arc<std::sync::RwLock<NodeAdmission>>,
     fatal_fence: CancellationToken,
 }
 
-impl ClusteringReadiness {
+impl NodeLifecycle {
+    /// Existing single-node/test callers start in their historical serving
+    /// state. Production startup uses [`Self::starting`] until all critical
+    /// services and routes are constructed.
     pub fn new() -> Self {
+        Self::with_admission(NodeAdmission::Serving)
+    }
+
+    pub fn starting() -> Self {
+        Self::with_admission(NodeAdmission::Starting)
+    }
+
+    fn with_admission(admission: NodeAdmission) -> Self {
         Self {
-            ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            admission: std::sync::Arc::new(std::sync::RwLock::new(admission)),
             fatal_fence: CancellationToken::new(),
         }
     }
 
-    pub fn is_ready(&self) -> bool {
-        self.ready.load(std::sync::atomic::Ordering::Acquire) && !self.fatal_fence.is_cancelled()
+    pub fn admission(&self) -> NodeAdmission {
+        self.admission
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
-    pub fn set_ready(&self, ready: bool) {
-        self.ready
-            .store(ready, std::sync::atomic::Ordering::Release);
+    pub fn admit(&self) -> Result<NodeAdmissionPermit, NodeAdmissionError> {
+        match self.admission() {
+            NodeAdmission::Serving => Ok(NodeAdmissionPermit),
+            state => Err(NodeAdmissionError::NotServing(state)),
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        matches!(self.admission(), NodeAdmission::Serving)
+    }
+
+    pub fn serve(&self) {
+        self.transition_nonterminal(NodeAdmission::Serving);
+    }
+
+    pub fn begin_drain(&self) {
+        self.transition_nonterminal(NodeAdmission::Draining);
+    }
+
+    pub fn begin_fenced_recovery(&self) {
+        self.transition_nonterminal(NodeAdmission::FencedRecovering);
+    }
+
+    pub fn fail(&self, failure: CriticalNodeFailure) {
+        *self
+            .admission
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = NodeAdmission::Failed(failure);
+        self.fatal_fence.cancel();
+    }
+
+    pub fn critical_failure(&self) -> Option<CriticalNodeFailure> {
+        match self.admission() {
+            NodeAdmission::Failed(failure) => Some(failure),
+            _ => None,
+        }
+    }
+
+    fn transition_nonterminal(&self, next: NodeAdmission) {
+        let mut current = self
+            .admission
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !matches!(*current, NodeAdmission::Failed(_)) {
+            *current = next;
+        }
     }
 
     #[cfg(any(test, feature = "clustering"))]
@@ -201,7 +285,7 @@ impl ClusteringReadiness {
     }
 }
 
-impl Default for ClusteringReadiness {
+impl Default for NodeLifecycle {
     fn default() -> Self {
         Self::new()
     }
@@ -209,16 +293,30 @@ impl Default for ClusteringReadiness {
 
 #[cfg(test)]
 mod readiness_tests {
-    use super::ClusteringReadiness;
+    use super::{CriticalNodeFailure, NodeAdmission, NodeLifecycle};
 
     #[test]
-    fn fatal_latch_immediately_overrides_a_ready_flag() {
-        let readiness = ClusteringReadiness::new();
-        assert!(readiness.is_ready());
-        readiness.fatal_fence_token().cancel();
-        assert!(!readiness.is_ready());
-        readiness.set_ready(true);
-        assert!(!readiness.is_ready());
+    fn failed_latch_overrides_every_later_nonterminal_transition() {
+        let lifecycle = NodeLifecycle::starting();
+        lifecycle.fail(CriticalNodeFailure::RoomRegistryTerminated);
+        lifecycle.serve();
+        lifecycle.begin_drain();
+        lifecycle.serve();
+        assert_eq!(
+            lifecycle.admission(),
+            NodeAdmission::Failed(CriticalNodeFailure::RoomRegistryTerminated)
+        );
+        assert!(!lifecycle.is_ready());
+    }
+
+    #[test]
+    fn only_serving_nodes_issue_admission_permits() {
+        let lifecycle = NodeLifecycle::starting();
+        assert!(lifecycle.admit().is_err());
+        lifecycle.serve();
+        assert!(lifecycle.admit().is_ok());
+        lifecycle.begin_fenced_recovery();
+        assert!(lifecycle.admit().is_err());
     }
 }
 
@@ -597,7 +695,7 @@ pub async fn start_if_enabled(
     config: &ClusteringConfig,
     db: &Database,
     stop_token: &CancellationToken,
-    readiness: ClusteringReadiness,
+    readiness: NodeLifecycle,
 ) -> Result<(ClusteringHandles, ClusteringShutdown), ClusteringError> {
     if !config.enabled {
         return Ok((ClusteringHandles::default(), ClusteringShutdown(None)));

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -159,8 +159,9 @@ pub(crate) fn keypair_slot_table_lock() -> &'static tokio::sync::Mutex<()> {
     LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
-/// Critical local services whose unexpected death makes clustered ownership
-/// unsafe. These are typed operational causes, not XMPP payloads.
+/// Critical local services whose unexpected death makes actor ownership and
+/// socket admission unsafe in every runtime mode. These are typed operational
+/// causes, not XMPP payloads.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CriticalNodeFailure {
     RoomRegistryTerminated,
@@ -195,6 +196,7 @@ impl NodeAdmissionGeneration {
 struct NodeLifecycleState {
     admission: NodeAdmission,
     generation: NodeAdmissionGeneration,
+    generation_revoked: CancellationToken,
 }
 
 /// A successful admission decision for one socket upgrade, bound to the
@@ -204,6 +206,7 @@ struct NodeLifecycleState {
 pub struct NodeAdmissionPermit {
     state: std::sync::Arc<std::sync::RwLock<NodeLifecycleState>>,
     generation: NodeAdmissionGeneration,
+    generation_revoked: CancellationToken,
 }
 
 impl NodeAdmissionPermit {
@@ -222,6 +225,13 @@ impl NodeAdmissionPermit {
             return Err(NodeAdmissionError::Revoked);
         }
         Ok(())
+    }
+
+    /// Resolve as soon as the lifecycle leaves the exact serving generation
+    /// that admitted this socket. The token stays cancelled after recovery,
+    /// so an old transport can never become authoritative again.
+    pub async fn revoked(&self) {
+        self.generation_revoked.cancelled().await;
     }
 }
 
@@ -270,6 +280,7 @@ impl NodeLifecycle {
             state: std::sync::Arc::new(std::sync::RwLock::new(NodeLifecycleState {
                 admission,
                 generation: NodeAdmissionGeneration(0),
+                generation_revoked: CancellationToken::new(),
             })),
             fatal_fence: CancellationToken::new(),
         }
@@ -292,6 +303,7 @@ impl NodeLifecycle {
             NodeAdmission::Serving => Ok(NodeAdmissionPermit {
                 state: std::sync::Arc::clone(&self.state),
                 generation: state.generation,
+                generation_revoked: state.generation_revoked.clone(),
             }),
             _ => Err(NodeAdmissionError::NotServing(state.admission.clone())),
         }
@@ -315,8 +327,10 @@ impl NodeLifecycle {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         match state.admission {
             NodeAdmission::Starting => {
+                state.generation_revoked.cancel();
                 state.admission = NodeAdmission::Serving;
                 state.generation = state.generation.next();
+                state.generation_revoked = CancellationToken::new();
                 StartupServingTransition::Promoted
             }
             NodeAdmission::Serving => StartupServingTransition::AlreadyServing,
@@ -339,8 +353,10 @@ impl NodeLifecycle {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let next = NodeAdmission::Failed(failure);
         if state.admission != next {
+            state.generation_revoked.cancel();
             state.admission = next;
             state.generation = state.generation.next();
+            state.generation_revoked = CancellationToken::new();
         }
         drop(state);
         self.fatal_fence.cancel();
@@ -359,8 +375,10 @@ impl NodeLifecycle {
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if !matches!(state.admission, NodeAdmission::Failed(_)) && state.admission != next {
+            state.generation_revoked.cancel();
             state.admission = next;
             state.generation = state.generation.next();
+            state.generation_revoked = CancellationToken::new();
         }
     }
 
@@ -420,6 +438,39 @@ mod readiness_tests {
             .expect("recovered serving permit")
             .revalidate()
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn old_generation_revocation_stays_latched_after_recovery() {
+        let lifecycle = NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+
+        lifecycle.begin_fenced_recovery();
+        lifecycle.serve();
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), permit.revoked())
+            .await
+            .expect("old permit must remain revoked after recovery");
+        assert_eq!(permit.revalidate(), Err(NodeAdmissionError::Revoked));
+    }
+
+    #[tokio::test]
+    async fn lifecycle_revocation_wins_over_ready_socket_work() {
+        let lifecycle = NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+        lifecycle.begin_fenced_recovery();
+        let mut dispatched = false;
+
+        tokio::select! {
+            biased;
+            _ = permit.revoked() => {}
+            _ = std::future::ready(()) => dispatched = true,
+        }
+
+        assert!(
+            !dispatched,
+            "no stanza may dispatch after generation revocation"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -182,17 +182,65 @@ pub enum NodeAdmission {
     Failed(CriticalNodeFailure),
 }
 
-/// A successful, point-in-time admission decision for one socket upgrade.
-/// The Ecdysis connection guard still owns the connection lifetime; this
-/// permit proves the node was serving immediately before the upgrade began.
-#[derive(Clone, Copy, Debug)]
-pub struct NodeAdmissionPermit;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct NodeAdmissionGeneration(u64);
+
+impl NodeAdmissionGeneration {
+    fn next(self) -> Self {
+        Self(self.0.wrapping_add(1))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct NodeLifecycleState {
+    admission: NodeAdmission,
+    generation: NodeAdmissionGeneration,
+}
+
+/// A successful admission decision for one socket upgrade, bound to the
+/// exact serving generation that issued it. Any lifecycle transition revokes
+/// the permit, including a fence followed by recovery back to `Serving`.
+#[derive(Debug)]
+pub struct NodeAdmissionPermit {
+    state: std::sync::Arc<std::sync::RwLock<NodeLifecycleState>>,
+    generation: NodeAdmissionGeneration,
+}
+
+impl NodeAdmissionPermit {
+    /// Revalidate at the last safe pre-upgrade boundary. This deliberately
+    /// takes only a short read lock: fencing/readiness transitions must never
+    /// wait for an HTTP/WebSocket handshake.
+    pub fn revalidate(&self) -> Result<(), NodeAdmissionError> {
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !matches!(state.admission, NodeAdmission::Serving) {
+            return Err(NodeAdmissionError::NotServing(state.admission.clone()));
+        }
+        if state.generation != self.generation {
+            return Err(NodeAdmissionError::Revoked);
+        }
+        Ok(())
+    }
+}
 
 /// Why an HTTP/XMPP connection was not admitted.
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 pub enum NodeAdmissionError {
     #[error("node is not accepting connections: {0:?}")]
     NotServing(NodeAdmission),
+    #[error("node admission permit was revoked by a lifecycle transition")]
+    Revoked,
+}
+
+/// Result of the one startup-only promotion attempted after every critical
+/// registry supervisor is armed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StartupServingTransition {
+    Promoted,
+    AlreadyServing,
+    Blocked(NodeAdmission),
 }
 
 /// Cloneable lifecycle state shared by readiness, socket admission, and the
@@ -201,7 +249,7 @@ pub enum NodeAdmissionError {
 /// here rather than by a separate readiness boolean.
 #[derive(Clone)]
 pub struct NodeLifecycle {
-    admission: std::sync::Arc<std::sync::RwLock<NodeAdmission>>,
+    state: std::sync::Arc<std::sync::RwLock<NodeLifecycleState>>,
     fatal_fence: CancellationToken,
 }
 
@@ -219,22 +267,33 @@ impl NodeLifecycle {
 
     fn with_admission(admission: NodeAdmission) -> Self {
         Self {
-            admission: std::sync::Arc::new(std::sync::RwLock::new(admission)),
+            state: std::sync::Arc::new(std::sync::RwLock::new(NodeLifecycleState {
+                admission,
+                generation: NodeAdmissionGeneration(0),
+            })),
             fatal_fence: CancellationToken::new(),
         }
     }
 
     pub fn admission(&self) -> NodeAdmission {
-        self.admission
+        self.state
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .admission
             .clone()
     }
 
     pub fn admit(&self) -> Result<NodeAdmissionPermit, NodeAdmissionError> {
-        match self.admission() {
-            NodeAdmission::Serving => Ok(NodeAdmissionPermit),
-            state => Err(NodeAdmissionError::NotServing(state)),
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match state.admission {
+            NodeAdmission::Serving => Ok(NodeAdmissionPermit {
+                state: std::sync::Arc::clone(&self.state),
+                generation: state.generation,
+            }),
+            _ => Err(NodeAdmissionError::NotServing(state.admission.clone())),
         }
     }
 
@@ -246,6 +305,25 @@ impl NodeLifecycle {
         self.transition_nonterminal(NodeAdmission::Serving);
     }
 
+    /// Complete startup only if no fence/drain/failure won the race while
+    /// the HTTP graph was being constructed. Recovery is intentionally a
+    /// separate explicit [`Self::serve`] call after the node re-registers.
+    pub fn finish_startup(&self) -> StartupServingTransition {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match state.admission {
+            NodeAdmission::Starting => {
+                state.admission = NodeAdmission::Serving;
+                state.generation = state.generation.next();
+                StartupServingTransition::Promoted
+            }
+            NodeAdmission::Serving => StartupServingTransition::AlreadyServing,
+            _ => StartupServingTransition::Blocked(state.admission.clone()),
+        }
+    }
+
     pub fn begin_drain(&self) {
         self.transition_nonterminal(NodeAdmission::Draining);
     }
@@ -255,10 +333,16 @@ impl NodeLifecycle {
     }
 
     pub fn fail(&self, failure: CriticalNodeFailure) {
-        *self
-            .admission
+        let mut state = self
+            .state
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = NodeAdmission::Failed(failure);
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let next = NodeAdmission::Failed(failure);
+        if state.admission != next {
+            state.admission = next;
+            state.generation = state.generation.next();
+        }
+        drop(state);
         self.fatal_fence.cancel();
     }
 
@@ -270,12 +354,13 @@ impl NodeLifecycle {
     }
 
     fn transition_nonterminal(&self, next: NodeAdmission) {
-        let mut current = self
-            .admission
+        let mut state = self
+            .state
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if !matches!(*current, NodeAdmission::Failed(_)) {
-            *current = next;
+        if !matches!(state.admission, NodeAdmission::Failed(_)) && state.admission != next {
+            state.admission = next;
+            state.generation = state.generation.next();
         }
     }
 
@@ -293,7 +378,10 @@ impl Default for NodeLifecycle {
 
 #[cfg(test)]
 mod readiness_tests {
-    use super::{CriticalNodeFailure, NodeAdmission, NodeLifecycle};
+    use super::{
+        CriticalNodeFailure, NodeAdmission, NodeAdmissionError, NodeLifecycle,
+        StartupServingTransition,
+    };
 
     #[test]
     fn failed_latch_overrides_every_later_nonterminal_transition() {
@@ -314,9 +402,54 @@ mod readiness_tests {
         let lifecycle = NodeLifecycle::starting();
         assert!(lifecycle.admit().is_err());
         lifecycle.serve();
-        assert!(lifecycle.admit().is_ok());
+        let permit = lifecycle.admit().expect("serving permit");
+        assert!(permit.revalidate().is_ok());
         lifecycle.begin_fenced_recovery();
         assert!(lifecycle.admit().is_err());
+        assert_eq!(
+            permit.revalidate(),
+            Err(NodeAdmissionError::NotServing(
+                NodeAdmission::FencedRecovering
+            ))
+        );
+
+        lifecycle.serve();
+        assert_eq!(permit.revalidate(), Err(NodeAdmissionError::Revoked));
+        assert!(lifecycle
+            .admit()
+            .expect("recovered serving permit")
+            .revalidate()
+            .is_ok());
+    }
+
+    #[test]
+    fn startup_promotion_cannot_overwrite_fencing_or_failure() {
+        let lifecycle = NodeLifecycle::starting();
+        assert_eq!(
+            lifecycle.finish_startup(),
+            StartupServingTransition::Promoted
+        );
+        assert_eq!(
+            lifecycle.finish_startup(),
+            StartupServingTransition::AlreadyServing
+        );
+
+        let fenced = NodeLifecycle::starting();
+        fenced.begin_fenced_recovery();
+        assert_eq!(
+            fenced.finish_startup(),
+            StartupServingTransition::Blocked(NodeAdmission::FencedRecovering)
+        );
+        assert_eq!(fenced.admission(), NodeAdmission::FencedRecovering);
+
+        let failed = NodeLifecycle::starting();
+        failed.fail(CriticalNodeFailure::UserRegistryTerminated);
+        assert_eq!(
+            failed.finish_startup(),
+            StartupServingTransition::Blocked(NodeAdmission::Failed(
+                CriticalNodeFailure::UserRegistryTerminated
+            ))
+        );
     }
 }
 

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -903,6 +903,7 @@ async fn run_pre_ready_heartbeat<L>(
     identity: NodeIdentity,
     cancel: CancellationToken,
     fatal_fence: CancellationToken,
+    readiness: NodeLifecycle,
     heartbeat_interval: Duration,
     lease_ttl: Duration,
 ) where
@@ -930,6 +931,7 @@ async fn run_pre_ready_heartbeat<L>(
                 match result {
                     Ok(Ok(true)) => {}
                     Ok(Ok(false)) | Ok(Err(_)) | Err(_) => {
+                        readiness.begin_fenced_recovery();
                         fatal_fence.cancel();
                         return;
                     }
@@ -1477,6 +1479,7 @@ pub async fn run_node_lease<L>(
                             identity.clone(),
                             recovery_heartbeat_cancel.clone(),
                             fatal_fence.clone(),
+                            readiness.clone(),
                             config.heartbeat_interval,
                             config.lease_ttl,
                         ));
@@ -1616,6 +1619,7 @@ pub async fn run_node_lease<L>(
                             result = final_heartbeat => matches!(result, Ok(Ok(true))),
                         };
                         if !heartbeat_is_fresh {
+                            readiness.begin_fenced_recovery();
                             fatal_fence.cancel();
                             terminal_fence_context
                                 .finish(&superseded_identity, &identity)

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -33,7 +33,7 @@ use waddle_xmpp::ownership::{
 
 use super::claims::NodeLeaseStore;
 use super::metrics;
-use super::ClusteringReadiness;
+use super::NodeLifecycle;
 use crate::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
 
 /// Readable snapshot of the swarm's current connected-peer count (Phase 2
@@ -389,7 +389,7 @@ pub struct NodeLeaseRunConfig {
     pub self_fence_config: ClusteringSelfFenceConfig,
     pub connected_peers: ConnectedPeerCount,
     pub local_claims: Arc<dyn LocallyClaimedEntities>,
-    pub readiness: ClusteringReadiness,
+    pub readiness: NodeLifecycle,
     /// FIX 4(b) (ADR-0017 Phase 3 Slice 5 corrigenda, council-adjudicated):
     /// the same `ClaimStore` handle every other clustering-aware call site
     /// binds — never a second, independent store — used by the
@@ -806,7 +806,7 @@ struct TerminalFenceContext<'a, L> {
     lease: &'a L,
     live_identity: &'a SharedNodeIdentity,
     local_claims: &'a Arc<dyn LocallyClaimedEntities>,
-    readiness: &'a ClusteringReadiness,
+    readiness: &'a NodeLifecycle,
     stop_token: &'a CancellationToken,
     fatal_fence: &'a CancellationToken,
     control_plane_budget: Duration,
@@ -827,7 +827,7 @@ where
         // admitting traffic and NEW claims first, but keep the current
         // identity authoritative while mailbox seal barriers complete the
         // final fenced writes for already-owned rooms.
-        self.readiness.set_ready(false);
+        self.readiness.begin_fenced_recovery();
         if self.fatal_fence.is_cancelled() {
             self.finish(identity, identity).await;
             return;
@@ -875,7 +875,7 @@ where
     }
 
     async fn finish(&self, prior_identity: &NodeIdentity, registered_identity: &NodeIdentity) {
-        self.readiness.set_ready(false);
+        self.readiness.begin_fenced_recovery();
         self.stop_token.cancel();
 
         // A registration call is deliberately allowed to finish instead of
@@ -1309,7 +1309,7 @@ pub async fn run_node_lease<L>(
         // demotion sweep complete even while recovery workers are winding
         // down.
         if terminal_fence {
-            readiness.set_ready(false);
+            readiness.begin_fenced_recovery();
             stop_token.cancel();
             let superseded_identity = identity.clone();
             live_identity.disable().await;
@@ -1321,7 +1321,7 @@ pub async fn run_node_lease<L>(
         for entity in local_claims.owned().await {
             local_claims.demote(&entity).await;
         }
-        readiness.set_ready(false);
+        readiness.begin_fenced_recovery();
         isolation.reset();
 
         // FIX 1(b): best-effort mark the just-fenced identity's row
@@ -1631,9 +1631,9 @@ pub async fn run_node_lease<L>(
                                 .await;
                             return;
                         }
-                        readiness.set_ready(true);
+                        readiness.serve();
                         if fatal_fence.is_cancelled() {
-                            readiness.set_ready(false);
+                            readiness.begin_fenced_recovery();
                             terminal_fence_context
                                 .finish(&superseded_identity, &identity)
                                 .await;
@@ -1986,7 +1986,7 @@ mod tests {
                 "simulated Postgres partition".to_string(),
             ))
         }));
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2033,7 +2033,7 @@ mod tests {
         let interval = Duration::from_millis(50);
         let lease_ttl = Duration::from_secs(10);
         let lease = FakeLease::new(Box::new(|| Ok(false)));
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2084,7 +2084,7 @@ mod tests {
             }
         }));
         let draining_calls = Arc::clone(&lease.draining_calls);
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity());
         let task = tokio::spawn(run_node_lease(
@@ -2157,7 +2157,7 @@ mod tests {
         lease.other_live_nodes.store(1, Ordering::SeqCst);
         let registered_node_ids = Arc::clone(&lease.registered_node_ids);
         let registrations = Arc::clone(&lease.registrations);
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2340,7 +2340,7 @@ mod tests {
         let interval = Duration::from_millis(80);
         let lease_ttl = Duration::from_millis(300);
         let connected_peers = ConnectedPeerCount::new();
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
 
         let task_store = PostgresClaimStore::new(db.clone());
@@ -2765,7 +2765,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2834,7 +2834,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2904,7 +2904,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -2977,7 +2977,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         tokio::spawn(run_node_lease(
             lease,
@@ -3050,7 +3050,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let fatal_fence = readiness.fatal_fence_token();
         let stop_token = CancellationToken::new();
         let initial_identity = identity();
@@ -3130,7 +3130,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let fatal_fence = readiness.fatal_fence_token();
         let stop_token = CancellationToken::new();
         let task = tokio::spawn(run_node_lease(
@@ -3206,7 +3206,7 @@ mod tests {
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         let task = tokio::spawn(run_node_lease(
             lease,
@@ -3271,7 +3271,7 @@ mod tests {
             seal_release,
             exact_demoted_owners: Arc::clone(&exact_demoted_owners),
         });
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let fatal_fence = readiness.fatal_fence_token();
         let stop_token = CancellationToken::new();
         let task = tokio::spawn(run_node_lease(
@@ -3363,7 +3363,7 @@ mod tests {
                 },
                 connected_peers: ConnectedPeerCount::new(),
                 local_claims,
-                readiness: ClusteringReadiness::new(),
+                readiness: NodeLifecycle::new(),
                 live_identity: live_identity.clone(),
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
@@ -3626,7 +3626,7 @@ mod tests {
         let interval = Duration::from_millis(80);
         let lease_ttl = Duration::from_millis(300);
         let connected_peers = ConnectedPeerCount::new();
-        let readiness = ClusteringReadiness::new();
+        let readiness = NodeLifecycle::new();
         let stop_token = CancellationToken::new();
         let hydrated = FakeLocalClaims::unhydrated();
         let live_identity =

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -1301,6 +1301,12 @@ pub async fn run_node_lease<L>(
             }
         }
 
+        // Revoke readiness and every admitted transport synchronously before
+        // asking any actor for its ownership snapshot. Those asks and the
+        // following demotions are best-effort and may stall; a node whose
+        // lease is no longer proven must stop serving first.
+        readiness.begin_fenced_recovery();
+
         // Fatal recovery ambiguity is terminal for this clustering lifetime.
         // Disable the shared identity before taking the final ownership
         // snapshot: `rotate` waits for every old-identity publication guard,
@@ -1309,7 +1315,6 @@ pub async fn run_node_lease<L>(
         // demotion sweep complete even while recovery workers are winding
         // down.
         if terminal_fence {
-            readiness.begin_fenced_recovery();
             stop_token.cancel();
             let superseded_identity = identity.clone();
             live_identity.disable().await;
@@ -1321,7 +1326,6 @@ pub async fn run_node_lease<L>(
         for entity in local_claims.owned().await {
             local_claims.demote(&entity).await;
         }
-        readiness.begin_fenced_recovery();
         isolation.reset();
 
         // FIX 1(b): best-effort mark the just-fenced identity's row
@@ -2070,6 +2074,65 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn fencing_revokes_readiness_and_socket_admission_before_claim_inventory_stalls() {
+        let interval = Duration::from_millis(50);
+        let readiness = NodeLifecycle::new();
+        let old_permit = readiness.admit().expect("initial serving permit");
+        let owned_started = Arc::new(tokio::sync::Notify::new());
+        let owned_release = Arc::new(tokio::sync::Notify::new());
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            FakeLease::new(Box::new(|| Ok(false))),
+            identity(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims: Arc::new(BlockingOwnedLocalClaims {
+                    owned_started: Arc::clone(&owned_started),
+                    owned_release: Arc::clone(&owned_release),
+                    block_once: AtomicBool::new(false),
+                }),
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::time::advance(interval).await;
+        owned_started.notified().await;
+
+        assert_eq!(
+            readiness.admission(),
+            crate::clustering::NodeAdmission::FencedRecovering
+        );
+        assert!(!readiness.is_ready(), "/ready must close before actor asks");
+        assert!(
+            readiness.admit().is_err(),
+            "/ws must reject before actor asks"
+        );
+        tokio::time::timeout(Duration::from_millis(1), old_permit.revoked())
+            .await
+            .expect("established socket generation must revoke before actor asks");
+
+        stop_token.cancel();
+        owned_release.notify_one();
+        task.await.expect("lease worker exits");
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn node_lease_re_registers_and_restores_readiness_after_a_fence() {
         let interval = Duration::from_millis(50);
         let lease_ttl = Duration::from_millis(150);
@@ -2598,6 +2661,29 @@ mod tests {
         seal_started: Arc<tokio::sync::Notify>,
         seal_release: Arc<tokio::sync::Notify>,
         exact_demoted_owners: Arc<std::sync::Mutex<Vec<NodeIdentity>>>,
+    }
+
+    struct BlockingOwnedLocalClaims {
+        owned_started: Arc<tokio::sync::Notify>,
+        owned_release: Arc<tokio::sync::Notify>,
+        block_once: AtomicBool,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for BlockingOwnedLocalClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            if !self.block_once.swap(true, Ordering::SeqCst) {
+                self.owned_started.notify_one();
+                self.owned_release.notified().await;
+            }
+            Vec::new()
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
     }
 
     #[async_trait]

--- a/server/crates/waddle-server/src/server/health.rs
+++ b/server/crates/waddle-server/src/server/health.rs
@@ -153,15 +153,16 @@ pub(crate) async fn health_handler(State(state): State<Arc<AppState>>) -> impl I
 /// node. Non-clustering deployments never flip this signal, so it is
 /// always ready — today's behavior, unchanged.
 pub(crate) async fn readiness_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    if !state.clustering_readiness.is_ready() {
-        warn!("Readiness check: this node has self-fenced its clustering claims");
+    if !state.node_lifecycle.is_ready() {
+        let admission = state.node_lifecycle.admission();
+        warn!(?admission, "Readiness check: node is not admitting clients");
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({
                 "status": "not_ready",
                 "service": "waddle-server",
                 "version": env!("CARGO_PKG_VERSION"),
-                "clustering": "self-fenced"
+                "admission": format!("{admission:?}")
             })),
         );
     }

--- a/server/crates/waddle-server/src/server/health.rs
+++ b/server/crates/waddle-server/src/server/health.rs
@@ -242,6 +242,55 @@ pub(crate) async fn metrics_handler() -> impl IntoResponse {
     )
 }
 
+/// Detailed health check endpoint (for monitoring)
+pub(crate) async fn detailed_health_handler(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    match state.db_pool.health_check().await {
+        Ok(health) => {
+            let status = if health.is_healthy() {
+                "healthy"
+            } else {
+                "degraded"
+            };
+            let status_code = if health.is_healthy() {
+                StatusCode::OK
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE
+            };
+
+            (
+                status_code,
+                Json(DetailedHealthResponse {
+                    status: status.to_string(),
+                    service: "waddle-server".to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    license: "AGPL-3.0".to_string(),
+                    database: health.into(),
+                }),
+            )
+        }
+        Err(e) => {
+            warn!("Detailed health check failed: {}", e);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(DetailedHealthResponse {
+                    status: "unhealthy".to_string(),
+                    service: "waddle-server".to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    license: "AGPL-3.0".to_string(),
+                    database: DatabaseHealthStatus {
+                        status: format!("error: {}", e),
+                        global_healthy: false,
+                        waddle_dbs_healthy: false,
+                        loaded_waddle_count: 0,
+                    },
+                }),
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod readiness_generation_tests {
     use super::*;
@@ -315,54 +364,5 @@ mod readiness_generation_tests {
         assert!(health_for_serving_generation(&lifecycle, async { true })
             .await
             .expect("serving generation"));
-    }
-}
-
-/// Detailed health check endpoint (for monitoring)
-pub(crate) async fn detailed_health_handler(
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    match state.db_pool.health_check().await {
-        Ok(health) => {
-            let status = if health.is_healthy() {
-                "healthy"
-            } else {
-                "degraded"
-            };
-            let status_code = if health.is_healthy() {
-                StatusCode::OK
-            } else {
-                StatusCode::SERVICE_UNAVAILABLE
-            };
-
-            (
-                status_code,
-                Json(DetailedHealthResponse {
-                    status: status.to_string(),
-                    service: "waddle-server".to_string(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    license: "AGPL-3.0".to_string(),
-                    database: health.into(),
-                }),
-            )
-        }
-        Err(e) => {
-            warn!("Detailed health check failed: {}", e);
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(DetailedHealthResponse {
-                    status: "unhealthy".to_string(),
-                    service: "waddle-server".to_string(),
-                    version: env!("CARGO_PKG_VERSION").to_string(),
-                    license: "AGPL-3.0".to_string(),
-                    database: DatabaseHealthStatus {
-                        status: format!("error: {}", e),
-                        global_healthy: false,
-                        waddle_dbs_healthy: false,
-                        loaded_waddle_count: 0,
-                    },
-                }),
-            )
-        }
     }
 }

--- a/server/crates/waddle-server/src/server/health.rs
+++ b/server/crates/waddle-server/src/server/health.rs
@@ -142,6 +142,33 @@ pub(crate) async fn health_handler(State(state): State<Arc<AppState>>) -> impl I
     }
 }
 
+async fn health_for_serving_generation<T>(
+    lifecycle: &crate::clustering::NodeLifecycle,
+    health_check: impl std::future::Future<Output = T>,
+) -> Result<T, crate::clustering::NodeAdmissionError> {
+    let permit = lifecycle.admit()?;
+    let health = health_check.await;
+    permit.revalidate()?;
+    Ok(health)
+}
+
+fn lifecycle_not_ready_response(
+    lifecycle: &crate::clustering::NodeLifecycle,
+    error: &crate::clustering::NodeAdmissionError,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let admission = lifecycle.admission();
+    warn!(?admission, %error, "Readiness check: node is not admitting clients");
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "status": "not_ready",
+            "service": "waddle-server",
+            "version": env!("CARGO_PKG_VERSION"),
+            "admission": format!("{admission:?}")
+        })),
+    )
+}
+
 /// Readiness check endpoint (for orchestrators).
 ///
 /// Readiness is stricter than liveness and validates overall DB pool health
@@ -150,24 +177,12 @@ pub(crate) async fn health_handler(State(state): State<Arc<AppState>>) -> impl I
 /// lost, or Postgres unreachable past the lease deadline) must not stay in
 /// the client Service/Ingress endpoint set — clients whose sockets it just
 /// closed would otherwise be routed straight back to the still-refusing
-/// node. Non-clustering deployments never flip this signal, so it is
-/// always ready — today's behavior, unchanged.
+/// node. The same lifecycle also fails closed when a critical local actor
+/// terminates in a single-node deployment.
 pub(crate) async fn readiness_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    if !state.node_lifecycle.is_ready() {
-        let admission = state.node_lifecycle.admission();
-        warn!(?admission, "Readiness check: node is not admitting clients");
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({
-                "status": "not_ready",
-                "service": "waddle-server",
-                "version": env!("CARGO_PKG_VERSION"),
-                "admission": format!("{admission:?}")
-            })),
-        );
-    }
-    match state.db_pool.health_check().await {
-        Ok(health) if health.is_healthy() => (
+    match health_for_serving_generation(&state.node_lifecycle, state.db_pool.health_check()).await {
+        Err(error) => lifecycle_not_ready_response(&state.node_lifecycle, &error),
+        Ok(Ok(health)) if health.is_healthy() => (
             StatusCode::OK,
             Json(json!({
                 "status": "ready",
@@ -176,7 +191,7 @@ pub(crate) async fn readiness_handler(State(state): State<Arc<AppState>>) -> imp
                 "database": "ready"
             })),
         ),
-        Ok(health) => {
+        Ok(Ok(health)) => {
             warn!(
                 global_healthy = health.global_healthy,
                 waddle_dbs_healthy = health.waddle_dbs_healthy,
@@ -198,7 +213,7 @@ pub(crate) async fn readiness_handler(State(state): State<Arc<AppState>>) -> imp
                 })),
             )
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             warn!(error = %e, "Readiness check failed");
             (
                 StatusCode::SERVICE_UNAVAILABLE,
@@ -225,6 +240,82 @@ pub(crate) async fn metrics_handler() -> impl IntoResponse {
         )],
         waddle_xmpp::prometheus::render_metrics(),
     )
+}
+
+#[cfg(test)]
+mod readiness_generation_tests {
+    use super::*;
+
+    async fn assert_transition_during_health_returns_unavailable(
+        transition: impl FnOnce(&crate::clustering::NodeLifecycle),
+    ) -> crate::clustering::NodeAdmissionError {
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        let worker_lifecycle = lifecycle.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let worker = tokio::spawn(async move {
+            health_for_serving_generation(&worker_lifecycle, async move {
+                let _ = started_tx.send(());
+                let _ = release_rx.await;
+                true
+            })
+            .await
+        });
+
+        started_rx.await.expect("health check started");
+        transition(&lifecycle);
+        let _ = release_tx.send(());
+        let error = worker
+            .await
+            .expect("health race task")
+            .expect_err("changed serving generation must not become ready");
+
+        assert_eq!(
+            lifecycle_not_ready_response(&lifecycle, &error)
+                .into_response()
+                .status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        error
+    }
+
+    #[tokio::test]
+    async fn fence_during_database_health_cannot_return_ready() {
+        let _ = assert_transition_during_health_returns_unavailable(|lifecycle| {
+            lifecycle.begin_fenced_recovery();
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn critical_failure_during_database_health_cannot_return_ready() {
+        let _ = assert_transition_during_health_returns_unavailable(|lifecycle| {
+            lifecycle.fail(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fence_and_recovery_during_database_health_revokes_old_readiness_probe() {
+        let error = assert_transition_during_health_returns_unavailable(|lifecycle| {
+            lifecycle.begin_fenced_recovery();
+            lifecycle.serve();
+            assert_eq!(
+                lifecycle.admission(),
+                crate::clustering::NodeAdmission::Serving
+            );
+        })
+        .await;
+        assert_eq!(error, crate::clustering::NodeAdmissionError::Revoked);
+    }
+
+    #[tokio::test]
+    async fn healthy_database_in_same_serving_generation_is_ready() {
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        assert!(health_for_serving_generation(&lifecycle, async { true })
+            .await
+            .expect("serving generation"));
+    }
 }
 
 /// Detailed health check endpoint (for monitoring)

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -55,6 +55,26 @@ pub(crate) struct HttpServerDeps {
     pub(crate) drain_complete: Arc<tokio::sync::Notify>,
 }
 
+const HTTP_FORCED_EXIT_MARGIN: std::time::Duration = std::time::Duration::from_secs(1);
+
+async fn await_http_server_or_forced_exit<F, T>(
+    server: F,
+    stop_token: tokio_util::sync::CancellationToken,
+    drain_timeout: std::time::Duration,
+) -> Option<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::pin!(server);
+    tokio::select! {
+        result = server.as_mut() => Some(result),
+        _ = async {
+            stop_token.cancelled().await;
+            tokio::time::sleep(drain_timeout + HTTP_FORCED_EXIT_MARGIN).await;
+        } => None,
+    }
+}
+
 /// Start the HTTP server with graceful shutdown support.
 pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
     let HttpServerDeps {
@@ -70,6 +90,8 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
     } = deps;
 
     let stop_token = shutdown_handle.stop_token();
+    let force_stop_token = stop_token.clone();
+    let drain_timeout = shutdown_handle.drain_timeout();
     let app = create_router(RouterDeps {
         state,
         server_config,
@@ -93,14 +115,31 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         }
     }
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            stop_token.cancelled().await;
-            info!("HTTP server received shutdown signal; awaiting SM Q6 drain");
-            drain_complete.notified().await;
+    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+        stop_token.cancelled().await;
+        info!("HTTP server received shutdown signal; awaiting SM Q6 drain");
+        if tokio::time::timeout(drain_timeout, drain_complete.notified())
+            .await
+            .is_err()
+        {
+            warn!(
+                timeout_secs = drain_timeout.as_secs(),
+                "HTTP server: SM drain notification timed out; forcing connection drain"
+            );
+        } else {
             info!("HTTP server: SM drain complete; draining connections");
-        })
-        .await?;
+        }
+    });
+    match await_http_server_or_forced_exit(server, force_stop_token, drain_timeout).await {
+        Some(result) => result?,
+        None => {
+            warn!(
+                timeout_secs = drain_timeout.as_secs(),
+                margin_secs = HTTP_FORCED_EXIT_MARGIN.as_secs(),
+                "HTTP graceful shutdown exceeded its absolute deadline; terminating remaining connection tasks"
+            );
+        }
+    }
 
     Ok(())
 }
@@ -1217,4 +1256,37 @@ fn env_flag(key: &str) -> bool {
             )
         })
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod shutdown_bound_tests {
+    use super::await_http_server_or_forced_exit;
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_connection_work_cannot_outlive_http_shutdown_deadline() {
+        let stop = tokio_util::sync::CancellationToken::new();
+        stop.cancel();
+
+        let outcome = await_http_server_or_forced_exit(
+            std::future::pending::<()>(),
+            stop,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(outcome.is_none());
+    }
+
+    #[tokio::test]
+    async fn completed_http_server_wins_before_forced_exit() {
+        let stop = tokio_util::sync::CancellationToken::new();
+        let outcome = await_http_server_or_forced_exit(
+            std::future::ready(7_u8),
+            stop,
+            std::time::Duration::from_secs(30),
+        )
+        .await;
+
+        assert_eq!(outcome, Some(7));
+    }
 }

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -24,6 +24,7 @@ use anyhow::Result;
 use axum::{middleware, routing::get, Router};
 use rustls_acme::tower::TowerHttp01ChallengeService;
 use sqlx::sqlite::SqliteConnectOptions;
+use std::future::IntoFuture as _;
 use std::str::FromStr;
 use std::sync::Arc;
 use tower_http::{compression::CompressionLayer, trace::TraceLayer};
@@ -115,21 +116,23 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         }
     }
 
-    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
-        stop_token.cancelled().await;
-        info!("HTTP server received shutdown signal; awaiting SM Q6 drain");
-        if tokio::time::timeout(drain_timeout, drain_complete.notified())
-            .await
-            .is_err()
-        {
-            warn!(
-                timeout_secs = drain_timeout.as_secs(),
-                "HTTP server: SM drain notification timed out; forcing connection drain"
-            );
-        } else {
-            info!("HTTP server: SM drain complete; draining connections");
-        }
-    });
+    let server = axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            stop_token.cancelled().await;
+            info!("HTTP server received shutdown signal; awaiting SM Q6 drain");
+            if tokio::time::timeout(drain_timeout, drain_complete.notified())
+                .await
+                .is_err()
+            {
+                warn!(
+                    timeout_secs = drain_timeout.as_secs(),
+                    "HTTP server: SM drain notification timed out; forcing connection drain"
+                );
+            } else {
+                info!("HTTP server: SM drain complete; draining connections");
+            }
+        })
+        .into_future();
     match await_http_server_or_forced_exit(server, force_stop_token, drain_timeout).await {
         Some(result) => result?,
         None => {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -289,9 +289,20 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
 
     spawn_critical_registry_supervisor(&websocket_state);
     // Both critical registries now have lifetime supervision. Only after
-    // that fence is armed may this node transition from `Starting` to
-    // `Serving` and admit WebSocket upgrades.
-    websocket_state.deps.app_state.node_lifecycle.serve();
+    // that fence is armed may a node still in `Starting` transition to
+    // `Serving`. A lease fence/drain/failure that won during slow startup
+    // remains authoritative until its own recovery path explicitly serves.
+    if let crate::clustering::StartupServingTransition::Blocked(admission) = websocket_state
+        .deps
+        .app_state
+        .node_lifecycle
+        .finish_startup()
+    {
+        warn!(
+            ?admission,
+            "HTTP graph completed after node admission left Starting; preserving non-serving state"
+        );
+    }
     spawn_sm_expiry_janitor(&websocket_state);
     spawn_orphan_reaper_janitor(
         &websocket_state,

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -12,10 +12,10 @@ use crate::server::routes::websocket::{
     ProtocolServices, WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 use crate::server::session_janitors::{
-    spawn_auth_state_janitor, spawn_graceful_shutdown_drain, spawn_notification_outbox_janitor,
-    spawn_orphan_reaper_janitor, spawn_pending_delivery_claim_janitor,
-    spawn_push_service_publish_job_janitor, spawn_room_dormancy_janitor, spawn_sm_expiry_janitor,
-    spawn_user_actor_reaper,
+    spawn_auth_state_janitor, spawn_critical_registry_supervisor, spawn_graceful_shutdown_drain,
+    spawn_notification_outbox_janitor, spawn_orphan_reaper_janitor,
+    spawn_pending_delivery_claim_janitor, spawn_push_service_publish_job_janitor,
+    spawn_room_dormancy_janitor, spawn_sm_expiry_janitor, spawn_user_actor_reaper,
 };
 use crate::server::topology::bootstrap_fresh_xmpp_topology;
 use crate::server::trace::{attach_http_route_template, make_request_span, observe_http_response};
@@ -287,6 +287,11 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         });
     }
 
+    spawn_critical_registry_supervisor(&websocket_state);
+    // Both critical registries now have lifetime supervision. Only after
+    // that fence is armed may this node transition from `Starting` to
+    // `Serving` and admit WebSocket upgrades.
+    websocket_state.deps.app_state.node_lifecycle.serve();
     spawn_sm_expiry_janitor(&websocket_state);
     spawn_orphan_reaper_janitor(
         &websocket_state,

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -287,7 +287,7 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         });
     }
 
-    spawn_critical_registry_supervisor(&websocket_state);
+    spawn_critical_registry_supervisor(&websocket_state).await;
     // Both critical registries now have lifetime supervision. Only after
     // that fence is armed may a node still in `Starting` transition to
     // `Serving`. A lease fence/drain/failure that won during slow startup

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -194,8 +194,16 @@ pub async fn start_with_config(
     // self-fencing loop, gated behind `clustering.enabled` + the
     // `clustering` build feature + the Postgres control plane. A no-op when
     // disabled — the default single-replica path is byte-for-byte unchanged,
-    // and `clustering_readiness` simply never flips (stays ready forever).
-    let clustering_readiness = crate::clustering::ClusteringReadiness::new();
+    // and the typed node lifecycle simply stays serving after startup.
+    let node_lifecycle = crate::clustering::NodeLifecycle::starting();
+    let lifecycle_on_shutdown = node_lifecycle.clone();
+    let stop_token_for_lifecycle = stop_token.clone();
+    tokio::spawn(async move {
+        stop_token_for_lifecycle.cancelled().await;
+        // A critical-service failure has already latched `Failed`; ordinary
+        // Ecdysis shutdowns become `Draining` and are intentionally nonfatal.
+        lifecycle_on_shutdown.begin_drain();
+    });
     // ADR-0017 Phase 3 Slice 10: `clustering_shutdown` is awaited after the
     // HTTP server exits below — see that await's own comment for why this
     // node's graceful per-entity claim drain must complete before process
@@ -204,7 +212,7 @@ pub async fn start_with_config(
         &server_config.clustering,
         db_pool.global(),
         &stop_token,
-        clustering_readiness.clone(),
+        node_lifecycle.clone(),
     )
     .await?;
 
@@ -262,7 +270,7 @@ pub async fn start_with_config(
         occupant_id_secret: server_config.occupant_id_secret.clone(),
         permission_actor: permission_actor.clone(),
         server_owner_jids,
-        clustering_readiness,
+        node_lifecycle: node_lifecycle.clone(),
         clustering_claims: clustering_handles,
     }));
     // ADR-0017 Phase 3 Slice 7 FIX 1: co-location-check MAM storage against
@@ -377,7 +385,12 @@ pub async fn start_with_config(
     shutdown_handle.abort();
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), shutdown_handle).await;
     info!("Graceful shutdown complete");
-    result.map(|()| metrics_flush)
+    match node_lifecycle.critical_failure() {
+        Some(failure) => Err(anyhow::anyhow!(
+            "critical clustered service terminated; node fenced and drained: {failure:?}"
+        )),
+        None => result.map(|()| metrics_flush),
+    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -387,7 +387,7 @@ pub async fn start_with_config(
     info!("Graceful shutdown complete");
     match node_lifecycle.critical_failure() {
         Some(failure) => Err(anyhow::anyhow!(
-            "critical clustered service terminated; node fenced and drained: {failure:?}"
+            "critical actor service terminated; node fenced and drained: {failure:?}"
         )),
         None => result.map(|()| metrics_flush),
     }

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -55,7 +55,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         occupant_id_secret,
         permission_actor,
         server_owner_jids: Arc::from(Vec::<jid::BareJid>::new()),
-        clustering_readiness: crate::clustering::ClusteringReadiness::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
         clustering_claims: crate::clustering::ClusteringHandles::default(),
     }));
 

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -12,7 +12,7 @@
 //! `ack_threshold`th countable stanza with an `<r/>` (XEP-0198 §4
 //! permits requesting acks at any time).
 
-use super::send::send_ws_message;
+use super::send::{send_ws_message_with_authority, AuthoritySendOutcome};
 use super::state::WsConnState;
 use super::stream_management::{apply_sm_ack, is_countable_stanza};
 use super::*;
@@ -138,21 +138,10 @@ where
     S: Sink<Message, Error = E> + Unpin,
     E: std::fmt::Display,
 {
-    if !batch_authoritative(authority) {
-        return Err(SendWindowOutcome::AuthorityRevoked);
-    }
-    let send = send_ws_message(sender, message, failure_message);
-    tokio::pin!(send);
-    tokio::select! {
-        biased;
-        _ = batch_authority_revoked(authority) => Err(SendWindowOutcome::AuthorityRevoked),
-        sent = send.as_mut() => {
-            if sent {
-                Ok(())
-            } else {
-                Err(SendWindowOutcome::TransportClosed)
-            }
-        }
+    match send_ws_message_with_authority(sender, message, failure_message, authority).await {
+        AuthoritySendOutcome::Sent => Ok(()),
+        AuthoritySendOutcome::TransportClosed => Err(SendWindowOutcome::TransportClosed),
+        AuthoritySendOutcome::AuthorityRevoked => Err(SendWindowOutcome::AuthorityRevoked),
     }
 }
 
@@ -257,29 +246,47 @@ where
         if !batch_authoritative(authority) {
             return BatchWriteOutcome::AuthorityRevoked;
         }
-        if !send_ws_message(
+        if let Err(outcome) = send_window_message(
             sender,
             Message::Text(frame.into()),
             "Failed to send WebSocket message",
+            authority,
         )
         .await
         {
-            record_remaining_for_replay(conn, frames, policy);
-            return BatchWriteOutcome::TransportClosed;
+            return match outcome {
+                SendWindowOutcome::TransportClosed => {
+                    record_remaining_for_replay(conn, frames, policy);
+                    BatchWriteOutcome::TransportClosed
+                }
+                SendWindowOutcome::AuthorityRevoked => BatchWriteOutcome::AuthorityRevoked,
+                SendWindowOutcome::Recovered
+                | SendWindowOutcome::DeferredCapReached
+                | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
+            };
         }
         if request_ack {
             if !batch_authoritative(authority) {
                 return BatchWriteOutcome::AuthorityRevoked;
             }
-            if !send_ws_message(
+            if let Err(outcome) = send_window_message(
                 sender,
                 Message::Text(SmRequest::to_xml().into()),
                 "Failed to send SM <r/> request",
+                authority,
             )
             .await
             {
-                record_remaining_for_replay(conn, frames, policy);
-                return BatchWriteOutcome::TransportClosed;
+                return match outcome {
+                    SendWindowOutcome::TransportClosed => {
+                        record_remaining_for_replay(conn, frames, policy);
+                        BatchWriteOutcome::TransportClosed
+                    }
+                    SendWindowOutcome::AuthorityRevoked => BatchWriteOutcome::AuthorityRevoked,
+                    SendWindowOutcome::Recovered
+                    | SendWindowOutcome::DeferredCapReached
+                    | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
+                };
             }
             // Give already-arrived inbound frames a chance to land:
             // `<a/>` acks shrink the unacked queue mid-flood instead
@@ -616,14 +623,23 @@ where
                         if !batch_authoritative(authority) {
                             return DrainSignal::AuthorityRevoked;
                         }
-                        if !send_ws_message(
+                        if let Err(outcome) = send_window_message(
                             sender,
                             Message::Text(response.into()),
                             "Failed to send SM ack stream error",
+                            authority,
                         )
                         .await
                         {
-                            return DrainSignal::TransportClosed;
+                            return match outcome {
+                                SendWindowOutcome::TransportClosed => DrainSignal::TransportClosed,
+                                SendWindowOutcome::AuthorityRevoked => {
+                                    DrainSignal::AuthorityRevoked
+                                }
+                                SendWindowOutcome::Recovered
+                                | SendWindowOutcome::DeferredCapReached
+                                | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
+                            };
                         }
                     }
                     if conn.phase.is_closing() {
@@ -635,8 +651,21 @@ where
             }
             Some(Ok(Message::Ping(data))) => {
                 conn.note_transport_activity();
-                if !send_ws_message(sender, Message::Pong(data), "Failed to send pong").await {
-                    return DrainSignal::TransportClosed;
+                if let Err(outcome) = send_window_message(
+                    sender,
+                    Message::Pong(data),
+                    "Failed to send pong",
+                    authority,
+                )
+                .await
+                {
+                    return match outcome {
+                        SendWindowOutcome::TransportClosed => DrainSignal::TransportClosed,
+                        SendWindowOutcome::AuthorityRevoked => DrainSignal::AuthorityRevoked,
+                        SendWindowOutcome::Recovered
+                        | SendWindowOutcome::DeferredCapReached
+                        | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
+                    };
                 }
             }
             Some(Ok(Message::Pong(_))) | Some(Ok(Message::Binary(_))) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -196,10 +196,11 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
+    let mut frames = frames.into_iter();
     if !batch_authoritative(authority) {
+        record_remaining_for_replay(conn, frames, policy);
         return BatchWriteOutcome::AuthorityRevoked;
     }
-    let mut frames = frames.into_iter();
     // Send-window pacing applies ONLY to batches that actually grow the SM
     // unacked queue (issue #1219 review). A `ReplaySuppressed` batch is the
     // XEP-0198 resume replay: its stanzas are ALREADY in the restored unacked
@@ -231,19 +232,25 @@ where
                 record_remaining_for_replay(conn, frames, policy);
                 return BatchWriteOutcome::TransportClosed;
             }
-            SendWindowOutcome::AuthorityRevoked => return BatchWriteOutcome::AuthorityRevoked,
+            SendWindowOutcome::AuthorityRevoked => {
+                record_remaining_for_replay(conn, frames, policy);
+                return BatchWriteOutcome::AuthorityRevoked;
+            }
         }
     }
     while let Some(frame) = frames.next() {
         if !batch_authoritative(authority) {
+            record_current_and_remaining_for_replay(conn, frame, frames, policy, false);
             return BatchWriteOutcome::AuthorityRevoked;
         }
-        let request_ack = if should_record(conn, &frame, policy) {
+        let current_recorded = should_record(conn, &frame, policy);
+        let request_ack = if current_recorded {
             conn.sm_state.record_outbound(frame.clone()).request_ack
         } else {
             false
         };
         if !batch_authoritative(authority) {
+            record_current_and_remaining_for_replay(conn, frame, frames, policy, current_recorded);
             return BatchWriteOutcome::AuthorityRevoked;
         }
         if let Err(outcome) = send_window_message(
@@ -259,7 +266,13 @@ where
                     record_remaining_for_replay(conn, frames, policy);
                     BatchWriteOutcome::TransportClosed
                 }
-                SendWindowOutcome::AuthorityRevoked => BatchWriteOutcome::AuthorityRevoked,
+                SendWindowOutcome::AuthorityRevoked => {
+                    // The countable current frame was recorded before the
+                    // readiness race; an uncountable control is intentionally
+                    // excluded from XEP-0198 replay. Preserve only the tail.
+                    record_remaining_for_replay(conn, frames, policy);
+                    BatchWriteOutcome::AuthorityRevoked
+                }
                 SendWindowOutcome::Recovered
                 | SendWindowOutcome::DeferredCapReached
                 | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
@@ -267,6 +280,7 @@ where
         }
         if request_ack {
             if !batch_authoritative(authority) {
+                record_remaining_for_replay(conn, frames, policy);
                 return BatchWriteOutcome::AuthorityRevoked;
             }
             if let Err(outcome) = send_window_message(
@@ -282,7 +296,10 @@ where
                         record_remaining_for_replay(conn, frames, policy);
                         BatchWriteOutcome::TransportClosed
                     }
-                    SendWindowOutcome::AuthorityRevoked => BatchWriteOutcome::AuthorityRevoked,
+                    SendWindowOutcome::AuthorityRevoked => {
+                        record_remaining_for_replay(conn, frames, policy);
+                        BatchWriteOutcome::AuthorityRevoked
+                    }
                     SendWindowOutcome::Recovered
                     | SendWindowOutcome::DeferredCapReached
                     | SendWindowOutcome::TimedOut => unreachable!("send outcome only"),
@@ -298,6 +315,7 @@ where
                     return BatchWriteOutcome::TransportClosed;
                 }
                 DrainSignal::AuthorityRevoked => {
+                    record_remaining_for_replay(conn, frames, policy);
                     return BatchWriteOutcome::AuthorityRevoked;
                 }
             }
@@ -333,6 +351,7 @@ where
                     return BatchWriteOutcome::TransportClosed;
                 }
                 SendWindowOutcome::AuthorityRevoked => {
+                    record_remaining_for_replay(conn, frames, policy);
                     return BatchWriteOutcome::AuthorityRevoked;
                 }
             }
@@ -535,6 +554,24 @@ pub(super) fn record_remaining_for_replay(
         if should_record(conn, &frame, policy) {
             let _ = conn.sm_state.record_outbound(frame);
         }
+    }
+}
+
+/// Preserve the current frame plus the unconsumed iterator tail when
+/// revocation lands before the current frame was locally recorded. Once a
+/// countable frame has entered the SM queue, recording it again would create
+/// a duplicate sequence entry; only the iterator tail remains to be saved.
+fn record_current_and_remaining_for_replay(
+    conn: &mut WsConnState,
+    current: String,
+    remaining: impl Iterator<Item = String>,
+    policy: BatchSmPolicy,
+    current_recorded: bool,
+) {
+    if current_recorded {
+        record_remaining_for_replay(conn, remaining, policy);
+    } else {
+        record_remaining_for_replay(conn, std::iter::once(current).chain(remaining), policy);
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -108,29 +108,10 @@ fn batch_authoritative(
         .is_none_or(|(permit, shutdown)| !shutdown.is_cancelled() && permit.revalidate().is_ok())
 }
 
-/// Write a response batch to the WebSocket, recording countable
-/// stanzas into the XEP-0198 unacked queue one frame at a time and
-/// interleaving an `<r/>` ack request after every `ack_threshold`th
-/// countable stanza.
-///
-/// Frames are recorded just before their own write: if the send
-/// fails they replay on resume, and the counters re-converge when
-/// the client receives them.
-pub(super) async fn write_response_batch<S, SE, R, RE>(
-    sender: &mut S,
-    reader: &mut R,
-    state: &WebSocketState,
-    conn: &mut WsConnState,
-    frames: Vec<String>,
-    policy: BatchSmPolicy,
-) -> BatchWriteOutcome
-where
-    S: Sink<Message, Error = SE> + Unpin,
-    SE: std::fmt::Display,
-    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
-    RE: std::fmt::Display,
-{
-    write_response_batch_impl(sender, reader, state, conn, frames, policy, None).await
+#[derive(Clone, Copy)]
+pub(super) struct BatchAuthority<'a> {
+    pub(super) permit: &'a crate::clustering::NodeAdmissionPermit,
+    pub(super) shutdown: &'a tokio_util::sync::CancellationToken,
 }
 
 pub(super) async fn write_response_batch_with_admission<S, SE, R, RE>(
@@ -140,8 +121,7 @@ pub(super) async fn write_response_batch_with_admission<S, SE, R, RE>(
     conn: &mut WsConnState,
     frames: Vec<String>,
     policy: BatchSmPolicy,
-    permit: &crate::clustering::NodeAdmissionPermit,
-    shutdown: &tokio_util::sync::CancellationToken,
+    authority: BatchAuthority<'_>,
 ) -> BatchWriteOutcome
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -156,7 +136,7 @@ where
         conn,
         frames,
         policy,
-        Some((permit, shutdown)),
+        Some((authority.permit, authority.shutdown)),
     )
     .await
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -51,6 +51,8 @@ pub(super) enum BatchWriteOutcome {
     /// must break the connection loop; the SM unacked queue already
     /// holds every replayable countable frame of the batch.
     TransportClosed,
+    /// The node serving generation changed before the next record/write.
+    AuthorityRevoked,
 }
 
 /// Upper bound on frames the mid-batch drain may park in
@@ -93,6 +95,17 @@ enum SendWindowOutcome {
     TimedOut,
     /// The transport went away while paused.
     TransportClosed,
+    AuthorityRevoked,
+}
+
+fn batch_authoritative(
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) -> bool {
+    authority
+        .is_none_or(|(permit, shutdown)| !shutdown.is_cancelled() && permit.revalidate().is_ok())
 }
 
 /// Write a response batch to the WebSocket, recording countable
@@ -117,6 +130,58 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
+    write_response_batch_impl(sender, reader, state, conn, frames, policy, None).await
+}
+
+pub(super) async fn write_response_batch_with_admission<S, SE, R, RE>(
+    sender: &mut S,
+    reader: &mut R,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    frames: Vec<String>,
+    policy: BatchSmPolicy,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> BatchWriteOutcome
+where
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
+    write_response_batch_impl(
+        sender,
+        reader,
+        state,
+        conn,
+        frames,
+        policy,
+        Some((permit, shutdown)),
+    )
+    .await
+}
+
+async fn write_response_batch_impl<S, SE, R, RE>(
+    sender: &mut S,
+    reader: &mut R,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    frames: Vec<String>,
+    policy: BatchSmPolicy,
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) -> BatchWriteOutcome
+where
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
+    if !batch_authoritative(authority) {
+        return BatchWriteOutcome::AuthorityRevoked;
+    }
     let mut frames = frames.into_iter();
     // Send-window pacing applies ONLY to batches that actually grow the SM
     // unacked queue (issue #1219 review). A `ReplaySuppressed` batch is the
@@ -142,21 +207,28 @@ where
     // `record_outbound` could evict from an already-full queue and re-poison
     // resume. Await recovery before recording anything.
     if pacing && conn.sm_state.needs_send_pause() {
-        match await_send_window_recovery(sender, reader, state, conn).await {
+        match await_send_window_recovery(sender, reader, state, conn, authority).await {
             SendWindowOutcome::Recovered => {}
             SendWindowOutcome::DeferredCapReached => send_window_degraded = true,
             SendWindowOutcome::TransportClosed | SendWindowOutcome::TimedOut => {
                 record_remaining_for_replay(conn, frames, policy);
                 return BatchWriteOutcome::TransportClosed;
             }
+            SendWindowOutcome::AuthorityRevoked => return BatchWriteOutcome::AuthorityRevoked,
         }
     }
     while let Some(frame) = frames.next() {
+        if !batch_authoritative(authority) {
+            return BatchWriteOutcome::AuthorityRevoked;
+        }
         let request_ack = if should_record(conn, &frame, policy) {
             conn.sm_state.record_outbound(frame.clone()).request_ack
         } else {
             false
         };
+        if !batch_authoritative(authority) {
+            return BatchWriteOutcome::AuthorityRevoked;
+        }
         if !send_ws_message(
             sender,
             Message::Text(frame.into()),
@@ -168,6 +240,9 @@ where
             return BatchWriteOutcome::TransportClosed;
         }
         if request_ack {
+            if !batch_authoritative(authority) {
+                return BatchWriteOutcome::AuthorityRevoked;
+            }
             if !send_ws_message(
                 sender,
                 Message::Text(SmRequest::to_xml().into()),
@@ -181,12 +256,15 @@ where
             // Give already-arrived inbound frames a chance to land:
             // `<a/>` acks shrink the unacked queue mid-flood instead
             // of waiting for the whole batch to finish.
-            if matches!(
-                drain_ready_inbound(sender, reader, state, conn).await,
-                DrainSignal::TransportClosed
-            ) {
-                record_remaining_for_replay(conn, frames, policy);
-                return BatchWriteOutcome::TransportClosed;
+            match drain_ready_inbound(sender, reader, state, conn, authority).await {
+                DrainSignal::Idle => {}
+                DrainSignal::TransportClosed => {
+                    record_remaining_for_replay(conn, frames, policy);
+                    return BatchWriteOutcome::TransportClosed;
+                }
+                DrainSignal::AuthorityRevoked => {
+                    return BatchWriteOutcome::AuthorityRevoked;
+                }
             }
         }
         // Send-window pacing (issue #1219): if recording this frame pushed
@@ -197,7 +275,7 @@ where
         // ack at any time and is under no obligation to transmit queued
         // stanzas immediately (xep-0198.xml:307/357).
         if pacing && !send_window_degraded && conn.sm_state.needs_send_pause() {
-            match await_send_window_recovery(sender, reader, state, conn).await {
+            match await_send_window_recovery(sender, reader, state, conn, authority).await {
                 SendWindowOutcome::Recovered => {}
                 SendWindowOutcome::DeferredCapReached => {
                     // Cannot read the awaited ack in order behind 64 parked
@@ -219,6 +297,9 @@ where
                     record_remaining_for_replay(conn, frames, policy);
                     return BatchWriteOutcome::TransportClosed;
                 }
+                SendWindowOutcome::AuthorityRevoked => {
+                    return BatchWriteOutcome::AuthorityRevoked;
+                }
             }
         }
     }
@@ -238,6 +319,10 @@ async fn await_send_window_recovery<S, SE, R, RE>(
     reader: &mut R,
     state: &WebSocketState,
     conn: &mut WsConnState,
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
 ) -> SendWindowOutcome
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -245,6 +330,9 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
+    if !batch_authoritative(authority) {
+        return SendWindowOutcome::AuthorityRevoked;
+    }
     waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause();
     let deadline = tokio::time::Instant::now() + SEND_WINDOW_PAUSE_DEADLINE;
     // Elicit an ack immediately — nothing more is being written until the
@@ -259,6 +347,9 @@ where
         return SendWindowOutcome::TransportClosed;
     }
     loop {
+        if !batch_authoritative(authority) {
+            return SendWindowOutcome::AuthorityRevoked;
+        }
         if conn.sm_state.send_window_recovered() {
             return SendWindowOutcome::Recovered;
         }
@@ -280,6 +371,9 @@ where
                 return SendWindowOutcome::TimedOut;
             }
         };
+        if !batch_authoritative(authority) {
+            return SendWindowOutcome::AuthorityRevoked;
+        }
         match next {
             Some(Ok(Message::Text(text))) => {
                 conn.note_transport_activity();
@@ -292,7 +386,13 @@ where
                 } else if let Some(h) = parse_sm_ack_h(text.as_str()) {
                     let responses =
                         apply_sm_ack(state, &mut conn.sm_state, &mut conn.phase, h).await;
+                    if !batch_authoritative(authority) {
+                        return SendWindowOutcome::AuthorityRevoked;
+                    }
                     for response in responses {
+                        if !batch_authoritative(authority) {
+                            return SendWindowOutcome::AuthorityRevoked;
+                        }
                         if !send_ws_message(
                             sender,
                             Message::Text(response.into()),
@@ -310,15 +410,19 @@ where
                     // latch clears once it reaches the low watermark). If it
                     // is not recovered yet, re-request so the client keeps
                     // acking — it does not ack unprompted.
-                    if !conn.sm_state.send_window_recovered()
-                        && !send_ws_message(
+                    if !conn.sm_state.send_window_recovered() {
+                        if !batch_authoritative(authority) {
+                            return SendWindowOutcome::AuthorityRevoked;
+                        }
+                        if !send_ws_message(
                             sender,
                             Message::Text(SmRequest::to_xml().into()),
                             "Failed to re-send SM <r/> during send-window pause",
                         )
                         .await
-                    {
-                        return SendWindowOutcome::TransportClosed;
+                        {
+                            return SendWindowOutcome::TransportClosed;
+                        }
                     }
                 } else {
                     conn.deferred_inbound.push_back(text);
@@ -390,6 +494,7 @@ enum DrainSignal {
     /// Peer closed (WS close frame, stream end, or read error). The
     /// batch must stop and the connection loop must exit.
     TransportClosed,
+    AuthorityRevoked,
 }
 
 /// Non-blockingly pull already-buffered inbound frames off the
@@ -405,6 +510,10 @@ async fn drain_ready_inbound<S, SE, R, RE>(
     reader: &mut R,
     state: &WebSocketState,
     conn: &mut WsConnState,
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
 ) -> DrainSignal
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -413,6 +522,9 @@ where
     RE: std::fmt::Display,
 {
     loop {
+        if !batch_authoritative(authority) {
+            return DrainSignal::AuthorityRevoked;
+        }
         if conn.deferred_inbound.len() >= DEFERRED_INBOUND_CAP {
             return DrainSignal::Idle;
         }
@@ -453,7 +565,13 @@ where
                     // batch — the connection is terminating.
                     let responses =
                         apply_sm_ack(state, &mut conn.sm_state, &mut conn.phase, h).await;
+                    if !batch_authoritative(authority) {
+                        return DrainSignal::AuthorityRevoked;
+                    }
                     for response in responses {
+                        if !batch_authoritative(authority) {
+                            return DrainSignal::AuthorityRevoked;
+                        }
                         if !send_ws_message(
                             sender,
                             Message::Text(response.into()),

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -108,6 +108,54 @@ fn batch_authoritative(
         .is_none_or(|(permit, shutdown)| !shutdown.is_cancelled() && permit.revalidate().is_ok())
 }
 
+async fn batch_authority_revoked(
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) {
+    let Some((permit, shutdown)) = authority else {
+        std::future::pending::<()>().await;
+        return;
+    };
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => {}
+        _ = permit.revoked() => {}
+    }
+}
+
+async fn send_window_message<S, E>(
+    sender: &mut S,
+    message: Message,
+    failure_message: &'static str,
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) -> Result<(), SendWindowOutcome>
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    if !batch_authoritative(authority) {
+        return Err(SendWindowOutcome::AuthorityRevoked);
+    }
+    let send = send_ws_message(sender, message, failure_message);
+    tokio::pin!(send);
+    tokio::select! {
+        biased;
+        _ = batch_authority_revoked(authority) => Err(SendWindowOutcome::AuthorityRevoked),
+        sent = send.as_mut() => {
+            if sent {
+                Ok(())
+            } else {
+                Err(SendWindowOutcome::TransportClosed)
+            }
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(super) struct BatchAuthority<'a> {
     pub(super) permit: &'a crate::clustering::NodeAdmissionPermit,
@@ -317,14 +365,15 @@ where
     let deadline = tokio::time::Instant::now() + SEND_WINDOW_PAUSE_DEADLINE;
     // Elicit an ack immediately — nothing more is being written until the
     // window recovers, so the client must be prompted.
-    if !send_ws_message(
+    if let Err(outcome) = send_window_message(
         sender,
         Message::Text(SmRequest::to_xml().into()),
         "Failed to send SM <r/> at send-window pause",
+        authority,
     )
     .await
     {
-        return SendWindowOutcome::TransportClosed;
+        return outcome;
     }
     loop {
         if !batch_authoritative(authority) {
@@ -336,7 +385,13 @@ where
         if conn.deferred_inbound.len() >= DEFERRED_INBOUND_CAP {
             return SendWindowOutcome::DeferredCapReached;
         }
-        let next = match tokio::time::timeout_at(deadline, reader.next()).await {
+        let next = match tokio::select! {
+            biased;
+            _ = batch_authority_revoked(authority) => {
+                return SendWindowOutcome::AuthorityRevoked;
+            }
+            result = tokio::time::timeout_at(deadline, reader.next()) => result,
+        } {
             Ok(next) => next,
             Err(_) => {
                 waddle_xmpp::telemetry::reliability::increment_sm_send_window_pause_timeout();
@@ -373,14 +428,15 @@ where
                         if !batch_authoritative(authority) {
                             return SendWindowOutcome::AuthorityRevoked;
                         }
-                        if !send_ws_message(
+                        if let Err(outcome) = send_window_message(
                             sender,
                             Message::Text(response.into()),
                             "Failed to send SM ack stream error",
+                            authority,
                         )
                         .await
                         {
-                            return SendWindowOutcome::TransportClosed;
+                            return outcome;
                         }
                     }
                     if conn.phase.is_closing() {
@@ -394,14 +450,15 @@ where
                         if !batch_authoritative(authority) {
                             return SendWindowOutcome::AuthorityRevoked;
                         }
-                        if !send_ws_message(
+                        if let Err(outcome) = send_window_message(
                             sender,
                             Message::Text(SmRequest::to_xml().into()),
                             "Failed to re-send SM <r/> during send-window pause",
+                            authority,
                         )
                         .await
                         {
-                            return SendWindowOutcome::TransportClosed;
+                            return outcome;
                         }
                     }
                 } else {
@@ -410,8 +467,15 @@ where
             }
             Some(Ok(Message::Ping(data))) => {
                 conn.note_transport_activity();
-                if !send_ws_message(sender, Message::Pong(data), "Failed to send pong").await {
-                    return SendWindowOutcome::TransportClosed;
+                if let Err(outcome) = send_window_message(
+                    sender,
+                    Message::Pong(data),
+                    "Failed to send pong",
+                    authority,
+                )
+                .await
+                {
+                    return outcome;
                 }
             }
             Some(Ok(Message::Pong(_))) | Some(Ok(Message::Binary(_))) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -47,6 +47,24 @@ fn revalidate_websocket_admission(
         .map_err(WebSocketAdmissionRevocation::Lifecycle)
 }
 
+async fn close_revoked_upgraded_socket<S, E>(socket: &mut S)
+where
+    S: futures::Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    let _ = send_ws_message(
+        socket,
+        Message::Close(None),
+        "Failed to send WebSocket close frame after admission revocation",
+    )
+    .await;
+    let _ = close_ws_connection(
+        socket,
+        "Failed to close WebSocket after admission revocation",
+    )
+    .await;
+}
+
 /// Create the WebSocket router
 pub fn router(state: Arc<WebSocketState>) -> Router {
     Router::new()
@@ -101,16 +119,21 @@ async fn xmpp_websocket_handler(
         return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
 
-    ws.protocols(["xmpp"]).on_upgrade(move |socket| async move {
-        if let Err(reason) = revalidate_websocket_admission(&state, &admission_permit) {
-            info!(
-                ?reason,
-                "Closing upgraded WebSocket: admission was revoked before XMPP start"
-            );
-            return;
-        }
-        handle_xmpp_websocket(socket, state, connection_guard).await;
-    })
+    ws.protocols(["xmpp"])
+        .on_upgrade(move |mut socket| async move {
+            if let Err(reason) = revalidate_websocket_admission(&state, &admission_permit) {
+                info!(
+                    ?reason,
+                    "Closing upgraded WebSocket: admission was revoked before XMPP start"
+                );
+                // HTTP 101 is already on the wire. RFC 7395 therefore requires a
+                // WebSocket close handshake rather than silently dropping the
+                // upgraded TCP stream; no XMPP stream exists at this boundary.
+                close_revoked_upgraded_socket(&mut socket).await;
+                return;
+            }
+            handle_xmpp_websocket(socket, state, connection_guard, admission_permit).await;
+        })
 }
 
 /// Size of the outbound message channel buffer
@@ -177,6 +200,7 @@ async fn handle_xmpp_websocket(
     // been closed AND its SM state handed to the session registry for
     // Q6 promotion.
     _connection_guard: waddle_ecdysis::ConnectionGuard,
+    admission_permit: crate::clustering::NodeAdmissionPermit,
 ) {
     let domain = state.deps.auth_state.xmpp_domain.clone();
     let shutdown_token = state.deps.shutdown.stop_token();
@@ -298,6 +322,19 @@ async fn handle_xmpp_websocket(
         tokio::select! {
             biased;
 
+            // The exact serving generation that admitted this socket is its
+            // authority. Revoke it ahead of every queued frame, outbound item,
+            // and deferred stanza; recovery mints a new generation and can
+            // never resurrect this transport.
+            _ = admission_permit.revoked() => {
+                info!(
+                    jid = ?conn.phase.bound_jid(),
+                    "Node lifecycle changed: closing live session"
+                );
+                close_live_session_for_node_unavailable(&mut ws_sender, &conn).await;
+                break;
+            }
+
             // Process stop is the highest-priority event. If cancellation and
             // a queued frame/work item are both ready, no further stanza work
             // starts after the node has begun draining or failed critically.
@@ -306,35 +343,7 @@ async fn handle_xmpp_websocket(
                     jid = ?conn.phase.bound_jid(),
                     "Graceful shutdown: closing live session with system-shutdown stream error"
                 );
-                let close_peer = async {
-                    if conn.stream_open_sent {
-                        let _ = send_ws_text_frames(
-                            &mut ws_sender,
-                            [
-                                build_system_shutdown_stream_error(),
-                                websocket_stream_close_xml(),
-                            ],
-                            "Failed to send system-shutdown stream error",
-                        )
-                        .await;
-                    }
-                    let _ = close_ws_connection(
-                        &mut ws_sender,
-                        "Failed to send WebSocket close frame after system-shutdown",
-                    )
-                    .await;
-                };
-                if tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_peer)
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        jid = ?conn.phase.bound_jid(),
-                        timeout_secs = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
-                        "Graceful shutdown: peer did not accept the close frames in time; \
-                         proceeding to detach without them"
-                    );
-                }
+                close_live_session_for_node_unavailable(&mut ws_sender, &conn).await;
                 break;
             }
 
@@ -644,12 +653,12 @@ async fn handle_xmpp_websocket(
     if superseded {
         super::stream_management::defer_superseded_sm_claim(state.as_ref(), &conn.sm_state);
     } else {
-        if shutdown_token.is_cancelled() {
+        if shutdown_token.is_cancelled() || admission_permit.revalidate().is_err() {
             let dropped = discard_deferred_inbound(&mut conn);
             if dropped > 0 {
                 info!(
                     dropped,
-                    "Dropping deferred inbound frames after process stop; sender may replay them"
+                    "Dropping deferred inbound frames after node authority revocation; sender may replay them"
                 );
             }
         } else {
@@ -696,6 +705,41 @@ async fn handle_xmpp_websocket(
     }
 
     info!("XMPP WebSocket connection closed");
+}
+
+async fn close_live_session_for_node_unavailable(
+    ws_sender: &mut SplitSink<WebSocket, Message>,
+    conn: &WsConnState,
+) {
+    let close_peer = async {
+        if conn.stream_open_sent {
+            let _ = send_ws_text_frames(
+                ws_sender,
+                [
+                    build_system_shutdown_stream_error(),
+                    websocket_stream_close_xml(),
+                ],
+                "Failed to send system-shutdown stream error",
+            )
+            .await;
+        }
+        let _ = close_ws_connection(
+            ws_sender,
+            "Failed to send WebSocket close frame after node became unavailable",
+        )
+        .await;
+    };
+    if tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_peer)
+        .await
+        .is_err()
+    {
+        warn!(
+            jid = ?conn.phase.bound_jid(),
+            timeout_secs = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
+            "Node unavailable: peer did not accept the close frames in time; \
+             proceeding to detach without them"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1204,6 +1248,56 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    #[derive(Default)]
+    struct UpgradeCloseSink {
+        sent: Vec<Message>,
+        closed: bool,
+    }
+
+    impl futures::Sink<Message> for UpgradeCloseSink {
+        type Error = &'static str;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+            self.sent.push(item);
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.closed = true;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn post_upgrade_admission_revocation_sends_websocket_close() {
+        let mut socket = UpgradeCloseSink::default();
+
+        close_revoked_upgraded_socket(&mut socket).await;
+
+        assert_eq!(socket.sent, vec![Message::Close(None)]);
+        assert!(socket.closed);
+    }
+
     #[tokio::test]
     async fn abandoned_inbound_slot_does_not_block_handoff_cleanup() {
         let mut conn = WsConnState::new();

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -2,14 +2,14 @@ use super::*;
 use super::{
     batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
     cleanup::cleanup_connection_shutdown,
-    frame::handle_xmpp_frame,
+    frame::{handle_xmpp_frame, handle_xmpp_frame_with_admission},
     interpret_loop::build_interpret_deps,
     outbound::handle_outbound_stanza,
     registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
     replay::drive_interpret_loop,
     send::{close_ws_connection, send_ws_message, send_ws_text_frames},
     session_init::build_internal_server_error_stream_error,
-    state::WsConnState,
+    state::{InboundFrameTerminal, WsConnState},
     stream_management::SmRegistrationFinalization,
     timers::TransportTimers,
     transport_xml::{
@@ -363,6 +363,8 @@ async fn handle_xmpp_websocket(
                     },
                     &mut ws_sender,
                     &mut ws_receiver,
+                    &admission_permit,
+                    &shutdown_token,
                 )
                 .await
                 {
@@ -385,6 +387,8 @@ async fn handle_xmpp_websocket(
                             },
                             &mut ws_sender,
                             &mut ws_receiver,
+                            &admission_permit,
+                            &shutdown_token,
                         )
                         .await
                         {
@@ -906,6 +910,8 @@ async fn handle_inbound_text(
     channels: RegistrationChannels<'_>,
     ws_sender: &mut SplitSink<WebSocket, Message>,
     ws_receiver: &mut SplitStream<WebSocket>,
+    admission_permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown_token: &tokio_util::sync::CancellationToken,
 ) -> bool {
     let RegistrationChannels {
         pending_tx,
@@ -917,7 +923,22 @@ async fn handle_inbound_text(
     conn.note_transport_activity();
 
     // Handle XMPP framing (RFC 7395)
-    let mut responses = handle_xmpp_frame(text, domain, state.as_ref(), conn).await;
+    let mut responses = handle_xmpp_frame_with_admission(
+        text,
+        domain,
+        state.as_ref(),
+        conn,
+        admission_permit,
+        shutdown_token,
+    )
+    .await;
+    if matches!(
+        conn.inbound_frame_terminal.take(),
+        Some(InboundFrameTerminal::AuthorityRevoked)
+    ) {
+        close_live_session_for_node_unavailable(ws_sender, conn).await;
+        return false;
+    }
 
     // Mirror any phase transition `handle_xmpp_frame` performed (most
     // importantly Ready → Closing on SASL failure / stream error)

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -17,7 +17,10 @@ use super::{
         build_system_shutdown_stream_error, websocket_stream_close_xml,
     },
 };
-use axum::response::IntoResponse;
+use axum::{
+    extract::{FromRequest, Request},
+    response::IntoResponse,
+};
 use futures::stream::{SplitSink, SplitStream};
 use waddle_xmpp::stream_management::SmRequest;
 
@@ -33,8 +36,8 @@ pub fn router(state: Arc<WebSocketState>) -> Router {
 /// WebSocket endpoint for XMPP over WebSocket (RFC 7395).
 /// Upgrades HTTP connection to WebSocket and handles XMPP framing.
 async fn xmpp_websocket_handler(
-    ws: WebSocketUpgrade,
     State(state): State<Arc<WebSocketState>>,
+    request: Request,
 ) -> Response {
     // Graceful shutdown gate (issue #1091). The guard is minted BEFORE
     // the stop-token check: the upgrade handshake spans a client
@@ -49,10 +52,28 @@ async fn xmpp_websocket_handler(
         info!("Rejecting XMPP WebSocket upgrade: server is draining");
         return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
+    // This is deliberately after Ecdysis's mint-then-check gate and before
+    // the RFC 7395 upgrade. A fenced, recovering, draining, or terminally
+    // failed node must return plain HTTP 503 rather than open an XMPP stream
+    // it cannot safely own.
+    let admission_permit = match state.deps.app_state.node_lifecycle.admit() {
+        Ok(permit) => permit,
+        Err(error) => {
+            info!(%error, "Rejecting XMPP WebSocket upgrade: node is not serving");
+            return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     info!("XMPP WebSocket connection request");
 
-    ws.protocols(["xmpp"])
-        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
+    let ws = match WebSocketUpgrade::from_request(request, &state).await {
+        Ok(ws) => ws,
+        Err(rejection) => return rejection.into_response(),
+    };
+
+    ws.protocols(["xmpp"]).on_upgrade(move |socket| async move {
+        let _admission_permit = admission_permit;
+        handle_xmpp_websocket(socket, state, connection_guard).await;
+    })
 }
 
 /// Size of the outbound message channel buffer
@@ -637,6 +658,76 @@ async fn handle_xmpp_websocket(
     }
 
     info!("XMPP WebSocket connection closed");
+}
+
+#[cfg(test)]
+mod admission_tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    fn websocket_request() -> Request<Body> {
+        Request::builder()
+            .uri("/ws")
+            .header("connection", "upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(Body::empty())
+            .expect("valid RFC 7395 websocket handshake request")
+    }
+
+    #[tokio::test]
+    async fn websocket_rejects_every_non_serving_admission_state_before_upgrade() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let app = router(state.clone());
+
+        // `tower::oneshot` has no Hyper upgrade extension, so a serving node
+        // reaches Axum's expected 426 rejection instead of attempting a real
+        // 101. The non-serving cases below are deliberately rejected before
+        // this extractor and therefore return plain HTTP 503.
+        assert_eq!(
+            app.clone()
+                .oneshot(websocket_request())
+                .await
+                .expect("response")
+                .status(),
+            axum::http::StatusCode::UPGRADE_REQUIRED
+        );
+
+        state.deps.app_state.node_lifecycle.begin_fenced_recovery();
+        assert_eq!(
+            app.clone()
+                .oneshot(websocket_request())
+                .await
+                .expect("response")
+                .status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        state.deps.app_state.node_lifecycle.begin_drain();
+        assert_eq!(
+            app.clone()
+                .oneshot(websocket_request())
+                .await
+                .expect("response")
+                .status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+
+        state
+            .deps
+            .app_state
+            .node_lifecycle
+            .fail(crate::clustering::CriticalNodeFailure::UserRegistryTerminated);
+        assert_eq!(
+            app.oneshot(websocket_request())
+                .await
+                .expect("response")
+                .status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
 }
 
 /// Handle one inbound XMPP text frame end to end: framing, phase

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -11,7 +11,7 @@ use super::{
     replay::drive_interpret_loop,
     send::{
         close_ws_connection, send_ws_message, send_ws_message_with_authority, send_ws_text_frames,
-        AuthoritySendOutcome,
+        send_ws_text_frames_with_authority, AuthoritySendOutcome,
     },
     session_init::build_internal_server_error_stream_error,
     state::{InboundFrameTerminal, WsConnState},
@@ -570,10 +570,11 @@ async fn handle_xmpp_websocket(
                                 "Cross-node resume: force-detaching this session (<conflict/> close)"
                             );
                             if conn.stream_open_sent {
-                                let _ = send_ws_text_frames(
+                                let _ = send_ws_text_frames_with_authority(
                                     &mut ws_sender,
                                     [build_conflict_stream_error(), websocket_stream_close_xml()],
                                     "Failed to send conflict stream error",
+                                    (&admission_permit, &shutdown_token),
                                 )
                                 .await;
                             }
@@ -1056,10 +1057,11 @@ async fn handle_inbound_text(
             let stream_error = build_internal_server_error_stream_error(
                 "Session initialization failed; please reconnect.",
             );
-            let _ = send_ws_text_frames(
+            let _ = send_ws_text_frames_with_authority(
                 ws_sender,
                 [stream_error, websocket_stream_close_xml()],
                 "Failed to send session-init stream error",
+                (admission_permit, shutdown_token),
             )
             .await;
             let _ = close_ws_connection(

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1,10 +1,12 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome},
+    batch_write::{
+        write_response_batch_with_admission, BatchAuthority, BatchSmPolicy, BatchWriteOutcome,
+    },
     cleanup::cleanup_connection_shutdown,
-    frame::{handle_xmpp_frame, handle_xmpp_frame_with_admission},
+    frame::handle_xmpp_frame_with_admission,
     interpret_loop::build_interpret_deps,
-    outbound::handle_outbound_stanza,
+    outbound::{handle_outbound_stanza, OutboundAuthority},
     registration::{register_bound_connection_after_frame_with_admission, RegistrationAfterFrame},
     replay::drive_interpret_loop,
     send::{close_ws_connection, send_ws_message, send_ws_text_frames},
@@ -174,6 +176,17 @@ const ORDERED_RELAY_HANDOFF_CLEANUP_MAX_COMPLETIONS: usize = 1_024;
 struct RegistrationChannels<'a> {
     pending_tx: &'a mut Option<mpsc::Sender<OutboundStanza>>,
     force_detach_rx: &'a mut Option<mpsc::Receiver<waddle_xmpp::registry::ForceDetachRequest>>,
+}
+
+struct ConnectionIo<'a> {
+    sender: &'a mut SplitSink<WebSocket, Message>,
+    receiver: &'a mut SplitStream<WebSocket>,
+}
+
+#[derive(Clone, Copy)]
+struct FrameAuthority<'a> {
+    permit: &'a crate::clustering::NodeAdmissionPermit,
+    shutdown: &'a tokio_util::sync::CancellationToken,
 }
 
 /// Poll `rx` if present, otherwise never resolve (ADR-0017 Phase 3 Slice 6).
@@ -365,10 +378,14 @@ async fn handle_xmpp_websocket(
                         pending_tx: &mut pending_tx,
                         force_detach_rx: &mut force_detach_rx,
                     },
-                    &mut ws_sender,
-                    &mut ws_receiver,
-                    &admission_permit,
-                    &shutdown_token,
+                    ConnectionIo {
+                        sender: &mut ws_sender,
+                        receiver: &mut ws_receiver,
+                    },
+                    FrameAuthority {
+                        permit: &admission_permit,
+                        shutdown: &shutdown_token,
+                    },
                 )
                 .await
                 {
@@ -389,10 +406,14 @@ async fn handle_xmpp_websocket(
                                 pending_tx: &mut pending_tx,
                                 force_detach_rx: &mut force_detach_rx,
                             },
-                            &mut ws_sender,
-                            &mut ws_receiver,
-                            &admission_permit,
-                            &shutdown_token,
+                            ConnectionIo {
+                                sender: &mut ws_sender,
+                                receiver: &mut ws_receiver,
+                            },
+                            FrameAuthority {
+                                permit: &admission_permit,
+                                shutdown: &shutdown_token,
+                            },
                         )
                         .await
                         {
@@ -449,8 +470,10 @@ async fn handle_xmpp_websocket(
                             &mut conn,
                             &mut timers,
                             outbound_stanza,
-                            &admission_permit,
-                            &shutdown_token,
+                            OutboundAuthority {
+                                permit: &admission_permit,
+                                shutdown: &shutdown_token,
+                            },
                         )
                         .await
                         {
@@ -682,7 +705,14 @@ async fn handle_xmpp_websocket(
                 );
             }
         } else {
-            process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+            process_deferred_inbound_after_transport_loss(
+                &domain,
+                state.as_ref(),
+                &mut conn,
+                &admission_permit,
+                &shutdown_token,
+            )
+            .await;
         }
         drain_ordered_relay_handoffs_before_cleanup(&mut handoff_rx, &mut conn).await;
     }
@@ -924,15 +954,21 @@ async fn handle_inbound_text(
     state: &Arc<WebSocketState>,
     conn: &mut WsConnState,
     channels: RegistrationChannels<'_>,
-    ws_sender: &mut SplitSink<WebSocket, Message>,
-    ws_receiver: &mut SplitStream<WebSocket>,
-    admission_permit: &crate::clustering::NodeAdmissionPermit,
-    shutdown_token: &tokio_util::sync::CancellationToken,
+    io: ConnectionIo<'_>,
+    authority: FrameAuthority<'_>,
 ) -> bool {
     let RegistrationChannels {
         pending_tx,
         force_detach_rx,
     } = channels;
+    let ConnectionIo {
+        sender: ws_sender,
+        receiver: ws_receiver,
+    } = io;
+    let FrameAuthority {
+        permit: admission_permit,
+        shutdown: shutdown_token,
+    } = authority;
     if close_if_frame_authority_revoked(state, conn, ws_sender, admission_permit, shutdown_token)
         .await
     {
@@ -1110,8 +1146,10 @@ async fn handle_inbound_text(
         conn,
         responses,
         policy,
-        admission_permit,
-        shutdown_token,
+        BatchAuthority {
+            permit: admission_permit,
+            shutdown: shutdown_token,
+        },
     )
     .await
     {
@@ -1172,6 +1210,12 @@ async fn close_if_frame_authority_revoked(
         return false;
     }
 
+    cleanup_frame_authority_revocation(state, conn).await;
+    close_live_session_for_node_unavailable(ws_sender, conn).await;
+    true
+}
+
+async fn cleanup_frame_authority_revocation(state: &WebSocketState, conn: &mut WsConnState) {
     // `<enable/>` has not reached its wire commit point yet. Dropping this
     // typed guard inventories exact claim release and provisional ISR token
     // revocation; a stale generation must never send `<enabled/>`.
@@ -1189,8 +1233,6 @@ async fn close_if_frame_authority_revoked(
         }
         state.deps.protocol.resumable_sessions.remove(&stream_id);
     }
-    close_live_session_for_node_unavailable(ws_sender, conn).await;
-    true
 }
 
 async fn handle_ordered_relay_handoff_completion(
@@ -1218,8 +1260,7 @@ async fn handle_ordered_relay_handoff_completion(
         conn,
         replies,
         BatchSmPolicy::Record,
-        permit,
-        shutdown,
+        BatchAuthority { permit, shutdown },
     )
     .await
     {
@@ -1320,6 +1361,8 @@ async fn process_deferred_inbound_after_transport_loss(
     domain: &str,
     state: &WebSocketState,
     conn: &mut WsConnState,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
 ) {
     if conn.sm_inbound_completion.has_unhandled_hole() {
         let dropped = discard_deferred_inbound(conn);
@@ -1332,7 +1375,27 @@ async fn process_deferred_inbound_after_transport_loss(
         return;
     }
     while let Some(text) = conn.deferred_inbound.pop_front() {
-        let responses = handle_xmpp_frame(&text, domain, state, conn).await;
+        let responses =
+            handle_xmpp_frame_with_admission(&text, domain, state, conn, permit, shutdown).await;
+        if matches!(
+            conn.inbound_frame_terminal.take(),
+            Some(InboundFrameTerminal::AuthorityRevoked)
+        ) || shutdown.is_cancelled()
+            || permit.revalidate().is_err()
+        {
+            // No transport remains to close. Release any provisional control
+            // ownership now; the caller immediately runs normal detach/full
+            // cleanup for the connection state that remains authoritative.
+            cleanup_frame_authority_revocation(state, conn).await;
+            let dropped = discard_deferred_inbound(conn);
+            if dropped > 0 {
+                warn!(
+                    dropped,
+                    "Dropping deferred inbound suffix after authority revocation"
+                );
+            }
+            break;
+        }
         conn.sync_state_machine_phase();
         let policy = if conn.suppress_sm_record_next_batch {
             conn.suppress_sm_record_next_batch = false;
@@ -1552,6 +1615,47 @@ mod tests {
         assert_eq!(discard_deferred_inbound(&mut conn), 2);
         assert!(conn.deferred_inbound.is_empty());
         assert_eq!(conn.sm_state.get_inbound_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn revoked_generation_drops_deferred_transport_loss_suffix_without_advancing_h() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("deferred-revoked".to_string(), true, Some(300));
+        let mut first = xmpp_parsers::message::Message::new(Some(
+            "bob@example.com".parse().expect("recipient JID"),
+        ));
+        first.id = Some("first".to_string());
+        let mut later = xmpp_parsers::message::Message::new(Some(
+            "carol@example.com".parse().expect("recipient JID"),
+        ));
+        later.id = Some("later".to_string());
+        conn.deferred_inbound.extend([
+            axum::extract::ws::Utf8Bytes::from(
+                waddle_xmpp::parser::stanza_to_string(first).expect("serialize first message"),
+            ),
+            axum::extract::ws::Utf8Bytes::from(
+                waddle_xmpp::parser::stanza_to_string(later).expect("serialize later message"),
+            ),
+        ]);
+        lifecycle.begin_fenced_recovery();
+
+        process_deferred_inbound_after_transport_loss(
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &permit,
+            &shutdown,
+        )
+        .await;
+
+        assert!(conn.deferred_inbound.is_empty());
+        assert_eq!(conn.sm_state.get_inbound_count(), 0);
+        assert!(conn.sm_state.get_stanzas_to_resend(0).is_empty());
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1529,7 +1529,7 @@ mod tests {
         type Error = &'static str;
 
         fn poll_ready(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
         ) -> Poll<Result<(), Self::Error>> {
             self.lifecycle.begin_fenced_recovery();

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1235,16 +1235,24 @@ async fn cleanup_frame_authority_revocation(state: &WebSocketState, conn: &mut W
     }
 }
 
-async fn handle_ordered_relay_handoff_completion(
-    ws_sender: &mut SplitSink<WebSocket, Message>,
-    ws_receiver: &mut SplitStream<WebSocket>,
+async fn handle_ordered_relay_handoff_completion<S, SE, R, RE>(
+    ws_sender: &mut S,
+    ws_receiver: &mut R,
     state: &Arc<WebSocketState>,
     conn: &mut WsConnState,
     completion: crate::server::routes::interpret::OrderedRelayHandoffCompletion,
     permit: &crate::clustering::NodeAdmissionPermit,
     shutdown: &tokio_util::sync::CancellationToken,
-) -> bool {
+) -> bool
+where
+    S: futures::Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
     if shutdown.is_cancelled() || permit.revalidate().is_err() {
+        conn.sm_inbound_completion
+            .abandon(completion.inbound_sequence);
         return false;
     }
     conn.sm_inbound_completion
@@ -1518,6 +1526,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn revoked_consumed_handoff_is_abandoned_before_cleanup() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("handoff-revoked".to_string(), true, Some(300));
+        let inbound_sequence = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        let completion = crate::server::routes::interpret::OrderedRelayHandoffCompletion {
+            inbound_sequence,
+            replies: Vec::new(),
+        };
+        let mut sender = UpgradeCloseSink::default();
+        let mut receiver = futures::stream::pending::<Result<Message, &'static str>>();
+        let (handoff_tx, mut handoff_rx) = tokio::sync::mpsc::unbounded_channel();
+        conn.ordered_relay_handoff_tx = Some(handoff_tx);
+        lifecycle.begin_fenced_recovery();
+
+        assert!(
+            !handle_ordered_relay_handoff_completion(
+                &mut sender,
+                &mut receiver,
+                &state,
+                &mut conn,
+                completion,
+                &permit,
+                &shutdown,
+            )
+            .await
+        );
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            drain_ordered_relay_handoffs_before_cleanup(&mut handoff_rx, &mut conn),
+        )
+        .await
+        .expect("abandoned consumed completion must not block cleanup");
+
+        assert_eq!(conn.sm_state.get_inbound_count(), 0);
+        assert!(!conn.sm_inbound_completion.has_pending());
+        assert!(sender.sent.is_empty());
+    }
+
+    #[tokio::test]
     async fn cleanup_waits_for_pre_hole_ordered_relay_completion() {
         let mut conn = WsConnState::new();
         conn.sm_state
@@ -1629,11 +1681,11 @@ mod tests {
         let mut first = xmpp_parsers::message::Message::new(Some(
             "bob@example.com".parse().expect("recipient JID"),
         ));
-        first.id = Some("first".to_string());
+        first.id = Some(xmpp_parsers::message::Id("first".to_string()));
         let mut later = xmpp_parsers::message::Message::new(Some(
             "carol@example.com".parse().expect("recipient JID"),
         ));
-        later.id = Some("later".to_string());
+        later.id = Some(xmpp_parsers::message::Id("later".to_string()));
         conn.deferred_inbound.extend([
             axum::extract::ws::Utf8Bytes::from(
                 waddle_xmpp::parser::stanza_to_string(first).expect("serialize first message"),

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -569,7 +569,7 @@ async fn handle_xmpp_websocket(
                                 jid = ?conn.phase.bound_jid(),
                                 "Cross-node resume: force-detaching this session (<conflict/> close)"
                             );
-                            if conn.stream_open_sent {
+                            if conn.has_committed_live_stream_open() {
                                 let _ = send_ws_text_frames_with_authority(
                                     &mut ws_sender,
                                     [build_conflict_stream_error(), websocket_stream_close_xml()],
@@ -774,12 +774,13 @@ async fn handle_xmpp_websocket(
     info!("XMPP WebSocket connection closed");
 }
 
-async fn close_live_session_for_node_unavailable(
-    ws_sender: &mut SplitSink<WebSocket, Message>,
-    conn: &WsConnState,
-) {
+async fn close_live_session_for_node_unavailable<S, E>(ws_sender: &mut S, conn: &WsConnState)
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
     let close_peer = async {
-        if conn.stream_open_sent {
+        if conn.has_committed_live_stream_open() {
             let _ = send_ws_text_frames(
                 ws_sender,
                 [
@@ -1172,6 +1173,7 @@ async fn handle_inbound_text(
     .await
     {
         BatchWriteOutcome::Continue => {
+            conn.commit_server_stream_open_response();
             conn.publish_pending_sm_enable(state.as_ref());
         }
         BatchWriteOutcome::TransportClosed => return false,
@@ -1471,6 +1473,12 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
 
 #[cfg(test)]
 mod tests {
+    use super::super::{
+        batch_write::{
+            write_response_batch_with_admission, BatchAuthority, BatchSmPolicy, BatchWriteOutcome,
+        },
+        transport_xml::websocket_stream_open_xml,
+    };
     use super::*;
     use std::pin::Pin;
     use std::task::{Context, Poll};
@@ -1512,6 +1520,42 @@ mod tests {
         }
     }
 
+    struct RevokeWhileReadyPendingSink {
+        lifecycle: crate::clustering::NodeLifecycle,
+        start_send_called: bool,
+    }
+
+    impl futures::Sink<Message> for RevokeWhileReadyPendingSink {
+        type Error = &'static str;
+
+        fn poll_ready(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.lifecycle.begin_fenced_recovery();
+            Poll::Pending
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+            self.start_send_called = true;
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
     #[tokio::test]
     async fn post_upgrade_admission_revocation_sends_websocket_close() {
         let mut socket = UpgradeCloseSink::default();
@@ -1520,6 +1564,95 @@ mod tests {
 
         assert_eq!(socket.sent, vec![Message::Close(None)]);
         assert!(socket.closed);
+    }
+
+    #[tokio::test]
+    async fn revocation_while_open_response_is_pending_closes_websocket_without_stream_error() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let mut conn = WsConnState::new();
+        conn.begin_server_stream_open_response();
+        let mut sender = RevokeWhileReadyPendingSink {
+            lifecycle,
+            start_send_called: false,
+        };
+        let mut reader = futures::stream::pending::<Result<Message, &'static str>>();
+
+        let outcome = write_response_batch_with_admission(
+            &mut sender,
+            &mut reader,
+            state.as_ref(),
+            &mut conn,
+            vec![websocket_stream_open_xml("example.com")],
+            BatchSmPolicy::Record,
+            BatchAuthority {
+                permit: &permit,
+                shutdown: &shutdown,
+            },
+        )
+        .await;
+
+        assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+        assert!(
+            !sender.start_send_called,
+            "the server <open/> must not reach start_send after revocation"
+        );
+        assert!(
+            !conn.has_committed_live_stream_open(),
+            "an interrupted open batch must not permit a server-first stream error"
+        );
+
+        let mut closing_sender = UpgradeCloseSink::default();
+        close_live_session_for_node_unavailable(&mut closing_sender, &conn).await;
+
+        assert_eq!(closing_sender.sent, vec![]);
+        assert!(closing_sender.closed, "the transport still closes");
+    }
+
+    #[tokio::test]
+    async fn committed_open_keeps_system_shutdown_and_rfc7395_close_on_revocation() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let lifecycle = crate::clustering::NodeLifecycle::new();
+        let permit = lifecycle.admit().expect("serving permit");
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let mut conn = WsConnState::new();
+        conn.begin_server_stream_open_response();
+        let mut sender = UpgradeCloseSink::default();
+        let mut reader = futures::stream::pending::<Result<Message, &'static str>>();
+
+        let outcome = write_response_batch_with_admission(
+            &mut sender,
+            &mut reader,
+            state.as_ref(),
+            &mut conn,
+            vec![websocket_stream_open_xml("example.com")],
+            BatchSmPolicy::Record,
+            BatchAuthority {
+                permit: &permit,
+                shutdown: &shutdown,
+            },
+        )
+        .await;
+        assert!(matches!(outcome, BatchWriteOutcome::Continue));
+        conn.commit_server_stream_open_response();
+        assert!(conn.has_committed_live_stream_open());
+
+        let mut closing_sender = UpgradeCloseSink::default();
+        close_live_session_for_node_unavailable(&mut closing_sender, &conn).await;
+
+        assert_eq!(
+            closing_sender.sent,
+            vec![
+                Message::Text(build_system_shutdown_stream_error().into()),
+                Message::Text(websocket_stream_close_xml().into()),
+            ]
+        );
+        assert!(
+            closing_sender.closed,
+            "the transport closes after RFC 7395 close"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -24,6 +24,29 @@ use axum::{
 use futures::stream::{SplitSink, SplitStream};
 use waddle_xmpp::stream_management::SmRequest;
 
+#[derive(Debug, PartialEq, Eq)]
+enum WebSocketAdmissionRevocation {
+    Shutdown,
+    Lifecycle(crate::clustering::NodeAdmissionError),
+}
+
+/// Revalidate immediately before returning the upgrade response, and again
+/// inside the upgrade callback before any XMPP state is created. Axum/Hyper
+/// writes HTTP 101 after the handler returns, so a lifecycle transition in
+/// that final transport-only gap may still result in 101; the callback check
+/// guarantees that socket is then dropped without processing XMPP.
+fn revalidate_websocket_admission(
+    state: &WebSocketState,
+    permit: &crate::clustering::NodeAdmissionPermit,
+) -> Result<(), WebSocketAdmissionRevocation> {
+    if state.deps.shutdown.stop_token().is_cancelled() {
+        return Err(WebSocketAdmissionRevocation::Shutdown);
+    }
+    permit
+        .revalidate()
+        .map_err(WebSocketAdmissionRevocation::Lifecycle)
+}
+
 /// Create the WebSocket router
 pub fn router(state: Arc<WebSocketState>) -> Router {
     Router::new()
@@ -70,8 +93,22 @@ async fn xmpp_websocket_handler(
         Err(rejection) => return rejection.into_response(),
     };
 
+    if let Err(reason) = revalidate_websocket_admission(&state, &admission_permit) {
+        info!(
+            ?reason,
+            "Rejecting XMPP WebSocket upgrade: admission was revoked"
+        );
+        return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
+
     ws.protocols(["xmpp"]).on_upgrade(move |socket| async move {
-        let _admission_permit = admission_permit;
+        if let Err(reason) = revalidate_websocket_admission(&state, &admission_permit) {
+            info!(
+                ?reason,
+                "Closing upgraded WebSocket: admission was revoked before XMPP start"
+            );
+            return;
+        }
         handle_xmpp_websocket(socket, state, connection_guard).await;
     })
 }
@@ -259,6 +296,48 @@ async fn handle_xmpp_websocket(
         // starve routed stanzas or dead-peer detection.
         let deferred_pending = !conn.deferred_inbound.is_empty();
         tokio::select! {
+            biased;
+
+            // Process stop is the highest-priority event. If cancellation and
+            // a queued frame/work item are both ready, no further stanza work
+            // starts after the node has begun draining or failed critically.
+            _ = shutdown_token.cancelled() => {
+                info!(
+                    jid = ?conn.phase.bound_jid(),
+                    "Graceful shutdown: closing live session with system-shutdown stream error"
+                );
+                let close_peer = async {
+                    if conn.stream_open_sent {
+                        let _ = send_ws_text_frames(
+                            &mut ws_sender,
+                            [
+                                build_system_shutdown_stream_error(),
+                                websocket_stream_close_xml(),
+                            ],
+                            "Failed to send system-shutdown stream error",
+                        )
+                        .await;
+                    }
+                    let _ = close_ws_connection(
+                        &mut ws_sender,
+                        "Failed to send WebSocket close frame after system-shutdown",
+                    )
+                    .await;
+                };
+                if tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_peer)
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        jid = ?conn.phase.bound_jid(),
+                        timeout_secs = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
+                        "Graceful shutdown: peer did not accept the close frames in time; \
+                         proceeding to detach without them"
+                    );
+                }
+                break;
+            }
+
             // Process one drain-deferred inbound frame.
             _ = std::future::ready(()), if deferred_pending => {
                 let Some(text) = conn.deferred_inbound.pop_front() else {
@@ -453,57 +532,6 @@ async fn handle_xmpp_websocket(
                 }
             }
 
-            // Graceful shutdown (issue #1091): SIGTERM cancelled the
-            // ecdysis stop token. Close this live session natively —
-            // RFC 6120 §4.9.3.20 <system-shutdown/> stream error, then
-            // the RFC 7395 <close/> frame and the WS close handshake —
-            // and break WITHOUT transitioning to Closing: the cleanup
-            // fork below must still see a resumable phase so an
-            // XEP-0198 session detaches into the SmSessionRegistry,
-            // where the shutdown drain promotes its unacked queue (Q6).
-            //
-            // Stream frames are sent only after the server has answered
-            // the client's <open/>: RFC 6120 §4.9.1.2 forbids a stream
-            // error before the response stream header, so a connection
-            // still in the upgrade-to-open gap gets the WS closing
-            // handshake alone.
-            _ = shutdown_token.cancelled() => {
-                info!(
-                    jid = ?conn.phase.bound_jid(),
-                    "Graceful shutdown: closing live session with system-shutdown stream error"
-                );
-                let close_peer = async {
-                    if conn.stream_open_sent {
-                        let _ = send_ws_text_frames(
-                            &mut ws_sender,
-                            [
-                                build_system_shutdown_stream_error(),
-                                websocket_stream_close_xml(),
-                            ],
-                            "Failed to send system-shutdown stream error",
-                        )
-                        .await;
-                    }
-                    let _ = close_ws_connection(
-                        &mut ws_sender,
-                        "Failed to send WebSocket close frame after system-shutdown",
-                    )
-                    .await;
-                };
-                if tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_peer)
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        jid = ?conn.phase.bound_jid(),
-                        timeout_secs = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
-                        "Graceful shutdown: peer did not accept the close frames in time; \
-                         proceeding to detach without them"
-                    );
-                }
-                break;
-            }
-
             // RFC 7395 §3.8 keepalive clock (issue #1090). Fires only
             // when the state machine armed a timer; the tick is fed
             // back into the machine, whose policy decides: quiet
@@ -616,7 +644,17 @@ async fn handle_xmpp_websocket(
     if superseded {
         super::stream_management::defer_superseded_sm_claim(state.as_ref(), &conn.sm_state);
     } else {
-        process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+        if shutdown_token.is_cancelled() {
+            let dropped = discard_deferred_inbound(&mut conn);
+            if dropped > 0 {
+                info!(
+                    dropped,
+                    "Dropping deferred inbound frames after process stop; sender may replay them"
+                );
+            }
+        } else {
+            process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+        }
         drain_ordered_relay_handoffs_before_cleanup(&mut handoff_rx, &mut conn).await;
     }
 
@@ -726,6 +764,85 @@ mod admission_tests {
                 .expect("response")
                 .status(),
             axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_transition_revokes_an_inflight_upgrade_permit() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let lifecycle = &state.deps.app_state.node_lifecycle;
+        let permit = lifecycle.admit().expect("initial serving permit");
+
+        lifecycle.begin_fenced_recovery();
+        assert_eq!(
+            revalidate_websocket_admission(&state, &permit),
+            Err(WebSocketAdmissionRevocation::Lifecycle(
+                crate::clustering::NodeAdmissionError::NotServing(
+                    crate::clustering::NodeAdmission::FencedRecovering
+                )
+            ))
+        );
+
+        lifecycle.serve();
+        assert_eq!(
+            revalidate_websocket_admission(&state, &permit),
+            Err(WebSocketAdmissionRevocation::Lifecycle(
+                crate::clustering::NodeAdmissionError::Revoked
+            ))
+        );
+
+        let recovered_permit = lifecycle.admit().expect("recovered serving permit");
+        lifecycle.fail(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated);
+        assert!(matches!(
+            revalidate_websocket_admission(&state, &recovered_permit),
+            Err(WebSocketAdmissionRevocation::Lifecycle(
+                crate::clustering::NodeAdmissionError::NotServing(
+                    crate::clustering::NodeAdmission::Failed(
+                        crate::clustering::CriticalNodeFailure::RoomRegistryTerminated
+                    )
+                )
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn ordinary_process_stop_revokes_upgrade_without_latching_critical_failure() {
+        let state = super::super::tests::create_test_websocket_state().await;
+        let permit = state
+            .deps
+            .app_state
+            .node_lifecycle
+            .admit()
+            .expect("initial serving permit");
+
+        state.deps.shutdown.stop_token().cancel();
+
+        assert_eq!(
+            revalidate_websocket_admission(&state, &permit),
+            Err(WebSocketAdmissionRevocation::Shutdown)
+        );
+        assert_eq!(state.deps.app_state.node_lifecycle.critical_failure(), None);
+    }
+
+    #[tokio::test]
+    async fn biased_connection_select_prefers_cancelled_stop_to_ready_bound_stanza() {
+        let stop = tokio_util::sync::CancellationToken::new();
+        stop.cancel();
+        let ready_bound_stanza =
+            std::future::ready(Stanza::Message(xmpp_parsers::message::Message::new(Some(
+                "peer@example.com".parse::<jid::Jid>().expect("peer JID"),
+            ))));
+        let mut routed = false;
+
+        tokio::select! {
+            biased;
+            _ = stop.cancelled() => {}
+            _ = ready_bound_stanza => routed = true,
+        }
+
+        assert!(
+            !routed,
+            "cancelled process stop must win before stanza work"
         );
     }
 }
@@ -1026,7 +1143,7 @@ async fn process_deferred_inbound_after_transport_loss(
     conn: &mut WsConnState,
 ) {
     if conn.sm_inbound_completion.has_unhandled_hole() {
-        let dropped = discard_deferred_inbound_after_unhandled_hole(conn);
+        let dropped = discard_deferred_inbound(conn);
         if dropped > 0 {
             warn!(
                 dropped,
@@ -1046,7 +1163,7 @@ async fn process_deferred_inbound_after_transport_loss(
         };
         batch_write::record_remaining_for_replay(conn, responses.into_iter(), policy);
         if conn.sm_inbound_completion.has_unhandled_hole() {
-            let dropped = discard_deferred_inbound_after_unhandled_hole(conn);
+            let dropped = discard_deferred_inbound(conn);
             if dropped > 0 {
                 warn!(
                     dropped,
@@ -1058,7 +1175,7 @@ async fn process_deferred_inbound_after_transport_loss(
     }
 }
 
-fn discard_deferred_inbound_after_unhandled_hole(conn: &mut WsConnState) -> usize {
+fn discard_deferred_inbound(conn: &mut WsConnState) -> usize {
     let dropped = conn.deferred_inbound.len();
     conn.deferred_inbound.clear();
     dropped
@@ -1203,7 +1320,7 @@ mod tests {
             axum::extract::ws::Utf8Bytes::from_static("<presence/>"),
         ]);
 
-        assert_eq!(discard_deferred_inbound_after_unhandled_hole(&mut conn), 2);
+        assert_eq!(discard_deferred_inbound(&mut conn), 2);
         assert!(conn.deferred_inbound.is_empty());
         assert_eq!(conn.sm_state.get_inbound_count(), 0);
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1,11 +1,11 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
+    batch_write::{write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome},
     cleanup::cleanup_connection_shutdown,
     frame::{handle_xmpp_frame, handle_xmpp_frame_with_admission},
     interpret_loop::build_interpret_deps,
     outbound::handle_outbound_stanza,
-    registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
+    registration::{register_bound_connection_after_frame_with_admission, RegistrationAfterFrame},
     replay::drive_interpret_loop,
     send::{close_ws_connection, send_ws_message, send_ws_text_frames},
     session_init::build_internal_server_error_stream_error,
@@ -293,6 +293,10 @@ async fn handle_xmpp_websocket(
             // bound, so a genuinely stuck client is still detached in time.
             if rising_edge || conn.sm_state.last_acked != conn.send_window_last_request_acked {
                 conn.send_window_last_request_acked = conn.sm_state.last_acked;
+                if shutdown_token.is_cancelled() || admission_permit.revalidate().is_err() {
+                    close_live_session_for_node_unavailable(&mut ws_sender, &conn).await;
+                    break;
+                }
                 if !send_ws_message(
                     &mut ws_sender,
                     Message::Text(SmRequest::to_xml().into()),
@@ -445,6 +449,8 @@ async fn handle_xmpp_websocket(
                             &mut conn,
                             &mut timers,
                             outbound_stanza,
+                            &admission_permit,
+                            &shutdown_token,
                         )
                         .await
                         {
@@ -477,6 +483,8 @@ async fn handle_xmpp_websocket(
                             &state,
                             &mut conn,
                             handoff,
+                            &admission_permit,
+                            &shutdown_token,
                         )
                         .await
                         {
@@ -512,6 +520,14 @@ async fn handle_xmpp_websocket(
                             let _ = request
                                 .ack
                                 .send(waddle_xmpp::registry::ForceDetachOutcome::IdentityMismatch);
+                        } else if shutdown_token.is_cancelled()
+                            || admission_permit.revalidate().is_err()
+                        {
+                            // The old serving generation may no longer emit
+                            // the optional `<conflict/>`. Still acknowledge
+                            // only after normal detach persistence below.
+                            pending_force_detach_ack = Some(request.ack);
+                            break;
                         } else {
                             info!(
                                 jid = ?conn.phase.bound_jid(),
@@ -917,6 +933,11 @@ async fn handle_inbound_text(
         pending_tx,
         force_detach_rx,
     } = channels;
+    if close_if_frame_authority_revoked(state, conn, ws_sender, admission_permit, shutdown_token)
+        .await
+    {
+        return false;
+    }
     debug!(len = text.len(), "Received XMPP WebSocket message");
     // Any inbound frame is liveness evidence for the
     // RFC 7395 §3.8 keepalive policy (issue #1090).
@@ -939,6 +960,11 @@ async fn handle_inbound_text(
         close_live_session_for_node_unavailable(ws_sender, conn).await;
         return false;
     }
+    if close_if_frame_authority_revoked(state, conn, ws_sender, admission_permit, shutdown_token)
+        .await
+    {
+        return false;
+    }
 
     // Mirror any phase transition `handle_xmpp_frame` performed (most
     // importantly Ready → Closing on SASL failure / stream error)
@@ -952,9 +978,29 @@ async fn handle_inbound_text(
     // resource binding. This keeps the transport loop focused on
     // WebSocket I/O while the registration module owns registry
     // publication and post-registration SM finalization.
-    match register_bound_connection_after_frame(state.as_ref(), domain, conn, pending_tx).await {
+    match register_bound_connection_after_frame_with_admission(
+        state.as_ref(),
+        domain,
+        conn,
+        pending_tx,
+        admission_permit,
+        shutdown_token,
+    )
+    .await
+    {
         RegistrationAfterFrame::Unchanged => {}
         RegistrationAfterFrame::SessionInitializationFailed => {
+            if close_if_frame_authority_revoked(
+                state,
+                conn,
+                ws_sender,
+                admission_permit,
+                shutdown_token,
+            )
+            .await
+            {
+                return false;
+            }
             let stream_error = build_internal_server_error_stream_error(
                 "Session initialization failed; please reconnect.",
             );
@@ -1023,6 +1069,18 @@ async fn handle_inbound_text(
                 }
             }
         }
+        RegistrationAfterFrame::AuthorityRevoked
+        | RegistrationAfterFrame::AuthorityRevokedAfterSmFinalization => {
+            let _ = close_if_frame_authority_revoked(
+                state,
+                conn,
+                ws_sender,
+                admission_permit,
+                shutdown_token,
+            )
+            .await;
+            return false;
+        }
     }
 
     ensure_websocket_stream_close_for_closing_phase(conn, &mut responses);
@@ -1045,13 +1103,15 @@ async fn handle_inbound_text(
     } else {
         BatchSmPolicy::Record
     };
-    match write_response_batch(
+    match write_response_batch_with_admission(
         ws_sender,
         ws_receiver,
         state.as_ref(),
         conn,
         responses,
         policy,
+        admission_permit,
+        shutdown_token,
     )
     .await
     {
@@ -1059,6 +1119,20 @@ async fn handle_inbound_text(
             conn.publish_pending_sm_enable(state.as_ref());
         }
         BatchWriteOutcome::TransportClosed => return false,
+        BatchWriteOutcome::AuthorityRevoked => {
+            // No further frame was recorded or written. Any `<enable/>`
+            // response that did reach the socket returned Continue and must
+            // still publish synchronously at its wire commit point.
+            let _ = close_if_frame_authority_revoked(
+                state,
+                conn,
+                ws_sender,
+                admission_permit,
+                shutdown_token,
+            )
+            .await;
+            return false;
+        }
     }
 
     // A timed-out message/presence dispatch was cancelled before the server
@@ -1087,31 +1161,71 @@ async fn handle_inbound_text(
     true
 }
 
+async fn close_if_frame_authority_revoked(
+    state: &Arc<WebSocketState>,
+    conn: &mut WsConnState,
+    ws_sender: &mut SplitSink<WebSocket, Message>,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> bool {
+    if !shutdown.is_cancelled() && permit.revalidate().is_ok() {
+        return false;
+    }
+
+    // `<enable/>` has not reached its wire commit point yet. Dropping this
+    // typed guard inventories exact claim release and provisional ISR token
+    // revocation; a stale generation must never send `<enabled/>`.
+    drop(conn.pending_sm_enable_commit.take());
+    if let Some(stream_id) = conn.pending_resume_stream_id.take() {
+        conn.pending_resume_h = None;
+        if let Err(error) = state
+            .deps
+            .protocol
+            .sm_session_registry
+            .release_claim(&stream_id)
+            .await
+        {
+            warn!(%stream_id, %error, "Failed to release SM resume claim after authority revocation");
+        }
+        state.deps.protocol.resumable_sessions.remove(&stream_id);
+    }
+    close_live_session_for_node_unavailable(ws_sender, conn).await;
+    true
+}
+
 async fn handle_ordered_relay_handoff_completion(
     ws_sender: &mut SplitSink<WebSocket, Message>,
     ws_receiver: &mut SplitStream<WebSocket>,
     state: &Arc<WebSocketState>,
     conn: &mut WsConnState,
     completion: crate::server::routes::interpret::OrderedRelayHandoffCompletion,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
 ) -> bool {
+    if shutdown.is_cancelled() || permit.revalidate().is_err() {
+        return false;
+    }
     conn.sm_inbound_completion
         .complete(completion.inbound_sequence, &mut conn.sm_state);
     let replies = serialize_ordered_relay_handoff_replies(completion.replies);
     if replies.is_empty() {
         return true;
     }
-    match write_response_batch(
+    match write_response_batch_with_admission(
         ws_sender,
         ws_receiver,
         state.as_ref(),
         conn,
         replies,
         BatchSmPolicy::Record,
+        permit,
+        shutdown,
     )
     .await
     {
         BatchWriteOutcome::Continue => true,
         BatchWriteOutcome::TransportClosed => false,
+        BatchWriteOutcome::AuthorityRevoked => false,
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -9,7 +9,10 @@ use super::{
     outbound::{handle_outbound_stanza, OutboundAuthority},
     registration::{register_bound_connection_after_frame_with_admission, RegistrationAfterFrame},
     replay::drive_interpret_loop,
-    send::{close_ws_connection, send_ws_message, send_ws_text_frames},
+    send::{
+        close_ws_connection, send_ws_message, send_ws_message_with_authority, send_ws_text_frames,
+        AuthoritySendOutcome,
+    },
     session_init::build_internal_server_error_stream_error,
     state::{InboundFrameTerminal, WsConnState},
     stream_management::SmRegistrationFinalization,
@@ -310,13 +313,16 @@ async fn handle_xmpp_websocket(
                     close_live_session_for_node_unavailable(&mut ws_sender, &conn).await;
                     break;
                 }
-                if !send_ws_message(
-                    &mut ws_sender,
-                    Message::Text(SmRequest::to_xml().into()),
-                    "Failed to send SM <r/> at send-window loop pause",
-                )
-                .await
-                {
+                if !matches!(
+                    send_ws_message_with_authority(
+                        &mut ws_sender,
+                        Message::Text(SmRequest::to_xml().into()),
+                        "Failed to send SM <r/> at send-window loop pause",
+                        Some((&admission_permit, &shutdown_token)),
+                    )
+                    .await,
+                    AuthoritySendOutcome::Sent
+                ) {
                     break;
                 }
             }
@@ -426,9 +432,16 @@ async fn handle_xmpp_websocket(
                     }
                     Some(Ok(Message::Ping(data))) => {
                         conn.note_transport_activity();
-                        if !send_ws_message(&mut ws_sender, Message::Pong(data), "Failed to send pong")
-                            .await
-                        {
+                        if !matches!(
+                            send_ws_message_with_authority(
+                                &mut ws_sender,
+                                Message::Pong(data),
+                                "Failed to send pong",
+                                Some((&admission_permit, &shutdown_token)),
+                            )
+                            .await,
+                            AuthoritySendOutcome::Sent
+                        ) {
                             break;
                         }
                     }
@@ -613,13 +626,16 @@ async fn handle_xmpp_websocket(
                 }
                 let mut ping_send_failed = false;
                 for _ in 0..drive.keepalive_probes {
-                    if !send_ws_message(
-                        &mut ws_sender,
-                        Message::Ping(axum::body::Bytes::new()),
-                        "Failed to send keepalive ping",
-                    )
-                    .await
-                    {
+                    if !matches!(
+                        send_ws_message_with_authority(
+                            &mut ws_sender,
+                            Message::Ping(axum::body::Bytes::new()),
+                            "Failed to send keepalive ping",
+                            Some((&admission_permit, &shutdown_token)),
+                        )
+                        .await,
+                        AuthoritySendOutcome::Sent
+                    ) {
                         ping_send_failed = true;
                         break;
                     }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -48,10 +48,9 @@ async fn await_control_stage<T>(
     )>,
     work: impl std::future::Future<Output = T>,
 ) -> Result<T, InboundFrameTerminal> {
-    // Control/auth/session futures own exact claim and rollback guards at
-    // internal await boundaries. Let the stage reach its defined completion
-    // boundary, then reject its response/publication if the generation moved;
-    // dropping these futures mid-commit could leak a claim.
+    // Claim-owning control futures must reach their typed completion boundary;
+    // dropping them mid-commit could strand durable ownership. The process
+    // boundary is independently hard-bounded by the HTTP drain deadline.
     let output = work.await;
     if let Some((permit, shutdown)) = admission {
         if shutdown.is_cancelled() || permit.revalidate().is_err() {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -97,7 +97,6 @@ async fn handle_xmpp_frame_impl(
         suppress_sm_record_next_batch,
         pending_sm_enable_commit,
         state_machine,
-        stream_open_sent,
         registry_owner,
         ..
     } = conn;
@@ -169,7 +168,7 @@ async fn handle_xmpp_frame_impl(
             let open_element = websocket_stream_open_xml(domain);
             let isr_available = state.deps.isr_available();
             let features_element = build_stream_features_for_phase(phase, isr_available);
-            *stream_open_sent = true;
+            conn.begin_server_stream_open_response();
             vec![open_element, features_element]
         }
 
@@ -178,7 +177,7 @@ async fn handle_xmpp_frame_impl(
             *phase = ConnectionPhase::closing(phase.bound_jid().cloned());
             // The stream is over: no response header remains to hang a
             // graceful-shutdown <stream:error> on.
-            *stream_open_sent = false;
+            conn.reset_stream_open_for_xmpp_lifecycle();
             vec![websocket_stream_close_xml()]
         }
 
@@ -221,7 +220,7 @@ async fn handle_xmpp_frame_impl(
             // exists for the new stream, so the graceful-shutdown arm
             // must not send a <stream:error> (§4.9.1.2).
             if phase.is_authenticated() {
-                *stream_open_sent = false;
+                conn.reset_stream_open_for_xmpp_lifecycle();
             }
             responses
         }
@@ -272,7 +271,7 @@ async fn handle_xmpp_frame_impl(
             // RFC 6120 §6.4.6 / XEP-0388: successful authentication restarts
             // the stream — same rule the SASL1 <auth>/<response> arms apply.
             if phase.is_authenticated() {
-                *stream_open_sent = false;
+                conn.reset_stream_open_for_xmpp_lifecycle();
             }
             responses
         }
@@ -292,7 +291,7 @@ async fn handle_xmpp_frame_impl(
             // SCRAM success no response header exists for the new
             // stream until the next <open/> is answered.
             if phase.is_authenticated() {
-                *stream_open_sent = false;
+                conn.reset_stream_open_for_xmpp_lifecycle();
             }
             responses
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -398,12 +398,17 @@ async fn handle_xmpp_frame_impl(
                     }
                 }
             };
-            let dispatch_result = match admission {
+            let (dispatch_result, authority_revoked_after_start) = match admission {
                 Some((permit, shutdown)) => {
-                    run_with_backstop_and_admission(backstop, dispatch, permit, shutdown).await
+                    let result =
+                        run_with_backstop_and_admission(backstop, dispatch, permit, shutdown).await;
+                    (result.result, result.authority_revoked_after_start)
                 }
-                None => run_with_backstop(backstop, dispatch).await,
+                None => (run_with_backstop(backstop, dispatch).await, false),
             };
+            if authority_revoked_after_start {
+                *inbound_frame_terminal = Some(InboundFrameTerminal::AuthorityRevoked);
+            }
             let (responses, disposition) = match dispatch_result {
                 Ok(responses) => (responses, InboundDisposition::Handled),
                 Err(StanzaTimeout::HandledIq(reply)) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -41,6 +41,26 @@ pub(super) async fn handle_xmpp_frame_with_admission(
     handle_xmpp_frame_impl(frame, domain, state, conn, Some((permit, shutdown))).await
 }
 
+async fn await_control_stage<T>(
+    admission: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+    work: impl std::future::Future<Output = T>,
+) -> Result<T, InboundFrameTerminal> {
+    // Control/auth/session futures own exact claim and rollback guards at
+    // internal await boundaries. Let the stage reach its defined completion
+    // boundary, then reject its response/publication if the generation moved;
+    // dropping these futures mid-commit could leak a claim.
+    let output = work.await;
+    if let Some((permit, shutdown)) = admission {
+        if shutdown.is_cancelled() || permit.revalidate().is_err() {
+            return Err(InboundFrameTerminal::AuthorityRevoked);
+        }
+    }
+    Ok(output)
+}
+
 async fn handle_xmpp_frame_impl(
     frame: &str,
     domain: &str,
@@ -81,6 +101,12 @@ async fn handle_xmpp_frame_impl(
         registry_owner,
         ..
     } = conn;
+    if let Some((permit, shutdown)) = admission {
+        if shutdown.is_cancelled() || permit.revalidate().is_err() {
+            *inbound_frame_terminal = Some(InboundFrameTerminal::AuthorityRevoked);
+            return Vec::new();
+        }
+    }
     let muc_domain = state.deps.service_domains.muc.clone();
 
     // SM nonzas (enable/resume/r/a) are not part of the parse_frame typed
@@ -105,7 +131,13 @@ async fn handle_xmpp_frame_impl(
                 blocklist_interested,
                 pending_sm_enable_commit,
             };
-            return handle_sm_stanza(sm, state, ctx).await;
+            return match await_control_stage(admission, handle_sm_stanza(sm, state, ctx)).await {
+                Ok(responses) => responses,
+                Err(terminal) => {
+                    *inbound_frame_terminal = Some(terminal);
+                    Vec::new()
+                }
+            };
         }
     }
 
@@ -162,16 +194,26 @@ async fn handle_xmpp_frame_impl(
                 }
                 return vec![sasl_failure_xml("not-authorized")];
             }
-            let responses = match mechanism.as_str() {
-                "SCRAM-SHA-256" => {
-                    handle_sasl_scram_client_first(&data, domain, state, phase).await
+            let responses = match await_control_stage(admission, async {
+                match mechanism.as_str() {
+                    "SCRAM-SHA-256" => {
+                        handle_sasl_scram_client_first(&data, domain, state, phase).await
+                    }
+                    "OAUTHBEARER" => {
+                        handle_sasl_oauthbearer(&data, state, authenticated_session, phase).await
+                    }
+                    other => {
+                        warn!(mechanism = %other, "Unsupported SASL mechanism");
+                        vec![sasl_failure_xml("invalid-mechanism")]
+                    }
                 }
-                "OAUTHBEARER" => {
-                    handle_sasl_oauthbearer(&data, state, authenticated_session, phase).await
-                }
-                other => {
-                    warn!(mechanism = %other, "Unsupported SASL mechanism");
-                    vec![sasl_failure_xml("invalid-mechanism")]
+            })
+            .await
+            {
+                Ok(responses) => responses,
+                Err(terminal) => {
+                    *inbound_frame_terminal = Some(terminal);
+                    return Vec::new();
                 }
             };
             // RFC 6120 §6.4.6: SASL success restarts the stream. Until
@@ -215,9 +257,18 @@ async fn handle_xmpp_frame_impl(
                 blocklist_interested,
                 pending_sm_enable_commit,
             };
-            let responses =
-                handle_isr_resume_authenticate(mechanism, initial_response, resume, state, ctx)
-                    .await;
+            let responses = match await_control_stage(
+                admission,
+                handle_isr_resume_authenticate(mechanism, initial_response, resume, state, ctx),
+            )
+            .await
+            {
+                Ok(responses) => responses,
+                Err(terminal) => {
+                    *inbound_frame_terminal = Some(terminal);
+                    return Vec::new();
+                }
+            };
             // RFC 6120 §6.4.6 / XEP-0388: successful authentication restarts
             // the stream — same rule the SASL1 <auth>/<response> arms apply.
             if phase.is_authenticated() {
@@ -247,22 +298,9 @@ async fn handle_xmpp_frame_impl(
         }
 
         InboundFrame::Stanza(stanza) => {
-            let reserved_inbound_for_sm = sm_state
-                .enabled
-                .then(|| sm_inbound_completion.reserve(sm_state));
-            let ordered_relay_origin = ordered_relay_origin_for_inbound_stanza(
-                state,
-                sm_state,
-                phase.bound_jid(),
-                registry_owner.as_ref(),
-                reserved_inbound_for_sm,
-                ordered_relay_handoff_tx.as_ref(),
-            )
-            .await;
-
-            // Resource binding is stream setup, not request processing: handle
-            // it inline and return BEFORE the wedge backstop (#808 ADR-008 scope
-            // guard). It must never be subject to, or delayed by, the timeout.
+            // Resource binding is stream setup, not a countable request. Keep
+            // it before SM reservation and the ordered-relay lookup so a
+            // lifecycle cancellation cannot leave an unsettled inbound slot.
             if let Stanza::Iq(iq) = &*stanza {
                 let is_bind = matches!(
                     &**iq,
@@ -271,13 +309,35 @@ async fn handle_xmpp_frame_impl(
                         if e.ns() == waddle_xmpp::ns::BIND
                 );
                 if is_bind {
-                    let responses = handle_resource_binding(iq, domain, phase);
-                    if let Some(inbound_sequence) = reserved_inbound_for_sm {
-                        sm_inbound_completion.complete(inbound_sequence, sm_state);
-                    }
-                    return responses;
+                    return handle_resource_binding(iq, domain, phase);
                 }
             }
+
+            let reserved_inbound_for_sm = sm_state
+                .enabled
+                .then(|| sm_inbound_completion.reserve(sm_state));
+            let ordered_relay_origin = match await_control_stage(
+                admission,
+                ordered_relay_origin_for_inbound_stanza(
+                    state,
+                    sm_state,
+                    phase.bound_jid(),
+                    registry_owner.as_ref(),
+                    reserved_inbound_for_sm,
+                    ordered_relay_handoff_tx.as_ref(),
+                ),
+            )
+            .await
+            {
+                Ok(origin) => origin,
+                Err(terminal) => {
+                    if let Some(inbound_sequence) = reserved_inbound_for_sm {
+                        sm_inbound_completion.abandon(inbound_sequence);
+                    }
+                    *inbound_frame_terminal = Some(terminal);
+                    return Vec::new();
+                }
+            };
 
             // #808: capture the conformant-reply metadata before the stanza is
             // moved into the dispatch future, then run dispatch under the

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -1,6 +1,9 @@
 use super::*;
 use super::{
-    frame_backstop::{run_with_backstop, InboundDisposition, StanzaBackstop, StanzaTimeout},
+    frame_backstop::{
+        run_with_backstop, run_with_backstop_and_admission, InboundDisposition, StanzaBackstop,
+        StanzaTimeout,
+    },
     isr_resume::handle_isr_resume_authenticate,
     parse_errors::{is_sasl_parse_failure, parse_error_responses},
     resource_binding::handle_resource_binding,
@@ -8,7 +11,7 @@ use super::{
         handle_sasl_oauthbearer, handle_sasl_scram_client_first, handle_sasl_scram_response,
         record_scram_failure,
     },
-    state::WsConnState,
+    state::{InboundFrameTerminal, WsConnState},
     stream_management::{handle_sm_stanza, SmCtx},
     transport_xml::{
         build_stream_features_for_phase, sasl_failure_xml, websocket_stream_close_xml,
@@ -24,7 +27,18 @@ pub(super) async fn handle_xmpp_frame(
     state: &WebSocketState,
     conn: &mut WsConnState,
 ) -> Vec<String> {
-    handle_xmpp_frame_impl(frame, domain, state, conn).await
+    handle_xmpp_frame_impl(frame, domain, state, conn, None).await
+}
+
+pub(super) async fn handle_xmpp_frame_with_admission(
+    frame: &str,
+    domain: &str,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> Vec<String> {
+    handle_xmpp_frame_impl(frame, domain, state, conn, Some((permit, shutdown))).await
 }
 
 async fn handle_xmpp_frame_impl(
@@ -32,6 +46,10 @@ async fn handle_xmpp_frame_impl(
     domain: &str,
     state: &WebSocketState,
     conn: &mut WsConnState,
+    admission: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
 ) -> Vec<String> {
     if frame.len() > MAX_FRAME_SIZE {
         warn!(len = frame.len(), "Dropping oversized XMPP frame");
@@ -43,6 +61,7 @@ async fn handle_xmpp_frame_impl(
         authenticated_session,
         sm_state,
         sm_inbound_completion,
+        inbound_frame_terminal,
         ordered_relay_handoff_tx,
         carbons_enabled,
         presence_available,
@@ -319,12 +338,22 @@ async fn handle_xmpp_frame_impl(
                     }
                 }
             };
-            let (responses, disposition) = match run_with_backstop(backstop, dispatch).await {
+            let dispatch_result = match admission {
+                Some((permit, shutdown)) => {
+                    run_with_backstop_and_admission(backstop, dispatch, permit, shutdown).await
+                }
+                None => run_with_backstop(backstop, dispatch).await,
+            };
+            let (responses, disposition) = match dispatch_result {
                 Ok(responses) => (responses, InboundDisposition::Handled),
                 Err(StanzaTimeout::HandledIq(reply)) => {
                     (vec![element_to_xml(reply)], InboundDisposition::Handled)
                 }
                 Err(StanzaTimeout::Unhandled) => (Vec::new(), InboundDisposition::Unhandled),
+                Err(StanzaTimeout::AdmissionRevoked) => {
+                    *inbound_frame_terminal = Some(InboundFrameTerminal::AuthorityRevoked);
+                    (Vec::new(), InboundDisposition::Unhandled)
+                }
             };
             settle_inbound_dispatch(
                 disposition,

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -21,6 +21,7 @@ use super::{
 use crate::server::routes::auth_telemetry::AuthFailure;
 
 /// Handle an XMPP frame per RFC 7395
+#[cfg(test)]
 pub(super) async fn handle_xmpp_frame(
     frame: &str,
     domain: &str,

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -296,6 +296,11 @@ where
         }
         None => dispatch.await,
     };
+    if let Some((permit, shutdown)) = admission {
+        if shutdown.is_cancelled() || permit.revalidate().is_err() {
+            return Err(StanzaTimeout::AdmissionRevoked);
+        }
+    }
     match result {
         Ok(responses) => {
             metrics::record_stanza(kind, "inbound");

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -45,6 +45,10 @@ pub(super) enum StanzaTimeout {
     /// Dispatch was cancelled without accepting responsibility or owing a
     /// protocol response.
     Unhandled,
+    /// The exact node serving generation was revoked while dispatch was
+    /// suspended. No timeout reply is owed and XEP-0198 responsibility stays
+    /// with the sender.
+    AdmissionRevoked,
 }
 
 /// Maximum wall-clock a single stanza's dispatch may take before the backstop
@@ -251,10 +255,48 @@ pub(super) async fn run_with_backstop<F>(
 where
     F: Future<Output = Vec<String>> + Send,
 {
+    run_with_backstop_impl(backstop, dispatch, None).await
+}
+
+pub(super) async fn run_with_backstop_and_admission<F>(
+    backstop: StanzaBackstop,
+    dispatch: F,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> Result<Vec<String>, StanzaTimeout>
+where
+    F: Future<Output = Vec<String>> + Send,
+{
+    run_with_backstop_impl(backstop, dispatch, Some((permit, shutdown))).await
+}
+
+async fn run_with_backstop_impl<F>(
+    backstop: StanzaBackstop,
+    dispatch: F,
+    admission: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) -> Result<Vec<String>, StanzaTimeout>
+where
+    F: Future<Output = Vec<String>> + Send,
+{
     let span = backstop.span.clone();
     let kind = backstop.kind;
     let started = std::time::Instant::now();
-    match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {
+    let dispatch = tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span));
+    let result = match admission {
+        Some((permit, shutdown)) => {
+            tokio::select! {
+                biased;
+                _ = permit.revoked() => return Err(StanzaTimeout::AdmissionRevoked),
+                _ = shutdown.cancelled() => return Err(StanzaTimeout::AdmissionRevoked),
+                result = dispatch => result,
+            }
+        }
+        None => dispatch.await,
+    };
+    match result {
         Ok(responses) => {
             metrics::record_stanza(kind, "inbound");
             metrics::record_stanza_latency(started.elapsed().as_secs_f64() * 1000.0, kind);

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -51,6 +51,17 @@ pub(super) enum StanzaTimeout {
     AdmissionRevoked,
 }
 
+/// Completion from an admission-fenced dispatch.
+///
+/// Once admission has allowed a handler to start, it may commit durable or
+/// external effects before its next suspension point. A later lifecycle
+/// transition therefore fences the transport response, but cannot turn the
+/// dispatch result back into an unhandled stanza.
+pub(super) struct AdmissionDispatchResult {
+    pub(super) result: Result<Vec<String>, StanzaTimeout>,
+    pub(super) authority_revoked_after_start: bool,
+}
+
 /// Maximum wall-clock a single stanza's dispatch may take before the backstop
 /// fires. This is a coarse *wedge* backstop, not a latency SLO: it sits above
 /// the slowest legitimate handler's own internal budget (the 10s
@@ -255,7 +266,9 @@ pub(super) async fn run_with_backstop<F>(
 where
     F: Future<Output = Vec<String>> + Send,
 {
-    run_with_backstop_impl(backstop, dispatch, None).await
+    run_with_backstop_impl(backstop, dispatch, None)
+        .await
+        .result
 }
 
 pub(super) async fn run_with_backstop_and_admission<F>(
@@ -263,7 +276,7 @@ pub(super) async fn run_with_backstop_and_admission<F>(
     dispatch: F,
     permit: &crate::clustering::NodeAdmissionPermit,
     shutdown: &tokio_util::sync::CancellationToken,
-) -> Result<Vec<String>, StanzaTimeout>
+) -> AdmissionDispatchResult
 where
     F: Future<Output = Vec<String>> + Send,
 {
@@ -277,37 +290,49 @@ async fn run_with_backstop_impl<F>(
         &crate::clustering::NodeAdmissionPermit,
         &tokio_util::sync::CancellationToken,
     )>,
-) -> Result<Vec<String>, StanzaTimeout>
+) -> AdmissionDispatchResult
 where
     F: Future<Output = Vec<String>> + Send,
 {
+    // This check is the responsibility boundary. It happens immediately
+    // before dispatch: a revoked generation never starts a new handler,
+    // while an admitted handler runs to the existing bounded backstop.
+    // Cancelling an admitted handler on revocation can replay a stanza whose
+    // durable/external effect already committed.
+    if admission
+        .is_some_and(|(permit, shutdown)| shutdown.is_cancelled() || permit.revalidate().is_err())
+    {
+        return AdmissionDispatchResult {
+            result: Err(StanzaTimeout::AdmissionRevoked),
+            authority_revoked_after_start: false,
+        };
+    }
     let span = backstop.span.clone();
     let kind = backstop.kind;
     let started = std::time::Instant::now();
     let dispatch = tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span));
-    let result = match admission {
-        Some((permit, shutdown)) => {
-            tokio::select! {
-                biased;
-                _ = permit.revoked() => return Err(StanzaTimeout::AdmissionRevoked),
-                _ = shutdown.cancelled() => return Err(StanzaTimeout::AdmissionRevoked),
-                result = dispatch => result,
-            }
-        }
-        None => dispatch.await,
-    };
-    if let Some((permit, shutdown)) = admission {
-        if shutdown.is_cancelled() || permit.revalidate().is_err() {
-            return Err(StanzaTimeout::AdmissionRevoked);
-        }
-    }
-    match result {
+    let result = dispatch.await;
+    let authority_revoked_after_start = admission
+        .is_some_and(|(permit, shutdown)| shutdown.is_cancelled() || permit.revalidate().is_err());
+    let result = match result {
         Ok(responses) => {
             metrics::record_stanza(kind, "inbound");
             metrics::record_stanza_latency(started.elapsed().as_secs_f64() * 1000.0, kind);
             Ok(responses)
         }
         Err(_elapsed) => Err(backstop.on_timeout()),
+    };
+    let result = if authority_revoked_after_start {
+        match result {
+            Ok(_) | Err(StanzaTimeout::HandledIq(_)) => Ok(Vec::new()),
+            Err(timeout) => Err(timeout),
+        }
+    } else {
+        result
+    };
+    AdmissionDispatchResult {
+        result,
+        authority_revoked_after_start,
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -122,7 +122,61 @@ fn responses_and_disposition(
             InboundDisposition::Handled,
         ),
         Err(StanzaTimeout::Unhandled) => (Vec::new(), InboundDisposition::Unhandled),
+        Err(StanzaTimeout::AdmissionRevoked) => (Vec::new(), InboundDisposition::Unhandled),
     }
+}
+
+#[tokio::test]
+async fn admission_revocation_cancels_suspended_dispatch_and_preserves_sm_hole() {
+    let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let stanza = message_stanza();
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let side_effect = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let dispatch_side_effect = Arc::clone(&side_effect);
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let dispatch = async move {
+        let _ = started_tx.send(());
+        let _ = release_rx.await;
+        dispatch_side_effect.store(true, std::sync::atomic::Ordering::SeqCst);
+        Vec::new()
+    };
+    let mut guarded = Box::pin(run_with_backstop_and_admission(
+        StanzaBackstop::capture(&stanza, None),
+        dispatch,
+        &permit,
+        &shutdown,
+    ));
+
+    assert!(futures::poll!(guarded.as_mut()).is_pending());
+    started_rx.await.expect("dispatch reached barrier");
+    lifecycle.begin_fenced_recovery();
+    let _ = release_tx.send(());
+    let (responses, disposition) = responses_and_disposition(guarded.await);
+
+    assert!(
+        responses.is_empty(),
+        "revocation must not synthesize a reply"
+    );
+    assert_eq!(disposition, InboundDisposition::Unhandled);
+    assert!(!side_effect.load(std::sync::atomic::Ordering::SeqCst));
+
+    let mut sm_state = waddle_xmpp::stream_management::StreamManagementState::new();
+    sm_state.enable("revoked-dispatch".to_string(), true, Some(300));
+    let mut completion = crate::server::routes::interpret::SmInboundCompletionTracker::default();
+    let sequence = completion.reserve(&sm_state);
+    crate::server::routes::websocket::frame::settle_inbound_dispatch(
+        disposition,
+        false,
+        Some(sequence),
+        &mut completion,
+        &mut sm_state,
+    );
+    assert_eq!(sm_state.get_inbound_count(), 0);
+    assert!(completion.has_unhandled_hole());
+    assert!(!completion.has_pending());
 }
 
 #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -127,7 +127,7 @@ fn responses_and_disposition(
 }
 
 #[tokio::test]
-async fn admission_revocation_cancels_suspended_dispatch_and_preserves_sm_hole() {
+async fn already_revoked_admission_never_starts_dispatch_and_preserves_sm_hole() {
     let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
     let stanza = message_stanza();
     let lifecycle = crate::clustering::NodeLifecycle::new();
@@ -135,26 +135,19 @@ async fn admission_revocation_cancels_suspended_dispatch_and_preserves_sm_hole()
     let shutdown = tokio_util::sync::CancellationToken::new();
     let side_effect = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let dispatch_side_effect = Arc::clone(&side_effect);
-    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    lifecycle.begin_fenced_recovery();
     let dispatch = async move {
-        let _ = started_tx.send(());
-        let _ = release_rx.await;
         dispatch_side_effect.store(true, std::sync::atomic::Ordering::SeqCst);
         Vec::new()
     };
-    let mut guarded = Box::pin(run_with_backstop_and_admission(
+    let guarded = run_with_backstop_and_admission(
         StanzaBackstop::capture(&stanza, None),
         dispatch,
         &permit,
         &shutdown,
-    ));
-
-    assert!(futures::poll!(guarded.as_mut()).is_pending());
-    started_rx.await.expect("dispatch reached barrier");
-    lifecycle.begin_fenced_recovery();
-    let _ = release_tx.send(());
-    let (responses, disposition) = responses_and_disposition(guarded.await);
+    )
+    .await;
+    let (responses, disposition) = responses_and_disposition(guarded.result);
 
     assert!(
         responses.is_empty(),
@@ -176,6 +169,63 @@ async fn admission_revocation_cancels_suspended_dispatch_and_preserves_sm_hole()
     );
     assert_eq!(sm_state.get_inbound_count(), 0);
     assert!(completion.has_unhandled_hole());
+    assert!(!completion.has_pending());
+}
+
+#[tokio::test]
+async fn revoked_after_committed_dispatch_suppresses_frames_but_settles_sm() {
+    let _metrics = waddle_xmpp::telemetry::test_support::acquire().await;
+    let stanza = message_stanza();
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let commits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let dispatch_commits = Arc::clone(&commits);
+    let (committed_tx, committed_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    let dispatch = async move {
+        dispatch_commits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let _ = committed_tx.send(());
+        let _ = release_rx.await;
+        vec!["<message type='result'/>".to_string()]
+    };
+    let mut guarded = Box::pin(run_with_backstop_and_admission(
+        StanzaBackstop::capture(&stanza, None),
+        dispatch,
+        &permit,
+        &shutdown,
+    ));
+
+    assert!(futures::poll!(guarded.as_mut()).is_pending());
+    committed_rx.await.expect("dispatch committed its effect");
+    lifecycle.begin_fenced_recovery();
+    release_tx
+        .send(())
+        .expect("dispatch remains owned by the backstop");
+    let guarded = guarded.await;
+    assert!(guarded.authority_revoked_after_start);
+
+    let (responses, disposition) = responses_and_disposition(guarded.result);
+    assert!(
+        responses.is_empty(),
+        "stale admission must not write responses"
+    );
+    assert_eq!(disposition, InboundDisposition::Handled);
+    assert_eq!(commits.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+    let mut sm_state = waddle_xmpp::stream_management::StreamManagementState::new();
+    sm_state.enable("revoked-after-commit".to_string(), true, Some(300));
+    let mut completion = crate::server::routes::interpret::SmInboundCompletionTracker::default();
+    let sequence = completion.reserve(&sm_state);
+    crate::server::routes::websocket::frame::settle_inbound_dispatch(
+        disposition,
+        false,
+        Some(sequence),
+        &mut completion,
+        &mut sm_state,
+    );
+    assert_eq!(sm_state.get_inbound_count(), 1);
+    assert!(!completion.has_unhandled_hole());
     assert!(!completion.has_pending());
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -6,7 +6,7 @@ use super::{
     frame::ordered_relay_origin_from_sm,
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
-    send::send_ws_message,
+    send::{send_ws_message_with_authority, AuthoritySendOutcome},
     state::WsConnState,
     stream_management::is_countable_stanza,
     timers::TransportTimers,
@@ -118,12 +118,19 @@ where
             if !authoritative() {
                 return false;
             }
-            let sent = send_ws_message(
+            let sent = match send_ws_message_with_authority(
                 sender,
                 Message::Text(xml.into()),
                 "Failed to send outbound stanza",
+                Some((permit, shutdown)),
             )
-            .await;
+            .await
+            {
+                AuthoritySendOutcome::Sent => true,
+                AuthoritySendOutcome::TransportClosed | AuthoritySendOutcome::AuthorityRevoked => {
+                    return false;
+                }
+            };
             // SM cadence: when `record_outbound` flagged the threshold,
             // follow the just-written stanza with an `<r/>` so the
             // client knows to send `<a h='N'/>`. The wasm client never
@@ -133,13 +140,16 @@ where
                 if !authoritative() {
                     return false;
                 }
-                if !send_ws_message(
-                    sender,
-                    Message::Text(SmRequest::to_xml().into()),
-                    "Failed to send SM <r/> request",
-                )
-                .await
-                {
+                if !matches!(
+                    send_ws_message_with_authority(
+                        sender,
+                        Message::Text(SmRequest::to_xml().into()),
+                        "Failed to send SM <r/> request",
+                        Some((permit, shutdown)),
+                    )
+                    .await,
+                    AuthoritySendOutcome::Sent
+                ) {
                     return false;
                 }
             }
@@ -177,13 +187,16 @@ where
                 if !authoritative() {
                     return false;
                 }
-                if !send_ws_message(
-                    sender,
-                    Message::Ping(axum::body::Bytes::new()),
-                    "Failed to send keepalive ping",
-                )
-                .await
-                {
+                if !matches!(
+                    send_ws_message_with_authority(
+                        sender,
+                        Message::Ping(axum::body::Bytes::new()),
+                        "Failed to send keepalive ping",
+                        Some((permit, shutdown)),
+                    )
+                    .await,
+                    AuthoritySendOutcome::Sent
+                ) {
                     return false;
                 }
             }

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
+    batch_write::{write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome},
     frame::ordered_relay_origin_from_sm,
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
@@ -19,6 +19,8 @@ pub(super) async fn handle_outbound_stanza<S, SE, R, RE>(
     conn: &mut WsConnState,
     timers: &mut TransportTimers,
     outbound_stanza: OutboundStanza,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
 ) -> bool
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -26,6 +28,10 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
+    let authoritative = || !shutdown.is_cancelled() && permit.revalidate().is_ok();
+    if !authoritative() {
+        return false;
+    }
     debug!(kind = ?outbound_stanza.kind, "Received outbound stanza from registry");
     match outbound_stanza.kind {
         DeliveryKind::DirectFrame => {
@@ -101,6 +107,9 @@ where
                     }
                 }
             }
+            if !authoritative() {
+                return false;
+            }
             let sent = send_ws_message(
                 sender,
                 Message::Text(xml.into()),
@@ -112,16 +121,19 @@ where
             // client knows to send `<a h='N'/>`. The wasm client never
             // acks proactively, so without this nudge the unacked queue
             // grows unbounded until eviction permanently breaks resume.
-            if sent
-                && request_ack_after
-                && !send_ws_message(
+            if sent && request_ack_after {
+                if !authoritative() {
+                    return false;
+                }
+                if !send_ws_message(
                     sender,
                     Message::Text(SmRequest::to_xml().into()),
                     "Failed to send SM <r/> request",
                 )
                 .await
-            {
-                return false;
+                {
+                    return false;
+                }
             }
             sent
         }
@@ -145,12 +157,18 @@ where
                 build_interpret_deps(state.as_ref(), conn.authenticated_session.as_ref())
                     .with_ordered_relay_origin(ordered_relay_origin);
             let drive = drive_interpret_loop(events, sm, &interpret_deps).await;
+            if !authoritative() {
+                return false;
+            }
             // Timer/keepalive effects can't arise from a StanzaFromPeer
             // dispatch today (only TransportReady/Tick produce them),
             // but honour them anyway so a future policy change can't
             // silently drop effects on this path.
             timers.apply(drive.timer_commands);
             for _ in 0..drive.keepalive_probes {
+                if !authoritative() {
+                    return false;
+                }
                 if !send_ws_message(
                     sender,
                     Message::Ping(axum::body::Bytes::new()),
@@ -172,18 +190,21 @@ where
             // already-arrived inbound `<a/>` acks after each `<r/>` so
             // a large outbound frame batch can't pin the unacked queue
             // at capacity.
-            match write_response_batch(
+            match write_response_batch_with_admission(
                 sender,
                 reader,
                 state.as_ref(),
                 conn,
                 drive.frames,
                 BatchSmPolicy::Record,
+                permit,
+                shutdown,
             )
             .await
             {
                 BatchWriteOutcome::Continue => {}
                 BatchWriteOutcome::TransportClosed => return false,
+                BatchWriteOutcome::AuthorityRevoked => return false,
             }
             if close {
                 info!("PeerStanza dispatch requested transport close");

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -1,6 +1,8 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome},
+    batch_write::{
+        write_response_batch_with_admission, BatchAuthority, BatchSmPolicy, BatchWriteOutcome,
+    },
     frame::ordered_relay_origin_from_sm,
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
@@ -12,6 +14,12 @@ use super::{
 };
 use waddle_xmpp::stream_management::SmRequest;
 
+#[derive(Clone, Copy)]
+pub(super) struct OutboundAuthority<'a> {
+    pub(super) permit: &'a crate::clustering::NodeAdmissionPermit,
+    pub(super) shutdown: &'a tokio_util::sync::CancellationToken,
+}
+
 pub(super) async fn handle_outbound_stanza<S, SE, R, RE>(
     sender: &mut S,
     reader: &mut R,
@@ -19,8 +27,7 @@ pub(super) async fn handle_outbound_stanza<S, SE, R, RE>(
     conn: &mut WsConnState,
     timers: &mut TransportTimers,
     outbound_stanza: OutboundStanza,
-    permit: &crate::clustering::NodeAdmissionPermit,
-    shutdown: &tokio_util::sync::CancellationToken,
+    authority: OutboundAuthority<'_>,
 ) -> bool
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -28,6 +35,7 @@ where
     R: futures::Stream<Item = Result<Message, RE>> + Unpin,
     RE: std::fmt::Display,
 {
+    let OutboundAuthority { permit, shutdown } = authority;
     let authoritative = || !shutdown.is_cancelled() && permit.revalidate().is_ok();
     if !authoritative() {
         return false;
@@ -197,8 +205,7 @@ where
                 conn,
                 drive.frames,
                 BatchSmPolicy::Record,
-                permit,
-                shutdown,
+                BatchAuthority { permit, shutdown },
             )
             .await
             {

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -11,6 +11,66 @@ pub(super) enum RegistrationAfterFrame {
     Unchanged,
     Registered(SmRegistrationFinalization),
     SessionInitializationFailed,
+    AuthorityRevoked,
+    /// Resume finalization has moved the durable detached snapshot into the
+    /// live connection. Retain registry ownership so normal shutdown cleanup
+    /// can store that exact live SM state before unregistering.
+    AuthorityRevokedAfterSmFinalization,
+}
+
+fn registration_authoritative(
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> bool {
+    !shutdown.is_cancelled() && permit.revalidate().is_ok()
+}
+
+async fn rollback_registered_connection(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    conn: &mut WsConnState,
+) {
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .unregister_if_owner(jid, owner);
+    crate::server::dual_registration::mirror_unregister(
+        &state.deps.protocol.user_registry,
+        jid,
+        Some(owner.clone()),
+    )
+    .await;
+    unregister_remote_clustered_resource_if_owner(state, jid, owner).await;
+    conn.registry_owner = None;
+}
+
+#[cfg(feature = "clustering")]
+async fn unregister_remote_clustered_resource_if_owner(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .unregister_remote_user_resource_if_owner(jid, owner)
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn unregister_remote_clustered_resource_if_owner(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
 }
 
 /// Single choke point for a failed post-auth session initialization (#1454).
@@ -134,18 +194,39 @@ pub(super) fn publish_stream_id_and_presence(
     }
 }
 
+#[cfg(test)]
 pub(super) async fn register_bound_connection_after_frame(
     state: &WebSocketState,
     domain: &str,
     conn: &mut WsConnState,
     pending_tx: &mut Option<mpsc::Sender<OutboundStanza>>,
 ) -> RegistrationAfterFrame {
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("fresh serving lifecycle");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    register_bound_connection_after_frame_with_admission(
+        state, domain, conn, pending_tx, &permit, &shutdown,
+    )
+    .await
+}
+
+pub(super) async fn register_bound_connection_after_frame_with_admission(
+    state: &WebSocketState,
+    domain: &str,
+    conn: &mut WsConnState,
+    pending_tx: &mut Option<mpsc::Sender<OutboundStanza>>,
+    permit: &crate::clustering::NodeAdmissionPermit,
+    shutdown: &tokio_util::sync::CancellationToken,
+) -> RegistrationAfterFrame {
+    if !registration_authoritative(permit, shutdown) {
+        return RegistrationAfterFrame::AuthorityRevoked;
+    }
     let Some(jid) = conn.phase.bound_jid().cloned() else {
         return RegistrationAfterFrame::Unchanged;
     };
-    let Some(tx) = pending_tx.take() else {
+    if pending_tx.is_none() {
         return RegistrationAfterFrame::Unchanged;
-    };
+    }
 
     // Mirror the bind transition into the per-connection state machine (#229
     // PR11). The SM stays `None` until here so unauthenticated traffic can't
@@ -166,6 +247,9 @@ pub(super) async fn register_bound_connection_after_frame(
         match load_blocklist_for_bind(&state.deps.app_state.db_pool, &jid).await {
             Ok(blocklist) => blocklist,
             Err(error) => {
+                if !registration_authoritative(permit, shutdown) {
+                    return RegistrationAfterFrame::AuthorityRevoked;
+                }
                 // Fail the bind rather than run the session with an empty
                 // blocklist (a session-long XEP-0191 fail-open). The choke
                 // point below is the single log line for this failure —
@@ -181,6 +265,10 @@ pub(super) async fn register_bound_connection_after_frame(
         }
     };
 
+    if !registration_authoritative(permit, shutdown) {
+        return RegistrationAfterFrame::AuthorityRevoked;
+    }
+
     conn.ensure_state_machine(
         domain,
         &state.deps.protocol.dispatcher,
@@ -188,6 +276,10 @@ pub(super) async fn register_bound_connection_after_frame(
         resumed,
         blocklist,
     );
+
+    let Some(tx) = pending_tx.take() else {
+        return RegistrationAfterFrame::Unchanged;
+    };
 
     let owner = state
         .deps
@@ -208,6 +300,11 @@ pub(super) async fn register_bound_connection_after_frame(
     // `publish_stream_id_and_presence`'s doc comment for the full
     // "run before the authoritative mirror ask" rationale).
     publish_stream_id_and_presence(state, &jid, &owner, conn);
+
+    if !registration_authoritative(permit, shutdown) {
+        rollback_registered_connection(state, &jid, &owner, conn).await;
+        return RegistrationAfterFrame::AuthorityRevoked;
+    }
 
     if resumed && conn.pending_subscribes_flushed {
         // XEP-0198 §5: a resumed stream is the SAME session. The
@@ -268,6 +365,10 @@ pub(super) async fn register_bound_connection_after_frame(
             }
             crate::server::dual_registration::MirrorRegisterOutcome::Failed => false,
         };
+        if !registration_authoritative(permit, shutdown) {
+            rollback_registered_connection(state, &jid, &owner, conn).await;
+            return RegistrationAfterFrame::AuthorityRevoked;
+        }
         if !registered {
             // Rollback also clears the presence_states published above.
             state
@@ -301,6 +402,19 @@ pub(super) async fn register_bound_connection_after_frame(
     }
 
     let sm_finalization = finalize_sm_after_registry_registration(state, conn, &jid, &owner).await;
+    #[cfg(test)]
+    if let Some((reached, release)) = conn.post_sm_finalization_test_hook.take() {
+        reached.notify_one();
+        release.notified().await;
+    }
+    if !registration_authoritative(permit, shutdown) {
+        // `complete_pending_resume_claim` persist-deletes the detached
+        // snapshot after restoring it into `conn.sm_state`. Clearing the
+        // registry owner here would make outer shutdown cleanup skip detach
+        // and lose that recovered queue. Preserve the owner and let the
+        // normal cleanup path re-store the live session before unregister.
+        return RegistrationAfterFrame::AuthorityRevokedAfterSmFinalization;
+    }
     info!(
         jid = %jid,
         resumed = conn.phase.is_resumed(),

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -149,16 +149,18 @@ where
     // `futures::SinkExt` does not expose a portable `ready` future for every
     // Sink version we support. Poll the required `Sink::poll_ready` directly
     // so cancellation remains selectable while transport readiness is parked.
-    let ready = std::future::poll_fn(|cx| std::pin::Pin::new(&mut *sender).poll_ready(cx));
-    tokio::pin!(ready);
-    let ready_result = match authority {
-        Some((permit, shutdown)) => tokio::select! {
-            biased;
-            _ = shutdown.cancelled() => return AuthoritySendOutcome::AuthorityRevoked,
-            _ = permit.revoked() => return AuthoritySendOutcome::AuthorityRevoked,
-            result = tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()) => result,
-        },
-        None => tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()).await,
+    let ready_result = {
+        let ready = std::future::poll_fn(|cx| std::pin::Pin::new(&mut *sender).poll_ready(cx));
+        tokio::pin!(ready);
+        match authority {
+            Some((permit, shutdown)) => tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => return AuthoritySendOutcome::AuthorityRevoked,
+                _ = permit.revoked() => return AuthoritySendOutcome::AuthorityRevoked,
+                result = tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()) => result,
+            },
+            None => tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()).await,
+        }
     };
     match ready_result {
         Ok(Ok(())) => {}
@@ -175,8 +177,6 @@ where
             return AuthoritySendOutcome::TransportClosed;
         }
     }
-    drop(ready);
-
     // `poll_ready` may have parked while the generation was revoked, then
     // returned Ready in the same poll that wakes this task. This is the last
     // point at which the pending frame can still be suppressed.

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Result of a WebSocket write that is bound to one admitted node generation.
+///
+/// `start_send` is the transport commit point: once it has run under a valid
+/// permit, a later lifecycle transition cannot retract the frame from the
+/// sink. Before that point, revocation must suppress the write entirely.
+pub(super) enum AuthoritySendOutcome {
+    Sent,
+    TransportClosed,
+    AuthorityRevoked,
+}
+
 /// Upper bound for a single WebSocket send (including the flush that
 /// `SinkExt::send` forces through to the socket).
 ///
@@ -57,6 +68,94 @@ where
                  treating connection as dead: {failure_message}"
             );
             false
+        }
+    }
+}
+
+/// Send one frame only while the admitting node generation remains
+/// authoritative.
+///
+/// A `SinkExt::send` future combines readiness, `start_send`, and flushing.
+/// That is too coarse for a generation fence: a revocation can occur while
+/// `poll_ready` is parked, and a later poll of that future would otherwise run
+/// `start_send` before the caller can observe cancellation. Keep readiness
+/// cancellable, then revalidate immediately before the synchronous
+/// `start_send` commit. Once committed, finish flushing normally; the frame
+/// was already legitimately accepted by the transport.
+pub(super) async fn send_ws_message_with_authority<S, E>(
+    sender: &mut S,
+    message: Message,
+    failure_message: &'static str,
+    authority: Option<(
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    )>,
+) -> AuthoritySendOutcome
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    let authoritative = || {
+        authority.is_none_or(|(permit, shutdown)| {
+            !shutdown.is_cancelled() && permit.revalidate().is_ok()
+        })
+    };
+    if !authoritative() {
+        return AuthoritySendOutcome::AuthorityRevoked;
+    }
+
+    let ready = sender.ready();
+    tokio::pin!(ready);
+    let ready_result = match authority {
+        Some((permit, shutdown)) => tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => return AuthoritySendOutcome::AuthorityRevoked,
+            _ = permit.revoked() => return AuthoritySendOutcome::AuthorityRevoked,
+            result = tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()) => result,
+        },
+        None => tokio::time::timeout(SEND_STALL_TIMEOUT, ready.as_mut()).await,
+    };
+    match ready_result {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            error!(error = %error, "{failure_message}");
+            return AuthoritySendOutcome::TransportClosed;
+        }
+        Err(_elapsed) => {
+            error!(
+                stall_timeout_secs = SEND_STALL_TIMEOUT.as_secs(),
+                "WebSocket send stalled past the write budget (peer not draining); \\
+                 treating connection as dead: {failure_message}"
+            );
+            return AuthoritySendOutcome::TransportClosed;
+        }
+    }
+    drop(ready);
+
+    // `poll_ready` may have parked while the generation was revoked, then
+    // returned Ready in the same poll that wakes this task. This is the last
+    // point at which the pending frame can still be suppressed.
+    if !authoritative() {
+        return AuthoritySendOutcome::AuthorityRevoked;
+    }
+    if let Err(error) = std::pin::Pin::new(sender).start_send(message) {
+        error!(error = %error, "{failure_message}");
+        return AuthoritySendOutcome::TransportClosed;
+    }
+
+    match tokio::time::timeout(SEND_STALL_TIMEOUT, sender.flush()).await {
+        Ok(Ok(())) => AuthoritySendOutcome::Sent,
+        Ok(Err(error)) => {
+            error!(error = %error, "{failure_message}");
+            AuthoritySendOutcome::TransportClosed
+        }
+        Err(_elapsed) => {
+            error!(
+                stall_timeout_secs = SEND_STALL_TIMEOUT.as_secs(),
+                "WebSocket send stalled past the write budget (peer not draining); \\
+                 treating connection as dead: {failure_message}"
+            );
+            AuthoritySendOutcome::TransportClosed
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -46,6 +46,48 @@ where
     true
 }
 
+/// Send a sequence of XMPP text frames while the admitting generation is
+/// authoritative.
+///
+/// This is for a typed XMPP control exchange that must not be committed to a
+/// superseded socket. A revocation between frames deliberately suppresses the
+/// remaining frame(s), so the old generation cannot commit any additional
+/// control frame after it has lost authority.
+pub(super) async fn send_ws_text_frames_with_authority<S, E, I>(
+    sender: &mut S,
+    frames: I,
+    failure_message: &'static str,
+    authority: (
+        &crate::clustering::NodeAdmissionPermit,
+        &tokio_util::sync::CancellationToken,
+    ),
+) -> AuthoritySendOutcome
+where
+    S: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+    I: IntoIterator<Item = String>,
+{
+    for frame in frames {
+        debug!(
+            len = frame.len(),
+            "Sending authority-bound XMPP WebSocket response"
+        );
+        match send_ws_message_with_authority(
+            sender,
+            Message::Text(frame.into()),
+            failure_message,
+            Some(authority),
+        )
+        .await
+        {
+            AuthoritySendOutcome::Sent => {}
+            outcome => return outcome,
+        }
+    }
+
+    AuthoritySendOutcome::Sent
+}
+
 pub(super) async fn send_ws_message<S, E>(
     sender: &mut S,
     message: Message,
@@ -104,7 +146,10 @@ where
         return AuthoritySendOutcome::AuthorityRevoked;
     }
 
-    let ready = sender.ready();
+    // `futures::SinkExt` does not expose a portable `ready` future for every
+    // Sink version we support. Poll the required `Sink::poll_ready` directly
+    // so cancellation remains selectable while transport readiness is parked.
+    let ready = std::future::poll_fn(|cx| std::pin::Pin::new(&mut *sender).poll_ready(cx));
     tokio::pin!(ready);
     let ready_result = match authority {
         Some((permit, shutdown)) => tokio::select! {

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -183,7 +183,7 @@ where
     if !authoritative() {
         return AuthoritySendOutcome::AuthorityRevoked;
     }
-    if let Err(error) = std::pin::Pin::new(sender).start_send(message) {
+    if let Err(error) = std::pin::Pin::new(&mut *sender).start_send(message) {
         error!(error = %error, "{failure_message}");
         return AuthoritySendOutcome::TransportClosed;
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1466,6 +1466,9 @@ pub(super) struct WsConnState {
     /// registered, closing the take-before-register fanout gap.
     pub(super) pending_resume_stream_id: Option<String>,
     pub(super) pending_resume_h: Option<u32>,
+    #[cfg(test)]
+    pub(super) post_sm_finalization_test_hook:
+        Option<(Arc<tokio::sync::Notify>, Arc<tokio::sync::Notify>)>,
     /// Ownership handle for the current connection-registry entry.
     pub(super) registry_owner: Option<Arc<std::sync::atomic::AtomicBool>>,
     /// One-shot flag: when set, the main loop must NOT push the current
@@ -1555,6 +1558,8 @@ impl WsConnState {
             pending_subscribes_flushed: false,
             pending_resume_stream_id: None,
             pending_resume_h: None,
+            #[cfg(test)]
+            post_sm_finalization_test_hook: None,
             registry_owner: None,
             suppress_sm_record_next_batch: false,
             pending_sm_enable_commit: None,

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1410,6 +1410,11 @@ pub fn default_link_preview_resolve_permits() -> Arc<tokio::sync::Semaphore> {
 /// Bundles the typed lifecycle phase and the remaining transport/session
 /// adjuncts (SM state, carbons flag, suppress-SM-record flag) into a single
 /// value threaded through the frame dispatcher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InboundFrameTerminal {
+    AuthorityRevoked,
+}
+
 pub(super) struct WsConnState {
     pub(super) phase: ConnectionPhase,
     /// True once the server has answered the client's RFC 7395 `<open/>`
@@ -1425,6 +1430,9 @@ pub(super) struct WsConnState {
     /// once enabled and holds the unacked queue used for resumption.
     pub(super) sm_state: StreamManagementState,
     pub(super) sm_inbound_completion: crate::server::routes::interpret::SmInboundCompletionTracker,
+    /// Set only after a selected stanza's reserved SM slot has been settled
+    /// as unhandled because its serving generation was revoked.
+    pub(super) inbound_frame_terminal: Option<InboundFrameTerminal>,
     pub(super) ordered_relay_handoff_tx: Option<
         tokio::sync::mpsc::UnboundedSender<
             crate::server::routes::interpret::OrderedRelayHandoffCompletion,
@@ -1534,6 +1542,7 @@ impl WsConnState {
             sm_state: StreamManagementState::new(),
             sm_inbound_completion:
                 crate::server::routes::interpret::SmInboundCompletionTracker::default(),
+            inbound_frame_terminal: None,
             ordered_relay_handoff_tx: None,
             carbons_enabled: false,
             roster_interested: false,

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -1415,14 +1415,31 @@ pub(super) enum InboundFrameTerminal {
     AuthorityRevoked,
 }
 
+/// Transport certainty for the server's RFC 7395 `<open/>` response.
+///
+/// The frame dispatcher handles a client `<open/>` before the batch writer
+/// reaches the socket, so lifecycle logic must distinguish that semantic fact
+/// from the conservative fact that the entire authority-aware response batch
+/// reached its wire commit point.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum StreamOpenWireState {
+    #[default]
+    NotCommitted,
+    PendingResponse,
+    Committed,
+}
+
 pub(super) struct WsConnState {
     pub(super) phase: ConnectionPhase,
-    /// True once the server has answered the client's RFC 7395 `<open/>`
-    /// with its own `<open/>` response. Gates the graceful-shutdown
-    /// stream error (issue #1091): RFC 6120 §4.9.1.2 forbids sending a
-    /// stream error before the response stream header, so a connection
-    /// still in the upgrade-to-open gap is closed at the WS layer only.
-    pub(super) stream_open_sent: bool,
+    /// Semantic state: the frame dispatcher has handled the client's current
+    /// RFC 7395 `<open/>`. This resets on an actual XMPP stream close or
+    /// restart, independently from lifecycle revocation.
+    pub(super) stream_open_handled: bool,
+    /// Conservative transport state for the current server `<open/>` response.
+    /// `Committed` is reached only after its entire authority-aware batch
+    /// returns `Continue`; lifecycle close uses this state to decide whether a
+    /// stream error is legal to send.
+    pub(super) stream_open_wire_state: StreamOpenWireState,
     /// The authenticated backend Session for this connection, if any.
     /// Populated on SASL success and used for SM resume/detach.
     pub(super) authenticated_session: Option<Session>,
@@ -1540,7 +1557,8 @@ impl WsConnState {
     pub(super) fn new() -> Self {
         Self {
             phase: ConnectionPhase::new(),
-            stream_open_sent: false,
+            stream_open_handled: false,
+            stream_open_wire_state: StreamOpenWireState::NotCommitted,
             authenticated_session: None,
             sm_state: StreamManagementState::new(),
             sm_inbound_completion:
@@ -1570,6 +1588,39 @@ impl WsConnState {
             state_machine: None,
             keepalive_config: waddle_xmpp::protocol::KeepaliveConfig::default(),
         }
+    }
+
+    /// Start the semantic handling of a typed client `<open/>` frame.
+    ///
+    /// The server response has not passed through the authority-aware writer
+    /// yet, so this deliberately removes the previous stream's wire proof.
+    pub(super) fn begin_server_stream_open_response(&mut self) {
+        self.stream_open_handled = true;
+        self.stream_open_wire_state = StreamOpenWireState::PendingResponse;
+    }
+
+    /// Mark the typed server `<open/>` response as wire-committed only after
+    /// its authority-aware response batch returned `Continue`.
+    pub(super) fn commit_server_stream_open_response(&mut self) {
+        if matches!(
+            self.stream_open_wire_state,
+            StreamOpenWireState::PendingResponse
+        ) {
+            self.stream_open_wire_state = StreamOpenWireState::Committed;
+        }
+    }
+
+    /// Clear state for an actual XMPP stream end or restart. Lifecycle
+    /// revocation intentionally does not call this: an established stream
+    /// remains eligible for the best-effort system-shutdown error.
+    pub(super) fn reset_stream_open_for_xmpp_lifecycle(&mut self) {
+        self.stream_open_handled = false;
+        self.stream_open_wire_state = StreamOpenWireState::NotCommitted;
+    }
+
+    pub(super) fn has_committed_live_stream_open(&self) -> bool {
+        self.stream_open_handled
+            && matches!(self.stream_open_wire_state, StreamOpenWireState::Committed)
     }
 
     /// Apply the typed `<enable/>` effect after its `<enabled/>` frame has

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -187,8 +187,115 @@ async fn authority_revocation_stops_batch_before_next_record_or_write() {
 
     assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
     assert_eq!(sink.sent.len(), 1);
-    assert_eq!(conn.sm_state.outbound_count, 1);
-    assert_eq!(conn.sm_state.queue_len(), 1);
+    assert_eq!(conn.sm_state.outbound_count, 2);
+    assert_eq!(conn.sm_state.queue_len(), 2);
+    let replay = conn.sm_state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 2);
+    assert_eq!(replay[0].stanza_xml, countable_message(1));
+    assert_eq!(replay[1].stanza_xml, countable_message(2));
+}
+
+#[tokio::test]
+async fn pre_current_revocation_records_the_entire_countable_batch_for_replay() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    lifecycle.begin_fenced_recovery();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state
+        .enable("pre-current-revoked".to_string(), true, Some(300));
+    let first = mam_result_frame(1);
+    let second = mam_result_frame(2);
+    let fin = mam_fin_frame();
+    let mut sink = CollectSink::default();
+    let mut reader = reader_with(vec![]);
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        vec![first.clone(), second.clone(), fin.clone()],
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert!(
+        sink.sent.is_empty(),
+        "revocation must fence every wire write"
+    );
+    let replay = conn.sm_state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 3);
+    assert_eq!(replay[0].stanza_xml, first);
+    assert_eq!(replay[1].stanza_xml, second);
+    assert_eq!(replay[2].stanza_xml, fin);
+}
+
+/// A MAM batch can contain result messages followed by the query's final IQ.
+/// Once an admitted generation revokes before the next `poll_ready`, the
+/// written result is acknowledged and every unwritten countable response must
+/// remain exactly once, in wire order, for the XEP-0198 resume window.
+#[tokio::test]
+async fn revoked_next_readiness_keeps_mam_result_tail_and_fin_for_resume() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 1);
+    conn.sm_state
+        .enable("revoked-mam-tail".to_string(), true, Some(300));
+    let first = mam_result_frame(1);
+    let second = mam_result_frame(2);
+    let fin = mam_fin_frame();
+    let mut sink = RevokeOnReadySink {
+        sent: Vec::new(),
+        lifecycle,
+        // First result and its threshold `<r/>` commit. The next result's
+        // readiness check observes revocation before `start_send`.
+        revoke_on_ready_call: 3,
+        ready_calls: 0,
+    };
+    let mut reader = reader_with(vec![ack_frame(1)]);
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        vec![first.clone(), second.clone(), fin.clone()],
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    let sent: Vec<String> = sink
+        .sent
+        .iter()
+        .filter_map(|message| match message {
+            Message::Text(text) => Some(text.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sent, vec![first, SmRequest::to_xml()]);
+    assert_eq!(
+        conn.sm_state.last_acked, 1,
+        "the inbound h settled the first result"
+    );
+    let replay = conn.sm_state.get_stanzas_to_resend(1);
+    assert_eq!(replay.len(), 2, "the tail must be retained exactly once");
+    assert_eq!(replay[0].stanza_xml, second);
+    assert_eq!(replay[1].stanza_xml, fin);
 }
 
 #[tokio::test]
@@ -711,6 +818,20 @@ fn mam_result_frame(i: usize) -> String {
                     .attr(minidom::rxml::xml_ncname!("queryid").to_owned(), "q1")
                     .attr(minidom::rxml::xml_ncname!("id").to_owned(), i.to_string())
                     .append(Element::builder("forwarded", "urn:xmpp:forward:0").build())
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+fn mam_fin_frame() -> String {
+    element_to_xml(
+        Element::builder("iq", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "mam-query")
+            .append(
+                Element::builder("fin", "urn:xmpp:mam:2")
+                    .attr(minidom::rxml::xml_ncname!("complete").to_owned(), "true")
                     .build(),
             )
             .build(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -1134,7 +1134,28 @@ async fn backpressured_send_window_write_stops_promptly_on_authority_revocation(
         .expect("authority revocation must preempt the 15 second pause deadline");
 
     assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
-    assert_eq!(conn.sm_state.outbound_count, 8);
+    assert_eq!(
+        sink.committed,
+        (1..=8)
+            .map(countable_message)
+            .map(Message::Text)
+            .collect::<Vec<_>>(),
+        "the first eight stanzas committed before the backpressured ninth send"
+    );
+    assert_eq!(
+        conn.sm_state.outbound_count, 9,
+        "the blocked ninth stanza must join the replay window on revocation"
+    );
+    assert_eq!(conn.sm_state.queue_len(), 9);
+    let replay = conn.sm_state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 9);
+    for (index, stanza) in replay.iter().enumerate() {
+        assert_eq!(
+            stanza.stanza_xml,
+            countable_message(index + 1),
+            "the replay window contains each committed prefix frame and the unsent tail exactly once, in order"
+        );
+    }
     assert_eq!(
         sink.committed.len(),
         8,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -63,6 +63,17 @@ struct RevokeAfterFirstSink {
     lifecycle: crate::clustering::NodeLifecycle,
 }
 
+/// Returns Ready only after it revokes the admitted generation. This models
+/// the critical readiness race: the task was parked in `poll_ready`, the
+/// lifecycle changed, and a later poll would otherwise call `start_send` in
+/// the same `SinkExt::send` poll before its caller observes cancellation.
+struct RevokeOnReadySink {
+    sent: Vec<Message>,
+    lifecycle: crate::clustering::NodeLifecycle,
+    revoke_on_ready_call: usize,
+    ready_calls: usize,
+}
+
 #[derive(Default)]
 struct BackpressuredAfterEightSink {
     committed: Vec<Message>,
@@ -117,6 +128,34 @@ impl Sink<Message> for RevokeAfterFirstSink {
     }
 }
 
+impl Sink<Message> for RevokeOnReadySink {
+    type Error = Infallible;
+
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        self.ready_calls += 1;
+        if self.ready_calls == self.revoke_on_ready_call {
+            self.lifecycle.begin_fenced_recovery();
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 #[tokio::test]
 async fn authority_revocation_stops_batch_before_next_record_or_write() {
     let state = create_test_websocket_state().await;
@@ -150,6 +189,141 @@ async fn authority_revocation_stops_batch_before_next_record_or_write() {
     assert_eq!(sink.sent.len(), 1);
     assert_eq!(conn.sm_state.outbound_count, 1);
     assert_eq!(conn.sm_state.queue_len(), 1);
+}
+
+#[tokio::test]
+async fn ready_revocation_suppresses_the_normal_batch_frame_before_start_send() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state
+        .enable("ready-revoked-frame".to_string(), true, Some(300));
+    let mut sink = RevokeOnReadySink {
+        sent: Vec::new(),
+        lifecycle,
+        revoke_on_ready_call: 1,
+        ready_calls: 0,
+    };
+    let mut reader = reader_with(vec![]);
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        vec![countable_message(1)],
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert!(
+        sink.sent.is_empty(),
+        "revoked frame must not reach start_send"
+    );
+    assert_eq!(
+        conn.sm_state.outbound_count, 1,
+        "the frame stays replayable"
+    );
+}
+
+#[tokio::test]
+async fn ready_revocation_suppresses_the_cadence_request_before_start_send() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state
+        .enable("ready-revoked-cadence".to_string(), true, Some(300));
+    let mut sink = RevokeOnReadySink {
+        sent: Vec::new(),
+        lifecycle,
+        // Five countable stanzas commit first; the sixth send is the XEP-0198
+        // cadence `<r/>` that must be suppressed.
+        revoke_on_ready_call: 6,
+        ready_calls: 0,
+    };
+    let mut reader = reader_with(vec![]);
+    let frames: Vec<String> = (1..=5).map(countable_message).collect();
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert_eq!(sink.sent.len(), 5, "the stale `<r/>` must not commit");
+    assert!(sink
+        .sent
+        .iter()
+        .filter_map(|message| match message {
+            Message::Text(text) => Some(text),
+            _ => None,
+        })
+        .all(|text| text.as_str() != SmRequest::to_xml()));
+}
+
+#[tokio::test]
+async fn ready_revocation_suppresses_the_mid_batch_drain_response_before_start_send() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state
+        .enable("ready-revoked-drain".to_string(), true, Some(300));
+    let mut sink = RevokeOnReadySink {
+        sent: Vec::new(),
+        lifecycle,
+        // Five stanzas plus their `<r/>` are valid. The bogus ack produces a
+        // handled-count-too-high error in the mid-batch drain; suppress that
+        // response if its readiness poll observes the new generation.
+        revoke_on_ready_call: 7,
+        ready_calls: 0,
+    };
+    let mut reader = ScriptedReader::new(vec![Some(ack_frame(999))]);
+    let frames: Vec<String> = (1..=5).map(countable_message).collect();
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert_eq!(
+        sink.sent.len(),
+        6,
+        "the stale drain response must not commit"
+    );
+    assert!(sink.sent.iter().all(|message| match message {
+        Message::Text(text) => !text.to_string().contains("handled-count-too-high"),
+        _ => true,
+    }));
 }
 
 impl Sink<Message> for CollectSink {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -7,7 +7,9 @@
 
 use super::super::transport_xml::{element_to_xml, websocket_stream_close_xml};
 use super::super::{
-    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
+    batch_write::{
+        write_response_batch, write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome,
+    },
     state::WsConnState,
 };
 use super::create_test_websocket_state;
@@ -54,6 +56,68 @@ fn ack_frame(h: u32) -> Message {
 #[derive(Default)]
 struct CollectSink {
     sent: Vec<Message>,
+}
+
+struct RevokeAfterFirstSink {
+    sent: Vec<Message>,
+    lifecycle: crate::clustering::NodeLifecycle,
+}
+
+impl Sink<Message> for RevokeAfterFirstSink {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        if self.sent.len() == 1 {
+            self.lifecycle.begin_fenced_recovery();
+        }
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn authority_revocation_stops_batch_before_next_record_or_write() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state
+        .enable("authority-batch".to_string(), true, Some(300));
+    let mut sink = RevokeAfterFirstSink {
+        sent: Vec::new(),
+        lifecycle,
+    };
+    let mut reader = reader_with(vec![]);
+
+    let outcome = write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        vec![countable_message(1), countable_message(2)],
+        BatchSmPolicy::Record,
+        &permit,
+        &shutdown,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert_eq!(sink.sent.len(), 1);
+    assert_eq!(conn.sm_state.outbound_count, 1);
+    assert_eq!(conn.sm_state.queue_len(), 1);
 }
 
 impl Sink<Message> for CollectSink {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -1138,7 +1138,7 @@ async fn backpressured_send_window_write_stops_promptly_on_authority_revocation(
         sink.committed,
         (1..=8)
             .map(countable_message)
-            .map(Message::Text)
+            .map(|frame| Message::Text(frame.into()))
             .collect::<Vec<_>>(),
         "the first eight stanzas committed before the backpressured ninth send"
     );

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -8,9 +8,9 @@
 use super::super::transport_xml::{element_to_xml, websocket_stream_close_xml};
 use super::super::{
     batch_write::{
-        write_response_batch, write_response_batch_with_admission, BatchSmPolicy, BatchWriteOutcome,
+        write_response_batch_with_admission, BatchAuthority, BatchSmPolicy, BatchWriteOutcome,
     },
-    state::WsConnState,
+    state::{WebSocketState, WsConnState},
 };
 use super::create_test_websocket_state;
 use futures::{stream, Sink, Stream, StreamExt as _};
@@ -109,8 +109,10 @@ async fn authority_revocation_stops_batch_before_next_record_or_write() {
         &mut conn,
         vec![countable_message(1), countable_message(2)],
         BatchSmPolicy::Record,
-        &permit,
-        &shutdown,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
     )
     .await;
 
@@ -152,6 +154,38 @@ fn sink_texts(sink: &CollectSink) -> Vec<String> {
 /// (like a live socket with nothing more to read — NOT end-of-stream).
 fn reader_with(frames: Vec<Message>) -> impl Stream<Item = Result<Message, Infallible>> + Unpin {
     stream::iter(frames.into_iter().map(Ok)).chain(stream::pending())
+}
+
+async fn write_response_batch<S, SE, R, RE>(
+    sender: &mut S,
+    reader: &mut R,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    frames: Vec<String>,
+    policy: BatchSmPolicy,
+) -> BatchWriteOutcome
+where
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving test permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    write_response_batch_with_admission(
+        sender,
+        reader,
+        state,
+        conn,
+        frames,
+        policy,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    )
+    .await
 }
 
 fn message_with_id(id: &str) -> String {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -63,6 +63,36 @@ struct RevokeAfterFirstSink {
     lifecycle: crate::clustering::NodeLifecycle,
 }
 
+#[derive(Default)]
+struct BackpressuredAfterEightSink {
+    committed: Vec<Message>,
+}
+
+impl Sink<Message> for BackpressuredAfterEightSink {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.committed.len() < 8 {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.committed.push(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 impl Sink<Message> for RevokeAfterFirstSink {
     type Error = Infallible;
 
@@ -774,6 +804,47 @@ async fn send_window_pause_awaits_ack_so_a_burst_over_cap_never_evicts() {
         "exactly one off-cadence <r/> per pause (at 8/16/24/32/40)"
     );
     assert_eq!(texts.len(), 45, "40 stanzas + 5 pacing <r/>");
+}
+
+#[tokio::test]
+async fn backpressured_send_window_write_stops_promptly_on_authority_revocation() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(10, 100);
+    conn.sm_state
+        .enable("authority-pause".to_string(), true, Some(300));
+    let mut sink = BackpressuredAfterEightSink::default();
+    let mut reader = reader_with(vec![]);
+    let frames: Vec<String> = (1..=9).map(countable_message).collect();
+    let mut writer = Box::pin(write_response_batch_with_admission(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::Record,
+        BatchAuthority {
+            permit: &permit,
+            shutdown: &shutdown,
+        },
+    ));
+
+    assert!(futures::poll!(writer.as_mut()).is_pending());
+    lifecycle.begin_fenced_recovery();
+    let outcome = tokio::time::timeout(std::time::Duration::from_millis(50), writer)
+        .await
+        .expect("authority revocation must preempt the 15 second pause deadline");
+
+    assert!(matches!(outcome, BatchWriteOutcome::AuthorityRevoked));
+    assert_eq!(conn.sm_state.outbound_count, 8);
+    assert_eq!(
+        sink.committed.len(),
+        8,
+        "the backpressured <r/> must never commit after revocation"
+    );
 }
 
 /// A dead/stalled peer never acks the window down. The pause deadline fires

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
@@ -262,7 +262,7 @@ async fn websocket_oauthbearer_authenticates_session_token() {
 }
 
 #[tokio::test]
-async fn websocket_stream_open_sent_tracks_current_stream_instance() {
+async fn websocket_stream_open_handling_tracks_current_stream_instance() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;
     let mut conn = WsConnState::new();
@@ -270,9 +270,19 @@ async fn websocket_stream_open_sent_tracks_current_stream_instance() {
         r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="example.com" version="1.0"/>"#;
     let close = r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#;
 
-    assert!(!conn.stream_open_sent, "no stream answered yet at upgrade");
+    assert!(
+        !conn.stream_open_handled,
+        "no stream handled yet at upgrade"
+    );
     handle_xmpp_frame(open, "example.com", state.as_ref(), &mut conn).await;
-    assert!(conn.stream_open_sent, "server answered the first <open/>");
+    assert!(conn.stream_open_handled, "server handled the first <open/>");
+    assert!(
+        matches!(
+            conn.stream_open_wire_state,
+            super::super::state::StreamOpenWireState::PendingResponse
+        ),
+        "frame handling alone must not claim the server <open/> reached the wire"
+    );
 
     // RFC 6120 §6.4.6: SASL success restarts the stream — the server
     // has not yet sent a response header for the NEW stream, so a
@@ -290,16 +300,16 @@ async fn websocket_stream_open_sent_tracks_current_stream_instance() {
     let responses = handle_xmpp_frame(&auth, "example.com", state.as_ref(), &mut conn).await;
     assert_eq!(responses, vec![sasl_success_xml()]);
     assert!(
-        !conn.stream_open_sent,
+        !conn.stream_open_handled,
         "SASL success restarts the stream; no response header exists for the new stream yet"
     );
 
     handle_xmpp_frame(open, "example.com", state.as_ref(), &mut conn).await;
-    assert!(conn.stream_open_sent, "restarted stream answered");
+    assert!(conn.stream_open_handled, "restarted stream handled");
 
     handle_xmpp_frame(close, "example.com", state.as_ref(), &mut conn).await;
     assert!(
-        !conn.stream_open_sent,
+        !conn.stream_open_handled,
         "a closed stream has no live response header to error on"
     );
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -2,13 +2,53 @@ use super::super::{
     frame::handle_xmpp_frame,
     registration::{
         publish_stream_id_and_presence, register_bound_connection_after_frame,
-        RegistrationAfterFrame,
+        register_bound_connection_after_frame_with_admission, RegistrationAfterFrame,
     },
     session_init::load_blocklist_for_bind,
     state::WsConnState,
     stream_management::SmRegistrationFinalization,
     transport_xml::element_to_xml,
 };
+
+#[tokio::test]
+async fn revoked_authority_cannot_publish_a_bound_connection() {
+    let state = create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    lifecycle.begin_fenced_recovery();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+
+    let outcome = register_bound_connection_after_frame_with_admission(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+        &permit,
+        &shutdown,
+    )
+    .await;
+
+    assert!(matches!(outcome, RegistrationAfterFrame::AuthorityRevoked));
+    assert!(
+        pending_tx.is_some(),
+        "revoked registration consumes no sender"
+    );
+    assert!(conn.registry_owner.is_none());
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .is_none(),
+        "revoked registration publishes no local routing entry"
+    );
+}
 use super::{create_test_session, create_test_websocket_state};
 use jid::{BareJid, FullJid};
 use std::sync::Arc;
@@ -273,6 +313,126 @@ async fn register_bound_connection_after_frame_completes_pending_resume_claim() 
     assert_eq!(presence.show.as_deref(), Some("chat"));
     assert_eq!(presence.status.as_deref(), Some("back"));
     assert_eq!(presence.priority, 5);
+}
+
+#[tokio::test]
+async fn authority_revoked_after_resume_finalization_restores_detached_session_on_cleanup() {
+    use waddle_xmpp::stream_management::{DetachedSession, SmSessionRegistry};
+
+    let state = create_test_websocket_state().await;
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let stream_id = "registration-resume-revoked-after-finalization".to_string();
+    let session = create_test_session(state.as_ref(), "alice").await;
+    state
+        .deps
+        .protocol
+        .resumable_sessions
+        .insert(stream_id.clone(), session.clone());
+    state
+        .deps
+        .protocol
+        .sm_session_registry
+        .store_session(DetachedSession {
+            stream_id: stream_id.clone(),
+            user_id: session.user_jid.clone(),
+            jid: jid.clone(),
+            inbound_count: 4,
+            outbound_count: 0,
+            last_acked: 0,
+            replay_gap_through: None,
+            unacked_stanzas: Vec::new(),
+            max_resume_time: Some(300),
+            detached_at: std::time::Instant::now(),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+            presence_payloads: Vec::new(),
+            pending_subscribes_flushed: false,
+        })
+        .await
+        .expect("store detached session");
+
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::authenticated(&jid);
+    conn.authenticated_session = Some(session);
+    let resume_frame = element_to_xml(
+        Element::builder("resume", SM_NS)
+            .attr(
+                minidom::rxml::xml_ncname!("previd").to_owned(),
+                stream_id.as_str(),
+            )
+            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+            .build(),
+    );
+    let _ = handle_xmpp_frame(&resume_frame, "example.com", state.as_ref(), &mut conn).await;
+
+    let reached = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    conn.post_sm_finalization_test_hook = Some((reached.clone(), release.clone()));
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let (tx, mut rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+    let registration_state = state.clone();
+    let registration = tokio::spawn(async move {
+        let outcome = register_bound_connection_after_frame_with_admission(
+            registration_state.as_ref(),
+            "example.com",
+            &mut conn,
+            &mut pending_tx,
+            &permit,
+            &shutdown,
+        )
+        .await;
+        (outcome, conn)
+    });
+
+    reached.notified().await;
+    lifecycle.begin_fenced_recovery();
+    release.notify_one();
+    let (outcome, mut conn) = registration.await.expect("registration task");
+    assert!(matches!(
+        outcome,
+        RegistrationAfterFrame::AuthorityRevokedAfterSmFinalization
+    ));
+    assert!(
+        conn.registry_owner.is_some(),
+        "post-finalization revocation retains cleanup authority"
+    );
+
+    let _ = super::super::cleanup::cleanup_connection_shutdown(
+        state.as_ref(),
+        &mut rx,
+        &mut conn,
+        false,
+    )
+    .await;
+
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .is_none(),
+        "cleanup removes the live routing entry"
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .sm_session_registry
+            .claim_session(&stream_id)
+            .await
+            .expect("claim restored session")
+            .is_some(),
+        "cleanup restores the finalized live SM state as a resumable session"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
@@ -1,4 +1,7 @@
-use super::super::send::{close_ws_connection, send_ws_message, send_ws_text_frames};
+use super::super::send::{
+    close_ws_connection, send_ws_message, send_ws_message_with_authority, send_ws_text_frames,
+    AuthoritySendOutcome,
+};
 use axum::extract::ws::Message;
 use futures::Sink;
 use std::pin::Pin;
@@ -116,6 +119,61 @@ impl Sink<Message> for StalledSink {
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Pending
     }
+}
+
+/// A ready transition that is concurrent with a lifecycle fence. It returns
+/// `Ready` only after it has revoked the permit, reproducing the gap hidden
+/// inside `SinkExt::send` between `poll_ready` and `start_send`.
+struct RevokeBeforeStartSendSink {
+    lifecycle: crate::clustering::NodeLifecycle,
+    sent: Vec<Message>,
+}
+
+impl Sink<Message> for RevokeBeforeStartSendSink {
+    type Error = &'static str;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.lifecycle.begin_fenced_recovery();
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn authority_bound_send_does_not_start_after_ready_revokes_its_generation() {
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut sink = RevokeBeforeStartSendSink {
+        lifecycle,
+        sent: Vec::new(),
+    };
+
+    let outcome = send_ws_message_with_authority(
+        &mut sink,
+        Message::Text("<stale/>".into()),
+        "ready revocation",
+        Some((&permit, &shutdown)),
+    )
+    .await;
+
+    assert!(matches!(outcome, AuthoritySendOutcome::AuthorityRevoked));
+    assert!(
+        sink.sent.is_empty(),
+        "a revoked frame must not reach start_send"
+    );
 }
 
 /// Issue #1090 write-stall budget: a send that cannot make progress

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
@@ -1,6 +1,6 @@
 use super::super::send::{
     close_ws_connection, send_ws_message, send_ws_message_with_authority, send_ws_text_frames,
-    AuthoritySendOutcome,
+    send_ws_text_frames_with_authority, AuthoritySendOutcome,
 };
 use axum::extract::ws::Message;
 use futures::Sink;
@@ -129,6 +129,34 @@ struct RevokeBeforeStartSendSink {
     sent: Vec<Message>,
 }
 
+/// A transport write that has parked in `poll_ready`. Tests explicitly fence
+/// the serving generation while the future is pending, then poll it again to
+/// prove no stale frame reaches the synchronous `start_send` commit point.
+struct PendingReadySink {
+    sent: Vec<Message>,
+}
+
+impl Sink<Message> for PendingReadySink {
+    type Error = &'static str;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 impl Sink<Message> for RevokeBeforeStartSendSink {
     type Error = &'static str;
 
@@ -173,6 +201,60 @@ async fn authority_bound_send_does_not_start_after_ready_revokes_its_generation(
     assert!(
         sink.sent.is_empty(),
         "a revoked frame must not reach start_send"
+    );
+}
+
+#[tokio::test]
+async fn force_detach_conflict_frames_are_suppressed_when_revoked_while_ready_is_pending() {
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut sink = PendingReadySink { sent: Vec::new() };
+    let outcome = {
+        let send = send_ws_text_frames_with_authority(
+            &mut sink,
+            vec!["<conflict/>".to_owned(), "<close/>".to_owned()],
+            "force-detach conflict",
+            (&permit, &shutdown),
+        );
+        tokio::pin!(send);
+
+        assert!(futures::poll!(send.as_mut()).is_pending());
+        lifecycle.begin_fenced_recovery();
+        send.await
+    };
+
+    assert!(matches!(outcome, AuthoritySendOutcome::AuthorityRevoked));
+    assert!(
+        sink.sent.is_empty(),
+        "stale conflict frames must not commit"
+    );
+}
+
+#[tokio::test]
+async fn session_init_error_frames_are_suppressed_when_revoked_while_ready_is_pending() {
+    let lifecycle = crate::clustering::NodeLifecycle::new();
+    let permit = lifecycle.admit().expect("serving permit");
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let mut sink = PendingReadySink { sent: Vec::new() };
+    let outcome = {
+        let send = send_ws_text_frames_with_authority(
+            &mut sink,
+            vec!["<internal-server-error/>".to_owned(), "<close/>".to_owned()],
+            "session initialization error",
+            (&permit, &shutdown),
+        );
+        tokio::pin!(send);
+
+        assert!(futures::poll!(send.as_mut()).is_pending());
+        lifecycle.begin_fenced_recovery();
+        send.await
+    };
+
+    assert!(matches!(outcome, AuthoritySendOutcome::AuthorityRevoked));
+    assert!(
+        sink.sent.is_empty(),
+        "stale session-init error frames must not commit"
     );
 }
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1098,7 +1098,7 @@ async fn clustered_test_state_for_critical_registry_watch() -> Arc<WebSocketStat
 #[cfg(test)]
 async fn assert_room_registry_death_is_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
-    spawn_critical_registry_supervisor(&state);
+    spawn_critical_registry_supervisor(&state).await;
     state.deps.protocol.room_registry.kill();
     state.deps.protocol.room_registry.wait_for_shutdown().await;
     tokio::task::yield_now().await;
@@ -1114,7 +1114,7 @@ async fn assert_room_registry_death_is_critical(state: Arc<WebSocketState>) {
 #[cfg(test)]
 async fn assert_user_registry_death_is_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
-    spawn_critical_registry_supervisor(&state);
+    spawn_critical_registry_supervisor(&state).await;
     state.deps.protocol.user_registry.kill();
     state.deps.protocol.user_registry.wait_for_shutdown().await;
     tokio::task::yield_now().await;
@@ -1130,7 +1130,7 @@ async fn assert_user_registry_death_is_critical(state: Arc<WebSocketState>) {
 #[cfg(test)]
 async fn assert_ordinary_shutdown_is_not_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
-    spawn_critical_registry_supervisor(&state);
+    spawn_critical_registry_supervisor(&state).await;
     process_stop.cancel();
     tokio::task::yield_now().await;
 
@@ -1164,6 +1164,70 @@ async fn single_node_ordinary_shutdown_is_not_critical() {
     .await;
 }
 
+#[cfg(test)]
+#[tokio::test]
+async fn already_dead_room_registry_blocks_startup_promotion() {
+    let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::starting();
+    let stop = tokio_util::sync::CancellationToken::new();
+    state.deps.protocol.room_registry.kill();
+    state.deps.protocol.room_registry.wait_for_shutdown().await;
+
+    let outcome = spawn_room_registry_lifetime_watch(
+        state.deps.protocol.room_registry.clone(),
+        lifecycle.clone(),
+        stop.clone(),
+    )
+    .await
+    .expect("room watcher arm outcome");
+
+    assert_eq!(
+        outcome,
+        CriticalRegistryArm::Failed(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated)
+    );
+    assert!(stop.is_cancelled());
+    assert!(matches!(
+        lifecycle.finish_startup(),
+        crate::clustering::StartupServingTransition::Blocked(
+            crate::clustering::NodeAdmission::Failed(
+                crate::clustering::CriticalNodeFailure::RoomRegistryTerminated
+            )
+        )
+    ));
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn already_dead_user_registry_blocks_startup_promotion() {
+    let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+    let lifecycle = crate::clustering::NodeLifecycle::starting();
+    let stop = tokio_util::sync::CancellationToken::new();
+    state.deps.protocol.user_registry.kill();
+    state.deps.protocol.user_registry.wait_for_shutdown().await;
+
+    let outcome = spawn_user_registry_lifetime_watch(
+        state.deps.protocol.user_registry.clone(),
+        lifecycle.clone(),
+        stop.clone(),
+    )
+    .await
+    .expect("user watcher arm outcome");
+
+    assert_eq!(
+        outcome,
+        CriticalRegistryArm::Failed(crate::clustering::CriticalNodeFailure::UserRegistryTerminated)
+    );
+    assert!(stop.is_cancelled());
+    assert!(matches!(
+        lifecycle.finish_startup(),
+        crate::clustering::StartupServingTransition::Blocked(
+            crate::clustering::NodeAdmission::Failed(
+                crate::clustering::CriticalNodeFailure::UserRegistryTerminated
+            )
+        )
+    ));
+}
+
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
 async fn clustered_room_registry_death_is_critical() {
@@ -1191,33 +1255,86 @@ async fn clustered_ordinary_shutdown_is_not_critical() {
     .await;
 }
 
-pub(crate) fn spawn_critical_registry_supervisor(websocket_state: &Arc<WebSocketState>) {
+pub(crate) async fn spawn_critical_registry_supervisor(websocket_state: &Arc<WebSocketState>) {
     let node_lifecycle = websocket_state.deps.app_state.node_lifecycle.clone();
     let process_stop = websocket_state.deps.shutdown.stop_token();
     let room_registry = websocket_state.deps.protocol.room_registry.clone();
     let user_registry = websocket_state.deps.protocol.user_registry.clone();
-    let _room_watch = spawn_room_registry_lifetime_watch(
+    let room_registry_liveness = room_registry.clone();
+    let user_registry_liveness = user_registry.clone();
+    let room_armed = spawn_room_registry_lifetime_watch(
         room_registry,
         node_lifecycle.clone(),
         process_stop.clone(),
     );
-    let _user_watch =
+    let user_armed =
         spawn_user_registry_lifetime_watch(user_registry, node_lifecycle, process_stop);
+    let (room_arm, user_arm) = tokio::join!(room_armed, user_armed);
+    for outcome in [
+        room_arm.unwrap_or(CriticalRegistryArm::Failed(
+            crate::clustering::CriticalNodeFailure::RoomRegistryTerminated,
+        )),
+        user_arm.unwrap_or(CriticalRegistryArm::Failed(
+            crate::clustering::CriticalNodeFailure::UserRegistryTerminated,
+        )),
+    ] {
+        if let CriticalRegistryArm::Failed(failure) = outcome {
+            websocket_state.deps.app_state.node_lifecycle.fail(failure);
+            websocket_state.deps.shutdown.stop_token().cancel();
+        }
+    }
+    // Close the arm-to-promotion gap synchronously. A registry that died
+    // after its shutdown future was first polled but before this barrier is
+    // failed before `finish_startup` can linearize Starting -> Serving.
+    if !room_registry_liveness.is_alive() {
+        websocket_state
+            .deps
+            .app_state
+            .node_lifecycle
+            .fail(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated);
+        websocket_state.deps.shutdown.stop_token().cancel();
+    }
+    if !user_registry_liveness.is_alive() {
+        websocket_state
+            .deps
+            .app_state
+            .node_lifecycle
+            .fail(crate::clustering::CriticalNodeFailure::UserRegistryTerminated);
+        websocket_state.deps.shutdown.stop_token().cancel();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CriticalRegistryArm {
+    Armed,
+    Failed(crate::clustering::CriticalNodeFailure),
 }
 
 fn spawn_room_registry_lifetime_watch(
     room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
     node_lifecycle: crate::clustering::NodeLifecycle,
     process_stop: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
+) -> tokio::sync::oneshot::Receiver<CriticalRegistryArm> {
+    let (armed_tx, armed_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
+        let shutdown = room_registry.wait_for_shutdown();
+        tokio::pin!(shutdown);
+        if futures::poll!(shutdown.as_mut()).is_ready() {
+            node_lifecycle.fail(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated);
+            process_stop.cancel();
+            let _ = armed_tx.send(CriticalRegistryArm::Failed(
+                crate::clustering::CriticalNodeFailure::RoomRegistryTerminated,
+            ));
+            return;
+        }
+        let _ = armed_tx.send(CriticalRegistryArm::Armed);
         tokio::select! {
             biased;
             // Ordered process shutdown is the sole non-fatal exit. Keeping it
             // first means a registry that terminates as part of that shutdown
             // cannot race into a terminal failure latch.
             _ = process_stop.cancelled() => {}
-            _ = room_registry.wait_for_shutdown() => {
+            _ = shutdown => {
                 // Room ownership retry state is actor-local. Losing the
                 // registry while this node's lease remains fresh can strand
                 // every retained exact fence, even while idle, so registry
@@ -1226,19 +1343,32 @@ fn spawn_room_registry_lifetime_watch(
                 process_stop.cancel();
             }
         }
-    })
+    });
+    armed_rx
 }
 
 fn spawn_user_registry_lifetime_watch(
     user_registry: kameo::actor::ActorRef<waddle_xmpp::registry::UserRegistryActor>,
     node_lifecycle: crate::clustering::NodeLifecycle,
     process_stop: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
+) -> tokio::sync::oneshot::Receiver<CriticalRegistryArm> {
+    let (armed_tx, armed_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
+        let shutdown = user_registry.wait_for_shutdown();
+        tokio::pin!(shutdown);
+        if futures::poll!(shutdown.as_mut()).is_ready() {
+            node_lifecycle.fail(crate::clustering::CriticalNodeFailure::UserRegistryTerminated);
+            process_stop.cancel();
+            let _ = armed_tx.send(CriticalRegistryArm::Failed(
+                crate::clustering::CriticalNodeFailure::UserRegistryTerminated,
+            ));
+            return;
+        }
+        let _ = armed_tx.send(CriticalRegistryArm::Armed);
         tokio::select! {
             biased;
             _ = process_stop.cancelled() => {}
-            _ = user_registry.wait_for_shutdown() => {
+            _ = shutdown => {
                 // UserActor claim/retry state is registry-local. Continuing
                 // to advertise this node after it dies would accept sockets
                 // whose logical owners cannot be activated safely.
@@ -1246,7 +1376,8 @@ fn spawn_user_registry_lifetime_watch(
                 process_stop.cancel();
             }
         }
-    })
+    });
+    armed_rx
 }
 
 #[cfg(feature = "clustering")]
@@ -2641,11 +2772,12 @@ async fn idle_room_registry_death_self_fences_the_node() {
     );
     let node_lifecycle = crate::clustering::NodeLifecycle::new();
     let process_stop = tokio_util::sync::CancellationToken::new();
-    let watcher = spawn_room_registry_lifetime_watch(
+    let armed = spawn_room_registry_lifetime_watch(
         registry.actor_ref().clone(),
         node_lifecycle.clone(),
         process_stop.clone(),
     );
+    armed.await.expect("registry lifetime watcher armed");
 
     registry.actor_ref().kill();
     registry.actor_ref().wait_for_shutdown().await;
@@ -2656,7 +2788,6 @@ async fn idle_room_registry_death_self_fences_the_node() {
         node_lifecycle.critical_failure(),
         Some(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated)
     );
-    watcher.await.expect("registry lifetime watcher");
 }
 
 #[cfg(all(test, feature = "clustering"))]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -738,11 +738,6 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         tokio::spawn(async move {
             let terminal_room_registry =
                 waddle_xmpp::muc::RoomRegistry::wrap(room_registry_actor.clone());
-            let registry_lifetime_watch = spawn_room_registry_lifetime_watch(
-                room_registry_actor,
-                stop.clone(),
-                fatal_fence.clone(),
-            );
             let mut supervisor = OrphanReaperSupervisor::new_with_fatal_fence(
                 registry.clone(),
                 stop.clone(),
@@ -839,7 +834,6 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     error!(%error, "orphan reaper: terminal RoomRegistry claim drain failed; node-expiry recovery remains authoritative");
                 }
             }
-            let _ = registry_lifetime_watch.await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -1110,11 +1104,104 @@ async fn clustering_disabled_orphan_reaper_does_not_bind_process_shutdown() {
     );
 }
 
+#[cfg(all(test, feature = "clustering"))]
+async fn clustered_test_state_for_critical_registry_watch() -> Arc<WebSocketState> {
+    let handles = crate::clustering::ClusteringHandles {
+        stop_token: Some(tokio_util::sync::CancellationToken::new()),
+        ..Default::default()
+    };
+    crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering(
+        handles,
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+    )
+    .await
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn room_registry_death_fences_admission_and_stops_the_process() {
+    let state = clustered_test_state_for_critical_registry_watch().await;
+    let process_stop = state.deps.shutdown.stop_token();
+    spawn_critical_registry_supervisor(&state);
+    state.deps.protocol.room_registry.kill();
+    state.deps.protocol.room_registry.wait_for_shutdown().await;
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        state.deps.app_state.node_lifecycle.critical_failure(),
+        Some(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated)
+    );
+    assert!(process_stop.is_cancelled());
+    assert!(state.deps.app_state.node_lifecycle.admit().is_err());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn user_registry_death_fences_admission_and_stops_the_process() {
+    let state = clustered_test_state_for_critical_registry_watch().await;
+    let process_stop = state.deps.shutdown.stop_token();
+    spawn_critical_registry_supervisor(&state);
+    state.deps.protocol.user_registry.kill();
+    state.deps.protocol.user_registry.wait_for_shutdown().await;
+    tokio::task::yield_now().await;
+
+    assert_eq!(
+        state.deps.app_state.node_lifecycle.critical_failure(),
+        Some(crate::clustering::CriticalNodeFailure::UserRegistryTerminated)
+    );
+    assert!(process_stop.is_cancelled());
+    assert!(state.deps.app_state.node_lifecycle.admit().is_err());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn ordinary_shutdown_does_not_latch_a_critical_registry_failure() {
+    let state = clustered_test_state_for_critical_registry_watch().await;
+    let process_stop = state.deps.shutdown.stop_token();
+    spawn_critical_registry_supervisor(&state);
+    process_stop.cancel();
+    tokio::task::yield_now().await;
+
+    assert_eq!(state.deps.app_state.node_lifecycle.critical_failure(), None);
+}
+
+#[cfg(feature = "clustering")]
+pub(crate) fn spawn_critical_registry_supervisor(websocket_state: &Arc<WebSocketState>) {
+    let Some(stop) = websocket_state
+        .deps
+        .app_state
+        .clustering_claims
+        .stop_token
+        .clone()
+    else {
+        // Clustering support may be compiled while the runtime is deliberately
+        // single-node. In that mode these actor deaths are not cluster fencing
+        // failures and must not turn an ordinary test/deploy shutdown fatal.
+        return;
+    };
+    let node_lifecycle = websocket_state.deps.app_state.node_lifecycle.clone();
+    let process_stop = websocket_state.deps.shutdown.stop_token();
+    let room_registry = websocket_state.deps.protocol.room_registry.clone();
+    let user_registry = websocket_state.deps.protocol.user_registry.clone();
+    let _room_watch = spawn_room_registry_lifetime_watch(
+        room_registry,
+        stop.clone(),
+        node_lifecycle.clone(),
+        process_stop.clone(),
+    );
+    let _user_watch =
+        spawn_user_registry_lifetime_watch(user_registry, stop, node_lifecycle, process_stop);
+}
+
+#[cfg(not(feature = "clustering"))]
+pub(crate) fn spawn_critical_registry_supervisor(_websocket_state: &Arc<WebSocketState>) {}
+
 #[cfg(feature = "clustering")]
 fn spawn_room_registry_lifetime_watch(
     room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
     stop: tokio_util::sync::CancellationToken,
-    fatal_fence: tokio_util::sync::CancellationToken,
+    node_lifecycle: crate::clustering::NodeLifecycle,
+    process_stop: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tokio::select! {
@@ -1125,7 +1212,30 @@ fn spawn_room_registry_lifetime_watch(
                 // registry while this node's lease remains fresh can strand
                 // every retained exact fence, even while idle, so registry
                 // lifetime is clustering-critical.
-                fatal_fence.cancel();
+                node_lifecycle.fail(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated);
+                process_stop.cancel();
+            }
+        }
+    })
+}
+
+#[cfg(feature = "clustering")]
+fn spawn_user_registry_lifetime_watch(
+    user_registry: kameo::actor::ActorRef<waddle_xmpp::registry::UserRegistryActor>,
+    stop: tokio_util::sync::CancellationToken,
+    node_lifecycle: crate::clustering::NodeLifecycle,
+    process_stop: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tokio::select! {
+            biased;
+            _ = stop.cancelled() => {}
+            _ = user_registry.wait_for_shutdown() => {
+                // UserActor claim/retry state is registry-local. Continuing
+                // to advertise this node after it dies would accept sockets
+                // whose logical owners cannot be activated safely.
+                node_lifecycle.fail(crate::clustering::CriticalNodeFailure::UserRegistryTerminated);
+                process_stop.cancel();
             }
         }
     })
@@ -2522,15 +2632,24 @@ async fn idle_room_registry_death_self_fences_the_node() {
         None,
     );
     let stop = tokio_util::sync::CancellationToken::new();
-    let fatal_fence = tokio_util::sync::CancellationToken::new();
-    let watcher =
-        spawn_room_registry_lifetime_watch(registry.actor_ref().clone(), stop, fatal_fence.clone());
+    let node_lifecycle = crate::clustering::NodeLifecycle::new();
+    let process_stop = tokio_util::sync::CancellationToken::new();
+    let watcher = spawn_room_registry_lifetime_watch(
+        registry.actor_ref().clone(),
+        stop,
+        node_lifecycle.clone(),
+        process_stop.clone(),
+    );
 
     registry.actor_ref().kill();
     registry.actor_ref().wait_for_shutdown().await;
-    tokio::time::timeout(Duration::from_secs(1), fatal_fence.cancelled())
+    tokio::time::timeout(Duration::from_secs(1), process_stop.cancelled())
         .await
         .expect("registry lifetime watcher must cancel the node promptly");
+    assert_eq!(
+        node_lifecycle.critical_failure(),
+        Some(crate::clustering::CriticalNodeFailure::RoomRegistryTerminated)
+    );
     watcher.await.expect("registry lifetime watcher");
 }
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1083,28 +1083,6 @@ mod orphan_sweep_supervision_tests {
 }
 
 #[cfg(all(test, feature = "clustering"))]
-#[tokio::test]
-async fn clustering_disabled_orphan_reaper_does_not_bind_process_shutdown() {
-    let state =
-        crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering(
-            crate::clustering::ClusteringHandles::default(),
-            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
-        )
-        .await;
-    let shutdown = state.deps.shutdown.stop_token();
-
-    spawn_orphan_reaper_janitor(&state, Duration::from_millis(1));
-    state.deps.protocol.room_registry.kill();
-    state.deps.protocol.room_registry.wait_for_shutdown().await;
-    tokio::task::yield_now().await;
-
-    assert!(
-        !shutdown.is_cancelled(),
-        "runtime-disabled clustering must not turn RoomRegistry death into process shutdown"
-    );
-}
-
-#[cfg(all(test, feature = "clustering"))]
 async fn clustered_test_state_for_critical_registry_watch() -> Arc<WebSocketState> {
     let handles = crate::clustering::ClusteringHandles {
         stop_token: Some(tokio_util::sync::CancellationToken::new()),
@@ -1117,10 +1095,8 @@ async fn clustered_test_state_for_critical_registry_watch() -> Arc<WebSocketStat
     .await
 }
 
-#[cfg(all(test, feature = "clustering"))]
-#[tokio::test]
-async fn room_registry_death_fences_admission_and_stops_the_process() {
-    let state = clustered_test_state_for_critical_registry_watch().await;
+#[cfg(test)]
+async fn assert_room_registry_death_is_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
     spawn_critical_registry_supervisor(&state);
     state.deps.protocol.room_registry.kill();
@@ -1135,10 +1111,8 @@ async fn room_registry_death_fences_admission_and_stops_the_process() {
     assert!(state.deps.app_state.node_lifecycle.admit().is_err());
 }
 
-#[cfg(all(test, feature = "clustering"))]
-#[tokio::test]
-async fn user_registry_death_fences_admission_and_stops_the_process() {
-    let state = clustered_test_state_for_critical_registry_watch().await;
+#[cfg(test)]
+async fn assert_user_registry_death_is_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
     spawn_critical_registry_supervisor(&state);
     state.deps.protocol.user_registry.kill();
@@ -1153,10 +1127,8 @@ async fn user_registry_death_fences_admission_and_stops_the_process() {
     assert!(state.deps.app_state.node_lifecycle.admit().is_err());
 }
 
-#[cfg(all(test, feature = "clustering"))]
-#[tokio::test]
-async fn ordinary_shutdown_does_not_latch_a_critical_registry_failure() {
-    let state = clustered_test_state_for_critical_registry_watch().await;
+#[cfg(test)]
+async fn assert_ordinary_shutdown_is_not_critical(state: Arc<WebSocketState>) {
     let process_stop = state.deps.shutdown.stop_token();
     spawn_critical_registry_supervisor(&state);
     process_stop.cancel();
@@ -1165,48 +1137,86 @@ async fn ordinary_shutdown_does_not_latch_a_critical_registry_failure() {
     assert_eq!(state.deps.app_state.node_lifecycle.critical_failure(), None);
 }
 
-#[cfg(feature = "clustering")]
+#[cfg(test)]
+#[tokio::test]
+async fn single_node_room_registry_death_is_critical() {
+    assert_room_registry_death_is_critical(
+        crate::server::routes::websocket::tests::create_test_websocket_state().await,
+    )
+    .await;
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn single_node_user_registry_death_is_critical() {
+    assert_user_registry_death_is_critical(
+        crate::server::routes::websocket::tests::create_test_websocket_state().await,
+    )
+    .await;
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn single_node_ordinary_shutdown_is_not_critical() {
+    assert_ordinary_shutdown_is_not_critical(
+        crate::server::routes::websocket::tests::create_test_websocket_state().await,
+    )
+    .await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn clustered_room_registry_death_is_critical() {
+    assert_room_registry_death_is_critical(
+        clustered_test_state_for_critical_registry_watch().await,
+    )
+    .await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn clustered_user_registry_death_is_critical() {
+    assert_user_registry_death_is_critical(
+        clustered_test_state_for_critical_registry_watch().await,
+    )
+    .await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn clustered_ordinary_shutdown_is_not_critical() {
+    assert_ordinary_shutdown_is_not_critical(
+        clustered_test_state_for_critical_registry_watch().await,
+    )
+    .await;
+}
+
 pub(crate) fn spawn_critical_registry_supervisor(websocket_state: &Arc<WebSocketState>) {
-    let Some(stop) = websocket_state
-        .deps
-        .app_state
-        .clustering_claims
-        .stop_token
-        .clone()
-    else {
-        // Clustering support may be compiled while the runtime is deliberately
-        // single-node. In that mode these actor deaths are not cluster fencing
-        // failures and must not turn an ordinary test/deploy shutdown fatal.
-        return;
-    };
     let node_lifecycle = websocket_state.deps.app_state.node_lifecycle.clone();
     let process_stop = websocket_state.deps.shutdown.stop_token();
     let room_registry = websocket_state.deps.protocol.room_registry.clone();
     let user_registry = websocket_state.deps.protocol.user_registry.clone();
     let _room_watch = spawn_room_registry_lifetime_watch(
         room_registry,
-        stop.clone(),
         node_lifecycle.clone(),
         process_stop.clone(),
     );
     let _user_watch =
-        spawn_user_registry_lifetime_watch(user_registry, stop, node_lifecycle, process_stop);
+        spawn_user_registry_lifetime_watch(user_registry, node_lifecycle, process_stop);
 }
 
-#[cfg(not(feature = "clustering"))]
-pub(crate) fn spawn_critical_registry_supervisor(_websocket_state: &Arc<WebSocketState>) {}
-
-#[cfg(feature = "clustering")]
 fn spawn_room_registry_lifetime_watch(
     room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
-    stop: tokio_util::sync::CancellationToken,
     node_lifecycle: crate::clustering::NodeLifecycle,
     process_stop: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tokio::select! {
             biased;
-            _ = stop.cancelled() => {}
+            // Ordered process shutdown is the sole non-fatal exit. Keeping it
+            // first means a registry that terminates as part of that shutdown
+            // cannot race into a terminal failure latch.
+            _ = process_stop.cancelled() => {}
             _ = room_registry.wait_for_shutdown() => {
                 // Room ownership retry state is actor-local. Losing the
                 // registry while this node's lease remains fresh can strand
@@ -1219,17 +1229,15 @@ fn spawn_room_registry_lifetime_watch(
     })
 }
 
-#[cfg(feature = "clustering")]
 fn spawn_user_registry_lifetime_watch(
     user_registry: kameo::actor::ActorRef<waddle_xmpp::registry::UserRegistryActor>,
-    stop: tokio_util::sync::CancellationToken,
     node_lifecycle: crate::clustering::NodeLifecycle,
     process_stop: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tokio::select! {
             biased;
-            _ = stop.cancelled() => {}
+            _ = process_stop.cancelled() => {}
             _ = user_registry.wait_for_shutdown() => {
                 // UserActor claim/retry state is registry-local. Continuing
                 // to advertise this node after it dies would accept sockets
@@ -2631,12 +2639,10 @@ async fn idle_room_registry_death_self_fences_the_node() {
         .expect("secret"),
         None,
     );
-    let stop = tokio_util::sync::CancellationToken::new();
     let node_lifecycle = crate::clustering::NodeLifecycle::new();
     let process_stop = tokio_util::sync::CancellationToken::new();
     let watcher = spawn_room_registry_lifetime_watch(
         registry.actor_ref().clone(),
-        stop,
         node_lifecycle.clone(),
         process_stop.clone(),
     );

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -735,6 +735,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             return;
         };
         let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
+        let node_lifecycle = websocket_state.deps.app_state.node_lifecycle.clone();
         tokio::spawn(async move {
             let terminal_room_registry =
                 waddle_xmpp::muc::RoomRegistry::wrap(room_registry_actor.clone());
@@ -742,6 +743,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                 registry.clone(),
                 stop.clone(),
                 fatal_fence,
+                node_lifecycle,
             );
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
@@ -771,6 +773,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                 let sweep_outcome = supervise_orphan_reaper_sweep(
                     &supervisor.workers.cancel,
                     &supervisor.workers.fatal_fence,
+                    &supervisor.workers.node_lifecycle,
                     ORPHAN_REAPER_SWEEP_TIMEOUT,
                     run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
                 )
@@ -872,6 +875,7 @@ fn orphan_sweep_heartbeat_outcome(
 async fn supervise_orphan_reaper_sweep<F>(
     cancel: &tokio_util::sync::CancellationToken,
     fatal_fence: &tokio_util::sync::CancellationToken,
+    node_lifecycle: &crate::clustering::NodeLifecycle,
     timeout: Duration,
     sweep: F,
 ) -> OrphanSweepOutcome
@@ -891,6 +895,7 @@ where
             }
             Ok(false) => OrphanSweepOutcome::Failed,
             Err(_) => {
+                node_lifecycle.begin_fenced_recovery();
                 fatal_fence.cancel();
                 crate::clustering::metrics::record_orphan_worker_failure("sweep", "timeout");
                 OrphanSweepOutcome::TimedOut
@@ -930,11 +935,16 @@ mod orphan_sweep_supervision_tests {
     #[tokio::test]
     async fn timed_out_outer_sweep_self_fences_uncertain_claim_handoffs() {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        let node_lifecycle = crate::clustering::NodeLifecycle::new();
+        let fatal_fence = node_lifecycle.fatal_fence_token();
+        let admitted = node_lifecycle
+            .admit()
+            .expect("serving permit before ambiguity");
 
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
             &fatal_fence,
+            &node_lifecycle,
             Duration::from_millis(1),
             std::future::pending(),
         )
@@ -942,17 +952,25 @@ mod orphan_sweep_supervision_tests {
 
         assert_eq!(outcome, OrphanSweepOutcome::TimedOut);
         assert!(fatal_fence.is_cancelled());
+        assert_eq!(
+            node_lifecycle.admission(),
+            crate::clustering::NodeAdmission::FencedRecovering
+        );
+        assert!(node_lifecycle.admit().is_err());
+        assert!(admitted.revalidate().is_err());
     }
 
     #[tokio::test]
     async fn ordinary_sweep_cancellation_does_not_invent_a_new_self_fence() {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        let node_lifecycle = crate::clustering::NodeLifecycle::new();
+        let fatal_fence = node_lifecycle.fatal_fence_token();
         cancel.cancel();
 
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
             &fatal_fence,
+            &node_lifecycle,
             Duration::from_secs(1),
             std::future::pending(),
         )
@@ -971,13 +989,15 @@ mod orphan_sweep_supervision_tests {
             worker_cancel.clone(),
         );
         let cancel = tokio_util::sync::CancellationToken::new();
-        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        let node_lifecycle = crate::clustering::NodeLifecycle::new();
+        let fatal_fence = node_lifecycle.fatal_fence_token();
         cancel.cancel();
         let spans = waddle_xmpp::telemetry::test_support::acquire_spans();
 
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
             &fatal_fence,
+            &node_lifecycle,
             Duration::from_secs(1),
             run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
         )
@@ -1061,7 +1081,8 @@ mod orphan_sweep_supervision_tests {
     #[tokio::test]
     async fn fatal_fence_cancels_a_sweep_before_it_can_make_progress() {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        let node_lifecycle = crate::clustering::NodeLifecycle::new();
+        let fatal_fence = node_lifecycle.fatal_fence_token();
         fatal_fence.cancel();
         let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let entered_by_sweep = Arc::clone(&entered);
@@ -1069,6 +1090,7 @@ mod orphan_sweep_supervision_tests {
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
             &fatal_fence,
+            &node_lifecycle,
             Duration::from_secs(1),
             async move {
                 entered_by_sweep.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -1537,6 +1559,7 @@ struct OrphanReaperWorkers {
     sm_cursor: Arc<std::sync::Mutex<Option<crate::clustering::claims::SmOrphanScanCursor>>>,
     cancel: tokio_util::sync::CancellationToken,
     fatal_fence: tokio_util::sync::CancellationToken,
+    node_lifecycle: crate::clustering::NodeLifecycle,
 }
 
 #[cfg(feature = "clustering")]
@@ -1863,17 +1886,16 @@ impl OrphanReaperSupervisor {
         registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
         parent_cancel: tokio_util::sync::CancellationToken,
     ) -> Self {
-        Self::new_with_fatal_fence(
-            registry,
-            parent_cancel,
-            tokio_util::sync::CancellationToken::new(),
-        )
+        let node_lifecycle = crate::clustering::NodeLifecycle::new();
+        let fatal_fence = node_lifecycle.fatal_fence_token();
+        Self::new_with_fatal_fence(registry, parent_cancel, fatal_fence, node_lifecycle)
     }
 
     fn new_with_fatal_fence(
         registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
         parent_cancel: tokio_util::sync::CancellationToken,
         fatal_fence: tokio_util::sync::CancellationToken,
+        node_lifecycle: crate::clustering::NodeLifecycle,
     ) -> Self {
         let cancel = parent_cancel.child_token();
         let (hydration_tx, mut hydration_rx) =
@@ -1893,6 +1915,7 @@ impl OrphanReaperSupervisor {
             sm_cursor: Arc::new(std::sync::Mutex::new(None)),
             cancel: cancel.clone(),
             fatal_fence,
+            node_lifecycle,
         };
 
         let hydration_cancel = cancel.clone();
@@ -2156,10 +2179,16 @@ impl OrphanReaperSupervisor {
             stopped
                 .workers
                 .restore_captured_terminal_work(hydration, releases);
+            stopped.workers.node_lifecycle.begin_fenced_recovery();
             fatal_fence.cancel();
             return stopped;
         }
-        let next = Self::new_with_fatal_fence(registry, parent_cancel, fatal_fence);
+        let next = Self::new_with_fatal_fence(
+            registry,
+            parent_cancel,
+            fatal_fence,
+            stopped.workers.node_lifecycle.clone(),
+        );
         next.workers.set_room_cursor(room_cursor);
         next.workers.set_sm_cursor(sm_cursor);
         for handoff in room_handoffs {
@@ -2440,6 +2469,7 @@ async fn reconcile_registered_room_or_self_fence(
             // handoff cannot produce a typed outcome, retain the supervisor's
             // exact fence for terminal transfer and stop this node's lease
             // lifecycle so another incarnation can recover after expiry.
+            workers.node_lifecycle.begin_fenced_recovery();
             workers.fatal_fence.cancel();
         }
     }
@@ -2700,11 +2730,13 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
         .reserve_pending_reclaimed_room(room_jid.clone())
         .await
         .expect("reserve adoption"));
-    let fatal_fence = tokio_util::sync::CancellationToken::new();
+    let node_lifecycle = crate::clustering::NodeLifecycle::new();
+    let fatal_fence = node_lifecycle.fatal_fence_token();
     let supervisor = OrphanReaperSupervisor::new_with_fatal_fence(
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
         tokio_util::sync::CancellationToken::new(),
         fatal_fence.clone(),
+        node_lifecycle,
     );
     let pending = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
         room_jid: room_jid.clone(),
@@ -3681,6 +3713,7 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
         fatal_fence: tokio_util::sync::CancellationToken::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
     };
     let reserved = (0..64)
         .filter(|index| {
@@ -3725,6 +3758,7 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
         fatal_fence: tokio_util::sync::CancellationToken::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -3780,6 +3814,7 @@ fn closed_hydration_channel_retains_restart_inventory() {
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
         fatal_fence: tokio_util::sync::CancellationToken::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -3860,6 +3895,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
         fatal_fence: tokio_util::sync::CancellationToken::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -3909,6 +3945,7 @@ fn closed_release_channel_retains_restart_inventory() {
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
         fatal_fence: tokio_util::sync::CancellationToken::new(),
+        node_lifecycle: crate::clustering::NodeLifecycle::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -4183,6 +4220,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             }
             Err(error) => {
                 debug!(%error, "orphan reaper: pending RoomActor listing failed");
+                workers.node_lifecycle.begin_fenced_recovery();
                 workers.fatal_fence.cancel();
                 return false;
             }

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -62,12 +62,10 @@ pub struct AppState {
     /// startup). Used to seed `Affiliation::Owner` rows on Spaces PubSub
     /// nodes so XEP-0060 admin operations work for these accounts.
     pub server_owner_jids: Arc<[BareJid]>,
-    /// Client-facing clustering readiness signal (ADR-0017 Phase 3 Slice 2):
-    /// the `/ready`/`/readyz` handlers report not-ready whenever this node
-    /// has self-fenced its entity-ownership claims. Non-clustering
-    /// deployments (and clustering-disabled builds) never flip it, so it
-    /// stays ready forever — today's behavior, unchanged.
-    pub clustering_readiness: crate::clustering::ClusteringReadiness,
+    /// Sole typed authority for HTTP readiness and WebSocket admission.
+    /// Cluster self-fencing moves it to `FencedRecovering`; an unexpected
+    /// critical registry death latches `Failed` until this process exits.
+    pub node_lifecycle: crate::clustering::NodeLifecycle,
     /// Live `ClaimStore`/node-identity handles from the clustering
     /// subsystem (ADR-0017 Phase 3 Slice 4 follow-up plumbing note), used
     /// to select and construct the Postgres-fenced `SmPersistenceStorage`
@@ -123,7 +121,7 @@ impl AppState {
             occupant_id_secret,
             permission_actor,
             server_owner_jids: Arc::from(Vec::<BareJid>::new()),
-            clustering_readiness: crate::clustering::ClusteringReadiness::new(),
+            node_lifecycle: crate::clustering::NodeLifecycle::new(),
             clustering_claims: crate::clustering::ClusteringHandles::default(),
         })
     }
@@ -145,7 +143,7 @@ impl AppState {
             occupant_id_secret,
             permission_actor,
             server_owner_jids,
-            clustering_readiness,
+            node_lifecycle,
             clustering_claims,
         } = deps;
         Self {
@@ -161,7 +159,7 @@ impl AppState {
             occupant_id_secret,
             permission_actor,
             server_owner_jids,
-            clustering_readiness,
+            node_lifecycle,
             clustering_claims,
         }
     }
@@ -183,7 +181,7 @@ pub struct AppStateDeps {
     pub occupant_id_secret: OccupantIdSecret,
     pub permission_actor: ActorRef<PermissionActor>,
     pub server_owner_jids: Arc<[BareJid]>,
-    pub clustering_readiness: crate::clustering::ClusteringReadiness,
+    pub node_lifecycle: crate::clustering::NodeLifecycle,
     pub clustering_claims: crate::clustering::ClusteringHandles,
 }
 

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -728,10 +728,10 @@ async fn test_readyz_alias_endpoint() {
 #[tokio::test]
 async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     let state = create_test_state().await;
-    state.node_lifecycle.begin_fenced_recovery();
-    // FIX 7(a): clone the readiness handle before `state` moves into the
-    // router below, so this test can flip it back and prove recovery on
-    // the SAME router/app instance, not just the not-ready direction.
+    // Clone the lifecycle before `state` moves into the router so this test
+    // drives the same running-node authority that the production self-fence
+    // loop changes. `create_router` finishes startup by arming critical
+    // registry supervision and transitioning `Starting` to `Serving`.
     let readiness_handle = state.node_lifecycle.clone();
     let server_config = ServerConfig::test_homeserver();
     let test_global_db = crate::db::Database::in_memory("test-mam-global")
@@ -758,6 +758,10 @@ async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     })
     .await
     .unwrap();
+
+    // A running clustered node loses claim authority: readiness and admission
+    // must become non-serving on the already-constructed router.
+    readiness_handle.begin_fenced_recovery();
 
     let response = app
         .clone()

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -728,11 +728,11 @@ async fn test_readyz_alias_endpoint() {
 #[tokio::test]
 async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     let state = create_test_state().await;
-    state.clustering_readiness.set_ready(false);
+    state.node_lifecycle.begin_fenced_recovery();
     // FIX 7(a): clone the readiness handle before `state` moves into the
     // router below, so this test can flip it back and prove recovery on
     // the SAME router/app instance, not just the not-ready direction.
-    let readiness_handle = state.clustering_readiness.clone();
+    let readiness_handle = state.node_lifecycle.clone();
     let server_config = ServerConfig::test_homeserver();
     let test_global_db = crate::db::Database::in_memory("test-mam-global")
         .await
@@ -774,12 +774,12 @@ async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "not_ready");
-    assert_eq!(json["clustering"], "self-fenced");
+    assert_eq!(json["admission"], "FencedRecovering");
 
     // FIX 7(a): recovery — once a node re-registers and clears its
     // self-fenced state, `/ready` must report healthy again on the same
     // router/state, not just flip one direction and stay stuck.
-    readiness_handle.set_ready(true);
+    readiness_handle.serve();
     let response = app
         .oneshot(
             Request::builder()

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -733,31 +733,7 @@ async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     // loop changes. `create_router` finishes startup by arming critical
     // registry supervision and transitioning `Starting` to `Serving`.
     let readiness_handle = state.node_lifecycle.clone();
-    let server_config = ServerConfig::test_homeserver();
-    let test_global_db = crate::db::Database::in_memory("test-mam-global")
-        .await
-        .expect("test global db");
-    let mam_storage = http::create_websocket_mam_storage(None, false, false, &test_global_db)
-        .await
-        .unwrap();
-    let pubsub_database_storage = Arc::new(
-        crate::pubsub::DatabasePubSubStorage::open(Some("sqlite::memory:"))
-            .await
-            .expect("test pubsub storage"),
-    );
-    let app = http::create_router(http::RouterDeps {
-        state,
-        server_config,
-        xmpp_config: test_xmpp_config(),
-        mam_storage,
-        pubsub_database_storage,
-        acme_http01_challenge_service: None,
-        shutdown_handle: waddle_ecdysis::GracefulShutdown::new(std::time::Duration::from_secs(1))
-            .handle(),
-        drain_complete: std::sync::Arc::new(tokio::sync::Notify::new()),
-    })
-    .await
-    .unwrap();
+    let app = test_app_for_state(state).await;
 
     // A running clustered node loses claim authority: readiness and admission
     // must become non-serving on the already-constructed router.
@@ -798,6 +774,62 @@ async fn test_ready_endpoint_reports_not_ready_when_clustering_self_fenced() {
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "ready");
+}
+
+#[tokio::test]
+async fn test_router_startup_preserves_a_concurrent_clustering_self_fence() {
+    let state = create_test_state().await;
+    let lifecycle = state.node_lifecycle.clone();
+    lifecycle.begin_fenced_recovery();
+
+    let app = test_app_for_state(state).await;
+
+    let ready_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ready_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let ws_response = app
+        .clone()
+        .oneshot(Request::builder().uri("/ws").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(ws_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    lifecycle.serve();
+    let ready_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/ready")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ready_response.status(), StatusCode::OK);
+
+    let ws_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ws")
+                .header("connection", "upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ws_response.status(), StatusCode::UPGRADE_REQUIRED);
 }
 
 #[tokio::test]
@@ -990,6 +1022,10 @@ async fn test_seed_fixed_test_account_replaces_existing_credentials() {
 
 async fn test_app() -> Router {
     let state = create_test_state().await;
+    test_app_for_state(state).await
+}
+
+async fn test_app_for_state(state: Arc<AppState>) -> Router {
     let server_config = ServerConfig::test_homeserver();
     let test_global_db = crate::db::Database::in_memory("test-mam-global")
         .await

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -1870,7 +1870,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     use waddle_server::clustering::self_fence::{
         self, ConnectedPeerCount, LocallyClaimedEntities, NodeLeaseRunConfig,
     };
-    use waddle_server::clustering::ClusteringReadiness;
+    use waddle_server::clustering::NodeLifecycle;
     use waddle_server::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
     use waddle_xmpp::muc::durable::{
         DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
@@ -2092,7 +2092,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
             self_fence_config: ClusteringSelfFenceConfig::default(),
             connected_peers: ConnectedPeerCount::new(),
             local_claims,
-            readiness: ClusteringReadiness::new(),
+            readiness: NodeLifecycle::new(),
             live_identity,
             peer_id: None,
             claim_store,
@@ -3064,7 +3064,7 @@ async fn subscription_presence_and_probe_route_to_foreign_user_owner() {
 /// `lone_survivor_and_isolation_fencing`'s Part 2 uses), extended with an
 /// assertion Part 2 does NOT make — genuine, unattended SELF-RECOVERY
 /// (re-registration under a fresh identity, `self_fence.rs`'s
-/// `readiness.set_ready(true)` re-arm path) once connectivity returns, with
+/// `readiness.serve()` re-arm path) once connectivity returns, with
 /// no process restart. This is the most faithful available proof that a
 /// connectivity degradation "degrades... without [permanently] fencing"
 /// rather than requiring manual/operator intervention to recover.
@@ -3168,7 +3168,7 @@ async fn whole_node_isolation_fences_then_self_heals_without_operator_interventi
     // genuine, unattended SELF-RECOVERY — no process restart, a fresh
     // internal identity re-registers and readiness re-arms once swarm
     // connectivity actually returns (`self_fence.rs`'s
-    // `can_reacquire_claims`/`readiness.set_ready(true)` path).
+    // `can_reacquire_claims`/`readiness.serve()` path).
     conn.execute(
         "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?)",
         waddle_server::db_params![peer_c.clone()],


### PR DESCRIPTION
## Plan

- Make `NodeLifecycle` the single typed authority for readiness, WebSocket admission, serving-generation fencing, drain, and critical actor failure.
- Fence every authority-bound WebSocket write before its irreversible `start_send` transport commit.
- Preserve RFC 7395 shutdown framing and XEP-0198 stream-management responsibility through admission revocation, batching, and resume.
- Commit server stream-open wire state only after the authority-aware response batch completes.
- Verify the exact immutable head with independent review and full CI before merge.

## Delivered

- Added typed serving, draining, fenced-recovery, and terminal-failure lifecycle states; readiness and WebSocket admission now share one serving-generation authority.
- Bound admitted sockets, deferred inbound work, registration, ordered relay, outbound routing, keepalives, and critical actor failure handling to revocable generations.
- Added the typed authority-aware WebSocket send boundary. Revocation is selectable while readiness is pending; the permit is revalidated immediately before `start_send`; a valid `start_send` remains the irreversible transport commit and any later flush uncertainty is intentionally preserved.
- Routed normal, cadence, direct outbound, keepalive, and connection-loop control writes through that boundary. Pre-XMPP RFC 7395 close and terminal close-only teardown remain deliberate transport-only paths.
- Preserved XEP-0198 responsibility across admission revocation. Batch writers retain the exact unconsumed countable replay tail on an authority-revoked exit, avoid duplicate SM records, preserve ordering, and retain multi-frame MAM result plus final IQ tails after an already-settled inbound `h`.
- Split semantic stream-open handling from conservative typed wire state. A pending server `<open/>` response is committed only after its batch returns `Continue`; lifecycle fencing then emits `system-shutdown` only for a committed stream, while XMPP close and restart transitions reset the marker.
- Added deterministic coverage for pending-ready revocation, committed-open shutdown, replay-tail ordering, and MAM result/fin resume behavior.

## Final verification

- Base: `9dc586a711b628002f62522cb4e0dc8a7634dfb0`
- Accepted head: `f613406d4381e0899646715ef354963fe01ab854`
- Three fresh Terra High adversarial reviews reached CLEAN, and Sol independently accepted the live exact PR, diff, checks, and signature state.
- All exact-head workflows reached terminal success:
  - [Code Quality](https://github.com/waddle-social/waddle/actions/runs/30572741823)
  - [CodeQL](https://github.com/waddle-social/waddle/actions/runs/30572745780)
  - [Copilot Code Review](https://github.com/waddle-social/waddle/actions/runs/30572750394)
  - [XMPP compliance](https://github.com/waddle-social/waddle/actions/runs/30572745819)
  - [Server pull-request suite](https://github.com/waddle-social/waddle/actions/runs/30572745938), including compile, clippy, tests, doctests, and XMPP FFI checks.
- No local cold build was run, to preserve disk custody; the exact-head CI above supplied full compile, test, clippy, and XMPP verification.

## Deferred scope

- The pre-existing 15-second dispatch-timeout uncertainty is unchanged and deferred to P1 durable ingress/idempotency. This packet neither broadens it nor treats it as delivery certainty.

## Custody ledger

- Packet: P0.2 clustered readiness, admission, lifecycle fencing, and authority-bound WebSocket I/O.
- Sole source writer: Terra High. This final custodian changed only PR metadata and merge state.
- Original writer workspace: `/private/tmp/waddle-terra-p0-2`; replay-tail remediation workspace: `/private/tmp/waddle-terra-p0-2-replay2`.
- Public bookmark: `codex/distributed-actors-p0-2`; current published candidate before merge: `f613406d4381e0899646715ef354963fe01ab854`.
- Remediation lineage: `f6b292cd3b4d21ba6dc8b7dde6d962664744fc47` preserved SM responsibility; `756a5c24667b0316c17b44f7be0d1ad41cd888bd` introduced the send boundary but was not accepted after its compile defect; `4c6995ebbd6d97fb94375b315652c1e010e08e66` fenced control writes; `02ab3d796d9503cafaba8b7b0e0fa78f7d6b8b18` introduced stream-open commit state but was not accepted after replay-tail review; `037056f71ac9c63148799b88baaf3f57ea8304c1`, `94cca462259f0bbb66a05124ba89ead1a0c13908`, `0c59834c3cc91e4153ce6c6179cb354412a17e81`, and `f613406d4381e0899646715ef354963fe01ab854` completed the retained-tail test and compilation repairs.
- Rejected candidate or bad-certificate records are not acceptance evidence. Only the exact accepted head above, its three CLEAN Terra reviews, Sol acceptance, and terminal CI are authoritative.
- GitHub reports the accepted source commit as unsigned (`verified=false`, reason `unsigned`); no signing claim is made.
- This PR is ready only because its exact published head, full independent review gate, and all terminal workflows are clean.
