### PR TITLE
fix(chat): LiveKit call lifecycle hardening (#1450)

### DIFF
--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -42,8 +42,7 @@ const state = useStore($callState);
 const { engine } = useCallEngine();
 
 function getSender(): CallWireSender | null {
-  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
-  return (client?.xmpp as CallWireSender | undefined) ?? null;
+  return connectionStore.client?.callWireSender() ?? null;
 }
 
 // XEP-0215: ask our own server for its advertised TURN/STUN before connecting

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -9,7 +9,10 @@ import {
 import type { CallWireSender } from "@/lib/calls/outbound";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { adoptCallCorrelationId, clearCallCorrelationId } from "@/lib/calls/call-correlation";
-import { iceServersFromExternalServices } from "@/lib/calls/ice-servers";
+import {
+  iceServerBundleFromExternalServices,
+  type IceServerBundle,
+} from "@/lib/calls/ice-servers";
 import { connectionStore } from "@/lib/connection-store";
 import {
   $callConnecting,
@@ -45,12 +48,12 @@ function getSender(): CallWireSender | null {
 
 // XEP-0215: ask our own server for its advertised TURN/STUN before connecting
 // so LiveKit negotiates ICE over the XMPP-native, client-controlled path.
-// Resolves to `[]` on any failure (the wrapper never throws) — the engine then
-// connects with LiveKit's default servers instead of an empty list.
-async function resolveIceServers(): Promise<RTCIceServer[]> {
+// Resolves to an empty bundle on any failure (the wrapper never throws) — the
+// engine then connects with LiveKit's default servers instead of an empty list.
+async function resolveIceServers(): Promise<IceServerBundle> {
   const client = connectionStore.client;
-  if (!client) return [];
-  return iceServersFromExternalServices(await client.fetchExternalServices());
+  if (!client) return { servers: [], earliestExpiryMs: null };
+  return iceServerBundleFromExternalServices(await client.fetchExternalServices());
 }
 
 // Connect to LiveKit when a fresh `active` phase appears with a new
@@ -74,7 +77,7 @@ watch(
     // a previous call's Speaker view or pin must not leak across.
     resetCallViewState();
     try {
-      const iceServers = await resolveIceServers();
+      const iceServerBundle = await resolveIceServers();
       // The ICE fetch can block for up to 10s. Re-confirm this is still the
       // same active call before connecting — a hang-up + redial during the
       // fetch would otherwise open a LiveKit session against a stale join/sid.
@@ -86,7 +89,12 @@ watch(
       // is kept so the failure path can await the adoption — a fast
       // connect failure must not emit its telemetry before the id lands.
       const correlationAdopted = adoptCallCorrelationId(current.join.room);
-      await engine.connect(current.join, { ...current.media, iceServers });
+      await engine.connect(current.join, {
+        ...current.media,
+        iceServers: iceServerBundle.servers,
+        iceServersExpiryMs: iceServerBundle.earliestExpiryMs,
+        refreshIceServers: resolveIceServers,
+      });
       // Capture is best-effort inside connect(): a missing device or a
       // denied mic/cam permission no longer throws — the user joins as a
       // receive-only participant and the engine emits `mediaDevicesError`

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -68,6 +68,10 @@ function getSender(): CallWireSender | null {
  */
 let micOpChain: Promise<void> = Promise.resolve();
 let micRequestGen = 0;
+let camOpChain: Promise<void> = Promise.resolve();
+let camRequestGen = 0;
+let screenShareOpChain: Promise<void> = Promise.resolve();
+let screenShareRequestGen = 0;
 
 /**
  * Drive the local microphone to `next` with optimistic UI + rollback, the
@@ -129,29 +133,45 @@ export function setPushToTalkActive(active: boolean): void {
  *  camera once a device is attached or access is granted. */
 export async function toggleCam(): Promise<void> {
   const next = !$callCamEnabled.get();
+  const gen = ++camRequestGen;
   $callCamEnabled.set(next);
-  try {
-    const { engine } = useCallEngine();
-    await engine.setCameraEnabled(next);
-    clearMediaIssue("cam");
-  } catch (err) {
-    $callCamEnabled.set(!next);
-    recordMediaIssue("cam", err);
-  }
+  const op = camOpChain.then(async () => {
+    if (gen !== camRequestGen) return;
+    try {
+      const { engine } = useCallEngine();
+      await engine.setCameraEnabled(next);
+      if (gen !== camRequestGen) return;
+      clearMediaIssue("cam");
+    } catch (err) {
+      if (gen !== camRequestGen) return;
+      $callCamEnabled.set(!next);
+      recordMediaIssue("cam", err);
+    }
+  });
+  camOpChain = op;
+  await op;
 }
 
 export async function toggleScreenShare(): Promise<void> {
   const next = !$callScreenShareEnabled.get();
+  const gen = ++screenShareRequestGen;
   $callScreenShareEnabled.set(next);
-  try {
-    const { engine } = useCallEngine();
-    await engine.setScreenShareEnabled(next, { audio: next });
-    clearMediaIssue("screen");
-  } catch (err) {
-    $callScreenShareEnabled.set(!next);
-    if (next && isScreenSharePickerCancel(err)) return;
-    recordMediaIssue("screen", err);
-  }
+  const op = screenShareOpChain.then(async () => {
+    if (gen !== screenShareRequestGen) return;
+    try {
+      const { engine } = useCallEngine();
+      await engine.setScreenShareEnabled(next, { audio: next });
+      if (gen !== screenShareRequestGen) return;
+      clearMediaIssue("screen");
+    } catch (err) {
+      if (gen !== screenShareRequestGen) return;
+      $callScreenShareEnabled.set(!next);
+      if (next && isScreenSharePickerCancel(err)) return;
+      recordMediaIssue("screen", err);
+    }
+  });
+  screenShareOpChain = op;
+  await op;
 }
 
 /**
@@ -211,6 +231,9 @@ export function suspendCallForPageHide(): void {
  * state once the engine has connected.
  */
 export function resetCallControls(micEnabled: boolean, camEnabled: boolean): void {
+  micRequestGen++;
+  camRequestGen++;
+  screenShareRequestGen++;
   $callMicEnabled.set(micEnabled);
   $callCamEnabled.set(camEnabled);
   $callScreenShareEnabled.set(false);

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -52,8 +52,10 @@ function isScreenSharePickerCancel(error: unknown): boolean {
 }
 
 function getSender(): CallWireSender | null {
-  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
-  return (client?.xmpp as CallWireSender | undefined) ?? null;
+  // Session-ready-gated: a half-open reconnect-phase handle must not
+  // consume a hangup's teardown — a null sender routes it into the
+  // pending-terminate retention instead (#1621 review round 4).
+  return connectionStore.client?.callWireSender() ?? null;
 }
 
 /**
@@ -234,6 +236,14 @@ export function resetCallControls(micEnabled: boolean, camEnabled: boolean): voi
   micRequestGen++;
   camRequestGen++;
   screenShareRequestGen++;
+  // Detach the new call's ops from any UNRESOLVED previous-call op (a
+  // camera permission prompt or display picker still open): the stale
+  // op is generation-dead when it finally settles, but chaining behind
+  // it would block the new call's first action until then (#1621
+  // review round 4).
+  micOpChain = Promise.resolve();
+  camOpChain = Promise.resolve();
+  screenShareOpChain = Promise.resolve();
   $callMicEnabled.set(micEnabled);
   $callCamEnabled.set(camEnabled);
   $callScreenShareEnabled.set(false);

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -1,4 +1,5 @@
 import {
+  missingCallDeviceError,
   resolveCallDevicePreference,
   type AudioProcessingPrefs,
   setAiNoiseModel,
@@ -33,9 +34,7 @@ export async function applyCallDeviceSelection(
 ): Promise<void> {
   const resolved = await resolveCallDevicePreference(kind, deviceId);
   if (resolved.missing && kind !== "speaker") {
-    const error = new Error(`${kind} device is no longer available`);
-    error.name = "NotFoundError";
-    recordMediaIssue(kind, error);
+    recordMediaIssue(kind, missingCallDeviceError(kind));
   }
   if (kind === "mic") {
     await engine.setMicDevice(resolved.activeDeviceId);

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -1,6 +1,5 @@
 import {
-  missingCallDeviceError,
-  resolveCallDevicePreference,
+  type ResolvedCallDevicePreference,
   type AudioProcessingPrefs,
   setAiNoiseModel,
   setBackgroundEffectPref,
@@ -13,14 +12,13 @@ import { clearAiNoiseFilterError } from "./ai-noise-filter-error-state";
 import { clearBackgroundEffectError } from "./background-effect-error-state";
 import type { NoiseModelId } from "./ai-noise-filter/model-id";
 import type { BackgroundEffect } from "./background-effect/effect-id";
-import { recordMediaIssue } from "./call-media-issues";
 
 export type CallDeviceKind = "mic" | "cam" | "speaker";
 
 export type CallDeviceSelectionEngine = {
-  setMicDevice(deviceId: string): Promise<void>;
-  setCameraDevice(deviceId: string): Promise<void>;
-  setSpeakerDevice(deviceId: string): Promise<void>;
+  setMicDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null>;
+  setCameraDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null>;
+  setSpeakerDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null>;
 };
 
 export type CallAudioProcessingSelectionEngine = {
@@ -32,22 +30,26 @@ export async function applyCallDeviceSelection(
   deviceId: string | null,
   engine: CallDeviceSelectionEngine,
 ): Promise<void> {
-  const resolved = await resolveCallDevicePreference(kind, deviceId);
-  if (resolved.missing && kind !== "speaker") {
-    recordMediaIssue(kind, missingCallDeviceError(kind));
-  }
+  // Resolve exactly ONCE — inside the engine, which returns what it
+  // actually applied. Persisting anything else lets the preference (and
+  // any UI reading it) claim a device the live call is not capturing
+  // from when the device list changes between two enumerations (#1621
+  // review round 2). A null resolution means no live room (settings
+  // outside a call) — persist the picker's intent verbatim; the picker
+  // only offers enumerated devices.
+  const requested = deviceId ?? "default";
   if (kind === "mic") {
-    await engine.setMicDevice(resolved.activeDeviceId);
-    setMicDevice(resolved.preferenceId);
+    const applied = await engine.setMicDevice(requested);
+    setMicDevice(applied ? applied.preferenceId : deviceId);
     return;
   }
   if (kind === "cam") {
-    await engine.setCameraDevice(resolved.activeDeviceId);
-    setCamDevice(resolved.preferenceId);
+    const applied = await engine.setCameraDevice(requested);
+    setCamDevice(applied ? applied.preferenceId : deviceId);
     return;
   }
-  await engine.setSpeakerDevice(resolved.activeDeviceId);
-  setSpeakerDevice(resolved.preferenceId);
+  const applied = await engine.setSpeakerDevice(requested);
+  setSpeakerDevice(applied ? applied.preferenceId : deviceId);
 }
 
 export async function applyAudioProcessingSelection(

--- a/chat/src/lib/calls/call-device-selection.ts
+++ b/chat/src/lib/calls/call-device-selection.ts
@@ -1,4 +1,5 @@
 import {
+  resolveCallDevicePreference,
   type AudioProcessingPrefs,
   setAiNoiseModel,
   setBackgroundEffectPref,
@@ -11,6 +12,7 @@ import { clearAiNoiseFilterError } from "./ai-noise-filter-error-state";
 import { clearBackgroundEffectError } from "./background-effect-error-state";
 import type { NoiseModelId } from "./ai-noise-filter/model-id";
 import type { BackgroundEffect } from "./background-effect/effect-id";
+import { recordMediaIssue } from "./call-media-issues";
 
 export type CallDeviceKind = "mic" | "cam" | "speaker";
 
@@ -29,19 +31,24 @@ export async function applyCallDeviceSelection(
   deviceId: string | null,
   engine: CallDeviceSelectionEngine,
 ): Promise<void> {
-  const activeDeviceId = deviceId ?? "default";
+  const resolved = await resolveCallDevicePreference(kind, deviceId);
+  if (resolved.missing && kind !== "speaker") {
+    const error = new Error(`${kind} device is no longer available`);
+    error.name = "NotFoundError";
+    recordMediaIssue(kind, error);
+  }
   if (kind === "mic") {
-    await engine.setMicDevice(activeDeviceId);
-    setMicDevice(deviceId);
+    await engine.setMicDevice(resolved.activeDeviceId);
+    setMicDevice(resolved.preferenceId);
     return;
   }
   if (kind === "cam") {
-    await engine.setCameraDevice(activeDeviceId);
-    setCamDevice(deviceId);
+    await engine.setCameraDevice(resolved.activeDeviceId);
+    setCamDevice(resolved.preferenceId);
     return;
   }
-  await engine.setSpeakerDevice(activeDeviceId);
-  setSpeakerDevice(deviceId);
+  await engine.setSpeakerDevice(resolved.activeDeviceId);
+  setSpeakerDevice(resolved.preferenceId);
 }
 
 export async function applyAudioProcessingSelection(

--- a/chat/src/lib/calls/call-ice-telemetry.ts
+++ b/chat/src/lib/calls/call-ice-telemetry.ts
@@ -48,6 +48,9 @@ type TurnReachability = "gathered" | "not-gathered" | "unknown";
 /** Coarse, low-cardinality bucket over the ICE restart count. */
 export type IceRestartBucket = "none" | "once" | "few" | "many";
 
+/** Lifecycle signal for expiring XEP-0215 TURN credentials. */
+export type IceCredentialEvent = "refreshed" | "expired";
+
 /**
  * One observed ICE state for a call. Every field is a closed enum or a
  * bucket, so the beacon stays low-cardinality and de-dupes usefully.
@@ -234,6 +237,8 @@ export function iceStatsEntries(report: { forEach(fn: (value: unknown) => void):
 export type CallIceBeacon = {
   /** Record an ICE restart; the next observation carries the new bucket. */
   noteIceRestart(): void;
+  /** Beacon a TURN credential lifecycle transition for this call. */
+  noteCredentials(event: IceCredentialEvent): void;
   /** The restart count observed so far this call. */
   restartCount(): number;
   /** Reduce `report` and beacon it unless an equal state already beaconed. */
@@ -263,12 +268,16 @@ function sameIceSnapshot(a: CallIceSnapshot, b: CallIceSnapshot): boolean {
  */
 export function createCallIceBeacon(
   report: (snapshot: CallIceSnapshot) => void,
+  reportCredentials: (event: IceCredentialEvent) => void = () => undefined,
 ): CallIceBeacon {
   let seen: CallIceSnapshot[] = [];
   let restarts = 0;
   return {
     noteIceRestart() {
       restarts += 1;
+    },
+    noteCredentials(event) {
+      reportCredentials(event);
     },
     restartCount() {
       return restarts;

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -1056,21 +1056,48 @@ export async function tearDownActiveCall(
     } catch (err) {
       reportWireError(err);
     }
-  } else if (s.phase === "active" && s.kind === "dm") {
-    // XMPP died before (or with) the media, so nothing can carry the
-    // terminate right now. Clean the local surfaces immediately — the
-    // accepted activity and cached join must stop offering a reconnect
-    // into a dead call — and retain a pending wire teardown that the
-    // next session-ready flushes, so the peer still receives the
-    // XEP-0166 terminate + XEP-0353 finish instead of dangling active
-    // (#1621 review round 2).
-    clearDmCallActivity(s.peer, s.sid);
-    forgetDmCallJoin({
-      selfBareJid: barePeerJid(s.join.identity),
-      peerJid: s.peer,
-      sid: s.sid,
-    });
-    $pendingDmCallTerminate.set({ peer: s.peer, sid: s.sid, reason });
+  } else {
+    // No sender: XMPP died before (or with) the media. The wire steps
+    // are impossible right now, but the LOCAL halves of each phase's
+    // teardown must still run (#1621 review rounds 2 and 4).
+    switch (s.phase) {
+      case "active":
+        if (s.kind === "dm") {
+          // The accepted activity and cached join must stop offering a
+          // reconnect into a dead call, and the peer still deserves the
+          // XEP-0166 terminate + XEP-0353 finish — retained for the
+          // next session-ready to flush.
+          clearDmCallActivity(s.peer, s.sid);
+          forgetDmCallJoin({
+            selfBareJid: barePeerJid(s.join.identity),
+            peerJid: s.peer,
+            sid: s.sid,
+          });
+          $pendingDmCallTerminate.set({ peer: s.peer, sid: s.sid, reason });
+        }
+        break;
+      case "incoming":
+        incomingCallAlerts?.stop(s.sid);
+        clearDmCallActivity(s.from, s.sid);
+        break;
+      case "outgoing":
+        clearDmCallActivity(s.to, s.sid);
+        break;
+      case "muc-pending":
+        rejectPendingMujiAccept(
+          s.sid,
+          new Error("Muji session-accept wait cancelled while clearing call state"),
+          s.attemptId,
+        );
+        cancelMucCallPreparationWaiters(
+          s.peer,
+          s.selfNick,
+          new Error("Muji preparing wait cancelled while clearing call state"),
+        );
+        break;
+      default:
+        break;
+    }
   }
 }
 

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -1070,42 +1070,65 @@ export async function tearDownActiveCall(
       peerJid: s.peer,
       sid: s.sid,
     });
-    pendingDmCallTerminate = { peer: s.peer, sid: s.sid, reason };
+    $pendingDmCallTerminate.set({ peer: s.peer, sid: s.sid, reason });
   }
 }
 
-let pendingDmCallTerminate: {
+type PendingDmCallTerminate = {
   peer: string;
   sid: string;
   reason: "success" | "gone";
-} | null = null;
+};
+
+/**
+ * The deferred wire teardown of a sender-less [`tearDownActiveCall`] —
+ * store-idiomatic (an atom like the call slot itself) so the state is
+ * observable and testable rather than hidden module mutation.
+ */
+const $pendingDmCallTerminate = atom<PendingDmCallTerminate | null>(null);
+let pendingDmTerminateFlushInFlight = false;
 
 /**
  * Deliver the wire teardown a sender-less [`tearDownActiveCall`] had to
  * defer. Called from the XMPP session-ready path; sid-scoped, so a
  * terminate for a call the peer already abandoned is a harmless no-op
- * on their side.
+ * on their side. The pending row is cleared only AFTER the terminate
+ * succeeds (or classifies orphaned) — a failed or interrupted send
+ * keeps it retained for the NEXT session-ready instead of silently
+ * dropping the peer's only end-of-call signal (#1621 review round 3).
  */
 export async function flushPendingDmCallTerminate(sender: CallWireSender): Promise<void> {
-  const pending = pendingDmCallTerminate;
+  if (pendingDmTerminateFlushInFlight) return;
+  const pending = $pendingDmCallTerminate.get();
   if (!pending) return;
-  pendingDmCallTerminate = null;
+  pendingDmTerminateFlushInFlight = true;
   try {
     const outcome = await boundedTeardownSend(
       () => outboundCalls.sessionTerminateWithOutcome(sender, pending.peer, pending.sid, pending.reason),
       { attempts: TERMINATE_SEND_ATTEMPTS },
     );
-    if (outcome === "ok" || outcome === "orphaned") {
+    if (outcome !== "ok" && outcome !== "orphaned") return;
+    if ($pendingDmCallTerminate.get() === pending) {
+      $pendingDmCallTerminate.set(null);
+    }
+    try {
+      // The XEP-0353 finish bookend is best-effort: the terminate above
+      // already ended the call for the peer.
       await boundedTeardownSend(() => outboundCalls.finish(sender, pending.peer, pending.sid), {});
+    } catch (err) {
+      reportCallError(err);
     }
   } catch (err) {
+    // Retained: the next session-ready retries with its fresh stream.
     reportCallError(err);
+  } finally {
+    pendingDmTerminateFlushInFlight = false;
   }
 }
 
 /** Logout must not leak a terminate into the next account's session. */
 export function clearPendingDmCallTerminate(): void {
-  pendingDmCallTerminate = null;
+  $pendingDmCallTerminate.set(null);
 }
 
 /**

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -12,6 +12,7 @@ import {
   applyDmCallEvent,
   clearDmCallActivity,
 } from "./dm-call-activity";
+import { forgetDmCallJoin } from "./dm-call-join-cache";
 import {
   forgetMucCallSession,
   rememberMucCallSession,
@@ -1055,7 +1056,56 @@ export async function tearDownActiveCall(
     } catch (err) {
       reportWireError(err);
     }
+  } else if (s.phase === "active" && s.kind === "dm") {
+    // XMPP died before (or with) the media, so nothing can carry the
+    // terminate right now. Clean the local surfaces immediately — the
+    // accepted activity and cached join must stop offering a reconnect
+    // into a dead call — and retain a pending wire teardown that the
+    // next session-ready flushes, so the peer still receives the
+    // XEP-0166 terminate + XEP-0353 finish instead of dangling active
+    // (#1621 review round 2).
+    clearDmCallActivity(s.peer, s.sid);
+    forgetDmCallJoin({
+      selfBareJid: barePeerJid(s.join.identity),
+      peerJid: s.peer,
+      sid: s.sid,
+    });
+    pendingDmCallTerminate = { peer: s.peer, sid: s.sid, reason };
   }
+}
+
+let pendingDmCallTerminate: {
+  peer: string;
+  sid: string;
+  reason: "success" | "gone";
+} | null = null;
+
+/**
+ * Deliver the wire teardown a sender-less [`tearDownActiveCall`] had to
+ * defer. Called from the XMPP session-ready path; sid-scoped, so a
+ * terminate for a call the peer already abandoned is a harmless no-op
+ * on their side.
+ */
+export async function flushPendingDmCallTerminate(sender: CallWireSender): Promise<void> {
+  const pending = pendingDmCallTerminate;
+  if (!pending) return;
+  pendingDmCallTerminate = null;
+  try {
+    const outcome = await boundedTeardownSend(
+      () => outboundCalls.sessionTerminateWithOutcome(sender, pending.peer, pending.sid, pending.reason),
+      { attempts: TERMINATE_SEND_ATTEMPTS },
+    );
+    if (outcome === "ok" || outcome === "orphaned") {
+      await boundedTeardownSend(() => outboundCalls.finish(sender, pending.peer, pending.sid), {});
+    }
+  } catch (err) {
+    reportCallError(err);
+  }
+}
+
+/** Logout must not leak a terminate into the next account's session. */
+export function clearPendingDmCallTerminate(): void {
+  pendingDmCallTerminate = null;
 }
 
 /**

--- a/chat/src/lib/calls/call-token-storage-migration.ts
+++ b/chat/src/lib/calls/call-token-storage-migration.ts
@@ -1,16 +1,20 @@
 import { reportError } from "@/lib/telemetry";
 
-const purgedLegacyPrefixes = new Set<string>();
-
+/**
+ * Runs on EVERY cache access, not once: during a rolling deployment an
+ * already-open pre-migration tab keeps writing bearer tokens into the
+ * shared origin-wide localStorage after this tab's first purge, so a
+ * one-shot guard would leave the recreated token persisted (#1621
+ * review round 5). The scan is a handful of keys on rare call-cache
+ * touches.
+ */
 export function purgeLegacyStoragePrefixFromLocalStorage(prefix: string): void {
-  if (purgedLegacyPrefixes.has(prefix)) return;
   const storage = legacyLocalStorage();
   if (!storage) return;
   try {
     for (const key of keysWithPrefix(storage, prefix)) storage.removeItem(key);
-    purgedLegacyPrefixes.add(prefix);
   } catch {
-    // Keep the prefix eligible for a later retry when storage access recovers.
+    // Retried on the next cache access when storage access recovers.
   }
 }
 
@@ -45,10 +49,6 @@ export function clearCallCacheKeysWithPrefix(
   } catch (err) {
     reportError("storage.write", err, { recoverable: true, detail });
   }
-}
-
-export function resetLegacyCallStorageMigrationForTests(): void {
-  purgedLegacyPrefixes.clear();
 }
 
 function keysWithPrefix(storage: Storage, prefix: string): string[] {

--- a/chat/src/lib/calls/call-token-storage-migration.ts
+++ b/chat/src/lib/calls/call-token-storage-migration.ts
@@ -1,3 +1,5 @@
+import { reportError } from "@/lib/telemetry";
+
 const purgedLegacyPrefixes = new Set<string>();
 
 export function purgeLegacyStoragePrefixFromLocalStorage(prefix: string): void {
@@ -5,12 +7,7 @@ export function purgeLegacyStoragePrefixFromLocalStorage(prefix: string): void {
   const storage = legacyLocalStorage();
   if (!storage) return;
   try {
-    const keys: string[] = [];
-    for (let index = 0; index < storage.length; index += 1) {
-      const key = storage.key(index);
-      if (key?.startsWith(`${prefix}.`)) keys.push(key);
-    }
-    for (const key of keys) storage.removeItem(key);
+    for (const key of keysWithPrefix(storage, prefix)) storage.removeItem(key);
     purgedLegacyPrefixes.add(prefix);
   } catch {
     // Keep the prefix eligible for a later retry when storage access recovers.
@@ -21,8 +18,46 @@ export function localStorageForLegacyPurge(): Storage | null {
   return legacyLocalStorage();
 }
 
+/**
+ * The call caches' storage: session-scoped (bearer tokens must not live in
+ * origin-wide persistent storage, #1450), with the legacy localStorage purge
+ * repeated here so SSR-first imports retry once hydration makes browser
+ * storage available.
+ */
+export function callCacheSessionStorage(cachePrefix: string): Storage | null {
+  purgeLegacyStoragePrefixFromLocalStorage(cachePrefix);
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearCallCacheKeysWithPrefix(
+  storage: Storage | null,
+  prefix: string,
+  detail: string,
+): void {
+  if (!storage) return;
+  try {
+    for (const key of keysWithPrefix(storage, prefix)) storage.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, { recoverable: true, detail });
+  }
+}
+
 export function resetLegacyCallStorageMigrationForTests(): void {
   purgedLegacyPrefixes.clear();
+}
+
+function keysWithPrefix(storage: Storage, prefix: string): string[] {
+  const keys: string[] = [];
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (key?.startsWith(`${prefix}.`)) keys.push(key);
+  }
+  return keys;
 }
 
 function legacyLocalStorage(): Storage | null {

--- a/chat/src/lib/calls/call-token-storage-migration.ts
+++ b/chat/src/lib/calls/call-token-storage-migration.ts
@@ -1,0 +1,35 @@
+const purgedLegacyPrefixes = new Set<string>();
+
+export function purgeLegacyStoragePrefixFromLocalStorage(prefix: string): void {
+  if (purgedLegacyPrefixes.has(prefix)) return;
+  const storage = legacyLocalStorage();
+  if (!storage) return;
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key?.startsWith(`${prefix}.`)) keys.push(key);
+    }
+    for (const key of keys) storage.removeItem(key);
+    purgedLegacyPrefixes.add(prefix);
+  } catch {
+    // Keep the prefix eligible for a later retry when storage access recovers.
+  }
+}
+
+export function localStorageForLegacyPurge(): Storage | null {
+  return legacyLocalStorage();
+}
+
+export function resetLegacyCallStorageMigrationForTests(): void {
+  purgedLegacyPrefixes.clear();
+}
+
+function legacyLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/chat/src/lib/calls/call-transport-recovery.ts
+++ b/chat/src/lib/calls/call-transport-recovery.ts
@@ -1,0 +1,53 @@
+export const CALL_TRANSPORT_RECOVERY_GRACE_MS = 60_000;
+
+export type CallTransportRecoveryClock = {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+};
+
+export type CallTransportRecovery = {
+  onTransportLost(): "deferred" | "not-deferred";
+  onTransportReady(): void;
+  dispose(): void;
+};
+
+const browserClock: CallTransportRecoveryClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+/**
+ * Keep established media alive while its XMPP control plane has a bounded
+ * chance to recover. Call activity is checked again at expiry so an obsolete
+ * timer cannot tear down a call that already ended locally.
+ */
+export function createCallTransportRecovery(options: {
+  isCallMediaActive(): boolean;
+  teardown(): void;
+  clock?: CallTransportRecoveryClock;
+}): CallTransportRecovery {
+  const clock = options.clock ?? browserClock;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function cancel(): void {
+    if (timer !== null) clock.clearTimeout(timer);
+    timer = null;
+  }
+
+  return {
+    onTransportLost() {
+      if (!options.isCallMediaActive()) return "not-deferred";
+      if (timer === null) {
+        timer = clock.setTimeout(() => {
+          timer = null;
+          if (options.isCallMediaActive()) options.teardown();
+        }, CALL_TRANSPORT_RECOVERY_GRACE_MS);
+      }
+      return "deferred";
+    },
+    onTransportReady: cancel,
+    dispose: cancel,
+  };
+}

--- a/chat/src/lib/calls/call-transport-recovery.ts
+++ b/chat/src/lib/calls/call-transport-recovery.ts
@@ -1,21 +1,11 @@
-export const CALL_TRANSPORT_RECOVERY_GRACE_MS = 60_000;
+import { browserTimerClock, type TimerClock } from "./timer-clock";
 
-export type CallTransportRecoveryClock = {
-  now(): number;
-  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
-  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
-};
+export const CALL_TRANSPORT_RECOVERY_GRACE_MS = 60_000;
 
 export type CallTransportRecovery = {
   onTransportLost(): "deferred" | "not-deferred";
   onTransportReady(): void;
   dispose(): void;
-};
-
-const browserClock: CallTransportRecoveryClock = {
-  now: () => Date.now(),
-  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
-  clearTimeout: (timer) => clearTimeout(timer),
 };
 
 /**
@@ -26,9 +16,9 @@ const browserClock: CallTransportRecoveryClock = {
 export function createCallTransportRecovery(options: {
   isCallMediaActive(): boolean;
   teardown(): void;
-  clock?: CallTransportRecoveryClock;
+  clock?: TimerClock;
 }): CallTransportRecovery {
-  const clock = options.clock ?? browserClock;
+  const clock = options.clock ?? browserTimerClock;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   function cancel(): void {

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -270,7 +270,20 @@ export async function resolveCallDevicePreference(
       missing: false,
     };
   }
-  const devices = await enumerateCallDevices();
+  let devices: EnumeratedDevices;
+  try {
+    devices = await enumerateCallDevices();
+  } catch {
+    // Enumeration failing must not fail the JOIN (this runs before the
+    // Room is even constructed). Resolve to browser defaults WITHOUT the
+    // missing flag — best-effort capture surfaces any real device error.
+    return {
+      activeDeviceId: "default",
+      preferenceId: null,
+      captureDeviceId: undefined,
+      missing: false,
+    };
+  }
   if (hasEnumeratedCallDeviceId(devices, kind, deviceId)) {
     return {
       activeDeviceId: deviceId,

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -211,6 +211,8 @@ type EnumeratedDevice = {
   label: string;
 };
 
+export type CallDevicePreferenceKind = "mic" | "cam" | "speaker";
+
 /**
  * Categorized list of devices for the settings popover. Empty arrays
  * when the user hasn't granted permission yet — the popover renders
@@ -221,6 +223,59 @@ export type EnumeratedDevices = {
   cams: EnumeratedDevice[];
   speakers: EnumeratedDevice[];
 };
+
+export type ResolvedCallDevicePreference = {
+  activeDeviceId: string;
+  preferenceId: string | null;
+  captureDeviceId: string | undefined;
+  missing: boolean;
+};
+
+function enumeratedDevicesForKind(
+  devices: EnumeratedDevices,
+  kind: CallDevicePreferenceKind,
+): readonly EnumeratedDevice[] {
+  if (kind === "mic") return devices.mics;
+  if (kind === "cam") return devices.cams;
+  return devices.speakers;
+}
+
+export function hasEnumeratedCallDeviceId(
+  devices: EnumeratedDevices,
+  kind: CallDevicePreferenceKind,
+  deviceId: string,
+): boolean {
+  return enumeratedDevicesForKind(devices, kind).some((device) => device.deviceId === deviceId);
+}
+
+export async function resolveCallDevicePreference(
+  kind: CallDevicePreferenceKind,
+  deviceId: string | null,
+): Promise<ResolvedCallDevicePreference> {
+  if (deviceId === null) {
+    return {
+      activeDeviceId: "default",
+      preferenceId: null,
+      captureDeviceId: undefined,
+      missing: false,
+    };
+  }
+  const devices = await enumerateCallDevices();
+  if (hasEnumeratedCallDeviceId(devices, kind, deviceId)) {
+    return {
+      activeDeviceId: deviceId,
+      preferenceId: deviceId,
+      captureDeviceId: deviceId,
+      missing: false,
+    };
+  }
+  return {
+    activeDeviceId: "default",
+    preferenceId: null,
+    captureDeviceId: undefined,
+    missing: true,
+  };
+}
 
 export async function enumerateCallDevices(): Promise<EnumeratedDevices> {
   if (typeof navigator === "undefined" || !navigator.mediaDevices?.enumerateDevices) {

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -240,6 +240,16 @@ function enumeratedDevicesForKind(
   return devices.speakers;
 }
 
+/**
+ * The one NotFoundError shape every missing-device path emits, so
+ * `recordMediaIssue`'s classifier sees a single canonical name.
+ */
+export function missingCallDeviceError(kind: "mic" | "cam"): Error {
+  const error = new Error(`${kind} device is no longer available`);
+  error.name = "NotFoundError";
+  return error;
+}
+
 export function hasEnumeratedCallDeviceId(
   devices: EnumeratedDevices,
   kind: CallDevicePreferenceKind,

--- a/chat/src/lib/calls/device-prefs.ts
+++ b/chat/src/lib/calls/device-prefs.ts
@@ -274,13 +274,16 @@ export async function resolveCallDevicePreference(
   try {
     devices = await enumerateCallDevices();
   } catch {
-    // Enumeration failing must not fail the JOIN (this runs before the
-    // Room is even constructed). Resolve to browser defaults WITHOUT the
-    // missing flag — best-effort capture surfaces any real device error.
+    // Enumeration is only a pre-check; failing must neither fail the
+    // JOIN (capture is best-effort) nor silently swap an EXPLICIT pick
+    // for the default. Attempt the requested device as-is: a genuinely
+    // unavailable id rejects at switch/capture time, and callers then
+    // keep the previous active device and saved preference (#1621
+    // review rounds 2 and 5).
     return {
-      activeDeviceId: "default",
-      preferenceId: null,
-      captureDeviceId: undefined,
+      activeDeviceId: deviceId,
+      preferenceId: deviceId,
+      captureDeviceId: deviceId,
       missing: false,
     };
   }

--- a/chat/src/lib/calls/dm-call-join-cache.ts
+++ b/chat/src/lib/calls/dm-call-join-cache.ts
@@ -1,9 +1,18 @@
 import type { CallMedia, LiveKitJoin } from "./types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { reportError } from "@/lib/telemetry";
+import {
+  localStorageForLegacyPurge,
+  purgeLegacyStoragePrefixFromLocalStorage,
+} from "./call-token-storage-migration";
 
 const CACHE_PREFIX = "waddle.chat.dm-call-joins";
 const MAX_CACHE_ENTRIES = 32;
+
+// Remove bearer tokens written by pre-#1450 builds as soon as this cache is
+// initialized. `storage()` repeats the one-shot call so SSR-first imports can
+// retry after hydration makes browser storage available.
+purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
 const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 type CachedDmCallJoin = {
@@ -85,21 +94,8 @@ export function clearDmCallJoinCacheForAccount(selfBareJid: string): void {
 }
 
 export function clearAllDmCallJoinCacheForTests(): void {
-  const s = storage();
-  if (!s) return;
-  try {
-    const keys: string[] = [];
-    for (let index = 0; index < s.length; index += 1) {
-      const key = s.key(index);
-      if (key?.startsWith(`${CACHE_PREFIX}.`)) keys.push(key);
-    }
-    for (const key of keys) s.removeItem(key);
-  } catch (err) {
-    reportError("storage.write", err, {
-      recoverable: true,
-      detail: "dm call join cache clear failed",
-    });
-  }
+  clearKeysWithPrefix(storage(), CACHE_PREFIX);
+  clearKeysWithPrefix(localStorageForLegacyPurge(), CACHE_PREFIX);
 }
 
 function normalizeEntry(entry: CachedDmCallJoin): CachedDmCallJoin | null {
@@ -222,10 +218,28 @@ function isLiveKitJoin(value: unknown): value is LiveKitJoin {
 }
 
 function storage(): Storage | null {
+  purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
   if (typeof window === "undefined") return null;
   try {
-    return window.localStorage;
+    return window.sessionStorage ?? null;
   } catch {
     return null;
+  }
+}
+
+function clearKeysWithPrefix(s: Storage | null, prefix: string): void {
+  if (!s) return;
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < s.length; index += 1) {
+      const key = s.key(index);
+      if (key?.startsWith(`${prefix}.`)) keys.push(key);
+    }
+    for (const key of keys) s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "dm call join cache clear failed",
+    });
   }
 }

--- a/chat/src/lib/calls/dm-call-join-cache.ts
+++ b/chat/src/lib/calls/dm-call-join-cache.ts
@@ -2,6 +2,8 @@ import type { CallMedia, LiveKitJoin } from "./types";
 import { barePeerJid } from "@/lib/xmpp/jid";
 import { reportError } from "@/lib/telemetry";
 import {
+  callCacheSessionStorage,
+  clearCallCacheKeysWithPrefix,
   localStorageForLegacyPurge,
   purgeLegacyStoragePrefixFromLocalStorage,
 } from "./call-token-storage-migration";
@@ -94,8 +96,12 @@ export function clearDmCallJoinCacheForAccount(selfBareJid: string): void {
 }
 
 export function clearAllDmCallJoinCacheForTests(): void {
-  clearKeysWithPrefix(storage(), CACHE_PREFIX);
-  clearKeysWithPrefix(localStorageForLegacyPurge(), CACHE_PREFIX);
+  clearCallCacheKeysWithPrefix(storage(), CACHE_PREFIX, "dm call join cache clear failed");
+  clearCallCacheKeysWithPrefix(
+    localStorageForLegacyPurge(),
+    CACHE_PREFIX,
+    "dm call join cache clear failed",
+  );
 }
 
 function normalizeEntry(entry: CachedDmCallJoin): CachedDmCallJoin | null {
@@ -218,28 +224,5 @@ function isLiveKitJoin(value: unknown): value is LiveKitJoin {
 }
 
 function storage(): Storage | null {
-  purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
-  if (typeof window === "undefined") return null;
-  try {
-    return window.sessionStorage ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function clearKeysWithPrefix(s: Storage | null, prefix: string): void {
-  if (!s) return;
-  try {
-    const keys: string[] = [];
-    for (let index = 0; index < s.length; index += 1) {
-      const key = s.key(index);
-      if (key?.startsWith(`${prefix}.`)) keys.push(key);
-    }
-    for (const key of keys) s.removeItem(key);
-  } catch (err) {
-    reportError("storage.write", err, {
-      recoverable: true,
-      detail: "dm call join cache clear failed",
-    });
-  }
+  return callCacheSessionStorage(CACHE_PREFIX);
 }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -36,6 +36,7 @@ import {
   type AudioProcessingConstraints,
   type AudioProcessingPrefs,
   type ResolvedCallDevicePreference,
+  missingCallDeviceError,
   resolveCallDevicePreference,
 } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
@@ -64,8 +65,8 @@ import type { IceServerBundle } from "./ice-servers";
 import {
   createIceCredentialRefresher,
   type IceCredentialRefresher,
-  type IceRefreshClock,
 } from "./ice-credential-refresh";
+import type { TimerClock } from "./timer-clock";
 
 /**
  * The local mic track surface the AI-noise reconciler drives — the subset of
@@ -172,12 +173,6 @@ export type ParticipantAudioVolumeIdentity = {
   source: CallAudioTrackSource;
 };
 
-function missingCallDeviceError(kind: "mic" | "cam"): Error {
-  const error = new Error(`${kind} device is no longer available`);
-  error.name = "NotFoundError";
-  return error;
-}
-
 function defaultCallDevicePreference(): ResolvedCallDevicePreference {
   return {
     activeDeviceId: "default",
@@ -263,7 +258,7 @@ export type CallEngineEvents = {
    * rather than ending the call. Mirrors LiveKit's
    * `RoomEvent.MediaDevicesError` but carries which capture failed.
    */
-  mediaDevicesError: (info: { source: "audio" | "video"; error: unknown }) => void;
+  mediaDevicesError: (info: { source: "audio" | "video" | "screen"; error: unknown }) => void;
   /**
    * Fires when the *applied* browser-native audio processing of the
    * local mic changes — on mic publish, unpublish, or a mid-call mic
@@ -453,7 +448,7 @@ export class CallEngine {
    * `RTCPeerConnection`, which `new Room()` reaches for at construction.
    */
   private readonly makeRoom: (options: RoomOptions) => Room;
-  private readonly iceRefreshClock: IceRefreshClock | undefined;
+  private readonly iceRefreshClock: TimerClock | undefined;
   private iceCredentialRefresher: IceCredentialRefresher | null = null;
   private readonly scopedRoomListeners = new WeakMap<Room, {
     activeDeviceChanged: RoomEventCallbacks[RoomEvent.ActiveDeviceChanged];
@@ -467,7 +462,7 @@ export class CallEngine {
     backgroundOps?: CameraBackgroundOps;
     videoCodecSupport?: VideoCodecSupport;
     makeRoom?: (options: RoomOptions) => Room;
-    iceRefreshClock?: IceRefreshClock;
+    iceRefreshClock?: TimerClock;
   }) {
     this.makeAiNoiseProcessor = opts?.makeAiNoiseProcessor ?? makeNoiseProcessor;
     this.backgroundOps = opts?.backgroundOps ?? cameraBackgroundOps;
@@ -1466,7 +1461,15 @@ export class CallEngine {
     }
     if (kind === "videoinput") {
       this.emit("mediaDevicesError", { source: "video", error });
+      return;
     }
+    // Playback-sink failures already surface via audioPlaybackStatusChanged.
+    if (kind === "audiooutput") return;
+    // livekit-client's sourceToKind maps ScreenShare (and Unknown) to an
+    // undefined kind. Screen capture is the only remaining local source, so
+    // an SDK-initiated screen failure (e.g. a track restart) surfaces there
+    // instead of being dropped without any actionable UI.
+    this.emit("mediaDevicesError", { source: "screen", error });
   }
 
   /**

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -572,13 +572,13 @@ export class CallEngine {
       // clones it when a FULL reconnect rebuilds its PeerConnections. Updating
       // it below therefore supplies fresh credentials to a later rebuild, but
       // deliberately cannot alter the already-running PeerConnection.
+      // No advertisement (or a failed fetch) = no rtcConfig at all — and no
+      // refresher either: with nothing to hand LiveKit at connect time there
+      // is no retained config object for a refresh to update, and the call
+      // never had a client-controlled relay to lose.
       const rtcConfig: RTCConfiguration | undefined =
-        opts.refreshIceServers || (opts.iceServers && opts.iceServers.length > 0)
-          ? {
-              ...(opts.iceServers && opts.iceServers.length > 0
-                ? { iceServers: opts.iceServers }
-                : {}),
-            }
+        opts.iceServers && opts.iceServers.length > 0
+          ? { iceServers: opts.iceServers }
           : undefined;
       const connectOptions: RoomConnectOptions | undefined = rtcConfig ? { rtcConfig } : undefined;
       try {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -569,9 +569,16 @@ export class CallEngine {
       // livekit-client 2.19.1 exposes rtcConfig only at connect time: Room has
       // no public setConfiguration/restartIce API. Keep this exact mutable
       // object alive because the SDK retains it as RTCEngine.rtcConfig and
-      // clones it when a FULL reconnect rebuilds its PeerConnections. Updating
-      // it below therefore supplies fresh credentials to a later rebuild, but
-      // deliberately cannot alter the already-running PeerConnection.
+      // reads it whenever it (re)builds a PeerConnection: a resume
+      // (ReconnectResponse -> makeRTCConfiguration -> pc.setConfiguration +
+      // ICE restart) and a full reconnect both consume the refreshed list.
+      // That is the designed recovery contract for a relay allocation that
+      // outlives its time-limited TURN REST credential: the allocation's
+      // refresh fails, ICE degrades, and the SDK's own reconnect comes back
+      // through THIS object with valid credentials — a brief automatic
+      // blip instead of a permanently dead relay path. Proactively
+      // restarting ICE ourselves is not possible against the SDK's private
+      // PeerConnections without reaching into internals.
       // No advertisement (or a failed fetch) = no rtcConfig at all — and no
       // refresher either: with nothing to hand LiveKit at connect time there
       // is no retained config object for a refresh to update, and the call
@@ -747,28 +754,32 @@ export class CallEngine {
    * publication in place — no re-publish, no Jingle round-trip — so
    * the change is invisible to the peer.
    */
-  async setMicDevice(deviceId: string): Promise<void> {
+  async setMicDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null> {
     const room = this.room;
-    if (!room) return;
+    if (!room) return null;
     const generation = this.connectGeneration;
     const resolved = await resolveCallDevicePreference(
       "mic",
       deviceId === "default" ? null : deviceId,
     );
-    if (!this.isCurrentRoom(room, generation)) return;
+    if (!this.isCurrentRoom(room, generation)) return null;
     try {
       await room.switchActiveDevice("audioinput", resolved.activeDeviceId);
     } catch (error) {
-      if (!this.isCurrentRoom(room, generation)) return;
+      if (!this.isCurrentRoom(room, generation)) return null;
       throw error;
     }
-    if (!this.isCurrentRoom(room, generation)) return;
+    if (!this.isCurrentRoom(room, generation)) return null;
     if (resolved.missing) {
       this.emit("mediaDevicesError", {
         source: "audio",
         error: missingCallDeviceError("mic"),
       });
     }
+    // The single authoritative resolution: callers persist THIS, so the
+    // saved preference can never claim a device the live call is not
+    // actually capturing from (#1621 review round 2).
+    return resolved;
   }
 
   /**
@@ -1068,28 +1079,29 @@ export class CallEngine {
   /**
    * Same shape as `setMicDevice` but for the camera device.
    */
-  async setCameraDevice(deviceId: string): Promise<void> {
+  async setCameraDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null> {
     const room = this.room;
-    if (!room) return;
+    if (!room) return null;
     const generation = this.connectGeneration;
     const resolved = await resolveCallDevicePreference(
       "cam",
       deviceId === "default" ? null : deviceId,
     );
-    if (!this.isCurrentRoom(room, generation)) return;
+    if (!this.isCurrentRoom(room, generation)) return null;
     try {
       await room.switchActiveDevice("videoinput", resolved.activeDeviceId);
     } catch (error) {
-      if (!this.isCurrentRoom(room, generation)) return;
+      if (!this.isCurrentRoom(room, generation)) return null;
       throw error;
     }
-    if (!this.isCurrentRoom(room, generation)) return;
+    if (!this.isCurrentRoom(room, generation)) return null;
     if (resolved.missing) {
       this.emit("mediaDevicesError", {
         source: "video",
         error: missingCallDeviceError("cam"),
       });
     }
+    return resolved;
   }
 
   /**
@@ -1098,8 +1110,8 @@ export class CallEngine {
    * route Web Audio output sinks; falls back to a no-op on unsupported
    * browsers.
    */
-  async setSpeakerDevice(deviceId: string): Promise<void> {
-    await this.applySpeakerDevice(deviceId);
+  async setSpeakerDevice(deviceId: string): Promise<ResolvedCallDevicePreference | null> {
+    return this.applySpeakerDevice(deviceId);
   }
 
   async startAudio(): Promise<void> {
@@ -1126,23 +1138,26 @@ export class CallEngine {
     }
   }
 
-  private async applySpeakerDevice(deviceId: string): Promise<void> {
+  private async applySpeakerDevice(
+    deviceId: string,
+  ): Promise<ResolvedCallDevicePreference | null> {
     const room = this.room;
-    if (!room) return;
+    if (!room) return null;
     const generation = this.connectGeneration;
-    if (typeof room.switchActiveDevice !== "function") return;
+    if (typeof room.switchActiveDevice !== "function") return null;
     const resolved = await resolveCallDevicePreference(
       "speaker",
       deviceId === "default" ? null : deviceId,
     );
-    if (!this.isCurrentRoom(room, generation)) return;
+    if (!this.isCurrentRoom(room, generation)) return null;
     try {
       await room.switchActiveDevice("audiooutput", resolved.activeDeviceId);
-      if (!this.isCurrentRoom(room, generation)) return;
+      if (!this.isCurrentRoom(room, generation)) return null;
     } catch {
       // Browser doesn't support sinkId; the user already saw the
       // disabled chip in the picker. Swallow silently here.
     }
+    return resolved;
   }
 
   async disconnect(): Promise<void> {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -36,7 +36,6 @@ import {
   type AudioProcessingConstraints,
   type AudioProcessingPrefs,
   type ResolvedCallDevicePreference,
-  missingCallDeviceError,
   resolveCallDevicePreference,
 } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
@@ -631,18 +630,12 @@ export class CallEngine {
         remoteIdentities: Array.from(room.remoteParticipants.values()).map((p) => p.identity),
         roomName: room.name || join.room,
       });
-      if (resolvedMic.missing) {
-        this.emit("mediaDevicesError", {
-          source: "audio",
-          error: missingCallDeviceError("mic"),
-        });
-      }
-      if (resolvedCam.missing) {
-        this.emit("mediaDevicesError", {
-          source: "video",
-          error: missingCallDeviceError("cam"),
-        });
-      }
+      // A stale saved device resolved to the browser default is NOT a
+      // capture issue: the default may publish perfectly well, and a
+      // "missing" notice here would mislabel a working call as
+      // listener-only (its "Enable mic" action would then DISABLE the
+      // live mic). Real capture failures surface from the best-effort
+      // publication below (#1621 review round 3).
       // Publishing is BEST-EFFORT and decoupled from joining. `room.connect`
       // above already succeeded, so the user is a fully working receive-only
       // (listen/watch) participant — a missing device or a denied
@@ -770,15 +763,11 @@ export class CallEngine {
       throw error;
     }
     if (!this.isCurrentRoom(room, generation)) return null;
-    if (resolved.missing) {
-      this.emit("mediaDevicesError", {
-        source: "audio",
-        error: missingCallDeviceError("mic"),
-      });
-    }
-    // The single authoritative resolution: callers persist THIS, so the
-    // saved preference can never claim a device the live call is not
-    // actually capturing from (#1621 review round 2).
+    // A missing requested device fell back to the browser default and the
+    // switch SUCCEEDED — capture is live, so no capture issue is recorded
+    // (#1621 review round 3). The single authoritative resolution: callers
+    // persist THIS, so the saved preference can never claim a device the
+    // live call is not actually capturing from (#1621 review round 2).
     return resolved;
   }
 
@@ -1095,12 +1084,6 @@ export class CallEngine {
       throw error;
     }
     if (!this.isCurrentRoom(room, generation)) return null;
-    if (resolved.missing) {
-      this.emit("mediaDevicesError", {
-        source: "video",
-        error: missingCallDeviceError("cam"),
-      });
-    }
     return resolved;
   }
 
@@ -1153,9 +1136,14 @@ export class CallEngine {
     try {
       await room.switchActiveDevice("audiooutput", resolved.activeDeviceId);
       if (!this.isCurrentRoom(room, generation)) return null;
-    } catch {
-      // Browser doesn't support sinkId; the user already saw the
-      // disabled chip in the picker. Swallow silently here.
+    } catch (error) {
+      // Mirror mic/cam: a failed sink switch must NOT hand back a
+      // resolution the caller would persist as applied. Unsupported
+      // browsers never reach here from the picker (the speaker section
+      // is disabled via isSpeakerOutputSelectionSupported); the connect
+      // path catches this rethrow itself.
+      if (!this.isCurrentRoom(room, generation)) return null;
+      throw error;
     }
     return resolved;
   }

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -35,6 +35,8 @@ import {
   audioProcessingConstraints,
   type AudioProcessingConstraints,
   type AudioProcessingPrefs,
+  type ResolvedCallDevicePreference,
+  resolveCallDevicePreference,
 } from "./device-prefs";
 import { validateLiveKitGrant } from "./dm-call-activity";
 import { activeMicAudioProcessing, type MicAudioProcessing } from "./mic-audio-processing";
@@ -58,6 +60,12 @@ import {
 import type { CameraBackgroundState } from "./background-effect/camera-background";
 import type { CameraBackgroundOps, VideoBackgroundProcessor } from "./background-effect/ops";
 import { cameraBackgroundOps } from "./background-effect/registry";
+import type { IceServerBundle } from "./ice-servers";
+import {
+  createIceCredentialRefresher,
+  type IceCredentialRefresher,
+  type IceRefreshClock,
+} from "./ice-credential-refresh";
 
 /**
  * The local mic track surface the AI-noise reconciler drives — the subset of
@@ -163,6 +171,21 @@ export type ParticipantAudioVolumeIdentity = {
   participantIdentity: string;
   source: CallAudioTrackSource;
 };
+
+function missingCallDeviceError(kind: "mic" | "cam"): Error {
+  const error = new Error(`${kind} device is no longer available`);
+  error.name = "NotFoundError";
+  return error;
+}
+
+function defaultCallDevicePreference(): ResolvedCallDevicePreference {
+  return {
+    activeDeviceId: "default",
+    preferenceId: null,
+    captureDeviceId: undefined,
+    missing: false,
+  };
+}
 
 type VolumeAdjustableTrack = {
   setVolume(volume: number): unknown;
@@ -308,6 +331,10 @@ export type CallEngineEvents = {
    * recovering while media keeps flowing (#1452 ICE-restart SLI).
    */
   transportReconnecting: () => void;
+  /** XEP-0215 credentials were refreshed for a future full reconnect. */
+  iceCredentialsRefreshed: () => void;
+  /** The current XEP-0215 TURN credentials reached their expiry mid-call. */
+  iceCredentialsExpired: () => void;
   /**
    * Fires when LiveKit re-derives which participants are actively speaking
    * (from audio levels). Carries the full speaking set — including the local
@@ -368,6 +395,8 @@ export class CallEngine {
     connectionQualityChanged: new Set(),
     connectionPhaseChanged: new Set(),
     transportReconnecting: new Set(),
+    iceCredentialsRefreshed: new Set(),
+    iceCredentialsExpired: new Set(),
     activeSpeakersChanged: new Set(),
   };
 
@@ -424,17 +453,27 @@ export class CallEngine {
    * `RTCPeerConnection`, which `new Room()` reaches for at construction.
    */
   private readonly makeRoom: (options: RoomOptions) => Room;
+  private readonly iceRefreshClock: IceRefreshClock | undefined;
+  private iceCredentialRefresher: IceCredentialRefresher | null = null;
+  private readonly scopedRoomListeners = new WeakMap<Room, {
+    activeDeviceChanged: RoomEventCallbacks[RoomEvent.ActiveDeviceChanged];
+    connectionStateChanged: RoomEventCallbacks[RoomEvent.ConnectionStateChanged];
+    mediaDevicesChanged: RoomEventCallbacks[RoomEvent.MediaDevicesChanged];
+    mediaDevicesError: RoomEventCallbacks[RoomEvent.MediaDevicesError];
+  }>();
 
   constructor(opts?: {
     makeAiNoiseProcessor?: (model: NoiseModelId) => Promise<AudioNoiseProcessor>;
     backgroundOps?: CameraBackgroundOps;
     videoCodecSupport?: VideoCodecSupport;
     makeRoom?: (options: RoomOptions) => Room;
+    iceRefreshClock?: IceRefreshClock;
   }) {
     this.makeAiNoiseProcessor = opts?.makeAiNoiseProcessor ?? makeNoiseProcessor;
     this.backgroundOps = opts?.backgroundOps ?? cameraBackgroundOps;
     this.codecSupport = opts?.videoCodecSupport ?? videoCodecSupport(currentVideoCodecSupportEnv());
     this.makeRoom = opts?.makeRoom ?? ((options) => new Room(options));
+    this.iceRefreshClock = opts?.iceRefreshClock;
   }
 
   /** LiveKit identity of the local participant, populated once
@@ -467,9 +506,19 @@ export class CallEngine {
     return this.room?.canPlaybackAudio ?? true;
   }
 
+  activeDeviceId(kind: MediaDeviceKind): string | null {
+    return this.room?.getActiveDevice(kind) ?? null;
+  }
+
   async connect(
     join: LiveKitJoin,
-    opts: { audio: boolean; video: boolean; iceServers?: RTCIceServer[] },
+    opts: {
+      audio: boolean;
+      video: boolean;
+      iceServers?: RTCIceServer[];
+      iceServersExpiryMs?: number | null;
+      refreshIceServers?: () => Promise<IceServerBundle>;
+    },
   ): Promise<void> {
     if (this.room || this.connecting) throw new Error("CallEngine already connected");
     // Defensive pre-flight: confirm the JWT actually carries a usable
@@ -493,84 +542,140 @@ export class CallEngine {
     this.desiredBackgroundEffect = prefs.backgroundEffect;
     this.backgroundFailedEffects = new Set();
     this.appliedBackgroundEffect = BACKGROUND_OFF;
-    const room = this.makeRoom(callRoomOptionsForPrefs(prefs));
-    this.updateRoomListeners(room, "on");
-    // XEP-0215 ICE injection: when the server advertised external services,
-    // make them the authoritative ICE list via `rtcConfig`. An empty/absent
-    // list means "no advertisement" — pass no `rtcConfig` so LiveKit keeps its
-    // own signalling-provided servers rather than connecting with none.
-    const connectOptions: RoomConnectOptions | undefined =
-      opts.iceServers && opts.iceServers.length > 0
-        ? { rtcConfig: { iceServers: opts.iceServers } }
-        : undefined;
-    // Reserve the engine now — AFTER the synchronous setup above, which can
-    // throw (`makeRoom`/`callRoomOptionsForPrefs` reach for WebRTC globals).
-    // There is no `await` between here and the guard at the top, so this still
-    // closes the concurrent-connect window without risking a stuck flag.
     this.connecting = true;
     const generation = ++this.connectGeneration;
     try {
-      await room.connect(join.url, join.token, connectOptions);
-    } catch (err) {
-      // Connect itself failed; the listeners we bound above would
-      // otherwise dangle on a `Room` that nothing references but the
-      // closure inside the listener — strip them so a future GC has
-      // a clean path. `this.room` was never set so the caller stays
-      // on the well-defined "not connected" path.
-      room.removeAllListeners();
-      // Only release the reservation if it's still ours — a disconnect() or
-      // newer connect() during the await owns `connecting` now.
-      if (this.connectGeneration === generation) this.connecting = false;
-      throw err;
-    }
-    // A disconnect() (or a newer connect()) during the await bumped the
-    // generation: this connect was cancelled. Tear our own Room down rather
-    // than publishing it as an orphan that nothing will ever disconnect.
-    if (this.connectGeneration !== generation) {
-      room.removeAllListeners();
-      await room.disconnect().catch(() => undefined);
-      return;
-    }
-    this.room = room;
-    this.connecting = false;
-    // Emit the initial participant snapshot so subscribers can seed
-    // their projection without missing peers that connected before
-    // our listeners attached.
-    this.emit("connected", {
-      localIdentity: room.localParticipant.identity,
-      remoteIdentities: Array.from(room.remoteParticipants.values()).map((p) => p.identity),
-      roomName: room.name || join.room,
-    });
-    // Publishing is BEST-EFFORT and decoupled from joining. `room.connect`
-    // above already succeeded, so the user is a fully working receive-only
-    // (listen/watch) participant — a missing device or a denied
-    // `getUserMedia` permission MUST NOT eject them from the call. Each
-    // track is enabled independently (a broken camera can't suppress a
-    // working mic) and failures are surfaced via `mediaDevicesError` so the
-    // UI can show a non-blocking "joined without mic/camera" notice and
-    // offer a retry, instead of tearing the half-joined call down.
-    await enableRequestedCapture(
-      room.localParticipant,
-      { audio: opts.audio, video: opts.video },
-      (source, error) => {
-        if (this.isCurrentRoom(room, generation)) {
-          this.emit("mediaDevicesError", { source, error });
-        }
-      },
-      {
-        audio: audioPublishOptions(),
-        camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }),
-      },
-      () => this.isCurrentRoom(room, generation),
-    );
-    if (!this.isCurrentRoom(room, generation)) return;
-    // Re-apply the speaker preference now that the room has remote
-    // audio elements to retarget; the engine ignores it on connect
-    // because no `<audio>` exists yet, but every subsequent
-    // RoomEvent.TrackSubscribed wires through this.applySpeaker.
-    if (prefs.speaker) {
-      await this.applySpeakerDevice(prefs.speaker).catch(() => undefined);
+      // Preserve the synchronous all-default path: only an actual saved id
+      // needs enumeration. This keeps disconnect-during-connect semantics from
+      // acquiring an extra microtask window before the Room is constructed.
+      let resolvedMic = defaultCallDevicePreference();
+      let resolvedCam = defaultCallDevicePreference();
+      let resolvedSpeaker = defaultCallDevicePreference();
+      if (prefs.mic !== null || prefs.cam !== null || prefs.speaker !== null) {
+        [resolvedMic, resolvedCam, resolvedSpeaker] = await Promise.all([
+          resolveCallDevicePreference("mic", prefs.mic),
+          resolveCallDevicePreference("cam", prefs.cam),
+          resolveCallDevicePreference("speaker", prefs.speaker),
+        ]);
+      }
+      if (this.connectGeneration !== generation) return;
+      const room = this.makeRoom(
+        callRoomOptionsForPrefs({
+          mic: resolvedMic.captureDeviceId ?? null,
+          cam: resolvedCam.captureDeviceId ?? null,
+          audioProcessing: prefs.audioProcessing,
+        }),
+      );
+      this.updateRoomListeners(room, "on");
+      // XEP-0215 ICE injection: when the server advertised external services,
+      // make them the authoritative ICE list via `rtcConfig`. An empty/absent
+      // list means "no advertisement" — pass no `rtcConfig` so LiveKit keeps its
+      // own signalling-provided servers rather than connecting with none.
+      // livekit-client 2.19.1 exposes rtcConfig only at connect time: Room has
+      // no public setConfiguration/restartIce API. Keep this exact mutable
+      // object alive because the SDK retains it as RTCEngine.rtcConfig and
+      // clones it when a FULL reconnect rebuilds its PeerConnections. Updating
+      // it below therefore supplies fresh credentials to a later rebuild, but
+      // deliberately cannot alter the already-running PeerConnection.
+      const rtcConfig: RTCConfiguration | undefined =
+        opts.refreshIceServers || (opts.iceServers && opts.iceServers.length > 0)
+          ? {
+              ...(opts.iceServers && opts.iceServers.length > 0
+                ? { iceServers: opts.iceServers }
+                : {}),
+            }
+          : undefined;
+      const connectOptions: RoomConnectOptions | undefined = rtcConfig ? { rtcConfig } : undefined;
+      try {
+        await room.connect(join.url, join.token, connectOptions);
+      } catch (err) {
+        // Connect itself failed; the listeners we bound above would
+        // otherwise dangle on a `Room` that nothing references but the
+        // closure inside the listener — strip them so a future GC has
+        // a clean path. `this.room` was never set so the caller stays
+        // on the well-defined "not connected" path.
+        room.removeAllListeners();
+        throw err;
+      }
+      // A disconnect() (or a newer connect()) during the await bumped the
+      // generation: this connect was cancelled. Tear our own Room down rather
+      // than publishing it as an orphan that nothing will ever disconnect.
+      if (this.connectGeneration !== generation) {
+        room.removeAllListeners();
+        await room.disconnect().catch(() => undefined);
+        return;
+      }
+      this.room = room;
+      this.connecting = false;
+      if (opts.refreshIceServers && rtcConfig) {
+        const refresher = createIceCredentialRefresher({
+          refresh: opts.refreshIceServers,
+          apply: (bundle) => {
+            rtcConfig.iceServers = bundle.servers;
+          },
+          isCurrent: () => this.isCurrentRoom(room, generation),
+          onRefreshed: () => this.emit("iceCredentialsRefreshed"),
+          onExpired: () => this.emit("iceCredentialsExpired"),
+          clock: this.iceRefreshClock,
+        });
+        this.iceCredentialRefresher = refresher;
+        refresher.start(opts.iceServersExpiryMs ?? null);
+      }
+      // Emit the initial participant snapshot so subscribers can seed
+      // their projection without missing peers that connected before
+      // our listeners attached.
+      this.emit("connected", {
+        localIdentity: room.localParticipant.identity,
+        remoteIdentities: Array.from(room.remoteParticipants.values()).map((p) => p.identity),
+        roomName: room.name || join.room,
+      });
+      if (resolvedMic.missing) {
+        this.emit("mediaDevicesError", {
+          source: "audio",
+          error: missingCallDeviceError("mic"),
+        });
+      }
+      if (resolvedCam.missing) {
+        this.emit("mediaDevicesError", {
+          source: "video",
+          error: missingCallDeviceError("cam"),
+        });
+      }
+      // Publishing is BEST-EFFORT and decoupled from joining. `room.connect`
+      // above already succeeded, so the user is a fully working receive-only
+      // (listen/watch) participant — a missing device or a denied
+      // `getUserMedia` permission MUST NOT eject them from the call. Each
+      // track is enabled independently (a broken camera can't suppress a
+      // working mic) and failures are surfaced via `mediaDevicesError` so the
+      // UI can show a non-blocking "joined without mic/camera" notice and
+      // offer a retry, instead of tearing the half-joined call down.
+      await enableRequestedCapture(
+        room.localParticipant,
+        { audio: opts.audio, video: opts.video },
+        (source, error) => {
+          if (this.isCurrentRoom(room, generation)) {
+            this.emit("mediaDevicesError", { source, error });
+          }
+        },
+        {
+          audio: audioPublishOptions(),
+          camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }),
+        },
+        () => this.isCurrentRoom(room, generation),
+      );
       if (!this.isCurrentRoom(room, generation)) return;
+      // Re-apply the speaker preference now that the room has remote
+      // audio elements to retarget; the engine ignores it on connect
+      // because no `<audio>` exists yet, but every subsequent
+      // RoomEvent.TrackSubscribed wires through this.applySpeaker.
+      if (resolvedSpeaker.preferenceId !== null) {
+        await this.applySpeakerDevice(resolvedSpeaker.activeDeviceId).catch(() => undefined);
+        if (!this.isCurrentRoom(room, generation)) return;
+      }
+    } finally {
+      if (this.connectGeneration === generation && this.connecting) {
+        this.connecting = false;
+      }
     }
   }
 
@@ -651,13 +756,24 @@ export class CallEngine {
     const room = this.room;
     if (!room) return;
     const generation = this.connectGeneration;
+    const resolved = await resolveCallDevicePreference(
+      "mic",
+      deviceId === "default" ? null : deviceId,
+    );
+    if (!this.isCurrentRoom(room, generation)) return;
     try {
-      await room.switchActiveDevice("audioinput", deviceId);
+      await room.switchActiveDevice("audioinput", resolved.activeDeviceId);
     } catch (error) {
       if (!this.isCurrentRoom(room, generation)) return;
       throw error;
     }
     if (!this.isCurrentRoom(room, generation)) return;
+    if (resolved.missing) {
+      this.emit("mediaDevicesError", {
+        source: "audio",
+        error: missingCallDeviceError("mic"),
+      });
+    }
   }
 
   /**
@@ -961,13 +1077,24 @@ export class CallEngine {
     const room = this.room;
     if (!room) return;
     const generation = this.connectGeneration;
+    const resolved = await resolveCallDevicePreference(
+      "cam",
+      deviceId === "default" ? null : deviceId,
+    );
+    if (!this.isCurrentRoom(room, generation)) return;
     try {
-      await room.switchActiveDevice("videoinput", deviceId);
+      await room.switchActiveDevice("videoinput", resolved.activeDeviceId);
     } catch (error) {
       if (!this.isCurrentRoom(room, generation)) return;
       throw error;
     }
     if (!this.isCurrentRoom(room, generation)) return;
+    if (resolved.missing) {
+      this.emit("mediaDevicesError", {
+        source: "video",
+        error: missingCallDeviceError("cam"),
+      });
+    }
   }
 
   /**
@@ -1009,8 +1136,13 @@ export class CallEngine {
     if (!room) return;
     const generation = this.connectGeneration;
     if (typeof room.switchActiveDevice !== "function") return;
+    const resolved = await resolveCallDevicePreference(
+      "speaker",
+      deviceId === "default" ? null : deviceId,
+    );
+    if (!this.isCurrentRoom(room, generation)) return;
     try {
-      await room.switchActiveDevice("audiooutput", deviceId);
+      await room.switchActiveDevice("audiooutput", resolved.activeDeviceId);
       if (!this.isCurrentRoom(room, generation)) return;
     } catch {
       // Browser doesn't support sinkId; the user already saw the
@@ -1024,6 +1156,7 @@ export class CallEngine {
     // and release the reservation so the engine can never wedge "connecting".
     this.connectGeneration++;
     this.connecting = false;
+    this.stopIceCredentialRefresh();
     const room = this.room;
     this.room = null;
     if (!room) return;
@@ -1046,6 +1179,11 @@ export class CallEngine {
     return this.connectGeneration === generation && this.room === room;
   }
 
+  private stopIceCredentialRefresh(): void {
+    this.iceCredentialRefresher?.stop();
+    this.iceCredentialRefresher = null;
+  }
+
   private updateRoomListeners(room: Room, operation: "on" | "off"): void {
     const update = <K extends keyof RoomEventCallbacks>(
       event: K,
@@ -1054,6 +1192,25 @@ export class CallEngine {
       if (operation === "on") room.on(event, listener);
       else room.off(event, listener);
     };
+    let scoped = this.scopedRoomListeners.get(room);
+    if (operation === "on") {
+      const generation = this.connectGeneration;
+      scoped = {
+        activeDeviceChanged: (kind) => {
+          if (this.isCurrentRoom(room, generation)) this.handleActiveDeviceChanged(kind);
+        },
+        connectionStateChanged: (state) => {
+          if (this.isCurrentRoom(room, generation)) this.handleConnectionStateChanged(state);
+        },
+        mediaDevicesChanged: () => {
+          if (this.isCurrentRoom(room, generation)) this.handleMediaDevicesChanged();
+        },
+        mediaDevicesError: (error, kind) => {
+          if (this.isCurrentRoom(room, generation)) this.handleMediaDevicesError(error, kind);
+        },
+      };
+      this.scopedRoomListeners.set(room, scoped);
+    }
     update(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     update(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     update(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
@@ -1062,12 +1219,17 @@ export class CallEngine {
     update(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     update(RoomEvent.Disconnected, this.handleDisconnected);
     update(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
-    update(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
+    if (scoped) {
+      update(RoomEvent.ActiveDeviceChanged, scoped.activeDeviceChanged);
+      update(RoomEvent.MediaDevicesChanged, scoped.mediaDevicesChanged);
+      update(RoomEvent.MediaDevicesError, scoped.mediaDevicesError);
+    }
     update(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
     update(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
     update(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
-    update(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
+    if (scoped) update(RoomEvent.ConnectionStateChanged, scoped.connectionStateChanged);
     update(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged);
+    if (operation === "off") this.scopedRoomListeners.delete(room);
   }
 
   private stopRoomProcessors(room: Room): Promise<void> {
@@ -1241,6 +1403,7 @@ export class CallEngine {
     if (!room) return;
     this.connectGeneration++;
     this.connecting = false;
+    this.stopIceCredentialRefresh();
     this.room = null;
     this.updateRoomListeners(room, "off");
     this.clearParticipantAudioVolumes();
@@ -1261,15 +1424,7 @@ export class CallEngine {
     this.emit("audioPlaybackStatusChanged", canPlaybackAudio);
   };
 
-  /**
-   * A mid-call device switch swaps the underlying capture track in
-   * place via `switchActiveDevice` — it does NOT re-fire
-   * `LocalTrackPublished`, so this is the only signal that the applied
-   * audio processing may have changed (a new mic can support a
-   * different set of constraints). Only `audioinput` matters; speaker /
-   * camera changes can't alter mic processing.
-   */
-  private handleActiveDeviceChanged = (kind: MediaDeviceKind) => {
+  private reconcileActiveDevice(kind: MediaDeviceKind): void {
     if (kind === "videoinput") {
       // A camera swap rewrites the publication's capture track in place. LiveKit
       // re-runs the processor across it, but reconcile is idempotent and
@@ -1282,7 +1437,37 @@ export class CallEngine {
     // Defensive: LiveKit re-runs the processor across a device switch, but
     // reconcile is idempotent and re-attaches if the new track came up bare.
     void this.ensureAiNoiseFilter();
+  }
+
+  /**
+   * A mid-call device switch swaps the underlying capture track in
+   * place via `switchActiveDevice` — it does NOT re-fire
+   * `LocalTrackPublished`, so this is the only signal that the applied
+   * audio processing may have changed (a new mic can support a
+   * different set of constraints). Only `audioinput` matters; speaker /
+   * camera changes can't alter mic processing.
+   */
+  private handleActiveDeviceChanged = (kind: MediaDeviceKind) => {
+    this.reconcileActiveDevice(kind);
   };
+
+  private handleMediaDevicesChanged(): void {
+    this.reconcileActiveDevice("audioinput");
+    this.reconcileActiveDevice("videoinput");
+  }
+
+  private handleMediaDevicesError(
+    error: Error,
+    kind?: MediaDeviceKind,
+  ): void {
+    if (kind === "audioinput") {
+      this.emit("mediaDevicesError", { source: "audio", error });
+      return;
+    }
+    if (kind === "videoinput") {
+      this.emit("mediaDevicesError", { source: "video", error });
+    }
+  }
 
   /**
    * Recompute when the local mic is muted or unmuted. Muting is the most
@@ -1350,8 +1535,12 @@ export class CallEngine {
     this.emit("connectionQualityChanged", mapLiveKitConnectionQuality(quality));
   };
 
-  private handleConnectionStateChanged = (state: ConnectionState) => {
+  private handleConnectionStateChanged = (state: ConnectionState): void => {
     if (state === ConnectionState.Reconnecting) {
+      // No public live-update API exists in livekit-client 2.19. Refresh now
+      // so the retained rtcConfig is ready if this reconnect becomes a full
+      // PeerConnection rebuild; the active PC itself is not reconfigured.
+      void this.iceCredentialRefresher?.refreshNow();
       this.emit("transportReconnecting");
     }
     this.emit("connectionPhaseChanged", mapLiveKitConnectionState(state));

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -1,6 +1,7 @@
 import {
   ConnectionQuality,
   ConnectionState,
+  DisconnectReason,
   Room,
   RoomEvent,
   Track,
@@ -15,6 +16,7 @@ import {
   type AudioCaptureOptions,
   type RoomConnectOptions,
   type RoomOptions,
+  type RoomEventCallbacks,
   type TrackPublishOptions,
   type VideoCaptureOptions,
 } from "livekit-client";
@@ -219,7 +221,10 @@ export type CallEngineEvents = {
      */
     roomName: string;
   }) => void;
-  disconnected: (reason: "local" | "transport") => void;
+  disconnected: (info: {
+    origin: "local" | "transport";
+    reason?: DisconnectReason;
+  }) => void;
   /**
    * Fires when LiveKit reports whether remote audio can currently
    * play. Browser autoplay policy can suspend Web Audio playback until
@@ -481,28 +486,15 @@ export class CallEngine {
     // call's mic publish; start each call with a clean failure guard and
     // capture-NS state (initial capture uses the user's stored constraints).
     this.desiredAiNoiseModel = prefs.aiNoiseModel;
-    this.aiNoiseFailedModels.clear();
+    this.aiNoiseFailedModels = new Set();
     this.appliedModelActiveForCapture = false;
     // Seed the desired background effect from prefs so it re-applies on this
     // call's camera publish; start each call with a clean failure guard.
     this.desiredBackgroundEffect = prefs.backgroundEffect;
-    this.backgroundFailedEffects.clear();
+    this.backgroundFailedEffects = new Set();
     this.appliedBackgroundEffect = BACKGROUND_OFF;
     const room = this.makeRoom(callRoomOptionsForPrefs(prefs));
-    room.on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
-    room.on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
-    room.on(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
-    room.on(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
-    room.on(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
-    room.on(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
-    room.on(RoomEvent.Disconnected, this.handleDisconnected);
-    room.on(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
-    room.on(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
-    room.on(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
-    room.on(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
-    room.on(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
-    room.on(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
-    room.on(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged);
+    this.updateRoomListeners(room, "on");
     // XEP-0215 ICE injection: when the server advertised external services,
     // make them the authoritative ICE list via `rtcConfig`. An empty/absent
     // list means "no advertisement" — pass no `rtcConfig` so LiveKit keeps its
@@ -560,44 +552,69 @@ export class CallEngine {
     await enableRequestedCapture(
       room.localParticipant,
       { audio: opts.audio, video: opts.video },
-      (source, error) => this.emit("mediaDevicesError", { source, error }),
+      (source, error) => {
+        if (this.isCurrentRoom(room, generation)) {
+          this.emit("mediaDevicesError", { source, error });
+        }
+      },
       {
         audio: audioPublishOptions(),
         camera: videoPublishPlan({ source: "camera", capability: this.codecSupport }),
       },
+      () => this.isCurrentRoom(room, generation),
     );
+    if (!this.isCurrentRoom(room, generation)) return;
     // Re-apply the speaker preference now that the room has remote
     // audio elements to retarget; the engine ignores it on connect
     // because no `<audio>` exists yet, but every subsequent
     // RoomEvent.TrackSubscribed wires through this.applySpeaker.
     if (prefs.speaker) {
       await this.applySpeakerDevice(prefs.speaker).catch(() => undefined);
+      if (!this.isCurrentRoom(room, generation)) return;
     }
   }
 
   async setMicEnabled(enabled: boolean): Promise<void> {
-    if (!this.room) return;
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
     // Forward the Opus voice-clarity profile (~64k mono, RED + DTX) so a mic
     // (re)enabled mid-call publishes at the same default as the initial join,
     // not LiveKit's lower `AudioPresets.music`. Scoped to the mic on purpose —
     // screen-share system audio keeps the SDK defaults. Inert on disable (mute).
-    await this.room.localParticipant.setMicrophoneEnabled(enabled, undefined, audioPublishOptions());
+    try {
+      await room.localParticipant.setMicrophoneEnabled(enabled, undefined, audioPublishOptions());
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   async setCameraEnabled(enabled: boolean): Promise<void> {
-    if (!this.room) return;
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
     // Forward the VP9+L3T3 / 720p camera plan — including the per-publish capture
     // cap — so a camera (re)enabled mid-call publishes at the same default as the
     // initial join, not LiveKit's 1080p/VP8 default.
     const { capture, publish } = videoPublishPlan({ source: "camera", capability: this.codecSupport });
-    await this.room.localParticipant.setCameraEnabled(enabled, capture, publish);
+    try {
+      await room.localParticipant.setCameraEnabled(enabled, capture, publish);
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   async setScreenShareEnabled(
     enabled: boolean,
     opts: { audio: boolean },
   ): Promise<void> {
-    if (!this.room) return;
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
     const { capture, publish } = videoPublishPlan({
       source: "screen",
       capability: this.codecSupport,
@@ -605,14 +622,22 @@ export class CallEngine {
     });
     const captureOptions = { ...capture, audio: opts.audio };
     try {
-      await this.room.localParticipant.setScreenShareEnabled(enabled, captureOptions, publish);
+      await room.localParticipant.setScreenShareEnabled(enabled, captureOptions, publish);
+      if (!this.isCurrentRoom(room, generation)) return;
     } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
       if (!enabled || !opts.audio || !isUnsupportedScreenAudioError(error)) throw error;
-      await this.room.localParticipant.setScreenShareEnabled(
-        true,
-        { ...captureOptions, audio: false },
-        publish,
-      );
+      try {
+        await room.localParticipant.setScreenShareEnabled(
+          true,
+          { ...captureOptions, audio: false },
+          publish,
+        );
+      } catch (fallbackError) {
+        if (!this.isCurrentRoom(room, generation)) return;
+        throw fallbackError;
+      }
+      if (!this.isCurrentRoom(room, generation)) return;
     }
   }
 
@@ -623,8 +648,16 @@ export class CallEngine {
    * the change is invisible to the peer.
    */
   async setMicDevice(deviceId: string): Promise<void> {
-    if (!this.room) return;
-    await this.room.switchActiveDevice("audioinput", deviceId);
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
+    try {
+      await room.switchActiveDevice("audioinput", deviceId);
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   /**
@@ -635,28 +668,42 @@ export class CallEngine {
    * model superseding the browser `noiseSuppression`.
    */
   async setAudioProcessing(prefs: AudioProcessingPrefs): Promise<void> {
-    await this.restartMicCapture(prefs);
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
+    await this.restartMicCapture(prefs, room, generation);
+    if (!this.isCurrentRoom(room, generation)) return;
     this.settleVerifiedMicProcessing();
   }
 
-  private async restartMicCapture(prefs: AudioProcessingPrefs): Promise<void> {
-    const publication = this.room?.localParticipant.getTrackPublication(Track.Source.Microphone);
+  private async restartMicCapture(
+    prefs: AudioProcessingPrefs,
+    room: Room,
+    generation: number,
+  ): Promise<void> {
+    const publication = room.localParticipant.getTrackPublication(Track.Source.Microphone);
     if (!publication || publication.isMuted) return;
     const track = publication.track;
     if (!track) return;
     const restartTrack = track?.restartTrack;
     if (typeof restartTrack !== "function") return;
     const settings = track.mediaStreamTrack?.getSettings();
-    await restartTrack.call(
-      track,
-      audioCaptureDefaultsForPrefs({
-        mic: settings?.deviceId ?? $devicePrefs.get().mic,
-        // Keyed on the VERIFIED attached model, not the desired one: if a
-        // selection failed to attach, the browser NS is left exactly as the
-        // user set it — never force-disabled with no filter to replace it.
-        audioProcessing: effectiveAudioProcessing(prefs, this.verifiedAiNoiseModel()),
-      }),
-    );
+    try {
+      await restartTrack.call(
+        track,
+        audioCaptureDefaultsForPrefs({
+          mic: settings?.deviceId ?? $devicePrefs.get().mic,
+          // Keyed on the VERIFIED attached model, not the desired one: if a
+          // selection failed to attach, the browser NS is left exactly as the
+          // user set it — never force-disabled with no filter to replace it.
+          audioProcessing: effectiveAudioProcessing(prefs, this.verifiedAiNoiseModel()),
+        }),
+      );
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
     this.emitMicAudioProcessing();
   }
 
@@ -669,7 +716,7 @@ export class CallEngine {
    */
   async setAiNoiseModel(model: NoiseModelId | null): Promise<void> {
     this.desiredAiNoiseModel = model;
-    this.aiNoiseFailedModels.clear();
+    this.aiNoiseFailedModels = new Set();
     await this.ensureAiNoiseFilter();
   }
 
@@ -688,10 +735,14 @@ export class CallEngine {
    * a model changed while muted, which only takes effect once the mic is live.
    */
   private async syncEffectiveCaptureConstraints(): Promise<void> {
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
     const modelActive = this.verifiedAiNoiseModel() !== null;
     if (modelActive === this.appliedModelActiveForCapture) return;
     this.appliedModelActiveForCapture = modelActive;
-    await this.restartMicCapture($devicePrefs.get().audioProcessing);
+    await this.restartMicCapture($devicePrefs.get().audioProcessing, room, generation);
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   /**
@@ -711,13 +762,18 @@ export class CallEngine {
    * publish). Fails open on attach error and emits a typed `aiNoiseFilterError`.
    */
   private ensureAiNoiseFilter(): Promise<void> {
+    const room = this.room;
+    const generation = this.connectGeneration;
     this.aiReconcileChain = this.aiReconcileChain
-      .then(() => this.runEnsureAiNoiseFilter())
+      .then(() => {
+        if (!room || !this.isCurrentRoom(room, generation)) return;
+        return this.runEnsureAiNoiseFilter(room, generation);
+      })
       .catch(() => undefined);
     return this.aiReconcileChain;
   }
 
-  private async runEnsureAiNoiseFilter(): Promise<void> {
+  private async runEnsureAiNoiseFilter(room: Room, generation: number): Promise<void> {
     const track = this.micProcessorTrack();
     if (!track) {
       // No live mic to attach to (none published, or muted) — surface the
@@ -728,8 +784,20 @@ export class CallEngine {
     }
     const target: ProcessorTarget<AudioNoiseProcessor> = {
       currentProcessorName: () => track.getProcessor()?.name,
-      attach: (processor) => track.setProcessor(processor),
-      clear: () => track.stopProcessor(),
+      attach: async (processor) => {
+        if (!this.isCurrentRoom(room, generation)) {
+          await processor.destroy().catch(() => undefined);
+          return;
+        }
+        await track.setProcessor(processor);
+        if (!this.isCurrentRoom(room, generation)) {
+          await track.stopProcessor().catch(() => undefined);
+        }
+      },
+      clear: async () => {
+        if (!this.isCurrentRoom(room, generation)) return;
+        await track.stopProcessor();
+      },
     };
     const outcome = await runAiNoiseFilterReconcile({
       target,
@@ -737,12 +805,14 @@ export class CallEngine {
       makeProcessor: this.makeAiNoiseProcessor,
       failedModels: this.aiNoiseFailedModels,
     });
+    if (!this.isCurrentRoom(room, generation)) return;
     if (outcome.action === "failed") {
       this.emit("aiNoiseFilterError", { model: outcome.model, error: outcome.error });
     }
     // Flip browser NS to match what actually attached, then surface the
     // settled verified state for the UI and the fleet beacon.
     await this.syncEffectiveCaptureConstraints();
+    if (!this.isCurrentRoom(room, generation)) return;
     this.emitAiNoiseFilter();
     this.settleVerifiedMicProcessing();
   }
@@ -780,7 +850,7 @@ export class CallEngine {
    */
   async setBackgroundEffect(effect: BackgroundEffect): Promise<void> {
     this.desiredBackgroundEffect = effect;
-    this.backgroundFailedEffects.clear();
+    this.backgroundFailedEffects = new Set();
     await this.ensureBackgroundEffect();
   }
 
@@ -802,13 +872,18 @@ export class CallEngine {
    * `backgroundEffectError`.
    */
   private ensureBackgroundEffect(): Promise<void> {
+    const room = this.room;
+    const generation = this.connectGeneration;
     this.backgroundReconcileChain = this.backgroundReconcileChain
-      .then(() => this.runEnsureBackgroundEffect())
+      .then(() => {
+        if (!room || !this.isCurrentRoom(room, generation)) return;
+        return this.runEnsureBackgroundEffect(room, generation);
+      })
       .catch(() => undefined);
     return this.backgroundReconcileChain;
   }
 
-  private async runEnsureBackgroundEffect(): Promise<void> {
+  private async runEnsureBackgroundEffect(room: Room, generation: number): Promise<void> {
     const track = this.cameraProcessorTrack();
     if (!track) {
       // No live camera to attach to — surface the honest `no-camera` state; the
@@ -823,10 +898,19 @@ export class CallEngine {
           : BACKGROUND_OFF,
       attach: async (effect) => {
         const processor = await this.backgroundOps.create(effect);
+        if (!this.isCurrentRoom(room, generation)) {
+          await processor.destroy().catch(() => undefined);
+          return;
+        }
         await track.setProcessor(processor);
+        if (!this.isCurrentRoom(room, generation)) {
+          await track.stopProcessor().catch(() => undefined);
+          return;
+        }
         this.appliedBackgroundEffect = effect;
       },
       switch: async (effect) => {
+        if (!this.isCurrentRoom(room, generation)) return;
         const processor = track.getProcessor() as unknown as VideoBackgroundProcessor | undefined;
         // The reconciler only decides `switch` when a processor was verifiably
         // present (its name was just read), so this is effectively always set.
@@ -836,10 +920,13 @@ export class CallEngine {
         // effect, so the next reconcile retries the switch honestly.
         if (!processor) return;
         await this.backgroundOps.switch(processor, effect);
+        if (!this.isCurrentRoom(room, generation)) return;
         this.appliedBackgroundEffect = effect;
       },
       clear: async () => {
+        if (!this.isCurrentRoom(room, generation)) return;
         await track.stopProcessor();
+        if (!this.isCurrentRoom(room, generation)) return;
         this.appliedBackgroundEffect = BACKGROUND_OFF;
       },
     };
@@ -848,6 +935,7 @@ export class CallEngine {
       desired: this.desiredBackgroundEffect,
       failed: this.backgroundFailedEffects,
     });
+    if (!this.isCurrentRoom(room, generation)) return;
     if (outcome.action === "failed") {
       this.emit("backgroundEffectError", { effect: outcome.effect, error: outcome.error });
     }
@@ -870,8 +958,16 @@ export class CallEngine {
    * Same shape as `setMicDevice` but for the camera device.
    */
   async setCameraDevice(deviceId: string): Promise<void> {
-    if (!this.room) return;
-    await this.room.switchActiveDevice("videoinput", deviceId);
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
+    try {
+      await room.switchActiveDevice("videoinput", deviceId);
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   /**
@@ -885,7 +981,16 @@ export class CallEngine {
   }
 
   async startAudio(): Promise<void> {
-    await this.room?.startAudio();
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
+    try {
+      await room.startAudio();
+    } catch (error) {
+      if (!this.isCurrentRoom(room, generation)) return;
+      throw error;
+    }
+    if (!this.isCurrentRoom(room, generation)) return;
   }
 
   setParticipantAudioVolume(
@@ -900,10 +1005,13 @@ export class CallEngine {
   }
 
   private async applySpeakerDevice(deviceId: string): Promise<void> {
-    if (!this.room) return;
-    if (typeof this.room.switchActiveDevice !== "function") return;
+    const room = this.room;
+    if (!room) return;
+    const generation = this.connectGeneration;
+    if (typeof room.switchActiveDevice !== "function") return;
     try {
-      await this.room.switchActiveDevice("audiooutput", deviceId);
+      await room.switchActiveDevice("audiooutput", deviceId);
+      if (!this.isCurrentRoom(room, generation)) return;
     } catch {
       // Browser doesn't support sinkId; the user already saw the
       // disabled chip in the picker. Swallow silently here.
@@ -926,32 +1034,60 @@ export class CallEngine {
     // us — without this synthetic emit, `useCallEngine` would carry the
     // last call's tracks into the next session and the overlay would
     // render duplicate tiles.
-    this.emit("disconnected", "local");
-    room.off(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
-    room.off(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
-    room.off(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
-    room.off(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
-    room.off(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
-    room.off(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
-    room.off(RoomEvent.Disconnected, this.handleDisconnected);
-    room.off(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
-    room.off(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
-    room.off(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
-    room.off(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
-    room.off(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
-    room.off(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
-    room.off(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged);
-    // Tear the mic noise processor down explicitly first: its destroy() stops a
-    // private clone of the capture track that holds the input device open. A
-    // normal room.disconnect() stops local tracks (which destroys the processor)
-    // for us, but doing it here means an erroring/partial disconnect can't leave
-    // the device — and its indicator — live until GC.
-    const micTrack = room.localParticipant?.getTrackPublication?.(Track.Source.Microphone)
-      ?.track as unknown as ProcessorCapableTrack | undefined;
-    if (micTrack && typeof micTrack.getProcessor === "function" && micTrack.getProcessor()) {
-      await micTrack.stopProcessor().catch(() => undefined);
+    this.emit("disconnected", { origin: "local" });
+    this.updateRoomListeners(room, "off");
+    const processorsStopped = this.stopRoomProcessors(room);
+    const roomDisconnected = room.disconnect();
+    await processorsStopped;
+    await roomDisconnected;
+  }
+
+  private isCurrentRoom(room: Room, generation: number): boolean {
+    return this.connectGeneration === generation && this.room === room;
+  }
+
+  private updateRoomListeners(room: Room, operation: "on" | "off"): void {
+    const update = <K extends keyof RoomEventCallbacks>(
+      event: K,
+      listener: RoomEventCallbacks[K],
+    ): void => {
+      if (operation === "on") room.on(event, listener);
+      else room.off(event, listener);
+    };
+    update(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
+    update(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
+    update(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);
+    update(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
+    update(RoomEvent.ParticipantConnected, this.handleParticipantConnected);
+    update(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
+    update(RoomEvent.Disconnected, this.handleDisconnected);
+    update(RoomEvent.AudioPlaybackStatusChanged, this.handleAudioPlaybackStatusChanged);
+    update(RoomEvent.ActiveDeviceChanged, this.handleActiveDeviceChanged);
+    update(RoomEvent.TrackMuted, this.handleTrackMuteChanged);
+    update(RoomEvent.TrackUnmuted, this.handleTrackMuteChanged);
+    update(RoomEvent.ConnectionQualityChanged, this.handleConnectionQualityChanged);
+    update(RoomEvent.ConnectionStateChanged, this.handleConnectionStateChanged);
+    update(RoomEvent.ActiveSpeakersChanged, this.handleActiveSpeakersChanged);
+  }
+
+  private stopRoomProcessors(room: Room): Promise<void> {
+    const stops: Array<Promise<unknown>> = [];
+    const seen = new Set<ProcessorCapableTrack | CameraProcessorTrack>();
+    const sources = [Track.Source.Microphone, Track.Source.Camera] as const;
+    for (const source of sources) {
+      const track = room.localParticipant?.getTrackPublication?.(source)
+        ?.track as unknown as ProcessorCapableTrack | CameraProcessorTrack | undefined;
+      if (
+        track &&
+        !seen.has(track) &&
+        typeof track.getProcessor === "function" &&
+        track.getProcessor()
+      ) {
+        seen.add(track);
+        stops.push(track.stopProcessor().catch(() => undefined));
+      }
     }
-    await room.disconnect();
+    return Promise.all(stops).then(() => undefined);
   }
 
   on<K extends keyof CallEngineEvents>(event: K, cb: CallEngineEvents[K]): () => void {
@@ -1100,20 +1236,25 @@ export class CallEngine {
     this.emit("participantDisconnected", participant.identity);
   };
 
-  private handleDisconnected = (_reason?: unknown) => {
+  private handleDisconnected = async (reason?: DisconnectReason) => {
+    const room = this.room;
+    if (!room) return;
+    this.connectGeneration++;
+    this.connecting = false;
+    this.room = null;
+    this.updateRoomListeners(room, "off");
     this.clearParticipantAudioVolumes();
     // LiveKit destroys the processor when the track stops; just reset our
     // per-track failure guard + capture-NS state so the next call starts clean.
-    this.aiNoiseFailedModels.clear();
+    this.aiNoiseFailedModels = new Set();
     this.appliedModelActiveForCapture = false;
     // LiveKit destroys the camera processor with the track on disconnect; reset
     // our per-track guard + applied effect so the next call starts clean.
-    this.backgroundFailedEffects.clear();
+    this.backgroundFailedEffects = new Set();
     this.appliedBackgroundEffect = BACKGROUND_OFF;
-    // LiveKit exposes a numeric SDK enum here. Keep that unstable detail at
-    // the boundary; lifecycle telemetry combines this terminal transport loss
-    // with the independently observed reconnect phase before classifying it.
-    this.emit("disconnected", "transport");
+    const processorsStopped = this.stopRoomProcessors(room);
+    this.emit("disconnected", { origin: "transport", reason });
+    await processorsStopped;
   };
 
   private handleAudioPlaybackStatusChanged = (canPlaybackAudio: boolean) => {
@@ -1376,6 +1517,7 @@ export async function enableRequestedCapture(
   opts: { audio: boolean; video: boolean },
   onError: (source: "audio" | "video", error: unknown) => void,
   publish: { audio: TrackPublishOptions; camera: CameraPublishPlan },
+  isCurrent: () => boolean = () => true,
 ): Promise<void> {
   if (opts.audio) {
     try {
@@ -1383,6 +1525,7 @@ export async function enableRequestedCapture(
     } catch (error) {
       onError("audio", error);
     }
+    if (!isCurrent()) return;
   }
   if (opts.video) {
     try {
@@ -1392,5 +1535,6 @@ export async function enableRequestedCapture(
     } catch (error) {
       onError("video", error);
     }
+    if (!isCurrent()) return;
   }
 }

--- a/chat/src/lib/calls/ice-credential-refresh.ts
+++ b/chat/src/lib/calls/ice-credential-refresh.ts
@@ -1,24 +1,13 @@
 import type { IceServerBundle } from "./ice-servers";
+import { browserTimerClock, type TimerClock } from "./timer-clock";
 
 const REFRESH_SKEW_MS = 60_000;
 const RETRY_MS = 30_000;
-
-export type IceRefreshClock = {
-  now(): number;
-  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
-  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
-};
 
 export type IceCredentialRefresher = {
   start(earliestExpiryMs: number | null): void;
   refreshNow(): Promise<void>;
   stop(): void;
-};
-
-const browserClock: IceRefreshClock = {
-  now: () => Date.now(),
-  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
-  clearTimeout: (timer) => clearTimeout(timer),
 };
 
 /**
@@ -32,9 +21,9 @@ export function createIceCredentialRefresher(options: {
   isCurrent: () => boolean;
   onRefreshed: () => void;
   onExpired: () => void;
-  clock?: IceRefreshClock;
+  clock?: TimerClock;
 }): IceCredentialRefresher {
-  const clock = options.clock ?? browserClock;
+  const clock = options.clock ?? browserTimerClock;
   let expiryMs: number | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let refreshInFlight: Promise<void> | null = null;

--- a/chat/src/lib/calls/ice-credential-refresh.ts
+++ b/chat/src/lib/calls/ice-credential-refresh.ts
@@ -1,0 +1,121 @@
+import type { IceServerBundle } from "./ice-servers";
+
+const REFRESH_SKEW_MS = 60_000;
+const RETRY_MS = 30_000;
+
+export type IceRefreshClock = {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+};
+
+export type IceCredentialRefresher = {
+  start(earliestExpiryMs: number | null): void;
+  refreshNow(): Promise<void>;
+  stop(): void;
+};
+
+const browserClock: IceRefreshClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+/**
+ * Own the call-scoped XEP-0215 refresh timer. The caller supplies the room
+ * generation guard, so a fetch that outlives disconnect can neither replace
+ * the next call's configuration nor emit telemetry for it.
+ */
+export function createIceCredentialRefresher(options: {
+  refresh: () => Promise<IceServerBundle>;
+  apply: (bundle: IceServerBundle) => void;
+  isCurrent: () => boolean;
+  onRefreshed: () => void;
+  onExpired: () => void;
+  clock?: IceRefreshClock;
+}): IceCredentialRefresher {
+  const clock = options.clock ?? browserClock;
+  let expiryMs: number | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let refreshInFlight: Promise<void> | null = null;
+  let stopped = true;
+  let expiryReported = false;
+
+  function clearTimer(): void {
+    if (timer === null) return;
+    clock.clearTimeout(timer);
+    timer = null;
+  }
+
+  function reportExpiryIfNeeded(): void {
+    if (expiryMs === null || expiryMs > clock.now() || expiryReported) return;
+    expiryReported = true;
+    options.onExpired();
+  }
+
+  function schedule(retryWhenDue: boolean): void {
+    clearTimer();
+    if (stopped || !options.isCurrent() || expiryMs === null) return;
+    const untilExpiryMs = expiryMs - clock.now();
+    const untilRefreshMs = untilExpiryMs - REFRESH_SKEW_MS;
+    const delayMs = untilRefreshMs > 0
+      ? untilRefreshMs
+      : retryWhenDue
+        ? untilExpiryMs > 0
+          ? Math.min(RETRY_MS, untilExpiryMs)
+          : RETRY_MS
+        : 0;
+    timer = clock.setTimeout(() => {
+      timer = null;
+      reportExpiryIfNeeded();
+      void refreshNow();
+    }, delayMs);
+  }
+
+  async function refreshNow(): Promise<void> {
+    if (stopped || !options.isCurrent()) return;
+    if (refreshInFlight) return refreshInFlight;
+    refreshInFlight = (async () => {
+      let bundle: IceServerBundle | null = null;
+      try {
+        bundle = await options.refresh();
+      } catch {
+        // The existing credentials remain the best available configuration;
+        // retry below while the current call generation is still alive.
+      }
+      if (stopped || !options.isCurrent()) return;
+      const now = clock.now();
+      const usable = bundle !== null
+        && bundle.servers.length > 0
+        && (bundle.earliestExpiryMs === null || bundle.earliestExpiryMs > now);
+      if (usable && bundle) {
+        options.apply(bundle);
+        expiryMs = bundle.earliestExpiryMs;
+        expiryReported = false;
+        options.onRefreshed();
+      }
+      reportExpiryIfNeeded();
+      schedule(true);
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+    return refreshInFlight;
+  }
+
+  return {
+    start(earliestExpiryMs) {
+      stopped = false;
+      expiryMs = earliestExpiryMs;
+      expiryReported = false;
+      reportExpiryIfNeeded();
+      schedule(false);
+    },
+    refreshNow,
+    stop() {
+      stopped = true;
+      expiryMs = null;
+      expiryReported = false;
+      clearTimer();
+    },
+  };
+}

--- a/chat/src/lib/calls/ice-servers.ts
+++ b/chat/src/lib/calls/ice-servers.ts
@@ -1,5 +1,11 @@
 import type { ExternalService } from "./types";
 
+export type IceServerBundle = {
+  servers: RTCIceServer[];
+  /** Earliest valid XEP-0215 TURN/TURNS credential expiry, as epoch ms. */
+  earliestExpiryMs: number | null;
+};
+
 const SERVICE_TYPES = new Set<ExternalService["serviceType"]>(["stun", "turn", "turns"]);
 const TRANSPORTS = new Set<NonNullable<ExternalService["transport"]>>(["udp", "tcp"]);
 
@@ -62,7 +68,20 @@ export function coerceExternalServices(raw: unknown): ExternalService[] {
 export function iceServersFromExternalServices(
   services: ReadonlyArray<ExternalService>,
 ): RTCIceServer[] {
+  return iceServerBundleFromExternalServices(services).servers;
+}
+
+/**
+ * Map XEP-0215 services and retain the earliest TURN credential deadline.
+ * `expires` is `xs:dateTime` in XEP-0215, so `Date.parse` converts the
+ * already-coerced string at this boundary; malformed optional values are
+ * ignored rather than invalidating otherwise usable ICE servers.
+ */
+export function iceServerBundleFromExternalServices(
+  services: ReadonlyArray<ExternalService>,
+): IceServerBundle {
   const iceServers: RTCIceServer[] = [];
+  let earliestExpiryMs: number | null = null;
   for (const service of services) {
     const hostPort = formatHostPort(service.host, service.port);
     if (service.serviceType === "stun") {
@@ -70,6 +89,12 @@ export function iceServersFromExternalServices(
       // credentials.
       iceServers.push({ urls: `stun:${hostPort}` });
       continue;
+    }
+    const expiryMs = service.expires === undefined ? Number.NaN : Date.parse(service.expires);
+    if (Number.isFinite(expiryMs)) {
+      earliestExpiryMs = earliestExpiryMs === null
+        ? expiryMs
+        : Math.min(earliestExpiryMs, expiryMs);
     }
     // turn / turns require credentials to be usable as a relay.
     if (service.username === undefined || service.password === undefined) {
@@ -80,7 +105,7 @@ export function iceServersFromExternalServices(
     const urls = `${service.serviceType}:${hostPort}${transportQuery}`;
     iceServers.push({ urls, username: service.username, credential: service.password });
   }
-  return iceServers;
+  return { servers: iceServers, earliestExpiryMs };
 }
 
 /**

--- a/chat/src/lib/calls/ice-servers.ts
+++ b/chat/src/lib/calls/ice-servers.ts
@@ -90,15 +90,19 @@ export function iceServerBundleFromExternalServices(
       iceServers.push({ urls: `stun:${hostPort}` });
       continue;
     }
+    // turn / turns require credentials to be usable as a relay.
+    if (service.username === undefined || service.password === undefined) {
+      continue;
+    }
+    // Only services that actually joined the bundle contribute a deadline:
+    // a discarded credential-less entry's (possibly already-past) expires
+    // must not make the refresher treat every otherwise-valid bundle as
+    // expired and spin on retries.
     const expiryMs = service.expires === undefined ? Number.NaN : Date.parse(service.expires);
     if (Number.isFinite(expiryMs)) {
       earliestExpiryMs = earliestExpiryMs === null
         ? expiryMs
         : Math.min(earliestExpiryMs, expiryMs);
-    }
-    // turn / turns require credentials to be usable as a relay.
-    if (service.username === undefined || service.password === undefined) {
-      continue;
     }
     // The `?transport` parameter is turn-specific (RFC 7065).
     const transportQuery = service.transport ? `?transport=${service.transport}` : "";

--- a/chat/src/lib/calls/muc-call-actions.ts
+++ b/chat/src/lib/calls/muc-call-actions.ts
@@ -375,3 +375,31 @@ export async function broadcastMucCallSelfMute(
     return false;
   }
 }
+
+/**
+ * Re-emit the active MUC call's full XEP-0272 advertisement (with the
+ * current hand/mute markers). A fresh XMPP bind wiped our server-side
+ * occupant, and the plain rejoin presence recreates it WITHOUT
+ * `<muji/>` — other occupants would show a still-running call as ended
+ * for its remainder. Called after the call room's rejoin confirms
+ * (#1621 review round 2).
+ */
+export async function readvertiseMucCallPresence(sender: RawIqSender): Promise<boolean> {
+  const state = $callState.get();
+  if (state.phase !== "active" || state.kind !== "muc" || !state.selfNick) {
+    return false;
+  }
+  if (!sender.update_muji_presence) return false;
+  const roomJid = normalizeMucCallRoomJid(state.peer);
+  if (!roomJid) return false;
+  try {
+    await sender.update_muji_presence(roomJid, state.selfNick, true, false, state.media.video, {
+      handRaised: selfRaisedHandFor(roomJid),
+      muted: selfCallMuted(),
+    });
+    return true;
+  } catch (err) {
+    reportCallError(err);
+    return false;
+  }
+}

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -3,9 +3,18 @@ import { normalizeMucCallRoomJid } from "./muc-call-presence";
 import { reportError } from "@/lib/telemetry";
 import { map } from "nanostores";
 import type { CallMedia, LiveKitJoin } from "./types";
+import {
+  localStorageForLegacyPurge,
+  purgeLegacyStoragePrefixFromLocalStorage,
+} from "./call-token-storage-migration";
 
 const CACHE_PREFIX = "waddle.chat.muc-call-sessions";
 const CACHE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+// Remove bearer tokens written by pre-#1450 builds as soon as this cache is
+// initialized. `storage()` repeats the one-shot call so SSR-first imports can
+// retry after hydration makes browser storage available.
+purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
 const MAX_CACHE_ENTRIES = 64;
 
 type CachedMucCallSession = {
@@ -159,23 +168,23 @@ export function forgetMucCallSession(options: {
   syncPendingEntries(next.filter((entry) => entry.terminatePending));
 }
 
+export function clearMucCallSessionCacheForAccount(selfBareJid: string): void {
+  const selfBare = normalizedBare(selfBareJid);
+  if (!selfBare) return;
+  removeKey(cacheKey(selfBare));
+  const current = $mucCallTerminatePendingSessions.get();
+  const next = Object.fromEntries(
+    Object.entries(current).filter(([, entry]) => normalizedBare(entry.selfFullJid) !== selfBare),
+  );
+  if (Object.keys(next).length !== Object.keys(current).length) {
+    $mucCallTerminatePendingSessions.set(next);
+  }
+}
+
 export function clearAllMucCallSessionCacheForTests(): void {
   $mucCallTerminatePendingSessions.set({});
-  const s = storage();
-  if (!s) return;
-  try {
-    const keys: string[] = [];
-    for (let index = 0; index < s.length; index += 1) {
-      const key = s.key(index);
-      if (key?.startsWith(`${CACHE_PREFIX}.`)) keys.push(key);
-    }
-    for (const key of keys) s.removeItem(key);
-  } catch (err) {
-    reportError("storage.write", err, {
-      recoverable: true,
-      detail: "muc call session cache clear failed",
-    });
-  }
+  clearKeysWithPrefix(storage(), CACHE_PREFIX);
+  clearKeysWithPrefix(localStorageForLegacyPurge(), CACHE_PREFIX);
 }
 
 function normalizeEntry(entry: CachedMucCallSession): CachedMucCallSession | null {
@@ -239,6 +248,20 @@ function writeEntries(selfBareJid: string, entries: CachedMucCallSession[]): voi
     reportError("storage.write", err, {
       recoverable: true,
       detail: "muc call session cache write failed",
+      storage_area: "muc-call-session-cache",
+    });
+  }
+}
+
+function removeKey(key: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "muc call session cache clear failed",
       storage_area: "muc-call-session-cache",
     });
   }
@@ -344,10 +367,28 @@ function isLiveKitJoin(value: unknown): value is LiveKitJoin {
 }
 
 function storage(): Storage | null {
+  purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
   if (typeof window === "undefined") return null;
   try {
-    return window.localStorage;
+    return window.sessionStorage ?? null;
   } catch {
     return null;
+  }
+}
+
+function clearKeysWithPrefix(s: Storage | null, prefix: string): void {
+  if (!s) return;
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < s.length; index += 1) {
+      const key = s.key(index);
+      if (key?.startsWith(`${prefix}.`)) keys.push(key);
+    }
+    for (const key of keys) s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "muc call session cache clear failed",
+    });
   }
 }

--- a/chat/src/lib/calls/muc-call-session-cache.ts
+++ b/chat/src/lib/calls/muc-call-session-cache.ts
@@ -4,6 +4,8 @@ import { reportError } from "@/lib/telemetry";
 import { map } from "nanostores";
 import type { CallMedia, LiveKitJoin } from "./types";
 import {
+  callCacheSessionStorage,
+  clearCallCacheKeysWithPrefix,
   localStorageForLegacyPurge,
   purgeLegacyStoragePrefixFromLocalStorage,
 } from "./call-token-storage-migration";
@@ -183,8 +185,12 @@ export function clearMucCallSessionCacheForAccount(selfBareJid: string): void {
 
 export function clearAllMucCallSessionCacheForTests(): void {
   $mucCallTerminatePendingSessions.set({});
-  clearKeysWithPrefix(storage(), CACHE_PREFIX);
-  clearKeysWithPrefix(localStorageForLegacyPurge(), CACHE_PREFIX);
+  clearCallCacheKeysWithPrefix(storage(), CACHE_PREFIX, "muc call session cache clear failed");
+  clearCallCacheKeysWithPrefix(
+    localStorageForLegacyPurge(),
+    CACHE_PREFIX,
+    "muc call session cache clear failed",
+  );
 }
 
 function normalizeEntry(entry: CachedMucCallSession): CachedMucCallSession | null {
@@ -367,28 +373,5 @@ function isLiveKitJoin(value: unknown): value is LiveKitJoin {
 }
 
 function storage(): Storage | null {
-  purgeLegacyStoragePrefixFromLocalStorage(CACHE_PREFIX);
-  if (typeof window === "undefined") return null;
-  try {
-    return window.sessionStorage ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function clearKeysWithPrefix(s: Storage | null, prefix: string): void {
-  if (!s) return;
-  try {
-    const keys: string[] = [];
-    for (let index = 0; index < s.length; index += 1) {
-      const key = s.key(index);
-      if (key?.startsWith(`${prefix}.`)) keys.push(key);
-    }
-    for (const key of keys) s.removeItem(key);
-  } catch (err) {
-    reportError("storage.write", err, {
-      recoverable: true,
-      detail: "muc call session cache clear failed",
-    });
-  }
+  return callCacheSessionStorage(CACHE_PREFIX);
 }

--- a/chat/src/lib/calls/timer-clock.ts
+++ b/chat/src/lib/calls/timer-clock.ts
@@ -1,0 +1,16 @@
+/**
+ * Injectable wall-clock + timer surface shared by the call-scoped
+ * schedulers (XEP-0215 credential refresh, transport-loss recovery), so
+ * their tests drive time deterministically with one fake.
+ */
+export type TimerClock = {
+  now(): number;
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+};
+
+export const browserTimerClock: TimerClock = {
+  now: () => Date.now(),
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -1,5 +1,7 @@
 import { ref, type Ref } from "vue";
-import { $callState, clearCallState, reportCallError } from "./call-store";
+import { $callState, clearCallState, reportCallError, tearDownActiveCall } from "./call-store";
+import type { CallWireSender } from "./outbound";
+import { connectionStore } from "@/lib/connection-store";
 import { DisconnectReason } from "livekit-client";
 import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engine";
 import {
@@ -73,6 +75,34 @@ import {
   finishCallAttemptForTransportDisconnect,
   type CallKind,
 } from "./call-lifecycle-telemetry";
+
+/**
+ * Reasons where the LiveKit loss is OURS alone — the peer's media may
+ * still be up and neither the SFU nor the server will tell them we're
+ * gone, so the XMPP wire teardown must. Server-initiated ends
+ * (room deleted/closed, participant removed, duplicate identity, …)
+ * are excluded: the authority that ended us also informs the peer, and
+ * a duplicate-identity takeover must not terminate the succeeding
+ * device's call.
+ */
+function peerUnawareOfTransportLoss(reason?: DisconnectReason): boolean {
+  switch (reason) {
+    case DisconnectReason.CONNECTION_TIMEOUT:
+    case DisconnectReason.MEDIA_FAILURE:
+    case DisconnectReason.JOIN_FAILURE:
+    case DisconnectReason.SIGNAL_CLOSE:
+    case DisconnectReason.UNKNOWN_REASON:
+    case undefined:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function currentCallWireSender(): CallWireSender | null {
+  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
+  return (client?.xmpp as CallWireSender | undefined) ?? null;
+}
 
 function transportDisconnectMessage(reason?: DisconnectReason): string {
   switch (reason) {
@@ -706,7 +736,16 @@ export function useCallEngine(): {
       const disconnectedMucSlot = activeMucCallSlot();
       if (origin !== "local" && disconnectedCall.phase === "active") {
         const terminal = finishCallAttemptForTransportDisconnect(disconnectedCall.sid);
-        clearCallState({ endReason: terminal?.endReason ?? "error" });
+        if (disconnectedCall.kind === "dm" && peerUnawareOfTransportLoss(reason)) {
+          // A local-transport death leaves the peer in a dangling active
+          // call unless we tell them: run the bounded wire teardown
+          // (XEP-0166 terminate + XEP-0353 finish + activity cleanup),
+          // which snapshots $callState itself — so it runs INSTEAD of
+          // clearCallState, not after it.
+          void tearDownActiveCall(currentCallWireSender(), "gone").catch(reportCallError);
+        } else {
+          clearCallState({ endReason: terminal?.endReason ?? "error" });
+        }
         reportCallError(new Error(transportDisconnectMessage(reason)));
       }
       remoteTracks.value = [];

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -2,6 +2,7 @@ import { ref, type Ref } from "vue";
 import { $callState, clearCallState, reportCallError } from "./call-store";
 import { DisconnectReason } from "livekit-client";
 import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engine";
+import { applyCallDeviceSelection } from "./call-device-selection";
 import {
   advanceActiveSpeakers,
   emptyActiveSpeakerState,
@@ -21,6 +22,7 @@ import {
   setLiveCallParticipants,
 } from "./muc-call-live-participants";
 import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
+import { enumerateCallDevices, hasEnumeratedCallDeviceId } from "./device-prefs";
 import { syncScreenShareEnabled } from "./screen-share-state";
 import { setCallAudioPlaybackBlocked } from "./call-audio-playback";
 import { resetMicAudioProcessing, setMicAudioProcessing } from "./mic-audio-processing-state";
@@ -49,12 +51,16 @@ import {
   type CallStatDirection,
   type CallStatSample,
 } from "./call-stats";
-import { reportCallAudioProcessing, reportCallIce, reportCallMediaPath } from "../telemetry";
+import {
+  reportCallAudioProcessing,
+  reportCallIce,
+  reportCallIceCredentials,
+  reportCallMediaPath,
+} from "../telemetry";
 import {
   resetCallConnectionQuality,
   setCallConnectionPhase,
   setCallConnectionQuality,
-  type CallConnectionPhase,
 } from "./connection-quality";
 import { resetCallActiveSince, setCallActiveSince } from "./call-duration";
 import {
@@ -240,6 +246,9 @@ const callMediaPathBeacon = createCallMediaPathBeacon((snapshot) => {
 const callIceBeacon = createCallIceBeacon((snapshot) => {
   const callKind = currentCallKind();
   if (callKind) reportCallIce(snapshot, callKind);
+}, (event) => {
+  const callKind = currentCallKind();
+  if (callKind) reportCallIceCredentials(event, callKind);
 });
 
 /** Cadence of the observational media-path poll. Codec/ICE settle within the
@@ -255,6 +264,92 @@ let mediaPathSampling = false;
 // just-reset beacon — which would otherwise suppress the next call's first
 // event when both calls share a codec/ICE path.
 let mediaPathGeneration = 0;
+
+const CALL_DEVICE_CHANGE_DEBOUNCE_MS = 200;
+let unsubscribeCallDeviceChange: (() => void) | null = null;
+let callDeviceChangeTimer: ReturnType<typeof setTimeout> | null = null;
+let callDeviceChangeGeneration = 0;
+let pendingCallDeviceChange: { micId: string | null; camId: string | null } | null = null;
+
+function missingActiveCallDeviceError(kind: "mic" | "cam"): Error {
+  const error = new Error(`${kind} device was removed during the call`);
+  error.name = "NotFoundError";
+  return error;
+}
+
+async function reconcileRemovedActiveDevices(
+  engine: CallEngine,
+  generation: number,
+  activeBeforeChange: { micId: string | null; camId: string | null },
+): Promise<void> {
+  const devices = await enumerateCallDevices();
+  if (generation !== callDeviceChangeGeneration) return;
+
+  const activeMicId = activeBeforeChange.micId;
+  if (
+    activeMicId &&
+    activeMicId !== "default" &&
+    !hasEnumeratedCallDeviceId(devices, "mic", activeMicId)
+  ) {
+    recordMediaIssue("mic", missingActiveCallDeviceError("mic"));
+    await applyCallDeviceSelection("mic", null, engine);
+    if (generation !== callDeviceChangeGeneration) return;
+  }
+
+  const activeCamId = activeBeforeChange.camId;
+  if (
+    activeCamId &&
+    activeCamId !== "default" &&
+    !hasEnumeratedCallDeviceId(devices, "cam", activeCamId)
+  ) {
+    recordMediaIssue("cam", missingActiveCallDeviceError("cam"));
+    await applyCallDeviceSelection("cam", null, engine);
+  }
+}
+
+function stopCallDeviceChangeListener(): void {
+  callDeviceChangeGeneration += 1;
+  if (callDeviceChangeTimer) {
+    clearTimeout(callDeviceChangeTimer);
+    callDeviceChangeTimer = null;
+  }
+  pendingCallDeviceChange = null;
+  unsubscribeCallDeviceChange?.();
+  unsubscribeCallDeviceChange = null;
+}
+
+function startCallDeviceChangeListener(engine: CallEngine): void {
+  stopCallDeviceChangeListener();
+  const generation = callDeviceChangeGeneration;
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.addEventListener) return;
+  const handler = () => {
+    // Capture BEFORE the debounce. LiveKit registers its own devicechange
+    // listener when the Room is built and may auto-switch activeDeviceMap to
+    // the first remaining device before our async enumeration finishes. A
+    // later read would then hide that the in-use device was removed.
+    const snapshot = {
+      micId: engine.activeDeviceId("audioinput"),
+      camId: engine.activeDeviceId("videoinput"),
+    };
+    pendingCallDeviceChange = {
+      micId: pendingCallDeviceChange?.micId ?? snapshot.micId,
+      camId: pendingCallDeviceChange?.camId ?? snapshot.camId,
+    };
+    if (callDeviceChangeTimer) clearTimeout(callDeviceChangeTimer);
+    callDeviceChangeTimer = setTimeout(() => {
+      callDeviceChangeTimer = null;
+      const activeBeforeChange = pendingCallDeviceChange;
+      pendingCallDeviceChange = null;
+      if (!activeBeforeChange) return;
+      void reconcileRemovedActiveDevices(engine, generation, activeBeforeChange)
+        .catch(reportCallError);
+    }, CALL_DEVICE_CHANGE_DEBOUNCE_MS);
+  };
+  navigator.mediaDevices.addEventListener("devicechange", handler);
+  unsubscribeCallDeviceChange = () => {
+    navigator.mediaDevices.removeEventListener("devicechange", handler);
+  };
+}
 // Previous byte/timestamp sample per audio track, so the media-path poll can
 // derive the send/recv bitrate (a rate needs two samples) and band it. Keyed by
 // the same track key used in the diagnostics dialog; cleared between calls in
@@ -509,6 +604,13 @@ export function useCallEngine(): {
       // connection-quality lifecycle.
       setCallActiveSince(Date.now());
     });
+    const engineForDeviceChanges = singletonEngine;
+    singletonEngine.on("connected", () => {
+      // Keep a call-lifetime `devicechange` listener active even when the
+      // settings dialog is closed, so a hot-unplugged in-use mic/camera can
+      // surface a notice and fall back to the browser default immediately.
+      startCallDeviceChangeListener(engineForDeviceChanges);
+    });
     singletonEngine.on("mediaDevicesError", ({ source, error }) => {
       // A best-effort mic/cam capture failed (no device / denied
       // permission). The call stays connected as receive-only; record
@@ -574,6 +676,12 @@ export function useCallEngine(): {
       // so signaling blips never inflate the ICE-restart SLI.
       callIceBeacon.noteIceRestart();
     });
+    singletonEngine.on("iceCredentialsRefreshed", () => {
+      callIceBeacon.noteCredentials("refreshed");
+    });
+    singletonEngine.on("iceCredentialsExpired", () => {
+      callIceBeacon.noteCredentials("expired");
+    });
     singletonEngine.on("activeSpeakersChanged", (identities) => {
       // LiveKit re-derived who is speaking. Feed it through the brief hold so
       // the Gallery highlight does not flicker on transient sounds.
@@ -625,6 +733,7 @@ export function useCallEngine(): {
       micAudioProcessingBeacon.reset();
       // Stop the media-path poll and re-arm its beacon for the next call.
       stopMediaPathPolling();
+      stopCallDeviceChangeListener();
       callMediaPathBeacon.reset();
       // Same for the ICE beacon: drop this call's seen-set and restart
       // count so the next call measures its own connectivity.

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -2,7 +2,6 @@ import { ref, type Ref } from "vue";
 import { $callState, clearCallState, reportCallError } from "./call-store";
 import { DisconnectReason } from "livekit-client";
 import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engine";
-import { applyCallDeviceSelection } from "./call-device-selection";
 import {
   advanceActiveSpeakers,
   emptyActiveSpeakerState,
@@ -22,7 +21,11 @@ import {
   setLiveCallParticipants,
 } from "./muc-call-live-participants";
 import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
-import { enumerateCallDevices, hasEnumeratedCallDeviceId } from "./device-prefs";
+import {
+  enumerateCallDevices,
+  hasEnumeratedCallDeviceId,
+  missingCallDeviceError,
+} from "./device-prefs";
 import { syncScreenShareEnabled } from "./screen-share-state";
 import { setCallAudioPlaybackBlocked } from "./call-audio-playback";
 import { resetMicAudioProcessing, setMicAudioProcessing } from "./mic-audio-processing-state";
@@ -271,12 +274,6 @@ let callDeviceChangeTimer: ReturnType<typeof setTimeout> | null = null;
 let callDeviceChangeGeneration = 0;
 let pendingCallDeviceChange: { micId: string | null; camId: string | null } | null = null;
 
-function missingActiveCallDeviceError(kind: "mic" | "cam"): Error {
-  const error = new Error(`${kind} device was removed during the call`);
-  error.name = "NotFoundError";
-  return error;
-}
-
 async function reconcileRemovedActiveDevices(
   engine: CallEngine,
   generation: number,
@@ -286,13 +283,16 @@ async function reconcileRemovedActiveDevices(
   if (generation !== callDeviceChangeGeneration) return;
 
   const activeMicId = activeBeforeChange.micId;
+  // Fall back on the ENGINE only — the saved preference survives, so
+  // replugging the device restores the user's choice on the next call
+  // (or the next explicit selection) instead of silently forgetting it.
   if (
     activeMicId &&
     activeMicId !== "default" &&
     !hasEnumeratedCallDeviceId(devices, "mic", activeMicId)
   ) {
-    recordMediaIssue("mic", missingActiveCallDeviceError("mic"));
-    await applyCallDeviceSelection("mic", null, engine);
+    recordMediaIssue("mic", missingCallDeviceError("mic"));
+    await engine.setMicDevice("default");
     if (generation !== callDeviceChangeGeneration) return;
   }
 
@@ -302,8 +302,8 @@ async function reconcileRemovedActiveDevices(
     activeCamId !== "default" &&
     !hasEnumeratedCallDeviceId(devices, "cam", activeCamId)
   ) {
-    recordMediaIssue("cam", missingActiveCallDeviceError("cam"));
-    await applyCallDeviceSelection("cam", null, engine);
+    recordMediaIssue("cam", missingCallDeviceError("cam"));
+    await engine.setCameraDevice("default");
   }
 }
 
@@ -617,7 +617,7 @@ export function useCallEngine(): {
       // the issue so the non-blocking notice can explain it and offer
       // a retry. NOT routed through reportCallError — the persistent
       // notice is the single channel, avoiding a double-surfaced error.
-      recordMediaIssue(source === "audio" ? "mic" : "cam", error);
+      recordMediaIssue(source === "audio" ? "mic" : source === "video" ? "cam" : "screen", error);
     });
     singletonEngine.on("audioPlaybackStatusChanged", (canPlaybackAudio) => {
       setCallAudioPlaybackBlocked(!canPlaybackAudio);

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -23,6 +23,8 @@ import {
   setLiveCallParticipants,
 } from "./muc-call-live-participants";
 import { clearAllMediaIssues, recordMediaIssue } from "./call-media-issues";
+import { clearDmCallActivity } from "./dm-call-activity";
+import { forgetDmCallJoin } from "./dm-call-join-cache";
 import {
   enumerateCallDevices,
   hasEnumeratedCallDeviceId,
@@ -100,8 +102,7 @@ function peerUnawareOfTransportLoss(reason?: DisconnectReason): boolean {
 }
 
 function currentCallWireSender(): CallWireSender | null {
-  const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
-  return (client?.xmpp as CallWireSender | undefined) ?? null;
+  return connectionStore.client?.callWireSender() ?? null;
 }
 
 function transportDisconnectMessage(reason?: DisconnectReason): string {
@@ -745,6 +746,19 @@ export function useCallEngine(): {
           void tearDownActiveCall(currentCallWireSender(), "gone").catch(reportCallError);
         } else {
           clearCallState({ endReason: terminal?.endReason ?? "error" });
+          if (disconnectedCall.kind === "dm" && reason !== DisconnectReason.DUPLICATE_IDENTITY) {
+            // The call is authoritatively over (room deleted/closed, we
+            // were removed, server shut down): the accepted activity and
+            // cached join must stop offering a reconnect into it.
+            // DUPLICATE_IDENTITY keeps both — the succeeding device owns
+            // the still-live call.
+            clearDmCallActivity(disconnectedCall.peer, disconnectedCall.sid);
+            forgetDmCallJoin({
+              selfBareJid: disconnectedCall.join.identity,
+              peerJid: disconnectedCall.peer,
+              sid: disconnectedCall.sid,
+            });
+          }
         }
         reportCallError(new Error(transportDisconnectMessage(reason)));
       }

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -1,5 +1,6 @@
 import { ref, type Ref } from "vue";
-import { $callState } from "./call-store";
+import { $callState, clearCallState, reportCallError } from "./call-store";
+import { DisconnectReason } from "livekit-client";
 import { CallEngine, type LocalMediaTrack, type RemoteMediaTrack } from "./engine";
 import {
   advanceActiveSpeakers,
@@ -63,6 +64,31 @@ import {
   finishCallAttemptForTransportDisconnect,
   type CallKind,
 } from "./call-lifecycle-telemetry";
+
+function transportDisconnectMessage(reason?: DisconnectReason): string {
+  switch (reason) {
+    case DisconnectReason.DUPLICATE_IDENTITY:
+      return "This call ended because the same account joined from another device.";
+    case DisconnectReason.PARTICIPANT_REMOVED:
+      return "You were removed from the call.";
+    case DisconnectReason.ROOM_DELETED:
+    case DisconnectReason.ROOM_CLOSED:
+      return "The call room was closed.";
+    case DisconnectReason.SERVER_SHUTDOWN:
+      return "The call service shut down unexpectedly.";
+    case DisconnectReason.USER_UNAVAILABLE:
+    case DisconnectReason.USER_REJECTED:
+      return "The other participant is no longer available for this call.";
+    case DisconnectReason.CONNECTION_TIMEOUT:
+      return "The call connection timed out.";
+    case DisconnectReason.MEDIA_FAILURE:
+      return "The call ended because the media connection failed.";
+    case DisconnectReason.JOIN_FAILURE:
+      return "The call ended because the room connection failed.";
+    default:
+      return "The call connection was lost.";
+  }
+}
 
 /**
  * Process-wide singleton: only one call engine should ever exist
@@ -567,10 +593,13 @@ export function useCallEngine(): {
       if (!roomJid) return;
       removeLiveCallParticipant(roomJid, identity);
     });
-    singletonEngine.on("disconnected", (reason) => {
+    singletonEngine.on("disconnected", ({ origin, reason }) => {
       const disconnectedCall = $callState.get();
-      if (reason !== "local" && disconnectedCall.phase === "active") {
-        finishCallAttemptForTransportDisconnect(disconnectedCall.sid);
+      const disconnectedMucSlot = activeMucCallSlot();
+      if (origin !== "local" && disconnectedCall.phase === "active") {
+        const terminal = finishCallAttemptForTransportDisconnect(disconnectedCall.sid);
+        clearCallState({ endReason: terminal?.endReason ?? "error" });
+        reportCallError(new Error(transportDisconnectMessage(reason)));
       }
       remoteTracks.value = [];
       localTracks.value = [];
@@ -613,7 +642,7 @@ export function useCallEngine(): {
       // view. Drop the LK snapshot so the room's UI reverts to the
       // Muji-derived (server-bridged) view, which the LK webhook
       // bridge keeps honest within seconds.
-      const slot = activeMucCallSlot();
+      const slot = disconnectedMucSlot;
       if (!slot) return;
       // Suppress our own stale Muji nick for one render cycle: the
       // server-authoritative `<muji/>` absence broadcast arrives ~1

--- a/chat/src/lib/calls/use-call-engine.ts
+++ b/chat/src/lib/calls/use-call-engine.ts
@@ -317,13 +317,20 @@ async function reconcileRemovedActiveDevices(
   // Fall back on the ENGINE only — the saved preference survives, so
   // replugging the device restores the user's choice on the next call
   // (or the next explicit selection) instead of silently forgetting it.
+  // A notice is recorded ONLY when the fallback itself fails: after a
+  // successful switch capture is live on the default, and a "missing"
+  // notice would mislabel the call as listener-only with an enable
+  // action that disables the working device (#1621 review round 4).
   if (
     activeMicId &&
     activeMicId !== "default" &&
     !hasEnumeratedCallDeviceId(devices, "mic", activeMicId)
   ) {
-    recordMediaIssue("mic", missingCallDeviceError("mic"));
-    await engine.setMicDevice("default");
+    try {
+      await engine.setMicDevice("default");
+    } catch (err) {
+      recordMediaIssue("mic", err instanceof Error ? err : missingCallDeviceError("mic"));
+    }
     if (generation !== callDeviceChangeGeneration) return;
   }
 
@@ -333,8 +340,11 @@ async function reconcileRemovedActiveDevices(
     activeCamId !== "default" &&
     !hasEnumeratedCallDeviceId(devices, "cam", activeCamId)
   ) {
-    recordMediaIssue("cam", missingCallDeviceError("cam"));
-    await engine.setCameraDevice("default");
+    try {
+      await engine.setCameraDevice("default");
+    } catch (err) {
+      recordMediaIssue("cam", err instanceof Error ? err : missingCallDeviceError("cam"));
+    }
   }
 }
 

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -48,6 +48,7 @@ import {
 } from "./calls/call-media-path-telemetry";
 import {
   callIceEventAttributes,
+  type IceCredentialEvent,
   type CallIceSnapshot,
 } from "./calls/call-ice-telemetry";
 import { callCorrelationId, deriveCallCorrelationId } from "./calls/call-correlation";
@@ -1206,6 +1207,19 @@ export function reportCallMediaPath(snapshot: CallMediaPathSnapshot, callKind: C
 export function reportCallIce(snapshot: CallIceSnapshot, callKind: CallKind): void {
   faro?.api.pushEvent("chat.call.ice", {
     ...callIceEventAttributes(snapshot),
+    call_kind: callKind,
+    call_id: callCorrelationId(),
+  });
+}
+
+/**
+ * Beacon XEP-0215 TURN credential refresh/expiry without including the
+ * credential, server address, or expiry timestamp. The closed status value is
+ * intentionally low-cardinality and shares the call ICE correlation id.
+ */
+export function reportCallIceCredentials(event: IceCredentialEvent, callKind: CallKind): void {
+  faro?.api.pushEvent("chat.call.ice_credentials", {
+    credential_state: event,
     call_kind: callKind,
     call_id: callCorrelationId(),
   });

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -5,7 +5,7 @@ import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filter
 import type { BroadcastShow } from "@/presence/effective-show";
 import type { MemberSummary, UserSearchResult } from "../chat-types";
 import type { WaddleSession } from "../server-auth";
-import { $callState, applyCallEvent, clearCallState, clearPendingDmCallTerminate, flushPendingDmCallTerminate, tearDownActiveCall, type RawIqSender } from "@/lib/calls/call-store";
+import { $callState, applyCallEvent, clearPendingDmCallTerminate, flushPendingDmCallTerminate, tearDownActiveCall, type RawIqSender } from "@/lib/calls/call-store";
 import { readvertiseMucCallPresence, setMucCallHandRaised } from "@/lib/calls/muc-call-actions";
 import {
   applyDmCallEvent,
@@ -2916,6 +2916,15 @@ export class BrowserXmppClient {
   private async readvertiseActiveMucCallPresence(xmpp: XmppClientInstance): Promise<void> {
     const state = $callState.get();
     if (state.phase !== "active" || state.kind !== "muc") return;
+    // Fence every await on the CAPTURED call identity: the slot can be
+    // replaced mid-flight (hang up + new call), and a stale restoration
+    // attempt must neither tear down nor advertise the replacement
+    // (#1621 review round 5).
+    const sid = state.sid;
+    const stillThisCall = (): boolean => {
+      const current = $callState.get();
+      return current.phase === "active" && current.kind === "muc" && current.sid === sid;
+    };
     // Resolves immediately when the rejoin already confirmed; joins
     // (single-flight) and waits otherwise. The advertisement must land
     // on the FRESH occupant, not race the join presence. One retry
@@ -2929,17 +2938,39 @@ export class BrowserXmppClient {
         await this.ensureJoined(state.peer);
         break;
       } catch {
-        if (this.xmpp !== xmpp || $callState.get().phase !== "active") return;
+        if (this.xmpp !== xmpp || !stillThisCall()) return;
         if (attempt === 1) {
-          await tearDownActiveCall(this.callWireSender(), "gone");
-          void useCallEngine().engine.disconnect();
+          await this.endCallAndClearProjections(this.callWireSender());
           return;
         }
       }
     }
     if (this.xmpp !== xmpp || !this.connected) return;
-    if ($callState.get().phase !== "active") return;
-    await readvertiseMucCallPresence(xmpp as unknown as RawIqSender);
+    if (!stillThisCall()) return;
+    const advertised = await readvertiseMucCallPresence(xmpp as unknown as RawIqSender);
+    if (!advertised && stillThisCall() && this.xmpp === xmpp) {
+      // The rejoin worked but the <muji/> advertisement did not (send
+      // rejected, or a stale wasm bundle without the FFI): the fresh
+      // occupant would stay unadvertised for the call's remainder with
+      // nothing left to retry it — same zombie as an unrestorable room.
+      await this.endCallAndClearProjections(this.callWireSender());
+    }
+  }
+
+  /**
+   * End the current call and clear every MUC projection store. The
+   * single teardown shape shared by transport-loss expiry and failed
+   * call restoration, so the two paths cannot drift (#1621 review
+   * rounds 4-5). With a null sender the wire steps are skipped and an
+   * active DM call retains its pending terminate.
+   */
+  private async endCallAndClearProjections(sender: CallWireSender | null): Promise<void> {
+    await tearDownActiveCall(sender, "gone");
+    clearMucCallParticipants();
+    clearAllRaisedHands();
+    clearAllMuted();
+    clearAllLiveCallParticipants();
+    void useCallEngine().engine.disconnect();
   }
 
   private teardownCallAfterTransportLoss(): void {
@@ -2948,12 +2979,7 @@ export class BrowserXmppClient {
     // terminate for the next session-ready — otherwise the peer dangles
     // active and the local reconnect offer survives for 24h (#1621
     // review round 4). Synchronous through the null-sender path.
-    void tearDownActiveCall(null, "gone");
-    clearMucCallParticipants();
-    clearAllRaisedHands();
-    clearAllMuted();
-    clearAllLiveCallParticipants();
-    void useCallEngine().engine.disconnect();
+    void this.endCallAndClearProjections(null);
   }
 
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -23,6 +23,7 @@ import {
 import { applyMutePresence, clearAllMuted } from "@/lib/calls/call-mute";
 import { clearAllLiveCallParticipants } from "@/lib/calls/muc-call-live-participants";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
+import { createCallTransportRecovery } from "@/lib/calls/call-transport-recovery";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent, ExternalService } from "@/lib/calls/types";
 import { coerceExternalServices } from "@/lib/calls/ice-servers";
@@ -130,6 +131,7 @@ import {
   type RoomAutoJoinBlock,
 } from "./room-auto-join-policy";
 import { clearDmCallJoinCacheForAccount } from "@/lib/calls/dm-call-join-cache";
+import { clearMucCallSessionCacheForAccount } from "@/lib/calls/muc-call-session-cache";
 import {
   discoverExtensionCommands,
   discoverExtensionRoutes,
@@ -452,6 +454,10 @@ export class BrowserXmppClient {
   private connectPromise: Promise<void> | null = null;
   private connected = false;
   private destroying = false;
+  private readonly callTransportRecovery = createCallTransportRecovery({
+    isCallMediaActive: () => $callState.get().phase === "active",
+    teardown: () => this.teardownCallAfterTransportLoss(),
+  });
   /** Terminal lifecycle latch. A disposed client is never reconnectable. */
   private disposed = false;
   private disposePromise: Promise<void> | null = null;
@@ -1210,6 +1216,7 @@ export class BrowserXmppClient {
 
   private async disconnectInternal(): Promise<void> {
     this.destroying = true;
+    this.callTransportRecovery.dispose();
     this.outboundQueue.dispose();
     this.roomDiscoveryGeneration += 1;
     this.currentRoomCatalogFingerprintEvidence.clear();
@@ -1263,6 +1270,7 @@ export class BrowserXmppClient {
     this.resumedSessionRoomKeys.clear();
     this.sessionReadyHandledXmpp = null;
     clearDmCallJoinCacheForAccount(this.session.jid);
+    clearMucCallSessionCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
     clearAllRaisedHands();
@@ -2668,6 +2676,7 @@ export class BrowserXmppClient {
 
   private async runSessionReady(xmpp: XmppClientInstance, lifecycle: { type: SessionLifecycleEvent["type"] }) {
     if (this.xmpp !== xmpp) return;
+    this.callTransportRecovery.onTransportReady();
     this.connected = true; this.reconnect.resetAttempts();
     this.emitStatus({ state: "online", detail: this.outboundQueue.persistedCount() > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
     // Coalesce duplicate triggers. Three event hooks call
@@ -2880,6 +2889,15 @@ export class BrowserXmppClient {
       try { await xmpp.subscribe_mds_displayed(); } catch { /* best-effort */ }
     }
   }
+  private teardownCallAfterTransportLoss(): void {
+    clearCallState({ endReason: "error" });
+    clearMucCallParticipants();
+    clearAllRaisedHands();
+    clearAllMuted();
+    clearAllLiveCallParticipants();
+    void useCallEngine().engine.disconnect();
+  }
+
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
     this.roomJoinRetry.cancelAll();
@@ -2889,25 +2907,12 @@ export class BrowserXmppClient {
     // readiness without re-sending join presence (#1221).
     this.resumedSessionRoomKeys = new Set(this.joinedMucReady);
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
-    // The wire is gone — no point trying to send session-terminate.
-    // Clear the local call slot so the UI doesn't strand on a stale
-    // active overlay across reconnect; the reconnect path doesn't
-    // re-establish call state (XEP-0353 has no resume semantics for
-    // an in-flight call once the responder's connection drops).
-    //
-    // We MUST also drop the LiveKit room. The CallOverlay's
-    // `onBeforeUnmount` is the usual route, but it won't fire when the
-    // overlay re-renders to `phase: idle` and stays mounted (the parent
-    // tree owns it) — the engine would keep an open SFU socket
-    // pumping bytes until the next call replaced it. Tearing the
-    // singleton engine down here is idempotent (no-op when nothing's
-    // connected).
-    clearCallState({ endReason: "error" });
-    clearMucCallParticipants();
-    clearAllRaisedHands();
-    clearAllMuted();
-    clearAllLiveCallParticipants();
-    void useCallEngine().engine.disconnect();
+    // Established media is independent of the transient XMPP transport.
+    // Preserve its UI projections while stream recovery has a bounded
+    // chance to restore the signalling plane; setup phases still fail fast.
+    const callTeardownDeferred = !this.destroying
+      && this.callTransportRecovery.onTransportLost() === "deferred";
+    if (!callTeardownDeferred) this.teardownCallAfterTransportLoss();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
     // `joinedMucs` keys are already canonical `roomJoinKey`s (#1221).
     this.retainedJoinedRoomJids = new Set([

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -5,8 +5,8 @@ import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filter
 import type { BroadcastShow } from "@/presence/effective-show";
 import type { MemberSummary, UserSearchResult } from "../chat-types";
 import type { WaddleSession } from "../server-auth";
-import { $callState, applyCallEvent, clearCallState, tearDownActiveCall, type RawIqSender } from "@/lib/calls/call-store";
-import { setMucCallHandRaised } from "@/lib/calls/muc-call-actions";
+import { $callState, applyCallEvent, clearCallState, clearPendingDmCallTerminate, flushPendingDmCallTerminate, tearDownActiveCall, type RawIqSender } from "@/lib/calls/call-store";
+import { readvertiseMucCallPresence, setMucCallHandRaised } from "@/lib/calls/muc-call-actions";
 import {
   applyDmCallEvent,
   clearDmCallActivities,
@@ -458,6 +458,15 @@ export class BrowserXmppClient {
     isCallMediaActive: () => $callState.get().phase === "active",
     teardown: () => this.teardownCallAfterTransportLoss(),
   });
+
+  /**
+   * The call-signalling surface of the live WASM handle, or null when
+   * disconnected. The single sanctioned way for call code to reach the
+   * wire — no peeking at the private handle through casts.
+   */
+  callWireSender(): CallWireSender | null {
+    return (this.xmpp as unknown as CallWireSender | null) ?? null;
+  }
   /** Terminal lifecycle latch. A disposed client is never reconnectable. */
   private disposed = false;
   private disposePromise: Promise<void> | null = null;
@@ -1217,6 +1226,7 @@ export class BrowserXmppClient {
   private async disconnectInternal(): Promise<void> {
     this.destroying = true;
     this.callTransportRecovery.dispose();
+    clearPendingDmCallTerminate();
     this.outboundQueue.dispose();
     this.roomDiscoveryGeneration += 1;
     this.currentRoomCatalogFingerprintEvidence.clear();
@@ -2677,6 +2687,9 @@ export class BrowserXmppClient {
   private async runSessionReady(xmpp: XmppClientInstance, lifecycle: { type: SessionLifecycleEvent["type"] }) {
     if (this.xmpp !== xmpp) return;
     this.callTransportRecovery.onTransportReady();
+    // A sender-less teardown during the outage deferred its wire
+    // terminate; deliver it now that a stream exists.
+    void flushPendingDmCallTerminate(xmpp as unknown as CallWireSender);
     this.connected = true; this.reconnect.resetAttempts();
     this.emitStatus({ state: "online", detail: this.outboundQueue.persistedCount() > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
     // Coalesce duplicate triggers. Three event hooks call
@@ -2708,6 +2721,10 @@ export class BrowserXmppClient {
       // Single-flight per epoch (`fanOutAutoJoin`) keeps this to one
       // join per room across the three fan-out triggers (#1221).
       this.fanOutJoinableRooms();
+      // The fresh bind's rejoin presence recreates our occupant WITHOUT
+      // the XEP-0272 advertisement the server wiped — re-emit it for a
+      // still-active MUC call once the call room's join confirms.
+      void this.readvertiseActiveMucCallPresence(xmpp);
     } else {
       // Resumed: occupancy survived the SM detach-for-resume server-side
       // (no MUC leave was broadcast). Re-seed readiness for the
@@ -2889,6 +2906,22 @@ export class BrowserXmppClient {
       try { await xmpp.subscribe_mds_displayed(); } catch { /* best-effort */ }
     }
   }
+  private async readvertiseActiveMucCallPresence(xmpp: XmppClientInstance): Promise<void> {
+    const state = $callState.get();
+    if (state.phase !== "active" || state.kind !== "muc") return;
+    try {
+      // Resolves immediately when the rejoin already confirmed; joins
+      // (single-flight) and waits otherwise. The advertisement must land
+      // on the FRESH occupant, not race the join presence.
+      await this.ensureJoined(state.peer);
+    } catch {
+      return;
+    }
+    if (this.xmpp !== xmpp || !this.connected) return;
+    if ($callState.get().phase !== "active") return;
+    await readvertiseMucCallPresence(xmpp as unknown as RawIqSender);
+  }
+
   private teardownCallAfterTransportLoss(): void {
     clearCallState({ endReason: "error" });
     clearMucCallParticipants();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2910,7 +2910,13 @@ export class BrowserXmppClient {
     // Established media is independent of the transient XMPP transport.
     // Preserve its UI projections while stream recovery has a bounded
     // chance to restore the signalling plane; setup phases still fail fast.
+    // A TERMINAL classification (auth rejection, resource conflict — the
+    // branch below that schedules no reconnect) or an already-latched
+    // terminal state makes recovery impossible: tear down now instead of
+    // leaving the room and capture alive for the full grace window.
     const callTeardownDeferred = !this.destroying
+      && this.terminalDisconnectDetail === null
+      && !this.inTerminalErrorState
       && this.callTransportRecovery.onTransportLost() === "deferred";
     if (!callTeardownDeferred) this.teardownCallAfterTransportLoss();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2916,13 +2916,26 @@ export class BrowserXmppClient {
   private async readvertiseActiveMucCallPresence(xmpp: XmppClientInstance): Promise<void> {
     const state = $callState.get();
     if (state.phase !== "active" || state.kind !== "muc") return;
-    try {
-      // Resolves immediately when the rejoin already confirmed; joins
-      // (single-flight) and waits otherwise. The advertisement must land
-      // on the FRESH occupant, not race the join presence.
-      await this.ensureJoined(state.peer);
-    } catch {
-      return;
+    // Resolves immediately when the rejoin already confirmed; joins
+    // (single-flight) and waits otherwise. The advertisement must land
+    // on the FRESH occupant, not race the join presence. One retry
+    // covers a self-presence timeout whose scheduled rejoin succeeds;
+    // after that a call whose room cannot be restored is a zombie —
+    // no occupancy, no XEP-0272 advertisement, no control plane — so
+    // it is ended cleanly instead of preserved indefinitely (#1621
+    // review round 4).
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await this.ensureJoined(state.peer);
+        break;
+      } catch {
+        if (this.xmpp !== xmpp || $callState.get().phase !== "active") return;
+        if (attempt === 1) {
+          await tearDownActiveCall(this.callWireSender(), "gone");
+          void useCallEngine().engine.disconnect();
+          return;
+        }
+      }
     }
     if (this.xmpp !== xmpp || !this.connected) return;
     if ($callState.get().phase !== "active") return;
@@ -2930,7 +2943,12 @@ export class BrowserXmppClient {
   }
 
   private teardownCallAfterTransportLoss(): void {
-    clearCallState({ endReason: "error" });
+    // Sender-less teardown, not a bare clearCallState: an active DM call
+    // gets its activity/cached-join cleanup AND retains the pending wire
+    // terminate for the next session-ready — otherwise the peer dangles
+    // active and the local reconnect offer survives for 24h (#1621
+    // review round 4). Synchronous through the null-sender path.
+    void tearDownActiveCall(null, "gone");
     clearMucCallParticipants();
     clearAllRaisedHands();
     clearAllMuted();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -465,6 +465,13 @@ export class BrowserXmppClient {
    * wire — no peeking at the private handle through casts.
    */
   callWireSender(): CallWireSender | null {
+    // A half-open handle (assigned during connect, before session-ready)
+    // defers application IQs and may be doomed: handing it out would
+    // route a DM teardown into the sender-present branch, burn the
+    // terminate on a dead stream, and skip the pending-teardown
+    // retention that the null-sender path provides (#1621 review
+    // round 3). Only a session-ready stream is a usable sender.
+    if (!this.connected) return null;
     return (this.xmpp as unknown as CallWireSender | null) ?? null;
   }
   /** Terminal lifecycle latch. A disposed client is never reconnectable. */

--- a/chat/tests/call-ai-noise-filter-engine.test.ts
+++ b/chat/tests/call-ai-noise-filter-engine.test.ts
@@ -37,7 +37,14 @@ function engineWithMic(opts: {
   const make =
     opts.make ?? ((model: NoiseModelId) => Promise.resolve(fakeProcessor(model)));
   const engine = new CallEngine({ makeAiNoiseProcessor: make });
-  (engine as unknown as { room: unknown }).room = { localParticipant };
+  const room = {
+    localParticipant,
+    off() {
+      return room;
+    },
+    async disconnect() {},
+  };
+  (engine as unknown as { room: unknown }).room = room;
 
   const states: AiNoiseFilterState[] = [];
   engine.on("aiNoiseFilterChanged", (s) => states.push(s));
@@ -179,5 +186,41 @@ describe("CallEngine — AI noise filter reconcile", () => {
     // the snapshot is internally consistent (no impossible {NS-on, model-on}).
     expect(last?.aiNoiseFilter).toEqual({ kind: "active", model: "rnnoise" });
     expect(last?.processing.kind).toBe("active");
+  });
+
+  test("a delayed processor from call N is destroyed instead of attaching after reconnect", async () => {
+    let release: () => void = () => {};
+    let started: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const makeStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const destroy = mock(async () => undefined);
+    const processor = {
+      ...fakeProcessor("rnnoise"),
+      destroy,
+    } as AudioNoiseProcessor;
+    const { engine, setProcessor } = engineWithMic({
+      make: async () => {
+        started();
+        await gate;
+        return processor;
+      },
+    });
+
+    const staleReconcile = engine.setAiNoiseModel("rnnoise");
+    await makeStarted;
+    await engine.disconnect();
+    const nextRoom = { localParticipant: { getTrackPublication: () => undefined } };
+    const internals = engine as unknown as { room: unknown; connectGeneration: number };
+    internals.room = nextRoom;
+    internals.connectGeneration += 1;
+    release();
+    await staleReconcile;
+
+    expect(setProcessor).not.toHaveBeenCalled();
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/chat/tests/call-cache-storage.test.ts
+++ b/chat/tests/call-cache-storage.test.ts
@@ -5,7 +5,6 @@ import {
   readMucCallSession,
   rememberMucCallSession,
 } from "../src/lib/calls/muc-call-session-cache";
-import { resetLegacyCallStorageMigrationForTests } from "../src/lib/calls/call-token-storage-migration";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
@@ -36,7 +35,6 @@ beforeEach(() => {
   installWindowStorage();
   clearAllDmCallJoinCacheForTests();
   clearAllMucCallSessionCacheForTests();
-  resetLegacyCallStorageMigrationForTests();
 });
 
 afterEach(() => {
@@ -45,12 +43,29 @@ afterEach(() => {
   const g = globalThis as ShimmedGlobal;
   g.window?.localStorage.clear();
   g.window?.sessionStorage.clear();
-  resetLegacyCallStorageMigrationForTests();
   if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
   else Reflect.deleteProperty(globalThis, "window");
 });
 
 describe("call cache storage", () => {
+  test("re-purges legacy localStorage tokens written after the first pass", () => {
+    const g = globalThis as ShimmedGlobal;
+    // First cache touch purges whatever pre-migration builds left behind.
+    readDmCallJoin({ selfBareJid: SELF_BARE_JID, peerJid: PEER_JID, sid: "s1", selfFullJid: SELF_FULL_JID });
+    // A still-open pre-migration tab (rolling deployment) writes another
+    // bearer token into the SHARED origin-wide localStorage afterwards.
+    g.window?.localStorage.setItem(DM_CACHE_KEY, JSON.stringify([{ sid: "stale" }]));
+    g.window?.localStorage.setItem(MUC_CACHE_KEY, JSON.stringify([{ sid: "stale" }]));
+
+    // The next cache access must purge it again — a one-shot guard would
+    // leave the recreated token persisted for its full exp.
+    readDmCallJoin({ selfBareJid: SELF_BARE_JID, peerJid: PEER_JID, sid: "s1", selfFullJid: SELF_FULL_JID });
+    readMucCallSession({ roomJid: ROOM_JID, selfFullJid: SELF_FULL_JID });
+
+    expect(g.window?.localStorage.getItem(DM_CACHE_KEY)).toBeNull();
+    expect(g.window?.localStorage.getItem(MUC_CACHE_KEY)).toBeNull();
+  });
+
   test("writes cached join tokens to sessionStorage, not localStorage", () => {
     rememberDmCallJoin({
       selfBareJid: SELF_BARE_JID,

--- a/chat/tests/call-cache-storage.test.ts
+++ b/chat/tests/call-cache-storage.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { rememberDmCallJoin, readDmCallJoin, clearAllDmCallJoinCacheForTests } from "../src/lib/calls/dm-call-join-cache";
+import {
+  clearAllMucCallSessionCacheForTests,
+  readMucCallSession,
+  rememberMucCallSession,
+} from "../src/lib/calls/muc-call-session-cache";
+import { resetLegacyCallStorageMigrationForTests } from "../src/lib/calls/call-token-storage-migration";
+import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+const WINDOW_SENTINEL = Symbol("call-cache-storage-window");
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const DM_CACHE_KEY = "waddle.chat.dm-call-joins.alice@example.com";
+const MUC_CACHE_KEY = "waddle.chat.muc-call-sessions.alice@example.com";
+const OTHER_DM_CACHE_KEY = "waddle.chat.dm-call-joins.bob@example.com";
+const OTHER_MUC_CACHE_KEY = "waddle.chat.muc-call-sessions.bob@example.com";
+const SELF_BARE_JID = "alice@example.com";
+const SELF_FULL_JID = "alice@example.com/web";
+const PEER_JID = "bob@example.com";
+const ROOM_JID = "room@muc.example.com";
+const MEDIA: CallMedia = { audio: true, video: false };
+const JOIN: LiveKitJoin = {
+  url: "wss://livekit.example.test",
+  room: ROOM_JID,
+  identity: SELF_FULL_JID,
+  token: "header.payload.sig",
+};
+
+type ShimmedGlobal = typeof globalThis & {
+  window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+};
+
+beforeEach(() => {
+  installWindowStorage();
+  clearAllDmCallJoinCacheForTests();
+  clearAllMucCallSessionCacheForTests();
+  resetLegacyCallStorageMigrationForTests();
+});
+
+afterEach(() => {
+  clearAllDmCallJoinCacheForTests();
+  clearAllMucCallSessionCacheForTests();
+  const g = globalThis as ShimmedGlobal;
+  g.window?.localStorage.clear();
+  g.window?.sessionStorage.clear();
+  resetLegacyCallStorageMigrationForTests();
+  if (originalWindow) Object.defineProperty(globalThis, "window", originalWindow);
+  else Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("call cache storage", () => {
+  test("writes cached join tokens to sessionStorage, not localStorage", () => {
+    rememberDmCallJoin({
+      selfBareJid: SELF_BARE_JID,
+      entry: {
+        peerJid: PEER_JID,
+        sid: "dm-sid",
+        selfFullJid: SELF_FULL_JID,
+        remoteFullJid: `${PEER_JID}/phone`,
+        media: MEDIA,
+        join: JOIN,
+        updatedAt: "2026-07-31T09:00:00.000Z",
+      },
+    });
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "muc-sid",
+      selfFullJid: SELF_FULL_JID,
+      media: MEDIA,
+      join: JOIN,
+    });
+
+    expect(window.sessionStorage.getItem(DM_CACHE_KEY)).toContain("\"token\":\"header.payload.sig\"");
+    expect(window.sessionStorage.getItem(MUC_CACHE_KEY)).toContain("\"token\":\"header.payload.sig\"");
+    expect(window.localStorage.getItem(DM_CACHE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(MUC_CACHE_KEY)).toBeNull();
+  });
+
+  test("purges legacy localStorage entries on first cache access", () => {
+    window.localStorage.setItem(DM_CACHE_KEY, "[{\"legacy\":true}]");
+    window.localStorage.setItem(MUC_CACHE_KEY, "[{\"legacy\":true}]");
+    window.localStorage.setItem("waddle.chat.keep-me", "1");
+
+    expect(
+      readDmCallJoin({
+        selfBareJid: SELF_BARE_JID,
+        peerJid: PEER_JID,
+        sid: "missing",
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBeNull();
+    expect(
+      readMucCallSession({
+        roomJid: ROOM_JID,
+        selfFullJid: SELF_FULL_JID,
+      }),
+    ).toBeNull();
+
+    expect(window.localStorage.getItem(DM_CACHE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(MUC_CACHE_KEY)).toBeNull();
+    expect(window.localStorage.getItem("waddle.chat.keep-me")).toBe("1");
+  });
+
+  test("disconnect clears both call caches for the logged-out account", async () => {
+    rememberDmCallJoin({
+      selfBareJid: SELF_BARE_JID,
+      entry: {
+        peerJid: PEER_JID,
+        sid: "dm-alice",
+        selfFullJid: SELF_FULL_JID,
+        remoteFullJid: `${PEER_JID}/phone`,
+        media: MEDIA,
+        join: JOIN,
+        updatedAt: "2026-07-31T09:00:00.000Z",
+      },
+    });
+    rememberDmCallJoin({
+      selfBareJid: "bob@example.com",
+      entry: {
+        peerJid: "carol@example.com",
+        sid: "dm-bob",
+        selfFullJid: "bob@example.com/web",
+        remoteFullJid: "carol@example.com/phone",
+        media: MEDIA,
+        join: {
+          ...JOIN,
+          identity: "bob@example.com/web",
+        },
+        updatedAt: "2026-07-31T09:05:00.000Z",
+      },
+    });
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "muc-alice",
+      selfFullJid: SELF_FULL_JID,
+      media: MEDIA,
+      join: JOIN,
+    });
+    rememberMucCallSession({
+      roomJid: ROOM_JID,
+      sid: "muc-bob",
+      selfFullJid: "bob@example.com/web",
+      media: MEDIA,
+      join: {
+        ...JOIN,
+        identity: "bob@example.com/web",
+      },
+    });
+
+    const client = new BrowserXmppClient(session());
+    await client.disconnect();
+
+    expect(window.sessionStorage.getItem(DM_CACHE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(MUC_CACHE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(OTHER_DM_CACHE_KEY)).not.toBeNull();
+    expect(window.sessionStorage.getItem(OTHER_MUC_CACHE_KEY)).not.toBeNull();
+  });
+});
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/web",
+    session_id: "session-id",
+    xmpp_websocket_url: "wss://xmpp.example.com/ws",
+  } as WaddleSession;
+}
+
+function installWindowStorage(): void {
+  const g = globalThis as ShimmedGlobal;
+  if (!g.window?.[WINDOW_SENTINEL]) {
+    g.window = Object.assign(
+      {
+        localStorage: createStorage(),
+        sessionStorage: createStorage(),
+      },
+      { [WINDOW_SENTINEL]: true as const },
+    );
+    return;
+  }
+  g.window.localStorage.clear();
+  g.window.sessionStorage.clear();
+}
+
+function createStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+}

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -179,7 +179,7 @@ describe("call page lifecycle controls", () => {
       send_raw_iq: mock(async () => "<iq type='result'/>"),
     };
     connectionStore.client = {
-      xmpp: sender,
+      callWireSender: () => sender,
     } as unknown as typeof connectionStore.client;
     $callState.set({
       phase: "active",
@@ -262,7 +262,7 @@ describe("hangupActiveCall media-first ordering (#1446)", () => {
         return new Promise<void>(() => undefined); // server never replies
       }),
     };
-    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    connectionStore.client = { callWireSender: () => sender } as unknown as typeof connectionStore.client;
     const { engine } = useCallEngine();
     (engine as unknown as { room: unknown }).room = {
       off: () => undefined,
@@ -297,7 +297,7 @@ describe("hangupActiveCall media-first ordering (#1446)", () => {
     const sender = {
       send_call_session_terminate: mock(async () => undefined),
     };
-    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    connectionStore.client = { callWireSender: () => sender } as unknown as typeof connectionStore.client;
     const { engine } = useCallEngine();
     (engine as unknown as { room: unknown }).room = {
       off: () => undefined,

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -20,6 +20,7 @@ import {
   seedCallControlsFromEngine,
   setPushToTalkActive,
   suspendCallForPageHide,
+  toggleCam,
   toggleScreenShare,
   toggleMic,
 } from "../src/lib/calls/call-controls";
@@ -526,6 +527,68 @@ describe("device-less call controls", () => {
     await toggleScreenShare();
     expect($callScreenShareEnabled.get()).toBe(false);
     expect($callMediaIssues.get().screen).toBe("in-use");
+  });
+
+  test("a stale camera failure cannot roll back the newest toggle", async () => {
+    const { engine } = useCallEngine();
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setCameraEnabled: async () => {
+          calls += 1;
+          if (calls !== 1) return;
+          await gate;
+          throw deviceError("NotReadableError");
+        },
+      },
+    };
+    $callCamEnabled.set(false);
+
+    const first = toggleCam();
+    await Promise.resolve();
+    const superseded = toggleCam();
+    const latest = toggleCam();
+    release();
+    await Promise.all([first, superseded, latest]);
+
+    expect(calls).toBe(2);
+    expect($callCamEnabled.get()).toBe(true);
+    expect($callMediaIssues.get().cam).toBeNull();
+  });
+
+  test("a stale screen-share failure cannot roll back the newest toggle", async () => {
+    const { engine } = useCallEngine();
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    (engine as unknown as { room: unknown }).room = {
+      localParticipant: {
+        setScreenShareEnabled: async () => {
+          calls += 1;
+          if (calls !== 1) return;
+          await gate;
+          throw deviceError("NotReadableError");
+        },
+      },
+    };
+    $callScreenShareEnabled.set(false);
+
+    const first = toggleScreenShare();
+    await Promise.resolve();
+    const superseded = toggleScreenShare();
+    const latest = toggleScreenShare();
+    release();
+    await Promise.all([first, superseded, latest]);
+
+    expect(calls).toBe(2);
+    expect($callScreenShareEnabled.get()).toBe(true);
+    expect($callMediaIssues.get().screen).toBeNull();
   });
 
   test("native browser stop syncs the screenshare toggle off through local track unpublish", () => {

--- a/chat/tests/call-device-prefs.test.ts
+++ b/chat/tests/call-device-prefs.test.ts
@@ -183,11 +183,12 @@ describe("call device preference resolution", () => {
     });
   });
 
-  test("enumeration failure resolves a saved device to defaults without failing the join", async () => {
-    // This runs BEFORE the Room is constructed: a rejecting
-    // enumerateDevices() must degrade to browser defaults (no `missing`
-    // notice — best-effort capture surfaces any real device error), never
-    // propagate and turn a saved preference into a fatal join failure.
+  test("enumeration failure keeps the requested device instead of failing or defaulting", async () => {
+    // Enumeration is only a pre-check: a rejecting enumerateDevices()
+    // must neither propagate (the join would die before the Room is
+    // built) nor silently swap an explicit pick for the default — the
+    // requested id is attempted as-is and a genuinely unavailable
+    // device rejects at switch/capture time instead.
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
       value: {
@@ -200,9 +201,9 @@ describe("call device preference resolution", () => {
     });
 
     await expect(resolveCallDevicePreference("mic", "headset-mic")).resolves.toEqual({
-      activeDeviceId: "default",
-      preferenceId: null,
-      captureDeviceId: undefined,
+      activeDeviceId: "headset-mic",
+      preferenceId: "headset-mic",
+      captureDeviceId: "headset-mic",
       missing: false,
     });
   });

--- a/chat/tests/call-device-prefs.test.ts
+++ b/chat/tests/call-device-prefs.test.ts
@@ -183,6 +183,30 @@ describe("call device preference resolution", () => {
     });
   });
 
+  test("enumeration failure resolves a saved device to defaults without failing the join", async () => {
+    // This runs BEFORE the Room is constructed: a rejecting
+    // enumerateDevices() must degrade to browser defaults (no `missing`
+    // notice — best-effort capture surfaces any real device error), never
+    // propagate and turn a saved preference into a fatal join failure.
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        mediaDevices: {
+          enumerateDevices: async () => {
+            throw new Error("enumeration unavailable");
+          },
+        },
+      },
+    });
+
+    await expect(resolveCallDevicePreference("mic", "headset-mic")).resolves.toEqual({
+      activeDeviceId: "default",
+      preferenceId: null,
+      captureDeviceId: undefined,
+      missing: false,
+    });
+  });
+
   test("falls back to the browser default when a saved device id is gone", async () => {
     setEnumeratedDevices([
       { deviceId: "desk-cam", kind: "videoinput", label: "Desk cam" },

--- a/chat/tests/call-device-prefs.test.ts
+++ b/chat/tests/call-device-prefs.test.ts
@@ -1,16 +1,38 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   $devicePrefs,
   audioProcessingConstraints,
   defaultAudioProcessingPrefs,
+  hasEnumeratedCallDeviceId,
   isSpeakerOutputSelectionSupported,
   normalizeAudioProcessingPrefs,
   parseDevicePrefsStorage,
+  resolveCallDevicePreference,
   serializeDevicePrefsStorage,
   setAiNoiseModel,
   setBackgroundEffectPref,
 } from "../src/lib/calls/device-prefs";
 import { BACKGROUND_OFF } from "../src/lib/calls/background-effect/effect-id";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+function setEnumeratedDevices(
+  devices: Array<{ deviceId: string; kind: MediaDeviceKind; label: string }>,
+): void {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        enumerateDevices: async () => devices,
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else Reflect.deleteProperty(globalThis, "navigator");
+});
 
 describe("call speaker output support", () => {
   test("is disabled during SSR or when media elements cannot switch sinks", () => {
@@ -131,6 +153,46 @@ describe("call audio processing preferences", () => {
       audioProcessing: defaultAudioProcessingPrefs(),
       aiNoiseModel: null,
       backgroundEffect: BACKGROUND_OFF,
+    });
+  });
+});
+
+describe("call device preference resolution", () => {
+  test("detects an enumerated device id for its picker kind", () => {
+    const devices = {
+      mics: [{ deviceId: "headset-mic", kind: "audioinput", label: "Headset" }],
+      cams: [{ deviceId: "desk-cam", kind: "videoinput", label: "Desk cam" }],
+      speakers: [{ deviceId: "usb-speaker", kind: "audiooutput", label: "USB speaker" }],
+    };
+
+    expect(hasEnumeratedCallDeviceId(devices, "mic", "headset-mic")).toBe(true);
+    expect(hasEnumeratedCallDeviceId(devices, "cam", "headset-mic")).toBe(false);
+  });
+
+  test("keeps an available saved device id for capture and active switching", async () => {
+    setEnumeratedDevices([
+      { deviceId: "headset-mic", kind: "audioinput", label: "Headset" },
+      { deviceId: "desk-cam", kind: "videoinput", label: "Desk cam" },
+    ]);
+
+    await expect(resolveCallDevicePreference("mic", "headset-mic")).resolves.toEqual({
+      activeDeviceId: "headset-mic",
+      preferenceId: "headset-mic",
+      captureDeviceId: "headset-mic",
+      missing: false,
+    });
+  });
+
+  test("falls back to the browser default when a saved device id is gone", async () => {
+    setEnumeratedDevices([
+      { deviceId: "desk-cam", kind: "videoinput", label: "Desk cam" },
+    ]);
+
+    await expect(resolveCallDevicePreference("mic", "stale-mic")).resolves.toEqual({
+      activeDeviceId: "default",
+      preferenceId: null,
+      captureDeviceId: undefined,
+      missing: true,
     });
   });
 });

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -13,6 +13,25 @@ import {
 import { $aiNoiseFilterError } from "../src/lib/calls/ai-noise-filter-error-state";
 import { $backgroundEffectError } from "../src/lib/calls/background-effect-error-state";
 import { BACKGROUND_OFF } from "../src/lib/calls/background-effect/effect-id";
+import {
+  $callMediaIssues,
+  clearAllMediaIssues,
+} from "../src/lib/calls/call-media-issues";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+function setEnumeratedDevices(
+  devices: Array<{ deviceId: string; kind: MediaDeviceKind; label: string }>,
+): void {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      mediaDevices: {
+        enumerateDevices: async () => devices,
+      },
+    },
+  });
+}
 
 afterEach(() => {
   $devicePrefs.set({
@@ -25,10 +44,18 @@ afterEach(() => {
   });
   $aiNoiseFilterError.set(null);
   $backgroundEffectError.set(null);
+  clearAllMediaIssues();
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else Reflect.deleteProperty(globalThis, "navigator");
 });
 
 describe("call device selection", () => {
   test("persists and applies mic, camera, and speaker selections to the active call", async () => {
+    setEnumeratedDevices([
+      { deviceId: "headset-mic", kind: "audioinput", label: "Headset" },
+      { deviceId: "desk-cam", kind: "videoinput", label: "Desk cam" },
+      { deviceId: "usb-speaker", kind: "audiooutput", label: "USB speaker" },
+    ]);
     const engine = {
       setMicDevice: mock(async (_id: string) => undefined),
       setCameraDevice: mock(async (_id: string) => undefined),
@@ -77,6 +104,9 @@ describe("call device selection", () => {
   });
 
   test("does not persist a preference when the active call rejects the device switch", async () => {
+    setEnumeratedDevices([
+      { deviceId: "fallback-mic", kind: "audioinput", label: "Fallback mic" },
+    ]);
     const engine = {
       setMicDevice: mock(async (_id: string) => {
         throw new Error("device unavailable");
@@ -104,6 +134,23 @@ describe("call device selection", () => {
       aiNoiseModel: null,
       backgroundEffect: BACKGROUND_OFF,
     });
+  });
+
+  test("persists the browser default when the requested saved device id is missing", async () => {
+    setEnumeratedDevices([
+      { deviceId: "fallback-mic", kind: "audioinput", label: "Fallback mic" },
+    ]);
+    const engine = {
+      setMicDevice: mock(async (_id: string) => undefined),
+      setCameraDevice: mock(async (_id: string) => undefined),
+      setSpeakerDevice: mock(async (_id: string) => undefined),
+    };
+
+    await applyCallDeviceSelection("mic", "stale-mic", engine);
+
+    expect(engine.setMicDevice).toHaveBeenCalledWith("default");
+    expect($devicePrefs.get().mic).toBeNull();
+    expect($callMediaIssues.get().mic).toBe("missing");
   });
 
   test("persists and applies audio processing selections to the active call", async () => {

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -13,10 +13,7 @@ import {
 import { $aiNoiseFilterError } from "../src/lib/calls/ai-noise-filter-error-state";
 import { $backgroundEffectError } from "../src/lib/calls/background-effect-error-state";
 import { BACKGROUND_OFF } from "../src/lib/calls/background-effect/effect-id";
-import {
-  $callMediaIssues,
-  clearAllMediaIssues,
-} from "../src/lib/calls/call-media-issues";
+import { clearAllMediaIssues } from "../src/lib/calls/call-media-issues";
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
 
@@ -134,6 +131,30 @@ describe("call device selection", () => {
       aiNoiseModel: null,
       backgroundEffect: BACKGROUND_OFF,
     });
+  });
+
+  test("a failed speaker switch persists no preference", async () => {
+    const engine = {
+      setMicDevice: mock(async (_id: string) => null),
+      setCameraDevice: mock(async (_id: string) => null),
+      setSpeakerDevice: mock(async (_id: string) => {
+        throw new Error("sink switch failed");
+      }),
+    };
+    $devicePrefs.set({
+      mic: null,
+      cam: null,
+      speaker: "old-speaker",
+      audioProcessing: defaultAudioProcessingPrefs(),
+      aiNoiseModel: null,
+      backgroundEffect: BACKGROUND_OFF,
+    });
+
+    await expect(applyCallDeviceSelection("speaker", "usb-speaker", engine)).rejects.toThrow(
+      "sink switch failed",
+    );
+
+    expect($devicePrefs.get().speaker).toBe("old-speaker");
   });
 
   test("persists what the engine actually applied when the saved device is missing", async () => {

--- a/chat/tests/call-device-selection.test.ts
+++ b/chat/tests/call-device-selection.test.ts
@@ -136,21 +136,26 @@ describe("call device selection", () => {
     });
   });
 
-  test("persists the browser default when the requested saved device id is missing", async () => {
-    setEnumeratedDevices([
-      { deviceId: "fallback-mic", kind: "audioinput", label: "Fallback mic" },
-    ]);
+  test("persists what the engine actually applied when the saved device is missing", async () => {
+    // Resolution happens ONCE, inside the engine; the selection layer
+    // persists the returned resolution so the preference can never claim
+    // a device the live call is not capturing from (#1621 round 2). The
+    // engine's own mediaDevicesError event carries the missing notice.
     const engine = {
-      setMicDevice: mock(async (_id: string) => undefined),
-      setCameraDevice: mock(async (_id: string) => undefined),
-      setSpeakerDevice: mock(async (_id: string) => undefined),
+      setMicDevice: mock(async (_id: string) => ({
+        activeDeviceId: "default",
+        preferenceId: null,
+        captureDeviceId: undefined,
+        missing: true,
+      })),
+      setCameraDevice: mock(async (_id: string) => null),
+      setSpeakerDevice: mock(async (_id: string) => null),
     };
 
     await applyCallDeviceSelection("mic", "stale-mic", engine);
 
-    expect(engine.setMicDevice).toHaveBeenCalledWith("default");
+    expect(engine.setMicDevice).toHaveBeenCalledWith("stale-mic");
     expect($devicePrefs.get().mic).toBeNull();
-    expect($callMediaIssues.get().mic).toBe("missing");
   });
 
   test("persists and applies audio processing selections to the active call", async () => {

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -194,6 +194,34 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
     expect(room.connectCalls[0].opts).toBeUndefined();
   });
 
+  test("an empty advertisement disables both rtcConfig and the refresher", async () => {
+    // resolveIceServers() returns an empty bundle on any failure. Refresh
+    // being wired must not force `{ rtcConfig: {} }` into existence (the
+    // engine's contract is to omit rtcConfig so LiveKit keeps its
+    // signalling-provided servers) — and with no retained config object a
+    // refresh would have nothing to update, so it must never fire.
+    const room = stubRoom();
+    const refreshCalls: number[] = [];
+    await engineWith(room).connect(join(), {
+      audio: false,
+      video: false,
+      iceServers: [],
+      iceServersExpiryMs: Date.now() + 1_000,
+      refreshIceServers: async () => {
+        refreshCalls.push(1);
+        return { servers: [], earliestExpiryMs: null };
+      },
+    });
+
+    expect(room.connectCalls[0].opts).toBeUndefined();
+    const onConnectionStateChanged = room.handlers.get(RoomEvent.ConnectionStateChanged) as
+      | ((state: ConnectionState) => void)
+      | undefined;
+    onConnectionStateChanged?.(ConnectionState.Reconnecting);
+    await Promise.resolve();
+    expect(refreshCalls).toEqual([]);
+  });
+
   test("refreshes credentials on transport reconnect for a future PeerConnection rebuild", async () => {
     const room = stubRoom();
     const engine = engineWith(room);

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { Room, RoomConnectOptions, RoomOptions } from "livekit-client";
+import {
+  DisconnectReason,
+  RoomEvent,
+  type Room,
+  type RoomConnectOptions,
+  type RoomOptions,
+} from "livekit-client";
 import { CallEngine } from "../src/lib/calls/engine";
 import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
 import type { LiveKitJoin } from "../src/lib/calls/types";
@@ -34,9 +40,23 @@ function join(): LiveKitJoin {
  */
 function stubRoom() {
   const connectCalls: Array<{ url: string; token: string; opts?: RoomConnectOptions }> = [];
+  const handlers = new Map<RoomEvent, unknown>();
+  const offCalls: RoomEvent[] = [];
+  let disconnectCalls = 0;
   const room = {
     connectCalls,
-    on() {
+    handlers,
+    offCalls,
+    get disconnectCalls() {
+      return disconnectCalls;
+    },
+    on(event: RoomEvent, handler: unknown) {
+      handlers.set(event, handler);
+      return room;
+    },
+    off(event: RoomEvent, handler: unknown) {
+      if (handlers.get(event) === handler) handlers.delete(event);
+      offCalls.push(event);
       return room;
     },
     removeAllListeners() {},
@@ -47,8 +67,15 @@ function stubRoom() {
       identity: "alice@waddle.test/desktop",
       async setMicrophoneEnabled() {},
       async setCameraEnabled() {},
+      async setScreenShareEnabled() {},
+      getTrackPublication() {
+        return undefined;
+      },
     },
     remoteParticipants: new Map(),
+    async disconnect() {
+      disconnectCalls += 1;
+    },
   };
   return room;
 }
@@ -173,5 +200,64 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
     // The engine is not wedged: a fresh connect proceeds (gate already resolved).
     await engine.connect(join(), { audio: false, video: false });
     expect(built).toBe(2);
+  });
+
+  test("terminal disconnect releases the room, unbinds listeners, and permits reconnect", async () => {
+    const room = stubRoom();
+    const engine = engineWith(room);
+    const disconnected: Array<{
+      origin: "local" | "transport";
+      reason?: DisconnectReason;
+    }> = [];
+    engine.on("disconnected", (info) => disconnected.push(info));
+
+    await engine.connect(join(), { audio: false, video: false });
+    const onDisconnected = room.handlers.get(RoomEvent.Disconnected) as
+      | ((reason?: DisconnectReason) => Promise<void>)
+      | undefined;
+    expect(onDisconnected).toBeDefined();
+    await onDisconnected?.(DisconnectReason.DUPLICATE_IDENTITY);
+
+    expect((engine as unknown as { room: Room | null }).room).toBeNull();
+    expect(room.offCalls).toHaveLength(14);
+    expect(room.handlers.size).toBe(0);
+    expect(disconnected).toEqual([{
+      origin: "transport",
+      reason: DisconnectReason.DUPLICATE_IDENTITY,
+    }]);
+
+    await engine.connect(join(), { audio: false, video: false });
+    expect(room.connectCalls).toHaveLength(2);
+  });
+
+  test("an operation from call N cannot fall back after call N+1 connects", async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = stubRoom();
+    const second = stubRoom();
+    let screenCalls = 0;
+    first.localParticipant.setScreenShareEnabled = async () => {
+      screenCalls += 1;
+      await gate;
+      const error = new Error("screen audio unsupported");
+      error.name = "NotSupportedError";
+      throw error;
+    };
+    let built = 0;
+    const engine = new CallEngine({
+      makeRoom: () => (built++ === 0 ? first : second) as unknown as Room,
+      videoCodecSupport: videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] }),
+    });
+
+    await engine.connect(join(), { audio: false, video: false });
+    const staleOperation = engine.setScreenShareEnabled(true, { audio: true });
+    await engine.disconnect();
+    await engine.connect(join(), { audio: false, video: false });
+    release();
+    await staleOperation;
+
+    expect(screenCalls).toBe(1);
   });
 });

--- a/chat/tests/call-ice-config.test.ts
+++ b/chat/tests/call-ice-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  ConnectionState,
   DisconnectReason,
   RoomEvent,
   type Room,
@@ -7,6 +8,7 @@ import {
   type RoomOptions,
 } from "livekit-client";
 import { CallEngine } from "../src/lib/calls/engine";
+import { createIceCredentialRefresher } from "../src/lib/calls/ice-credential-refresh";
 import { videoCodecSupport } from "../src/lib/calls/video-codec/support";
 import type { LiveKitJoin } from "../src/lib/calls/types";
 
@@ -92,6 +94,80 @@ const iceServers: RTCIceServer[] = [
   { urls: "stun:turn.waddle.social:3478" },
 ];
 
+describe("XEP-0215 credential refresh scheduling", () => {
+  test("fires one minute before the earliest expiry and applies fresh credentials", async () => {
+    const now = Date.parse("2026-07-31T12:00:00Z");
+    let scheduled: (() => void) | null = null;
+    let scheduledDelay = -1;
+    const applied: RTCIceServer[][] = [];
+    let resolveRefreshed: () => void = () => undefined;
+    const refreshed = new Promise<void>((resolve) => {
+      resolveRefreshed = resolve;
+    });
+    const refresher = createIceCredentialRefresher({
+      refresh: async () => ({
+        servers: [{ urls: "turns:fresh.waddle.test:443", username: "u2", credential: "p2" }],
+        earliestExpiryMs: now + 600_000,
+      }),
+      apply: (bundle) => applied.push(bundle.servers),
+      isCurrent: () => true,
+      onRefreshed: resolveRefreshed,
+      onExpired: () => undefined,
+      clock: {
+        now: () => now,
+        setTimeout: (callback, delayMs) => {
+          scheduled = callback;
+          scheduledDelay = delayMs;
+          return 1 as unknown as ReturnType<typeof setTimeout>;
+        },
+        clearTimeout: () => undefined,
+      },
+    });
+
+    refresher.start(now + 300_000);
+    expect(scheduledDelay).toBe(240_000);
+    expect(scheduled).not.toBeNull();
+    (scheduled as unknown as () => void)();
+    await refreshed;
+
+    expect(applied).toEqual([[
+      { urls: "turns:fresh.waddle.test:443", username: "u2", credential: "p2" },
+    ]]);
+  });
+
+  test("stop clears the call-scoped timer and prevents a stale callback from refreshing", async () => {
+    const cleared: Array<ReturnType<typeof setTimeout>> = [];
+    let scheduled: (() => void) | null = null;
+    let refreshCalls = 0;
+    const timer = 7 as unknown as ReturnType<typeof setTimeout>;
+    const refresher = createIceCredentialRefresher({
+      refresh: async () => {
+        refreshCalls += 1;
+        return { servers: iceServers, earliestExpiryMs: null };
+      },
+      apply: () => undefined,
+      isCurrent: () => true,
+      onRefreshed: () => undefined,
+      onExpired: () => undefined,
+      clock: {
+        now: () => 1_000,
+        setTimeout: (callback) => {
+          scheduled = callback;
+          return timer;
+        },
+        clearTimeout: (handle) => cleared.push(handle),
+      },
+    });
+
+    refresher.start(120_000);
+    refresher.stop();
+    expect(cleared).toEqual([timer]);
+    (scheduled as unknown as () => void)();
+    await Promise.resolve();
+    expect(refreshCalls).toBe(0);
+  });
+});
+
 describe("CallEngine.connect — XEP-0215 ICE injection", () => {
   test("passes the mapped iceServers via rtcConfig at connect", async () => {
     const room = stubRoom();
@@ -116,6 +192,74 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
     await engineWith(room).connect(join(), { audio: false, video: false, iceServers: [] });
 
     expect(room.connectCalls[0].opts).toBeUndefined();
+  });
+
+  test("refreshes credentials on transport reconnect for a future PeerConnection rebuild", async () => {
+    const room = stubRoom();
+    const engine = engineWith(room);
+    const refreshed: number[] = [];
+    engine.on("iceCredentialsRefreshed", () => refreshed.push(1));
+    let releaseRefresh: (bundle: {
+      servers: RTCIceServer[];
+      earliestExpiryMs: number | null;
+    }) => void = () => undefined;
+    const refreshResult = new Promise<{
+      servers: RTCIceServer[];
+      earliestExpiryMs: number | null;
+    }>((resolve) => {
+      releaseRefresh = resolve;
+    });
+
+    await engine.connect(join(), {
+      audio: false,
+      video: false,
+      iceServers,
+      iceServersExpiryMs: null,
+      refreshIceServers: () => refreshResult,
+    });
+    const rtcConfig = room.connectCalls[0].opts?.rtcConfig;
+    const onConnectionStateChanged = room.handlers.get(RoomEvent.ConnectionStateChanged) as
+      | ((state: ConnectionState) => void)
+      | undefined;
+    const freshServers: RTCIceServer[] = [
+      { urls: "turns:fresh.waddle.test:443", username: "new", credential: "secret" },
+    ];
+
+    onConnectionStateChanged?.(ConnectionState.Reconnecting);
+    releaseRefresh({ servers: freshServers, earliestExpiryMs: null });
+    await refreshResult;
+    await Promise.resolve();
+
+    // LiveKit 2.19 retains this config object and clones it for a full
+    // reconnect. Its current PeerConnection is not updated in place.
+    expect(rtcConfig?.iceServers).toEqual(freshServers);
+    expect(refreshed).toEqual([1]);
+  });
+
+  test("disconnect clears the proactive credential refresh timer", async () => {
+    const room = stubRoom();
+    const timer = 11 as unknown as ReturnType<typeof setTimeout>;
+    const cleared: Array<ReturnType<typeof setTimeout>> = [];
+    const engine = new CallEngine({
+      makeRoom: () => room as unknown as Room,
+      videoCodecSupport: videoCodecSupport({ encode: ["video/vp8"], decode: ["video/vp8"] }),
+      iceRefreshClock: {
+        now: () => 1_000,
+        setTimeout: () => timer,
+        clearTimeout: (handle) => cleared.push(handle),
+      },
+    });
+
+    await engine.connect(join(), {
+      audio: false,
+      video: false,
+      iceServers,
+      iceServersExpiryMs: 120_000,
+      refreshIceServers: async () => ({ servers: iceServers, earliestExpiryMs: null }),
+    });
+    await engine.disconnect();
+
+    expect(cleared).toEqual([timer]);
   });
 
   test("rejects a second concurrent connect before the first resolves, building only one Room", async () => {
@@ -219,7 +363,7 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
     await onDisconnected?.(DisconnectReason.DUPLICATE_IDENTITY);
 
     expect((engine as unknown as { room: Room | null }).room).toBeNull();
-    expect(room.offCalls).toHaveLength(14);
+    expect(room.offCalls).toHaveLength(16);
     expect(room.handlers.size).toBe(0);
     expect(disconnected).toEqual([{
       origin: "transport",
@@ -228,6 +372,32 @@ describe("CallEngine.connect — XEP-0215 ICE injection", () => {
 
     await engine.connect(join(), { audio: false, video: false });
     expect(room.connectCalls).toHaveLength(2);
+  });
+
+  test("forwards LiveKit media-device errors for active mic and camera failures", async () => {
+    const room = stubRoom();
+    const engine = engineWith(room);
+    const seen: Array<{ source: "audio" | "video"; error: Error }> = [];
+    engine.on("mediaDevicesError", (info) => {
+      seen.push(info as { source: "audio" | "video"; error: Error });
+    });
+
+    await engine.connect(join(), { audio: false, video: false });
+    const onMediaDevicesError = room.handlers.get(RoomEvent.MediaDevicesError) as
+      | ((error: Error, kind?: MediaDeviceKind) => void)
+      | undefined;
+    const micError = new Error("mic gone");
+    micError.name = "NotFoundError";
+    const camError = new Error("cam gone");
+    camError.name = "NotReadableError";
+
+    onMediaDevicesError?.(micError, "audioinput");
+    onMediaDevicesError?.(camError, "videoinput");
+
+    expect(seen).toEqual([
+      { source: "audio", error: micError },
+      { source: "video", error: camError },
+    ]);
   });
 
   test("an operation from call N cannot fall back after call N+1 connects", async () => {

--- a/chat/tests/call-ice-telemetry.test.ts
+++ b/chat/tests/call-ice-telemetry.test.ts
@@ -210,6 +210,16 @@ describe("callIceEventAttributes", () => {
 });
 
 describe("createCallIceBeacon", () => {
+  test("forwards credential refresh and expiry lifecycle beacons", () => {
+    const credentials: string[] = [];
+    const beacon = createCallIceBeacon(() => undefined, (event) => credentials.push(event));
+
+    beacon.noteCredentials("refreshed");
+    beacon.noteCredentials("expired");
+
+    expect(credentials).toEqual(["refreshed", "expired"]);
+  });
+
   test("a report that measured nothing is not beaconed", () => {
     const seen: CallIceSnapshot[] = [];
     const beacon = createCallIceBeacon((snapshot) => seen.push(snapshot));

--- a/chat/tests/call-media-issues.test.ts
+++ b/chat/tests/call-media-issues.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/lib/calls/call-media-issues";
 import { __setFaroForTesting } from "../src/lib/telemetry";
 import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import { $devicePrefs, setMicDevice } from "../src/lib/calls/device-prefs";
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
 
@@ -161,6 +162,21 @@ describe("$callMediaIssues store", () => {
     expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });
   });
 
+  test("an engine media error without a device kind surfaces as a screen issue", () => {
+    const engine = useCallEngine().engine as unknown as {
+      emit: (event: string, ...args: unknown[]) => void;
+    };
+
+    // livekit maps ScreenShare/Unknown sources to an undefined kind; the
+    // engine routes those to source "screen" instead of dropping them.
+    engine.emit("mediaDevicesError", {
+      source: "screen",
+      error: domError("NotReadableError"),
+    });
+
+    expect($callMediaIssues.get()).toEqual({ mic: null, cam: null, screen: "in-use" });
+  });
+
   test("devicechange falling out from under the active mic records missing and falls back", async () => {
     let onDeviceChange: (() => void) | null = null;
     let removedHandler: (() => void) | null = null;
@@ -194,6 +210,7 @@ describe("$callMediaIssues store", () => {
     const originalSetSpeakerDevice = engine.setSpeakerDevice;
     const micCalls: string[] = [];
     let activeMicId = "gone-mic";
+    setMicDevice("gone-mic");
     try {
       engine.activeDeviceId = (kind: MediaDeviceKind) =>
         kind === "audioinput" ? activeMicId : null;
@@ -217,10 +234,14 @@ describe("$callMediaIssues store", () => {
 
       expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });
       expect(micCalls).toEqual(["default"]);
+      // The fallback is engine-only: the SAVED preference survives, so
+      // replugging the device restores the user's choice on the next call.
+      expect($devicePrefs.get().mic).toBe("gone-mic");
 
       engine.emit("disconnected", { origin: "local" });
       expect(removedHandler).toBe(onDeviceChange);
     } finally {
+      setMicDevice(null);
       engine.activeDeviceId = originalActiveDeviceId;
       engine.setMicDevice = originalSetMicDevice;
       engine.setCameraDevice = originalSetCameraDevice;

--- a/chat/tests/call-media-issues.test.ts
+++ b/chat/tests/call-media-issues.test.ts
@@ -9,6 +9,9 @@ import {
   recordMediaIssue,
 } from "../src/lib/calls/call-media-issues";
 import { __setFaroForTesting } from "../src/lib/telemetry";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
 
 function domError(name: string): Error {
   const err = new Error(`${name} message`);
@@ -19,6 +22,12 @@ function domError(name: string): Error {
 afterEach(() => {
   clearAllMediaIssues();
   __setFaroForTesting(null);
+  const engine = useCallEngine().engine as unknown as {
+    emit: (event: string, ...args: unknown[]) => void;
+  };
+  engine.emit("disconnected", { origin: "local" });
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else Reflect.deleteProperty(globalThis, "navigator");
 });
 
 describe("classifyMediaError", () => {
@@ -137,5 +146,85 @@ describe("$callMediaIssues store", () => {
     recordMediaIssue("screen", domError("AbortError"));
     clearAllMediaIssues();
     expect($callMediaIssues.get()).toEqual({ mic: null, cam: null, screen: null });
+  });
+
+  test("the engine mediaDevicesError event records a mid-call issue", () => {
+    const engine = useCallEngine().engine as unknown as {
+      emit: (event: string, ...args: unknown[]) => void;
+    };
+
+    engine.emit("mediaDevicesError", {
+      source: "audio",
+      error: domError("NotFoundError"),
+    });
+
+    expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });
+  });
+
+  test("devicechange falling out from under the active mic records missing and falls back", async () => {
+    let onDeviceChange: (() => void) | null = null;
+    let removedHandler: (() => void) | null = null;
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: {
+        mediaDevices: {
+          enumerateDevices: async () => [
+            { deviceId: "replacement-mic", kind: "audioinput", label: "Replacement" },
+          ],
+          addEventListener: (_event: string, handler: () => void) => {
+            onDeviceChange = handler;
+          },
+          removeEventListener: (_event: string, handler: () => void) => {
+            removedHandler = handler;
+          },
+        },
+      },
+    });
+
+    const engine = useCallEngine().engine as unknown as {
+      activeDeviceId: (kind: MediaDeviceKind) => string | null;
+      emit: (event: string, ...args: unknown[]) => void;
+      setMicDevice: (deviceId: string) => Promise<void>;
+      setCameraDevice: (deviceId: string) => Promise<void>;
+      setSpeakerDevice: (deviceId: string) => Promise<void>;
+    };
+    const originalActiveDeviceId = engine.activeDeviceId;
+    const originalSetMicDevice = engine.setMicDevice;
+    const originalSetCameraDevice = engine.setCameraDevice;
+    const originalSetSpeakerDevice = engine.setSpeakerDevice;
+    const micCalls: string[] = [];
+    let activeMicId = "gone-mic";
+    try {
+      engine.activeDeviceId = (kind: MediaDeviceKind) =>
+        kind === "audioinput" ? activeMicId : null;
+      engine.setMicDevice = async (deviceId: string) => {
+        micCalls.push(deviceId);
+      };
+      engine.setCameraDevice = async () => undefined;
+      engine.setSpeakerDevice = async () => undefined;
+
+      engine.emit("connected", {
+        localIdentity: "alice@waddle.test/web",
+        remoteIdentities: [],
+        roomName: "room@muc.waddle.test::call",
+      });
+      onDeviceChange?.();
+      // LiveKit's own listener auto-selects the first remaining device before
+      // our debounced reconciliation runs. We must still remember that the
+      // device active at event time was the one removed.
+      activeMicId = "replacement-mic";
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });
+      expect(micCalls).toEqual(["default"]);
+
+      engine.emit("disconnected", { origin: "local" });
+      expect(removedHandler).toBe(onDeviceChange);
+    } finally {
+      engine.activeDeviceId = originalActiveDeviceId;
+      engine.setMicDevice = originalSetMicDevice;
+      engine.setCameraDevice = originalSetCameraDevice;
+      engine.setSpeakerDevice = originalSetSpeakerDevice;
+    }
   });
 });

--- a/chat/tests/call-media-issues.test.ts
+++ b/chat/tests/call-media-issues.test.ts
@@ -177,7 +177,7 @@ describe("$callMediaIssues store", () => {
     expect($callMediaIssues.get()).toEqual({ mic: null, cam: null, screen: "in-use" });
   });
 
-  test("devicechange falling out from under the active mic records missing and falls back", async () => {
+  test("devicechange falling out from under the active mic falls back without a false notice", async () => {
     let onDeviceChange: (() => void) | null = null;
     let removedHandler: (() => void) | null = null;
     Object.defineProperty(globalThis, "navigator", {
@@ -232,10 +232,12 @@ describe("$callMediaIssues store", () => {
       activeMicId = "replacement-mic";
       await new Promise((resolve) => setTimeout(resolve, 250));
 
-      expect($callMediaIssues.get()).toEqual({ mic: "missing", cam: null, screen: null });
+      // The fallback SUCCEEDED: capture is live on the default, so no
+      // "missing" notice is recorded (its enable action would disable
+      // the working device — #1621 round 4), and the SAVED preference
+      // survives so replugging restores the user's choice.
+      expect($callMediaIssues.get()).toEqual({ mic: null, cam: null, screen: null });
       expect(micCalls).toEqual(["default"]);
-      // The fallback is engine-only: the SAVED preference survives, so
-      // replugging the device restores the user's choice on the next call.
       expect($devicePrefs.get().mic).toBe("gone-mic");
 
       engine.emit("disconnected", { origin: "local" });

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -23,6 +23,14 @@ import {
   markCallAttemptAccepted,
 } from "../src/lib/calls/call-lifecycle-telemetry";
 import { __setFaroForTesting, callLifecycleEmissionSettled } from "../src/lib/telemetry";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import { DisconnectReason, type Room } from "livekit-client";
+import {
+  $mucCallLeavingRooms,
+  $mucCallLiveParticipants,
+  clearAllLiveCallParticipants,
+  setLiveCallParticipants,
+} from "../src/lib/calls/muc-call-live-participants";
 
 const audioVideo: CallMedia = { audio: true, video: true };
 const join: LiveKitJoin = {
@@ -35,6 +43,7 @@ const join: LiveKitJoin = {
 afterEach(() => {
   clearCallState();
   clearDmCallActivities();
+  clearAllLiveCallParticipants();
   __resetCallLifecycleTelemetryForTesting();
   __setFaroForTesting(null);
 });
@@ -611,5 +620,77 @@ describe("clearLastCallError", () => {
       context: expect.objectContaining({ recoverable: "true", detail: "call-operation" }),
     });
     __setFaroForTesting(null);
+  });
+});
+
+describe("terminal LiveKit disconnect", () => {
+  test("clears an active call and reports the transport reason", async () => {
+    const engine = useCallEngine().engine;
+    const room = {
+      off() {
+        return room;
+      },
+      localParticipant: {
+        getTrackPublication() {
+          return undefined;
+        },
+      },
+    };
+    (engine as unknown as { room: Room | null }).room = room as unknown as Room;
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "transport-lost",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    });
+
+    await (
+      engine as unknown as {
+        handleDisconnected: (reason?: DisconnectReason) => Promise<void>;
+      }
+    ).handleDisconnected(DisconnectReason.DUPLICATE_IDENTITY);
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect($lastCallError.get()).toBe(
+      "This call ended because the same account joined from another device.",
+    );
+  });
+
+  test("preserves MUC leave cleanup after the call store becomes idle", async () => {
+    const engine = useCallEngine().engine;
+    const room = {
+      off() {
+        return room;
+      },
+      localParticipant: {
+        getTrackPublication() {
+          return undefined;
+        },
+      },
+    };
+    (engine as unknown as { room: Room | null }).room = room as unknown as Room;
+    setLiveCallParticipants("room@conference.waddle.test", ["alice@waddle.test/web"]);
+    $callState.set({
+      phase: "active",
+      peer: "room@conference.waddle.test",
+      sid: "muc-transport-lost",
+      media: audioVideo,
+      join,
+      kind: "muc",
+      selfNick: "alice",
+    });
+
+    await (
+      engine as unknown as {
+        handleDisconnected: (reason?: DisconnectReason) => Promise<void>;
+      }
+    ).handleDisconnected(DisconnectReason.ROOM_DELETED);
+
+    expect($mucCallLiveParticipants.get()).toEqual({});
+    expect($mucCallLeavingRooms.get()).toEqual({
+      "room@conference.waddle.test": "alice",
+    });
   });
 });

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -20,8 +20,17 @@ import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../
 
 import {
   $mucCallLiveParticipants,
+  clearAllLiveCallParticipants,
   setLiveCallParticipants,
 } from "../src/lib/calls/muc-call-live-participants";
+import {
+  $mucRaisedHands,
+  clearAllRaisedHands,
+} from "../src/lib/calls/call-raised-hand";
+import {
+  $mucMutedParticipants,
+  clearAllMuted,
+} from "../src/lib/calls/call-mute";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import { leaveRetainedMucCallAction, startMucCallAction } from "../src/lib/calls/muc-call-actions";
 import {
@@ -55,6 +64,8 @@ function wireClientEvents(sender: Partial<CallWireSender> = {}) {
     presence_type?: string;
     muc_jid?: string | null;
     muji?: { preparing: boolean; active: boolean };
+    hand_raised?: boolean;
+    muted?: boolean;
   }) => void) | null = null;
   let onCall: ((event: CallEvent) => void) | null = null;
   let onDisconnected: (() => void) | null = null;
@@ -211,22 +222,15 @@ function mockSender(): CallWireSender {
 
 const WINDOW_SENTINEL = Symbol("call-teardown-window");
 type ShimmedGlobal = typeof globalThis & {
-  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+  window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
 };
 
 beforeAll(() => {
   const g = globalThis as ShimmedGlobal;
   if (typeof g.window !== "undefined") return;
-  const store = new Map<string, string>();
-  const storage: Storage = {
-    get length() { return store.size; },
-    clear: () => store.clear(),
-    getItem: (key) => store.get(key) ?? null,
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key) => { store.delete(key); },
-    setItem: (key, value) => { store.set(key, String(value)); },
-  };
-  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+  const storage = createStorage();
+  const sessionStorage = createStorage();
+  g.window = Object.assign({ localStorage: storage, sessionStorage }, { [WINDOW_SENTINEL]: true as const });
 });
 
 afterAll(() => {
@@ -235,6 +239,18 @@ afterAll(() => {
     delete (g as { window?: unknown }).window;
   }
 });
+
+function createStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
+}
 
 afterEach(() => {
   clearCallState();
@@ -247,6 +263,9 @@ afterEach(() => {
   // keeps that state from leaking into other test files (e.g.
   // `muc-call-presence.test.ts`) that expect an empty store.
   clearMucCallParticipants();
+  clearAllRaisedHands();
+  clearAllMuted();
+  clearAllLiveCallParticipants();
   clearAllMucCallSessionCacheForTests();
   __resetCallLifecycleTelemetryForTesting();
   __setFaroForTesting(null);
@@ -1957,6 +1976,91 @@ describe("MUC group call", () => {
 
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect($mucCallParticipants.get()).toEqual({});
+  });
+
+  test("transient XMPP disconnect preserves an active media call and its projections", async () => {
+    const events = wireClientEvents();
+    const client = events.client as unknown as {
+      disconnect: () => Promise<void>;
+    };
+    $callState.set({
+      phase: "active",
+      peer: "chan@muc.test",
+      sid: "active-during-reconnect",
+      media: audioVideo,
+      join: {
+        url: "wss://livekit.test",
+        room: "chan@muc.test",
+        identity: "alice@waddle.test/web",
+        token: "jwt.payload.sig",
+      },
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/web",
+    });
+    events.emitPresence({
+      from: "chan@muc.test/alice",
+      presence_type: "available",
+      muc_jid: "alice@waddle.test/web",
+      muji: { preparing: false, active: true },
+      hand_raised: true,
+      muted: true,
+    });
+    setLiveCallParticipants("chan@muc.test", [
+      "alice@waddle.test/web",
+      "bob@waddle.test/phone",
+    ]);
+
+    events.emitDisconnected();
+
+    expect($callState.get()).toMatchObject({
+      phase: "active",
+      sid: "active-during-reconnect",
+    });
+    expect($mucCallParticipants.get()).toEqual({
+      "chan@muc.test": ["alice"],
+    });
+    expect($mucRaisedHands.get()).toEqual({
+      "chan@muc.test": ["alice@waddle.test/web"],
+    });
+    expect($mucMutedParticipants.get()).toEqual({
+      "chan@muc.test": ["alice@waddle.test/web"],
+    });
+    expect($mucCallLiveParticipants.get()).toEqual({
+      "chan@muc.test": [
+        "alice@waddle.test/web",
+        "bob@waddle.test/phone",
+      ],
+    });
+
+    await client.disconnect();
+  });
+
+  test("session-ready cancels call recovery before duplicate-ready coalescing", async () => {
+    const events = wireClientEvents();
+    const onTransportReady = mock(() => undefined);
+    const client = events.client as unknown as {
+      callTransportRecovery: {
+        dispose(): void;
+        onTransportLost(): "deferred" | "not-deferred";
+        onTransportReady(): void;
+      };
+      runSessionReady(
+        xmpp: typeof events.xmpp,
+        lifecycle: { type: "fresh" | "resumed" },
+      ): Promise<void>;
+    };
+    client.callTransportRecovery = {
+      dispose: () => undefined,
+      onTransportLost: () => "not-deferred",
+      onTransportReady,
+    };
+
+    await client.runSessionReady(events.xmpp, { type: "fresh" });
+    await client.runSessionReady(events.xmpp, { type: "fresh" });
+
+    expect(onTransportReady).toHaveBeenCalledTimes(2);
+    await client.disconnect();
   });
 
   test("BrowserXmppClient ignores stale call and presence events after disconnect", async () => {

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import {
   $callState,
+  clearPendingDmCallTerminate,
+  flushPendingDmCallTerminate,
   $lastCallError,
   beginOutgoingCall,
   clearCallState,
@@ -3224,7 +3226,9 @@ describe("LiveKit transport loss on an active DM call", () => {
 
   test("a peer-unaware media failure sends the bounded wire teardown", async () => {
     const sender = mockSender();
-    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    connectionStore.client = {
+      callWireSender: () => sender,
+    } as unknown as typeof connectionStore.client;
     activeDmCall();
     const engine = useCallEngine().engine as unknown as {
       emit: (event: string, ...args: unknown[]) => void;
@@ -3249,7 +3253,9 @@ describe("LiveKit transport loss on an active DM call", () => {
 
   test("a server-initiated end sends no wire teardown", async () => {
     const sender = mockSender();
-    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    connectionStore.client = {
+      callWireSender: () => sender,
+    } as unknown as typeof connectionStore.client;
     activeDmCall();
     const engine = useCallEngine().engine as unknown as {
       emit: (event: string, ...args: unknown[]) => void;
@@ -3265,5 +3271,82 @@ describe("LiveKit transport loss on an active DM call", () => {
 
     expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
     expect($callState.get().phase).not.toBe("active");
+  });
+});
+
+describe("sender-less DM teardown retention", () => {
+  afterEach(() => {
+    clearPendingDmCallTerminate();
+    clearCallState();
+    clearDmCallActivities();
+  });
+
+  test("a null-sender teardown clears local surfaces and defers the wire terminate", async () => {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-outage",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+
+    // XMPP died first: nothing can carry the terminate right now.
+    await tearDownActiveCall(null, "gone");
+    expect($callState.get()).toEqual({ phase: "idle" });
+    expect(readDmCallActivity("bob@waddle.test/desktop")).toBeNull();
+
+    // The next session-ready delivers the retained teardown so the peer
+    // does not dangle in an active call.
+    const sender = mockSender();
+    await flushPendingDmCallTerminate(sender);
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "dm-outage",
+      "gone",
+    );
+    expect(sender.send_call_finish).toHaveBeenCalledTimes(1);
+
+    // One-shot: a second flush must not re-send.
+    await flushPendingDmCallTerminate(sender);
+    expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
+  });
+
+  test("terminal server disconnect reasons clear the DM activity", async () => {
+    connectionStore.client = null;
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-room-deleted",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    applyDmCallEvent({
+      selfBareJid: "alice@waddle.test",
+      selfFullJid: "alice@waddle.test/web",
+      timestamp: new Date().toISOString(),
+      now: new Date(),
+      event: {
+        kind: "proceed",
+        from: "bob@waddle.test/desktop",
+        to: "alice@waddle.test/web",
+        sid: "dm-room-deleted",
+      },
+    });
+    const engine = useCallEngine().engine as unknown as {
+      emit: (event: string, ...args: unknown[]) => void;
+    };
+
+    engine.emit("disconnected", {
+      origin: "transport",
+      reason: DisconnectReason.ROOM_DELETED,
+    });
+    await flushCallSideEffects();
+
+    expect($callState.get().phase).not.toBe("active");
+    expect(readDmCallActivity("bob@waddle.test/desktop")).toBeNull();
   });
 });

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -3313,6 +3313,40 @@ describe("sender-less DM teardown retention", () => {
     expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
   });
 
+  test("transport-loss teardown of an active DM call retains the wire terminate", async () => {
+    // The 60s grace expiring (or a terminal disconnect classification)
+    // routes through the sender-less teardown: local surfaces clear NOW,
+    // and the peer's XEP-0166/0353 signal survives for the next session.
+    const events = wireClientEvents();
+    const client = events.client as unknown as {
+      terminalDisconnectDetail: string | null;
+      disconnect: () => Promise<void>;
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-grace-expiry",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    client.terminalDisconnectDetail = "Signed out: resource conflict";
+
+    events.emitDisconnected();
+    await flushCallSideEffects();
+
+    expect($callState.get()).toEqual({ phase: "idle" });
+    const sender = mockSender();
+    await flushPendingDmCallTerminate(sender);
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "dm-grace-expiry",
+      "gone",
+    );
+    await client.disconnect();
+  });
+
   test("a failed flush retains the pending terminate for the next session-ready", async () => {
     $callState.set({
       phase: "active",

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -44,6 +44,9 @@ import type { CallWireSender } from "../src/lib/calls/outbound";
 import type { CallEvent, CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 import { createIncomingCallAlertController } from "../src/shell/audio-alerts";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import { useCallEngine } from "../src/lib/calls/use-call-engine";
+import { connectionStore } from "../src/lib/connection-store";
+import { DisconnectReason } from "livekit-client";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { __resetCallLifecycleTelemetryForTesting } from "../src/lib/calls/call-lifecycle-telemetry";
 import { __setFaroForTesting, callLifecycleEmissionSettled } from "../src/lib/telemetry";
@@ -1978,6 +1981,39 @@ describe("MUC group call", () => {
     expect($mucCallParticipants.get()).toEqual({});
   });
 
+  test("terminal disconnect classification bypasses the call recovery grace", async () => {
+    const events = wireClientEvents();
+    const client = events.client as unknown as {
+      terminalDisconnectDetail: string | null;
+      disconnect: () => Promise<void>;
+    };
+    $callState.set({
+      phase: "active",
+      peer: "chan@muc.test",
+      sid: "terminal-during-call",
+      media: audioVideo,
+      join: {
+        url: "wss://livekit.test",
+        room: "chan@muc.test",
+        identity: "alice@waddle.test/web",
+        token: "jwt.payload.sig",
+      },
+      kind: "muc",
+      selfNick: "alice",
+      selfFullJid: "alice@waddle.test/web",
+    });
+    // The WASM error callback classified this cycle as terminal (auth
+    // rejection / resource conflict) BEFORE the disconnect callback fired.
+    // Recovery is impossible — the grace window must not keep the room,
+    // capture, and call UI alive for a minute.
+    client.terminalDisconnectDetail = "Signed out: resource conflict";
+
+    events.emitDisconnected();
+
+    expect($callState.get().phase).not.toBe("active");
+    await client.disconnect();
+  });
+
   test("transient XMPP disconnect preserves an active media call and its projections", async () => {
     const events = wireClientEvents();
     const client = events.client as unknown as {
@@ -3165,5 +3201,69 @@ describe("scheduleOutgoingTimeout", () => {
     beginOutgoingCall("carol@waddle.test", "c-new", audioVideo);
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(sender.send_call_retract).not.toHaveBeenCalled();
+  });
+});
+
+describe("LiveKit transport loss on an active DM call", () => {
+  afterEach(() => {
+    connectionStore.client = null;
+    clearCallState();
+  });
+
+  function activeDmCall(): void {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-media-loss",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+  }
+
+  test("a peer-unaware media failure sends the bounded wire teardown", async () => {
+    const sender = mockSender();
+    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    activeDmCall();
+    const engine = useCallEngine().engine as unknown as {
+      emit: (event: string, ...args: unknown[]) => void;
+    };
+
+    // The SFU died on OUR side only: nobody else tells the peer, so the
+    // XEP-0166 terminate (+ XEP-0353 finish) must go out before the
+    // active-call snapshot is cleared.
+    engine.emit("disconnected", {
+      origin: "transport",
+      reason: DisconnectReason.MEDIA_FAILURE,
+    });
+    await flushCallSideEffects();
+
+    expect(sender.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "dm-media-loss",
+      "gone",
+    );
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("a server-initiated end sends no wire teardown", async () => {
+    const sender = mockSender();
+    connectionStore.client = { xmpp: sender } as unknown as typeof connectionStore.client;
+    activeDmCall();
+    const engine = useCallEngine().engine as unknown as {
+      emit: (event: string, ...args: unknown[]) => void;
+    };
+
+    // A duplicate-identity takeover means ANOTHER device of ours now owns
+    // the call — terminating would kill the succeeding device's session.
+    engine.emit("disconnected", {
+      origin: "transport",
+      reason: DisconnectReason.DUPLICATE_IDENTITY,
+    });
+    await flushCallSideEffects();
+
+    expect(sender.send_call_session_terminate).not.toHaveBeenCalled();
+    expect($callState.get().phase).not.toBe("active");
   });
 });

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -3313,6 +3313,52 @@ describe("sender-less DM teardown retention", () => {
     expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
   });
 
+  test("a failed flush retains the pending terminate for the next session-ready", async () => {
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "dm-retained",
+      media: audioVideo,
+      join,
+      kind: "dm",
+      initiator: "alice@waddle.test/web",
+    });
+    await tearDownActiveCall(null, "gone");
+
+    // The first recovered stream dies mid-send: the peer's only
+    // end-of-call signal must survive for the NEXT session-ready.
+    const doomed = mockSender();
+    (doomed.send_call_session_terminate as unknown as { mockImplementation: (fn: () => Promise<void>) => void })
+      .mockImplementation(async () => {
+        throw new Error("stream died mid-send");
+      });
+    await flushPendingDmCallTerminate(doomed);
+
+    const healthy = mockSender();
+    await flushPendingDmCallTerminate(healthy);
+    expect(healthy.send_call_session_terminate).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "dm-retained",
+      "gone",
+    );
+  });
+
+  test("callWireSender is null until the session is ready", () => {
+    const events = wireClientEvents();
+    const client = events.client as unknown as {
+      callWireSender: () => unknown;
+      connected: boolean;
+    };
+
+    // The handle exists (wireEvents bound it) but no session-ready ran:
+    // handing it out would burn a teardown on a doomed half-open stream
+    // instead of retaining it for the next session.
+    expect(client.callWireSender()).toBeNull();
+
+    client.connected = true;
+    expect(client.callWireSender()).not.toBeNull();
+  });
+
   test("terminal server disconnect reasons clear the DM activity", async () => {
     connectionStore.client = null;
     $callState.set({

--- a/chat/tests/call-transport-recovery.test.ts
+++ b/chat/tests/call-transport-recovery.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  CALL_TRANSPORT_RECOVERY_GRACE_MS,
+  createCallTransportRecovery,
+  type CallTransportRecoveryClock,
+} from "../src/lib/calls/call-transport-recovery";
+
+type ScheduledTimer = {
+  callback: () => void;
+  dueAtMs: number;
+  id: number;
+};
+
+class FakeClock implements CallTransportRecoveryClock {
+  private currentMs = 0;
+  private nextId = 1;
+  private timers: ScheduledTimer[] = [];
+
+  now(): number {
+    return this.currentMs;
+  }
+
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const id = this.nextId++;
+    this.timers.push({ callback, dueAtMs: this.currentMs + delayMs, id });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void {
+    const id = timer as unknown as number;
+    this.timers = this.timers.filter((candidate) => candidate.id !== id);
+  }
+
+  advanceBy(delayMs: number): void {
+    const targetMs = this.currentMs + delayMs;
+    while (true) {
+      const next = this.timers
+        .filter((timer) => timer.dueAtMs <= targetMs)
+        .sort((left, right) => left.dueAtMs - right.dueAtMs)[0];
+      if (!next) break;
+      this.timers = this.timers.filter((timer) => timer.id !== next.id);
+      this.currentMs = next.dueAtMs;
+      next.callback();
+    }
+    this.currentMs = targetMs;
+  }
+}
+
+function setup(active = true) {
+  let mediaActive = active;
+  const clock = new FakeClock();
+  const teardown = mock(() => undefined);
+  const recovery = createCallTransportRecovery({
+    isCallMediaActive: () => mediaActive,
+    teardown,
+    clock,
+  });
+  return {
+    clock,
+    recovery,
+    setMediaActive: (value: boolean) => {
+      mediaActive = value;
+    },
+    teardown,
+  };
+}
+
+describe("call transport recovery", () => {
+  test("defers teardown while call media is active", () => {
+    const { clock, recovery, teardown } = setup();
+
+    expect(recovery.onTransportLost()).toBe("deferred");
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS - 1);
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  test("does not defer teardown when call media is not active", () => {
+    const { recovery, teardown } = setup(false);
+
+    expect(recovery.onTransportLost()).toBe("not-deferred");
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  test("tears down once when the recovery grace expires", () => {
+    const { clock, recovery, teardown } = setup();
+    recovery.onTransportLost();
+
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS);
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS);
+
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
+  test("session readiness cancels deferred teardown", () => {
+    const { clock, recovery, teardown } = setup();
+    recovery.onTransportLost();
+
+    recovery.onTransportReady();
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS);
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  test("dispose cancels deferred teardown", () => {
+    const { clock, recovery, teardown } = setup();
+    recovery.onTransportLost();
+
+    recovery.dispose();
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS);
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  test("expiry is a no-op after the active call ends locally", () => {
+    const { clock, recovery, setMediaActive, teardown } = setup();
+    recovery.onTransportLost();
+
+    setMediaActive(false);
+    clock.advanceBy(CALL_TRANSPORT_RECOVERY_GRACE_MS);
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+});

--- a/chat/tests/call-transport-recovery.test.ts
+++ b/chat/tests/call-transport-recovery.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, mock, test } from "bun:test";
 import {
   CALL_TRANSPORT_RECOVERY_GRACE_MS,
   createCallTransportRecovery,
-  type CallTransportRecoveryClock,
 } from "../src/lib/calls/call-transport-recovery";
+import type { TimerClock } from "../src/lib/calls/timer-clock";
 
 type ScheduledTimer = {
   callback: () => void;
@@ -11,7 +11,7 @@ type ScheduledTimer = {
   id: number;
 };
 
-class FakeClock implements CallTransportRecoveryClock {
+class FakeClock implements TimerClock {
   private currentMs = 0;
   private nextId = 1;
   private timers: ScheduledTimer[] = [];

--- a/chat/tests/dm-call-activity.test.ts
+++ b/chat/tests/dm-call-activity.test.ts
@@ -19,22 +19,15 @@ const audio = { audio: true, video: false };
 const now = new Date("2026-05-25T10:00:00.000Z");
 const WINDOW_SENTINEL = Symbol("dm-call-activity-window");
 type ShimmedGlobal = typeof globalThis & {
-  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+  window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
 };
 
 beforeAll(() => {
   const g = globalThis as ShimmedGlobal;
   if (typeof g.window !== "undefined") return;
-  const store = new Map<string, string>();
-  const storage: Storage = {
-    get length() { return store.size; },
-    clear: () => store.clear(),
-    getItem: (key) => store.get(key) ?? null,
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    removeItem: (key) => { store.delete(key); },
-    setItem: (key, value) => { store.set(key, String(value)); },
-  };
-  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+  const storage = createStorage();
+  const sessionStorage = createStorage();
+  g.window = Object.assign({ localStorage: storage, sessionStorage }, { [WINDOW_SENTINEL]: true as const });
 });
 
 afterAll(() => {
@@ -61,6 +54,18 @@ function base64UrlJson(value: Record<string, unknown>): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function createStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
 }
 
 describe("DM call activity", () => {

--- a/chat/tests/ice-servers.test.ts
+++ b/chat/tests/ice-servers.test.ts
@@ -109,6 +109,19 @@ describe("iceServerBundleFromExternalServices", () => {
     expect(bundle.earliestExpiryMs).toBe(Date.parse("2026-06-17T12:00:00Z"));
   });
 
+  test("a discarded credential-less TURN entry contributes no expiry", () => {
+    // An already-past deadline on an unusable (credential-less) entry must
+    // not poison the bundle: the refresher would treat every refresh as
+    // instantly expired and spin without ever applying the valid relay.
+    const bundle = iceServerBundleFromExternalServices([
+      turns({ expires: "2020-01-01T00:00:00Z", username: undefined, password: undefined }),
+      turns({ expires: "2026-06-17T12:00:00Z" }),
+    ]);
+
+    expect(bundle.servers).toHaveLength(1);
+    expect(bundle.earliestExpiryMs).toBe(Date.parse("2026-06-17T12:00:00Z"));
+  });
+
   test("ignores malformed optional expiries", () => {
     expect(iceServerBundleFromExternalServices([
       turns({ expires: "not-a-date" }),

--- a/chat/tests/ice-servers.test.ts
+++ b/chat/tests/ice-servers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   coerceExternalServices,
+  iceServerBundleFromExternalServices,
   iceServersFromExternalServices,
 } from "../src/lib/calls/ice-servers";
 import type { ExternalService } from "../src/lib/calls/types";
@@ -93,6 +94,25 @@ describe("iceServersFromExternalServices", () => {
     expect(stunServer.urls).toBe("stun:turn.waddle.social");
     const [turnsServer] = iceServersFromExternalServices([turns({ port: undefined })]);
     expect(turnsServer.urls).toBe("turns:turn.waddle.social?transport=tcp");
+  });
+});
+
+describe("iceServerBundleFromExternalServices", () => {
+  test("parses XEP-0215 xs:dateTime expiries and chooses the earliest TURN credential", () => {
+    const bundle = iceServerBundleFromExternalServices([
+      stun({ expires: "2025-01-01T00:00:00Z" }),
+      turns({ expires: "2026-06-17T12:05:00Z" }),
+      turns({ expires: "2026-06-17T12:00:00Z", host: "turn-two.waddle.test" }),
+    ]);
+
+    expect(bundle.servers).toHaveLength(3);
+    expect(bundle.earliestExpiryMs).toBe(Date.parse("2026-06-17T12:00:00Z"));
+  });
+
+  test("ignores malformed optional expiries", () => {
+    expect(iceServerBundleFromExternalServices([
+      turns({ expires: "not-a-date" }),
+    ]).earliestExpiryMs).toBeNull();
   });
 });
 

--- a/chat/tests/muc-call-resume.test.ts
+++ b/chat/tests/muc-call-resume.test.ts
@@ -56,14 +56,27 @@ const AUDIO_CALL: CallMedia = { audio: true, video: false };
 
 const WINDOW_SENTINEL = Symbol("muc-call-resume-window");
 type ShimmedGlobal = typeof globalThis & {
-  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+  window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
 };
 
 beforeAll(() => {
   const g = globalThis as ShimmedGlobal;
   if (typeof g.window !== "undefined") return;
+  const storage = createStorage();
+  const sessionStorage = createStorage();
+  g.window = Object.assign({ localStorage: storage, sessionStorage }, { [WINDOW_SENTINEL]: true as const });
+});
+
+afterAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) {
+    delete (g as { window?: unknown }).window;
+  }
+});
+
+function createStorage(): Storage {
   const store = new Map<string, string>();
-  const storage: Storage = {
+  return {
     get length() {
       return store.size;
     },
@@ -77,15 +90,7 @@ beforeAll(() => {
       store.set(key, String(value));
     },
   };
-  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
-});
-
-afterAll(() => {
-  const g = globalThis as ShimmedGlobal;
-  if (g.window?.[WINDOW_SENTINEL]) {
-    delete (g as { window?: unknown }).window;
-  }
-});
+}
 
 beforeEach(() => {
   clearAllMucCallSessionCacheForTests();

--- a/chat/tests/muc-call-resume.test.ts
+++ b/chat/tests/muc-call-resume.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } fr
 import { $callState, clearCallState, tearDownActiveCall } from "../src/lib/calls/call-store";
 import {
   canResumeMucCallActivity,
+  readvertiseMucCallPresence,
   resumeMucCallActivity,
 } from "../src/lib/calls/muc-call-actions";
 import {
@@ -272,6 +273,57 @@ describe("resumeMucCallActivity", () => {
         video: true,
       },
     ]);
+  });
+
+  test("readvertiseMucCallPresence re-emits the full advertisement for the active call", async () => {
+    // A fresh XMPP bind wiped the server-side occupant; the plain rejoin
+    // presence carries no <muji/>, so the still-running call must
+    // re-advertise (with current hand/mute markers) once the room join
+    // confirms (#1621 round 2).
+    $callState.set({
+      phase: "active",
+      peer: ROOM_JID,
+      sid: "sid-readvertise",
+      media: { audio: true, video: true },
+      join: forgeLiveKitJoin({ identity: SELF_FULL_JID, secondsFromNow: 600 }),
+      kind: "muc",
+      selfNick: SELF_NICK,
+      selfFullJid: SELF_FULL_JID,
+    });
+    const calls: Array<{
+      roomJid: string;
+      nick: string;
+      active: boolean;
+      video: boolean;
+      flags: unknown;
+    }> = [];
+
+    const ok = await readvertiseMucCallPresence({
+      update_muji_presence: async (roomJid, nick, active, _preparing, video, flags) => {
+        calls.push({ roomJid, nick, active, video, flags });
+      },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls).toEqual([
+      {
+        roomJid: ROOM_JID,
+        nick: SELF_NICK,
+        active: true,
+        video: true,
+        flags: { handRaised: false, muted: false },
+      },
+    ]);
+  });
+
+  test("readvertiseMucCallPresence is a no-op without an active MUC call", async () => {
+    clearCallState();
+    const ok = await readvertiseMucCallPresence({
+      update_muji_presence: async () => {
+        throw new Error("must not be called");
+      },
+    });
+    expect(ok).toBe(false);
   });
 
   test("refuses to resume when $callState is not idle", async () => {


### PR DESCRIPTION
Fixes #1450.

## What shipped (six lanes)

- **Terminal LiveKit disconnect fully resets the engine and UI.** The disconnected handler nulls the room, releases the connect reservation, and stops the ICE refresher; structured `DisconnectReason`s map to user-facing end messages instead of being discarded. A subsequent call connects — no more "already connected" stranding.
- **Transient XMPP loss no longer tears down a healthy media call.** `handleDisconnected` defers call teardown when media is established (`phase: active`) and the client isn't destroying: the LiveKit room and all call UI projections survive a 60s bounded recovery window (`call-transport-recovery.ts`). Any session-ready — resumed or fresh — cancels the timer; expiry re-checks the call is still active before running the original full teardown. Setup phases and logout keep immediate teardown, and logout during a deferred blip still hangs up via `disconnectInternal`'s `tearDownActiveCall`.
- **No bearer tokens in persistent storage.** The DM join cache and MUC session cache moved to `sessionStorage` behind one shared helper; entries written to `localStorage` by pre-#1450 builds are purged on first cache touch, and logout clears both caches for the account.
- **TURN credentials refresh before expiry.** XEP-0215 `expires` is retained as `earliestExpiryMs`; a call-scoped refresher re-fetches credentials ahead of the deadline (and eagerly on transport reconnecting) into the retained `rtcConfig` object — which livekit-client 2.19 applies on resume (`updateConfiguration` → ICE restart) and full reconnects. Refresh/expiry emit low-cardinality Faro events.
- **Mid-call device unplug and permission loss surface actionable UI and recover.** `RoomEvent.MediaDevicesError` / `MediaDevicesChanged` are handled for the call's lifetime; a debounced call-lifetime `devicechange` listener (with a pre-debounce active-device snapshot, since LiveKit auto-switches before our enumeration lands) records a "missing" media issue and falls back to the browser default — without erasing the saved preference, so replugging restores the user's choice. Saved-but-unavailable devices at connect resolve to defaults with a non-blocking notice; capture stays best-effort/receive-only-tolerant. Kindless SDK media errors (screen share) surface as screen issues instead of being dropped.
- **Generation guards + last-writer-wins toggles.** Room-scoped listeners and every post-connect async op (device switches, processor reconciles, speaker re-apply, capture) check `isCurrentRoom(room, generation)`; camera/screen/mic toggles serialize per-control with generation bumps on reset.

## Tests

bun tests per lane (`call-transport-recovery`, `call-cache-storage`, `call-ice-config`, `ice-servers`, `call-media-issues`, `call-device-selection`, `call-device-prefs`, teardown/resume updates) — 3667 pass; knip clean; two-axis (standards + spec) review round applied.

## Review round (c15b8177)

All five review comments implemented (answered in-thread): an empty XEP-0215 advertisement passes no `rtcConfig` even with refresh wired, and the credential refresher only starts from a non-empty retained config; a terminal XMPP disconnect classification bypasses the 60s recovery grace and tears the call down immediately; an active DM call ended by a peer-unaware LiveKit loss now sends the bounded XEP-0166 terminate + XEP-0353 finish instead of only clearing local state (server-initiated ends still skip it); device-preference resolution degrades enumeration failures to browser defaults instead of failing the join; and a discarded credential-less TURN entry no longer poisons the bundle's refresh deadline. Six regression tests added; 3,673 tests green, knip clean.

## Review round 2 (dde80429)

All six comments implemented or answered in-thread: a public `callWireSender()` accessor replaces the private-field cast; fresh-bind recovery re-advertises the XEP-0272 `<muji/>` presence (current hand/mute markers) once the call room's rejoin confirms; a sender-less active-DM teardown clears local surfaces immediately and defers the wire terminate to the next session-ready (one-shot, sid-scoped, logout-cleared); terminal server disconnect reasons clear the DM activity and cached join (`DUPLICATE_IDENTITY` retains them for the succeeding device); device selection resolves exactly once inside the engine, which returns the applied resolution for persistence; and the TURN-refresh comment now documents the actual SDK recovery contract (both the resume path and full reconnects consume the refreshed retained rtcConfig — no public API can rotate a live PeerConnection). Ten tests added/updated; 3,677 green, knip clean.

## Review round 3 (cd12de91)

All six comments implemented (answered in-thread): the deferred DM terminate is durable — cleared only after a successful (or orphaned) send, retained across failed flushes with an in-flight guard, and held in a store atom rather than hidden module state; `callWireSender()` is gated on session-ready so a half-open connect-phase handle can never consume a teardown that the null-sender retention should keep; a stale saved device resolving to a working browser default no longer raises a misleading missing-device notice (real capture failures still surface from publication); a failed speaker sink switch rethrows so an unapplied output is never persisted; unused test import dropped. Four regression tests added; 3,680 green, knip clean.

## Review round 4 (1040f741)

All five comments implemented (answered in-thread): transport-loss teardown routes through the sender-less `tearDownActiveCall` (activity/join-cache cleanup + pending-terminate retention; the null-sender path now mirrors every phase's local cleanup); call-controls' hangup sender is session-ready-gated; fresh-bind Muji restoration retries once then ends an unrestorable call instead of preserving a zombie; the devicechange fallback raises a notice only when the fallback fails; and `resetCallControls` detaches op chains from unresolved previous-call prompts. Tests updated/added; 3,681 green, knip clean.

## Review round 5 (6dd5ff31)

All six comments implemented (answered in-thread): the MUC call restoration path is sid-fenced across every await (no stale attempt can tear down or advertise a replacement call), routes both failure modes — unrestorable room AND failed `<muji/>` re-advertisement — through a new shared `endCallAndClearProjections` helper (also used by transport-loss expiry, so the teardown shapes cannot drift), and clears the MUC projection stores it previously left stale; enumeration failures keep the user's requested device instead of silently substituting the default; the legacy localStorage token purge runs on every cache access so rolling-deployment pre-migration tabs cannot resurrect a persisted bearer token; unused import dropped. Tests updated/added; 3,682 green, knip clean.
